### PR TITLE
WIP: make title-to-back transition look more native on iOS

### DIFF
--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -228,6 +228,7 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
             // todo: determine if we really need to splat all this.props
             ...this.props,
             ...props,
+            widths: this.state.widths,
           }),
         ]}
       >

--- a/src/views/HeaderStyleInterpolator.js
+++ b/src/views/HeaderStyleInterpolator.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import { I18nManager } from 'react-native';
+import { I18nManager, Dimensions } from 'react-native';
 
 import type { NavigationSceneRendererProps } from '../TypeDefinition';
 
@@ -16,31 +16,69 @@ import type { NavigationSceneRendererProps } from '../TypeDefinition';
  */
 
 function forLeft(props: NavigationSceneRendererProps): Object {
-  const { position, scene } = props;
+  const { position, scene, scenes, widths } = props;
   const { index } = scene;
+
+  const lastScene = scenes[index - 1];
+
+  const offset = 27;
+  let distance = 200;
+
+  if (lastScene && widths[lastScene.key]) {
+    const diff = Dimensions.get('window').width - widths[lastScene.key];
+    distance = diff / 2 - offset;
+  }
+
   return {
     opacity: position.interpolate({
-      inputRange: [index - 1, index - 0.5, index, index + 0.5, index + 1],
+      inputRange: [index - 1, index - 0.4, index, index + 0.4, index + 1],
       outputRange: ([0, 0, 1, 0, 0]: Array<number>),
     }),
-  };
-}
-
-function forCenter(props: NavigationSceneRendererProps): Object {
-  const { position, scene } = props;
-  const { index } = scene;
-  return {
-    opacity: position.interpolate({
-      inputRange: [index - 1, index, index + 1],
-      outputRange: ([0, 1, 0]: Array<number>),
-    }),
     transform: [
+      {
+        scaleX: position.interpolate({
+          inputRange: [index - 1, index, index + 1],
+          outputRange: [1.15, 1, 1.15],
+        }),
+      },
       {
         translateX: position.interpolate({
           inputRange: [index - 1, index + 1],
           outputRange: I18nManager.isRTL
-            ? ([-200, 200]: Array<number>)
-            : ([200, -200]: Array<number>),
+            ? ([-distance, distance]: Array<number>)
+            : ([distance, -distance]: Array<number>),
+        }),
+      },
+    ],
+  };
+}
+
+function forCenter(props: NavigationSceneRendererProps): Object {
+  const { position, scene, widths } = props;
+  const { index, key } = scene;
+
+  const offset = 27;
+  let leftDistance = 200;
+  let rightDistance = 200;
+
+  if (widths[key]) {
+    const diff = Dimensions.get('window').width - widths[key];
+    leftDistance = diff / 2 - offset;
+    rightDistance = diff - offset;
+  }
+
+  return {
+    opacity: position.interpolate({
+      inputRange: [index - 1, index - 0.75, index, index + 0.75, index + 1],
+      outputRange: ([0, 0, 1, 0, 0]: Array<number>),
+    }),
+    transform: [
+      {
+        translateX: position.interpolate({
+          inputRange: [index - 1, index, index + 1],
+          outputRange: I18nManager.isRTL
+            ? ([-leftDistance, 0, rightDistance]: Array<number>)
+            : ([rightDistance, 0, -leftDistance]: Array<number>),
         }),
       },
     ],


### PR DESCRIPTION
While discussing the working of #1083, I noticed that the transition from back button to title was not matching the native iOS implementation.

This is a draft version, where the transition is almost seamless, but the implementation has some rough edges:

https://www.dropbox.com/s/dm1c0t9phcgy8iz/title-to-back.mov?dl=0

Also still have to test if this doesn't introduce issues on Android, and also the RTL implementation is not tested yet.

And to make it truly look like the iOS native transition, the title should move, but the back icon should only fade in and out. For comparison the "App Store" app; https://www.dropbox.com/s/k11exzy8c370app/nav-transition.mov?dl=0
But it might be that that would be too custom for the generic header component.


- [x] iOS
- [ ] Android
- [ ] RTL
- [ ] ...

Let me know what you think! 