### PR TITLE
Remove header spacing from DrawerNavigator TabRouter

### DIFF
--- a/src/navigators/DrawerNavigator.js
+++ b/src/navigators/DrawerNavigator.js
@@ -66,6 +66,9 @@ const DrawerNavigator = (
     },
     {
       initialRouteName: 'DrawerClose',
+      navigationOptions: {
+        header: null,
+      },
     },
   );
 


### PR DESCRIPTION
If a DrawerNavigator is nested inside a StackNavigator (particularly a modal one), then opening the drawer shifts everything (the drawer and the active screen behind it) down by the standard height of a StackNavigator header:

<img width="320" alt="4650f97a-e8ba-11e6-95c4-3d0fe0bfc7ce" src="https://cloud.githubusercontent.com/assets/134837/25554880/dcbadc8e-2c8d-11e7-80fe-b884b5a83005.png">

DrawerNavigator is implemented as two nested TabRouters. Setting `header: null` on the `navigationOptions` of the outer TabRouter prevents it from adding a header gap when nested inside a StackNavigator.

This PR fixes #1305.

**Test plan**

1. Nest a DrawerNavigator inside a modal StackNavigator.
2. Set `header: null` on the `navigationOptions` of the DrawerNavigator. (This gets passed to the inner TabRouter.)
3. Open the DrawerNavigator in the UI.
4. Observe that there is a header gap without this PR, and that the header gap goes away when this PR is applied.