### PR TITLE
Add screen option to allow interactivity during transition

### DIFF
--- a/src/TypeDefinition.js
+++ b/src/TypeDefinition.js
@@ -235,6 +235,7 @@ export type NavigationStackScreenOptions = NavigationScreenOptions & {
   headerRight?: React.Element<*>,
   headerStyle?: Style,
   gesturesEnabled?: boolean,
+  transitionInteractivityThreshold?: number,
 };
 
 export type NavigationStackRouterConfig = {
@@ -394,6 +395,9 @@ export type NavigationTransitionProps = {
   // is the index of the scene
   scene: NavigationScene,
   index: number,
+
+  // The progress value at which the scene will accept pointer events.
+  interactivityThreshold?: number,
 
   screenProps?: {},
 };

--- a/src/views/CardStack.js
+++ b/src/views/CardStack.js
@@ -412,6 +412,10 @@ class CardStack extends Component {
   _renderCard = (scene: NavigationScene): React.Element<*> => {
     const isModal = this.props.mode === 'modal';
 
+    const { transitionInteractivityThreshold } = this._getScreenDetails(
+      scene
+    ).options;
+
     /* $FlowFixMe */
     const { screenInterpolator } = TransitionConfigs.getTransitionConfig(
       this.props.transitionConfig,
@@ -432,6 +436,7 @@ class CardStack extends Component {
         key={`card_${scene.key}`}
         style={[style, this.props.cardStyle]}
         scene={scene}
+        interactivityThreshold={transitionInteractivityThreshold}
       >
         {this._renderInnerScene(SceneComponent, scene)}
       </Card>

--- a/src/views/PointerEventsContainer.js
+++ b/src/views/PointerEventsContainer.js
@@ -89,7 +89,12 @@ export default function create(Component: ReactClass<*>): ReactClass<*> {
     }
 
     _computePointerEvents(): string {
-      const { navigation, position, scene } = this.props;
+      const {
+        navigation,
+        position,
+        scene,
+        interactivityThreshold,
+      } = this.props;
 
       if (scene.isStale || navigation.state.index !== scene.index) {
         // The scene isn't focused.
@@ -97,7 +102,10 @@ export default function create(Component: ReactClass<*>): ReactClass<*> {
       }
 
       const offset = position.__getAnimatedValue() - navigation.state.index;
-      if (Math.abs(offset) > MIN_POSITION_OFFSET) {
+      const threshold = interactivityThreshold != null
+        ? interactivityThreshold
+        : MIN_POSITION_OFFSET;
+      if (Math.abs(offset) > threshold) {
         // The positon is still away from scene's index.
         // Scene's children should not receive touches until the position
         // is close enough to scene's index.


### PR DESCRIPTION
In some cases it is desirable for screens to be interactive sooner than the hardcoded `MIN_POSITION_OFFSET` 99% progress into the transition animation. This patch adds optional per-screen configuration of how soon in the transition the screen will become interactive.

In the case of Keybase Chat, when the back button is pressed on a conversation, we currently have the perception of early taps being dropped while the current conversation is sliding away. This change makes the conversation list feel more responsive to fast taps.