### PR TITLE
Fix queued transition being dropped if interrupted

### DIFF
--- a/src/views/Transitioner.js
+++ b/src/views/Transitioner.js
@@ -50,11 +50,11 @@ class Transitioner extends React.Component<*, Props, State> {
   _transitionProps: NavigationTransitionProps;
   _isMounted: boolean;
   _isTransitionRunning: boolean;
-  _queuedTransition: ?{
+  _queuedTransition: Array<{
     nextProps: Props,
     nextScenes: Array<NavigationScene>,
     indexHasChanged: boolean,
-  };
+  }>;
 
   props: Props;
   state: State;
@@ -83,7 +83,7 @@ class Transitioner extends React.Component<*, Props, State> {
     this._transitionProps = buildTransitionProps(props, this.state);
     this._isMounted = false;
     this._isTransitionRunning = false;
-    this._queuedTransition = null;
+    this._queuedTransition = [];
   }
 
   componentWillMount(): void {
@@ -113,7 +113,7 @@ class Transitioner extends React.Component<*, Props, State> {
     const indexHasChanged =
       nextProps.navigation.state.index !== this.props.navigation.state.index;
     if (this._isTransitionRunning) {
-      this._queuedTransition = { nextProps, nextScenes, indexHasChanged };
+      this._queuedTransition.push({ nextProps, nextScenes, indexHasChanged });
       return;
     }
 
@@ -234,13 +234,13 @@ class Transitioner extends React.Component<*, Props, State> {
     this.setState(nextState, () => {
       this.props.onTransitionEnd &&
         this.props.onTransitionEnd(this._transitionProps, prevTransitionProps);
-      if (this._queuedTransition) {
-        this._startTransition(
-          this._queuedTransition.nextProps,
-          this._queuedTransition.nextScenes,
-          this._queuedTransition.indexHasChanged
-        );
-        this._queuedTransition = null;
+      if (this._queuedTransition.length) {
+        const {
+          nextProps,
+          nextScenes,
+          indexHasChanged,
+        } = this._queuedTransition.shift();
+        this._startTransition(nextProps, nextScenes, indexHasChanged);
       } else {
         this._isTransitionRunning = false;
       }


### PR DESCRIPTION
During rapid updates to the card stack, `_queuedTransition` can be replaced before the animation has a chance to be performed. This can lead to a state in which navigation was performed but the card positions are not updated, leaving you stuck on the previous route. This patch makes `_queuedTransition` an array which executes in order, so that no queued transitions are dropped.

An alternate approach might be to apply the end state of the queued transition immediately and skip it. I didn't try this route because I was concerned this could cause abrupt jumps in transitions.