### PR TITLE
fix($TabRouter): make `paths` option work

### DIFF
--- a/src/routers/TabRouter.js
+++ b/src/routers/TabRouter.js
@@ -38,9 +38,11 @@ export default (
   const tabRouters = {};
   order.forEach((routeName: string) => {
     const routeConfig = routeConfigs[routeName];
-    paths[routeName] = typeof routeConfig.path === 'string'
-      ? routeConfig.path
-      : routeName;
+    if (!paths[routeName]) {
+      paths[routeName] = typeof routeConfig.path === 'string'
+        ? routeConfig.path
+        : routeName;
+    }
     tabRouters[routeName] = null;
     if (routeConfig.screen && routeConfig.screen.router) {
       tabRouters[routeName] = routeConfig.screen.router;


### PR DESCRIPTION
The `paths` option to TabNavigator and TabRouter was not in fact implemented, yet it was documented. Here's the small fix for it.

That said, I'm not even sure what the purpose of the `paths` option is, as there's nothing to override since the `routeConfigs` are defined in the exact same place, rather than imported and ***reused***. Since there is no *re-use* capability currently for paths, there is no need for a `paths` option :)

See my issue related to this: https://github.com/react-community/react-navigation/issues/1665