### PR TITLE
Remove non-configurable properties from contentOptions in DrawerNavigator doc

### DIFF
--- a/docs/api/navigators/DrawerNavigator.md
+++ b/docs/api/navigators/DrawerNavigator.md
@@ -130,13 +130,10 @@ const styles = StyleSheet.create({
 
 ### `contentOptions` for `DrawerItems`
 
-- `items` - the array of routes, can be modified or overridden
-- `activeItemKey` - key identifying the active route
 - `activeTintColor` - label and icon color of the active label
 - `activeBackgroundColor` - background color of the active label
 - `inactiveTintColor` - label and icon color of the inactive label
 - `inactiveBackgroundColor` - background color of the inactive label
-- `onItemPress(route)` - function to be invoked when an item is pressed
 - `style` - style object for the content section
 - `labelStyle` - style object to overwrite `Text` style inside content section, when your label is a string
 


### PR DESCRIPTION
As far as I understand, `items`, `activeItemKey ` & `onItemPress` can not be configured from DrawerNavigatorConfig. They are useful when defining custom `contentComponent`.

We can add a separate section about which props are available for custom `contentComponent`. That way it'll be less confusing I think.