### PR TITLE
fix($DrawerView): allow drawer to mount in open state

### DIFF
--- a/src/views/Drawer/DrawerView.js
+++ b/src/views/Drawer/DrawerView.js
@@ -55,7 +55,7 @@ export default class DrawerView<T: *> extends PureComponent<void, Props, void> {
     const { routes, index } = this.props.navigation.state;
 
     if (routes[index].routeName === 'DrawerOpen') {
-      this._drawer.openDrawer()
+      this._drawer.openDrawer();
     }
   }
                                 

--- a/src/views/Drawer/DrawerView.js
+++ b/src/views/Drawer/DrawerView.js
@@ -51,6 +51,14 @@ export default class DrawerView<T: *> extends PureComponent<void, Props, void> {
     this._updateScreenNavigation(this.props.navigation);
   }
 
+  componentDidMount() {
+    const { routes, index } = this.props.navigation.state;
+
+    if (routes[index].routeName === 'DrawerOpen') {
+      this._drawer.openDrawer()
+    }
+  }
+                                
   componentWillReceiveProps(nextProps: Props) {
     if (
       this.props.navigation.state.index !== nextProps.navigation.state.index


### PR DESCRIPTION
For URL-driven apps this important. Imagine you have a StackNavigator as a `customComponent`, and as is typical in such a navigator, there is a settings screen, and then you send emails to your users with links to that settings screen so they can update some settings. Well that link won't work unless the app can open in the open state. Obviously you could use additional redux state to control this, but that defeats the purpose of a fully state-driven navigation solution. This should be built in. 

Also, it would be nice if the drawer didn't have to animate open, as when the app starts a lot can be going on, and this animation may not be as smooth if the only interaction occurring. I checked the polyfill and the react-native Android Drawer, etc, and it doesn't support that. The following `Animated.Value` would have to to set its value to 0 by default but allow for another prop such as `openOnMount: true` to toggle the animated value to 0 for the initial state:

https://github.com/react-native-community/react-native-drawer-layout/blob/master/src/DrawerLayout.js#L87

eg:

```js
constructor(props: PropType, context: any) {
    super(props, context);
    const initialOpenValue = props.openOnMount ? 1 : 0
    this.state = {
      accessibilityViewIsModal: false,
      drawerShown: false,
      openValue: new Animated.Value(initialOpenValue),
    };
  }
```

This commit should be good enough for now.

