### PR TITLE
add key to default back button

### DIFF
--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -129,7 +129,7 @@ class Header extends React.PureComponent<void, HeaderProps, HeaderState> {
     return (
       <HeaderBackButton
         onPress={() => {
-          this.props.navigation.goBack(null);
+          this.props.navigation.goBack(this.props.scene.route.key);
         }}
         pressColorAndroid={options.headerPressColorAndroid}
         tintColor={options.headerTintColor}


### PR DESCRIPTION
It is nice to have separate Stack Navigators each connected to their own Redux stores via their own
`addNavigationHelpers`

When having multiple Stack Navigations, each connected to custom Redux Stores, the default Header's back button emits a back action, captured by all navigators, causing all navigators to go back a screen on the back press.

Adding a custom element to the header allows for the intended behavior, but I want to use the default Header back element.

If the key is passed in,  the intended screen is removed with the default Header's back button.

This change does not seem to affect standard implementation.

