### PR TITLE
Changed the default getStateForAction of StackRouter with recusrsive …

### DIFF
--- a/src/routers/StackRouter.js
+++ b/src/routers/StackRouter.js
@@ -99,15 +99,21 @@ export default (
           action.type === NavigationActions.NAVIGATE &&
           childRouters[action.routeName] !== undefined
         ) {
+          let definedRoute = {
+            ...action,
+            type: undefined,
+            key: `Init-${_getUuid()}`,
+          };
+          if (childRouters[action.routeName] !== null) {
+            definedRoute = Object.assign(
+              {},
+              childRouters[action.routeName].getStateForAction(action),
+              definedRoute
+            );
+          }
           return {
             index: 0,
-            routes: [
-              {
-                ...action,
-                type: undefined,
-                key: `Init-${_getUuid()}`,
-              },
-            ],
+            routes: [definedRoute],
           };
         }
         if (initialChildRouter) {


### PR DESCRIPTION
…in case arg state is empty, in order to fix a bug replicated at nested navigator which has StackRouter as parent.

## Detail

Trying to make nested navigator with "redux" as a way like below, I faced fatal errors.
The errors occur only at StackNavigator is the parent of the nest.

```javascript
export const ExclusiveNavigator = StackNavigator({
  Main: { screen: MainNavigator },
  Auth: { screen: AuthNavigator },
})

export const MainNavigator = DrawerNavigator(
{
  Top: { screen: TopScreen },
  ArticleList: { screen: ArticleListScreen },
  ArticleDetail: { screen: ArticleDetailScreen },
},
{
  initialRouteName: 'Top',
  contentOptions: {
    activeTintColor: '#e91e63',
  },
})

export const AuthNavigator = StackNavigator({
  Login: { screen: LoginScreen },
  AuthTop: { screen: MainScreen },
  Profile: { screen: ProfileScreen },
})

const initialNavState = ExclusiveNavigator.router.getStateForAction(
  ExclusiveNavigator.router.getActionForPathAndParams('Main') // Error occurs at TabRouter (screenshot 2nd)
  // ExclusiveNavigator.router.getActionForPathAndParams('Auth') // Error occurs at TabRouter (screenshot 1st)
)

function nav(state = initialNavState, action) {
  let nextState
  nextState = ExclusiveNavigator.router.getStateForAction(action, state)
  return nextState || state
}

...
```

![img_1684](https://user-images.githubusercontent.com/956564/28373612-c14ae620-6cdd-11e7-8354-560a206862b2.PNG)
![img_1685](https://user-images.githubusercontent.com/956564/28373613-c16e453e-6cdd-11e7-9f82-afaee3305b84.PNG)

I tried to find out the cause, and I guess the return value of `getStateForAction` of `StackRouter` isn't considered for nested router in case empty `state` is passed as its arg.

■Original return value of `getStateForAction` of `StackRouter`

```
return {
  index: 0,
  routes: [
    {
      ...action,
      type: undefined,
      key: `Init-${_getUuid()}`,
    },
  ],
};
```

■Change

I guess if `childRouters[action.routeName]` is not null, it can be decided it is nested navigator, so the value should have `routes` property as `Array`.
Therefore, let me suggest calling `getStateForAction` for childRoute. (For this implementation, I referred to `TabRouter`. `TabRouter` seems to solve states of children recursively.)

```
return {
  index: 0,
  routes: [
    {
      ...childRouters[action.routeName].getStateForAction(action)
      ...action,
      type: undefined,
      key: `Init-${_getUuid()}`,
    },
  ],
};
```

version

```
"react-navigation": "^1.0.0-beta.11"
```

## Motivation

As I described above, an error occurs at `getStateForAction` of nested navigator which has StackRouter as parent of the nest.
The issue below is similar to this request.
https://github.com/react-community/react-navigation/issues/1942

## Test

■Test
I show the return value of `getStateForAction` with 2ng argument empty.
Also I confirmed the errors above cleared.

```
const initialNavState = ExclusiveNavigator.router.getStateForAction(
  ExclusiveNavigator.router.getActionForPathAndParams('Main')
)
//------------------
Object {
  "index": 0,
  "routes": Array [
    Object {
      "index": 0,
      "key": "Init-id-1500478130891-0",
      "routeName": "Main",
      "routes": Array [
        Object {
          "index": 0,
          "key": "DrawerClose",
          "routeName": "DrawerClose",
          "routes": Array [
            Object {
              "key": "Top",
              "routeName": "Top",
            },
            Object {
              "key": "ArticleList",
              "routeName": "ArticleList",
            },
            Object {
              "key": "ArticleDetail",
              "routeName": "ArticleDetail",
            },
          ],
        },
        Object {
          "key": "DrawerOpen",
          "routeName": "DrawerOpen",
        },
      ],
      "type": undefined,
    },
  ],
}
```

```
const initialNavState = ExclusiveNavigator.router.getStateForAction(
  ExclusiveNavigator.router.getActionForPathAndParams('Auth')
)
// ----------------------
Object {
  "index": 0,
  "routes": Array [
    Object {
      "action": Object {
        "routeName": "Login",
        "type": "Navigation/NAVIGATE",
      },
      "index": 0,
      "key": "Init-id-1500478314436-0",
      "routeName": "Auth",
      "routes": Array [
        Object {
          "key": "Init-id-1500478314436-1",
          "routeName": "Login",
        },
      ],
      "type": undefined,
    },
  ],
}
```
