### PR TITLE
Ignore reset action in stack navigator if reset key does not match current navigator

### DIFF
--- a/src/routers/StackRouter.js
+++ b/src/routers/StackRouter.js
@@ -243,7 +243,9 @@ export default (
         }
       }
 
-      if (action.type === NavigationActions.RESET) {
+      // if action key is provided make sure it's matching navigation state
+      if (action.type === NavigationActions.RESET &&
+      (!action.key || action.key === state.key)) {
         const resetAction: NavigationResetAction = action;
 
         return {


### PR DESCRIPTION
Fall through if reset action key does not match navigation state.

Use case scenario:
In our app we have triple stack navigation structure like this:
Modal **StackNavigator** -> Home **TabNavigator** -> Child **StackNavigator**

With the current implementation, if you try to reset an **inactive** route in Home Tab Navigator by specifying a reset key to the reset action, it's not going to work because it will attempt to reset the active route of the tab navigator only.

Basically, the StackRouter is not able to ignore a reset action which is assigned to another stack router.

You can check this issue as well for more info https://github.com/react-community/react-navigation/issues/2291