### PR TITLE
Set STATUSBAR_HEIGHT for android.

### DIFF
--- a/src/views/Header/Header.js
+++ b/src/views/Header/Header.js
@@ -4,7 +4,7 @@
 
 import React from 'react';
 
-import { Animated, Platform, StyleSheet, View } from 'react-native';
+import { Animated, Platform, StyleSheet, View, StatusBar } from 'react-native';
 
 import HeaderTitle from './HeaderTitle';
 import HeaderBackButton from './HeaderBackButton';
@@ -34,7 +34,7 @@ type HeaderState = {
 };
 
 const APPBAR_HEIGHT = Platform.OS === 'ios' ? 44 : 56;
-const STATUSBAR_HEIGHT = Platform.OS === 'ios' ? 20 : 0;
+const STATUSBAR_HEIGHT = Platform.OS === 'ios' ? 20 : StatusBar.currentHeight;
 const TITLE_OFFSET = Platform.OS === 'ios' ? 70 : 56;
 
 class Header extends React.PureComponent<void, HeaderProps, HeaderState> {


### PR DESCRIPTION
This is to fix the `Header` component not taking the status bar into account on android:

![android_header](https://user-images.githubusercontent.com/42500/29578385-3226758a-87c3-11e7-93af-f138129a6d51.png)

Currently you have to patch it manually:

```javascript
if (Platform.OS=="android") {
  headerStyles.paddingTop = Constants.statusBarHeight
  headerStyles.height     = Constants.statusBarHeight + 56
}
```

This fixes #2164 and #2410.