### PR TITLE
Fix idempotent pushes during transition.

### DIFF
--- a/src/NavigationActions.js
+++ b/src/NavigationActions.js
@@ -9,6 +9,8 @@ const INIT = 'Navigation/INIT';
 const NAVIGATE = 'Navigation/NAVIGATE';
 const RESET = 'Navigation/RESET';
 const SET_PARAMS = 'Navigation/SET_PARAMS';
+const SET_TRANSITION_END = 'Navigation/SET_TRANSITION_END';
+const SET_TRANSITION_START = 'Navigation/SET_TRANSITION_START';
 const URI = 'Navigation/URI';
 
 const createAction = (type: string) => (payload: Object = {}) => ({
@@ -21,6 +23,8 @@ const init = createAction(INIT);
 const navigate = createAction(NAVIGATE);
 const reset = createAction(RESET);
 const setParams = createAction(SET_PARAMS);
+const setTransitionStart = createAction(SET_TRANSITION_START);
+const setTransitionEnd = createAction(SET_TRANSITION_END);
 const uri = createAction(URI);
 
 const deprecatedActionMap = {
@@ -29,6 +33,8 @@ const deprecatedActionMap = {
   Navigate: NAVIGATE,
   Reset: RESET,
   SetParams: SET_PARAMS,
+  SetTransitionStart: SET_TRANSITION_START,
+  SetTransitionEnd: SET_TRANSITION_END,
   Uri: URI,
 };
 
@@ -63,6 +69,8 @@ export default {
   NAVIGATE,
   RESET,
   SET_PARAMS,
+  SET_TRANSITION_START,
+  SET_TRANSITION_END,
   URI,
 
   // Action creators
@@ -71,6 +79,8 @@ export default {
   navigate,
   reset,
   setParams,
+  setTransitionStart,
+  setTransitionEnd,
   uri,
 
   // TODO: Remove once old actions are deprecated

--- a/src/TypeDefinition.js
+++ b/src/TypeDefinition.js
@@ -382,6 +382,8 @@ export type NavigationScreenProp<S, A> = {
     action?: NavigationAction
   ) => boolean,
   setParams: (newParams: NavigationParams) => boolean,
+  setTransitionStart: () => boolean,
+  setTransitionEnd: () => boolean,
 };
 
 export type NavigationNavigatorProps<O, S> = {

--- a/src/addNavigationHelpers.js
+++ b/src/addNavigationHelpers.js
@@ -33,6 +33,10 @@ export default function<S: *>(navigation: NavigationProp<S, NavigationAction>) {
           action,
         })
       ),
+    setTransitionStart: () =>
+      navigation.dispatch(NavigationActions.setTransitionStart()),
+    setTransitionEnd: () =>
+      navigation.dispatch(NavigationActions.setTransitionEnd()),
     /**
      * For updating current route params. For example the nav bar title and
      * buttons are based on the route params.

--- a/src/routers/StackRouter.js
+++ b/src/routers/StackRouter.js
@@ -141,6 +141,48 @@ export default (
         };
       }
 
+      // params can be set while in transition
+      if (action.type === NavigationActions.SET_PARAMS) {
+        const lastRoute = state.routes.find(
+          /* $FlowFixMe */
+          (route: *) => route.key === action.key
+        );
+        if (lastRoute) {
+          const params = {
+            ...lastRoute.params,
+            ...action.params,
+          };
+          const routes = [...state.routes];
+          routes[state.routes.indexOf(lastRoute)] = {
+            ...lastRoute,
+            params,
+          };
+          return {
+            ...state,
+            routes,
+          };
+        }
+      }
+
+      // when in a transition, do not allow new transitions to start
+      if (action.type === NavigationActions.SET_TRANSITION_START) {
+        return {
+          ...state,
+          inTransition: true,
+        };
+      }
+
+      if (action.type === NavigationActions.SET_TRANSITION_END) {
+        return {
+          ...state,
+          inTransition: false,
+        };
+      }
+
+      if (state.inTransition) {
+        return state;
+      }
+
       // Check if a child scene wants to handle the action as long as it is not a reset to the root stack
       if (action.type !== NavigationActions.RESET || action.key !== null) {
         const keyIndex = action.key
@@ -218,28 +260,6 @@ export default (
               });
             }
           }
-        }
-      }
-
-      if (action.type === NavigationActions.SET_PARAMS) {
-        const lastRoute = state.routes.find(
-          /* $FlowFixMe */
-          (route: *) => route.key === action.key
-        );
-        if (lastRoute) {
-          const params = {
-            ...lastRoute.params,
-            ...action.params,
-          };
-          const routes = [...state.routes];
-          routes[state.routes.indexOf(lastRoute)] = {
-            ...lastRoute,
-            params,
-          };
-          return {
-            ...state,
-            routes,
-          };
         }
       }
 

--- a/src/views/Transitioner.js
+++ b/src/views/Transitioner.js
@@ -49,7 +49,7 @@ const DefaultTransitionSpec = ({
 
 class Transitioner extends React.Component<*, Props, State> {
   _onLayout: (event: any) => void;
-  _onTransitionEnd: () => void;
+  _onTransitionEnd: (indexHasChanged: boolean) => void;
   _prevTransitionProps: ?NavigationTransitionProps;
   _transitionProps: NavigationTransitionProps;
   _isMounted: boolean;

--- a/src/views/Transitioner.js
+++ b/src/views/Transitioner.js
@@ -175,6 +175,9 @@ class Transitioner extends React.Component<*, Props, State> {
           ]
         : [];
 
+    if (indexHasChanged) {
+      nextProps.navigation.setTransitionStart();
+    }
     // update scenes and play the transition
     this._isTransitionRunning = true;
     this.setState(nextState, () => {
@@ -183,7 +186,9 @@ class Transitioner extends React.Component<*, Props, State> {
           this._transitionProps,
           this._prevTransitionProps
         );
-      Animated.parallel(animations).start(this._onTransitionEnd);
+      Animated.parallel(animations).start(() =>
+        this._onTransitionEnd(indexHasChanged)
+      );
     });
   }
 
@@ -222,7 +227,7 @@ class Transitioner extends React.Component<*, Props, State> {
     this.setState(nextState);
   }
 
-  _onTransitionEnd(): void {
+  _onTransitionEnd(indexHasChanged: boolean): void {
     if (!this._isMounted) {
       return;
     }
@@ -235,6 +240,10 @@ class Transitioner extends React.Component<*, Props, State> {
     };
 
     this._transitionProps = buildTransitionProps(this.props, nextState);
+
+    if (indexHasChanged) {
+      this.props.navigation.setTransitionEnd();
+    }
 
     this.setState(nextState, () => {
       this.props.onTransitionEnd &&


### PR DESCRIPTION
This fixes #135. This solution attempts to make idempotent pushes automatic by setting nav state from within Transitioner when a transition starts and ends. While `inTransition === true`, `getStateForAction` in `StackRouter` will ignore `NAVIGATE`, `BACK`, and `RESET` actions.

Several different solutions have been proposed for this issue, this attempts to be zero work for devs to get it working, nail the transition timing, and also keep logic and flow simple.