### PR TITLE
Fixes issues with change to navigation.navigate(object only)

### DIFF
--- a/docs/api/navigators/DrawerNavigator.md
+++ b/docs/api/navigators/DrawerNavigator.md
@@ -65,14 +65,14 @@ const MyApp = DrawerNavigator({
 To open and close drawer, navigate to `'DrawerOpen'` and `'DrawerClose'` respectively.
 
 ```js
-this.props.navigation.navigate('DrawerOpen'); // open drawer
-this.props.navigation.navigate('DrawerClose'); // close drawer
+this.props.navigation.navigate({ routeName: 'DrawerOpen' }); // open drawer
+this.props.navigation.navigate({ routeName: 'DrawerClose' }); // close drawer
 ```
 If you would like to toggle the drawer you can navigate to `'DrawerToggle'`, and this will choose which navigation is appropriate for you given the drawers current state.
 
 ```js
 // fires 'DrawerOpen'/'DrawerClose' accordingly
-this.props.navigation.navigate('DrawerToggle');
+this.props.navigation.navigate({ routeName: 'DrawerToggle' });
 ```
 
 ## API Definition

--- a/examples/NavigationPlayground/js/Drawer.js
+++ b/examples/NavigationPlayground/js/Drawer.js
@@ -12,7 +12,7 @@ const MyNavScreen = ({ navigation, banner }) => (
   <ScrollView style={styles.container}>
     <SampleText>{banner}</SampleText>
     <Button
-      onPress={() => navigation.navigate('DrawerOpen')}
+      onPress={() => navigation.navigate({ routeName: 'DrawerOpen' })}
       title="Open drawer"
     />
     <Button onPress={() => navigation.goBack(null)} title="Go back" />

--- a/src/views/Drawer/DrawerView.js
+++ b/src/views/Drawer/DrawerView.js
@@ -67,9 +67,9 @@ export default class DrawerView<T: *> extends PureComponent<void, Props, void> {
         this._drawer.openDrawer();
       } else if (routes[index].routeName === 'DrawerToggle') {
         if (this._drawer.state.drawerShown) {
-          this.props.navigation.navigate('DrawerClose');
+          this.props.navigation.navigate({ routeName: 'DrawerClose' });
         } else {
-          this.props.navigation.navigate('DrawerOpen');
+          this.props.navigation.navigate({ routeName: 'DrawerOpen' });
         }
       } else {
         this._drawer.closeDrawer();
@@ -84,7 +84,7 @@ export default class DrawerView<T: *> extends PureComponent<void, Props, void> {
     const { navigation } = this.props;
     const { routes, index } = navigation.state;
     if (routes[index].routeName !== 'DrawerOpen') {
-      this.props.navigation.navigate('DrawerOpen');
+      this.props.navigation.navigate({ routeName: 'DrawerOpen' });
     }
   };
 
@@ -92,7 +92,7 @@ export default class DrawerView<T: *> extends PureComponent<void, Props, void> {
     const { navigation } = this.props;
     const { routes, index } = navigation.state;
     if (routes[index].routeName !== 'DrawerClose') {
-      this.props.navigation.navigate('DrawerClose');
+      this.props.navigation.navigate({ routeName: 'DrawerClose' });
     }
   };
 


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

Explain the **motivation** for making this change. What existing problem does the pull request solve?

`navigation.navigate('DrawerOpen')` and its similar calls no longer works. An error is thrown asking that you replace DrawerOpen calls with an object of `{ routeName: 'DrawerOpen' }`. This fixes issues in: docs, example, DrawerView component.

See the example code in the repo for an example.
