### PR TITLE
bugfix: Allow action in navigate to determine tab position

### DIFF
--- a/src/routers/TabRouter.js
+++ b/src/routers/TabRouter.js
@@ -136,6 +136,12 @@ export default (
       if (action.type === NavigationActions.NAVIGATE) {
         const navigateAction = ((action: *): NavigationNavigateAction);
         didNavigate = !!order.find((tabId: string, i: number) => {
+          if (navigateAction.action && navigateAction.action.routeName) {
+            if (tabId == navigateAction.action.routeName) {
+              activeTabIndex = i;
+              return true;
+            }
+          }
           if (tabId === navigateAction.routeName) {
             activeTabIndex = i;
             return true;

--- a/src/routers/__tests__/TabRouter-test.js
+++ b/src/routers/__tests__/TabRouter-test.js
@@ -701,7 +701,6 @@ describe('TabRouter', () => {
         {
           index: 0,
           type: NavigationActions.RESET,
-          params: { key: 'a' },
           actions: [
             NavigationActions.navigate({
               index: 0,
@@ -724,7 +723,7 @@ describe('TabRouter', () => {
             },
             index: 1,
             params: { key: 'b' },
-            key: 'id-0-1',
+            key: 'id-0-5',
             routeName: 'FooStack',
             routes: [
               { key: 'FooTab', routeName: 'FooTab' },

--- a/src/routers/__tests__/TabRouter-test.js
+++ b/src/routers/__tests__/TabRouter-test.js
@@ -2,6 +2,8 @@
 /* eslint react/display-name:0 */
 
 import React from 'react';
+
+import StackRouter from '../StackRouter';
 import TabRouter from '../TabRouter';
 import StackRouter from '../StackRouter';
 
@@ -673,5 +675,61 @@ describe('TabRouter', () => {
     expect(expectedState && comparable(expectedState)).toEqual(
       innerState && comparable(innerState)
     );
+  });
+
+  test('Handles the tab selection action when moving to tabrouter', () => {
+    const ChildNavigator = () => <div />;
+    ChildNavigator.router = TabRouter({
+      FooTabs: BareLeafRouteConfig,
+      BarTabs: BareLeafRouteConfig,
+    });
+
+    const BarScreen = () => <div />;
+    const router = StackRouter({
+      BarStack: {
+        screen: BarScreen,
+      },
+      FooStack: {
+        screen: ChildNavigator,
+      },
+    });
+    const state = router.getStateForAction({ type: NavigationActions.INIT });
+    const state2 = router.getStateForAction(
+      {
+        index: 0,
+        type: NavigationActions.RESET,
+        params: { key: 'a' },
+        actions: [
+          NavigationActions.navigate({
+            index: 0,
+            routeName: 'FooStack',
+            params: { key: 'b' },
+            action: NavigationActions.navigate({ routeName: 'BarTabs' }),
+          }),
+        ],
+      },
+      state
+    );
+
+    expect(state2).toEqual({
+      index: 0,
+      routes: [
+        {
+          action: {
+            routeName: 'BarTabs',
+            type: 'Navigation/NAVIGATE',
+          },
+          index: 1,
+          params: { key: 'b' },
+          key: 'id-0-1',
+          routeName: 'FooStack',
+          routes: [
+            { key: 'FooTabs', routeName: 'FooTabs' },
+            { key: 'BarTabs', routeName: 'BarTabs' },
+          ],
+          type: 'Navigation/NAVIGATE',
+        },
+      ],
+    });
   });
 });

--- a/src/routers/__tests__/TabRouter-test.js
+++ b/src/routers/__tests__/TabRouter-test.js
@@ -5,7 +5,6 @@ import React from 'react';
 
 import StackRouter from '../StackRouter';
 import TabRouter from '../TabRouter';
-import StackRouter from '../StackRouter';
 
 import NavigationActions from '../../NavigationActions';
 
@@ -677,59 +676,64 @@ describe('TabRouter', () => {
     );
   });
 
-  test('Handles the tab selection action when moving to tabrouter', () => {
-    const ChildNavigator = () => <div />;
-    ChildNavigator.router = TabRouter({
-      FooTabs: BareLeafRouteConfig,
-      BarTabs: BareLeafRouteConfig,
-    });
+  test(
+    'Given a StackRouter with nested TabRouter, it is possible to reset ' +
+      'the StackRouter and navigate to an arbitrary tab (BarTab) in the ' +
+      'TabRouter by supplying sub-actions to the RESET action.',
+    () => {
+      const ChildNavigator = () => <div />;
+      ChildNavigator.router = TabRouter({
+        FooTab: BareLeafRouteConfig,
+        BarTab: BareLeafRouteConfig,
+      });
 
-    const BarScreen = () => <div />;
-    const router = StackRouter({
-      BarStack: {
-        screen: BarScreen,
-      },
-      FooStack: {
-        screen: ChildNavigator,
-      },
-    });
-    const state = router.getStateForAction({ type: NavigationActions.INIT });
-    const state2 = router.getStateForAction(
-      {
-        index: 0,
-        type: NavigationActions.RESET,
-        params: { key: 'a' },
-        actions: [
-          NavigationActions.navigate({
-            index: 0,
-            routeName: 'FooStack',
-            params: { key: 'b' },
-            action: NavigationActions.navigate({ routeName: 'BarTabs' }),
-          }),
-        ],
-      },
-      state
-    );
-
-    expect(state2).toEqual({
-      index: 0,
-      routes: [
+      const BarScreen = () => <div />;
+      const router = StackRouter({
+        BarStack: {
+          screen: BarScreen,
+        },
+        FooStack: {
+          screen: ChildNavigator,
+        },
+      });
+      const state = router.getStateForAction({ type: NavigationActions.INIT });
+      const state2 = router.getStateForAction(
         {
-          action: {
-            routeName: 'BarTabs',
+          index: 0,
+          type: NavigationActions.RESET,
+          params: { key: 'a' },
+          actions: [
+            NavigationActions.navigate({
+              index: 0,
+              routeName: 'FooStack',
+              params: { key: 'b' },
+              action: NavigationActions.navigate({ routeName: 'BarTab' }),
+            }),
+          ],
+        },
+        state
+      );
+
+      expect(state2).toEqual({
+        index: 0,
+        routes: [
+          {
+            action: {
+              routeName: 'BarTab',
+              type: 'Navigation/NAVIGATE',
+            },
+            index: 1,
+            params: { key: 'b' },
+            key: 'id-0-1',
+            routeName: 'FooStack',
+            routes: [
+              { key: 'FooTab', routeName: 'FooTab' },
+              { key: 'BarTab', routeName: 'BarTab' },
+            ],
             type: 'Navigation/NAVIGATE',
           },
-          index: 1,
-          params: { key: 'b' },
-          key: 'id-0-1',
-          routeName: 'FooStack',
-          routes: [
-            { key: 'FooTabs', routeName: 'FooTabs' },
-            { key: 'BarTabs', routeName: 'BarTabs' },
-          ],
-          type: 'Navigation/NAVIGATE',
-        },
-      ],
-    });
-  });
+        ],
+      });
+    }
+  );
 });


### PR DESCRIPTION
Previously there was no good way (at least anything apparent to me) to navigate back to a specific tab when tab navigator is nested in multiple stack navigators. This allows us to reset back to our tab navigator with a specific tab selected.

I'm open to changing how this works, but i should be able to reset or navigate to my tab router without then later changing to a new tab.

Here's an example of this:

 ```
 const resetAction = NavigationActions.reset({
            index: 0,
            actions: [
                NavigationActions.navigate(
                    {
                        index: 0,
                        routeName: MainPages.Home,
                        action: NavigationActions.navigate({ routeName: HomePages.Scenes })
                    }
                ),
            ]
        });
        dispatch(resetAction)
```
