### PR TITLE
Try to not initiate transition when only route parameters are changed.

### DIFF
--- a/src/views/ScenesReducer.js
+++ b/src/views/ScenesReducer.js
@@ -42,16 +42,20 @@ function compareScenes(one: NavigationScene, two: NavigationScene): number {
 /**
  * Whether two routes are the same.
  */
-function areScenesShallowEqual(
+export function areScenesShallowEqual(
   one: NavigationScene,
-  two: NavigationScene
+  two: NavigationScene,
+  routesEqual: (
+    ?NavigationRoute,
+    ?NavigationRoute
+  ) => boolean = areRoutesShallowEqual
 ): boolean {
   return (
     one.key === two.key &&
     one.index === two.index &&
     one.isStale === two.isStale &&
     one.isActive === two.isActive &&
-    areRoutesShallowEqual(one.route, two.route)
+    routesEqual(one.route, two.route)
   );
 }
 

--- a/src/views/__tests__/Transitioner-test.js
+++ b/src/views/__tests__/Transitioner-test.js
@@ -1,0 +1,59 @@
+/* @flow */
+/* eslint react/display-name:0 */
+
+import * as React from 'react';
+import renderer from 'react-test-renderer';
+import Transitioner from '../Transitioner';
+import type { NavigationTransitionProps } from '../../TypeDefinition';
+
+describe('Transitioner', () => {
+  it('should not trigger transition on SET_PARAMS', () => {
+    let transitionStartCalled = false;
+    let transitionEndCalled = false;
+    const transitionerProps = {
+      configureTransition: (
+        transitionProps: NavigationTransitionProps,
+        prevTransitionProps: ?NavigationTransitionProps
+      ) => ({}),
+      navigation: {
+        state: {
+          index: 0,
+          routes: [
+            { key: '1', routeName: 'Foo' },
+            { key: '2', routeName: 'Bar' },
+          ],
+        },
+        goBack: () => false,
+        dispatch: () => false,
+        setParams: () => false,
+        navigate: () => false,
+      },
+      render: () => <div />,
+      onTransitionStart: () => {
+        transitionStartCalled = true;
+      },
+      onTransitionEnd: () => {
+        transitionEndCalled = true;
+      },
+    };
+    const nextTransitionerProps = {
+      ...transitionerProps,
+      navigation: {
+        ...transitionerProps.navigation,
+        state: {
+          index: 0,
+          routes: [
+            { key: '1', routeName: 'Foo', params: { name: 'Zoom' } },
+            { key: '2', routeName: 'Bar' },
+          ],
+        },
+      },
+    };
+    const component = renderer.create(<Transitioner {...transitionerProps} />);
+    expect(transitionStartCalled).toEqual(false);
+    expect(transitionEndCalled).toEqual(false);
+    component.update(<Transitioner {...nextTransitionerProps} />);
+    expect(transitionStartCalled).toEqual(false);
+    expect(transitionEndCalled).toEqual(false);
+  });
+});


### PR DESCRIPTION
I'm using `onTransitionStart` hook like the following to dismiss the software keyboard when the transition is triggered.  When it's used in combination with `navigation.setParams()`, the hook is triggered as opposed to my expectation; the action also initiates the no-op transition.

The changes in this PR prevents unnecessary transitions and triggering hooks around them.

```javascript
import React from 'react';
import { StackNavigator } from 'react-navigation';
import { TextInput, Text, Button, View, Keyboard } from 'react-native';


const Top = ({ navigation }) => (
  <View style={{ flex: 1, alignItems: 'center', alignContent: 'center', justifyContent: 'center' }}>
    <Text>Top</Text>
    <Button onPress={() => navigation.navigate("Form")} title="Go to Form" />
  </View>
);


class Form extends React.Component {
  static navigationOptions = ({ navigation }) => ({
    headerTitle: navigation.state.params && navigation.state.params.title,
  });
  render() {
    return (
      <View style={{ flex: 1, alignItems: 'center', alignContent: 'center', justifyContent: 'center' }}>
        <Text>Form</Text>
        <TextInput style={{ width: 300, textAlign: 'center' }} placeholder="Input here" onChange={(ev) => this.props.navigation.setParams({ title: ev.nativeEvent.text })} />
      </View>
    );
  }
}

export default StackNavigator({
  Top: { screen: Top },
  Form: { screen: Form },
}, {
  onTransitionStart: () => Keyboard.dismiss(),
});
```

| Without the hook | What I expect with the hook | What I got instead |
| --- | --- | --- |
| ![](http://g.recordit.co/kZtMfFEemf.gif) | ![](http://g.recordit.co/N9UwRqjNlo.gif) | ![](http://recordit.co/m7UkCxveqH.gif) |

