### PR TITLE
Allow overrides of route parameters on BACK navigation action

### DIFF
--- a/src/NavigationActions.js
+++ b/src/NavigationActions.js
@@ -22,9 +22,12 @@ const RESET = 'Navigation/RESET';
 const SET_PARAMS = 'Navigation/SET_PARAMS';
 const URI = 'Navigation/URI';
 
-const back = (payload: { key?: ?string } = {}): NavigationBackAction => ({
+const back = (
+  payload: { key?: ?string, params?: ?NavigationParams } = {}
+): NavigationBackAction => ({
   type: BACK,
   key: payload.key,
+  params: payload.params,
 });
 const init = (
   payload: { params?: NavigationParams } = {}

--- a/src/TypeDefinition.js
+++ b/src/TypeDefinition.js
@@ -48,11 +48,13 @@ export type DeprecatedNavigationNavigateAction = {|
 export type NavigationBackAction = {|
   type: 'Navigation/BACK',
   key?: ?string,
+  params?: ?NavigationParams,
 |};
 
 export type DeprecatedNavigationBackAction = {|
   type: 'Back',
   key?: ?string,
+  params: ?NavigationParams,
 |};
 
 export type NavigationSetParamsAction = {|

--- a/src/addNavigationHelpers.js
+++ b/src/addNavigationHelpers.js
@@ -19,7 +19,7 @@ export default function<S: {}>(
 ): NavigationScreenProp<S> {
   return {
     ...navigation,
-    goBack: (key?: ?string): boolean => {
+    goBack: (key?: ?string, params?: ?NavigationParams): boolean => {
       let actualizedKey: ?string = key;
       if (key === undefined && navigation.state.key) {
         invariant(
@@ -29,7 +29,7 @@ export default function<S: {}>(
         actualizedKey = navigation.state.key;
       }
       return navigation.dispatch(
-        NavigationActions.back({ key: actualizedKey })
+        NavigationActions.back({ key: actualizedKey, params })
       );
     },
     navigate: (

--- a/src/routers/StackRouter.js
+++ b/src/routers/StackRouter.js
@@ -276,25 +276,48 @@ export default (
 
       if (action.type === NavigationActions.BACK) {
         const key = action.key;
-        let backRouteIndex = null;
+        let backRouteIndex = -1;
         if (key) {
-          const backRoute = state.routes.find(
+          backRouteIndex = state.routes.findIndex(
             (route: NavigationRoute) => route.key === key
           );
-          /* $FlowFixMe */
-          backRouteIndex = state.routes.indexOf(backRoute);
+          if (backRouteIndex < 0) {
+            backRouteIndex = state.routes.length;
+          }
+        } else {
+          backRouteIndex = state.routes.length - 1;
         }
-        if (backRouteIndex == null) {
-          return StateUtils.pop(state);
+
+        let newRoutes = null;
+        if (backRouteIndex > 0 && backRouteIndex !== state.routes.length) {
+          newRoutes = state.routes.slice(0, backRouteIndex);
         }
-        if (backRouteIndex > 0) {
-          return {
-            ...state,
-            routes: state.routes.slice(0, backRouteIndex),
-            index: backRouteIndex - 1,
+
+        const lastRouteIndex = backRouteIndex > 0 ? backRouteIndex - 1 : 0;
+        if (action.params) {
+          if (!newRoutes) {
+            newRoutes = [...state.routes];
+          }
+          const lastRoute = newRoutes[lastRouteIndex];
+          const params = {
+            ...lastRoute.params,
+            ...action.params,
+          };
+          newRoutes[lastRouteIndex] = {
+            ...lastRoute,
+            params,
           };
         }
+        if (newRoutes) {
+          return {
+            ...state,
+            routes: newRoutes,
+            index: lastRouteIndex,
+          };
+        }
+        return state;
       }
+
       return state;
     },
 

--- a/src/routers/__tests__/StackRouter-test.js
+++ b/src/routers/__tests__/StackRouter-test.js
@@ -963,4 +963,56 @@ describe('StackRouter', () => {
       },
     });
   });
+
+  test('Handle goBack with params', () => {
+    const FooScreen = () => <div />;
+    FooScreen.router = StackRouter({
+      Aaa: {
+        screen: () => <div />,
+      },
+      Bbb: {
+        screen: () => <div />,
+      },
+    });
+    const BarScreen = () => <div />;
+    const router = StackRouter({
+      Ccc: {
+        screen: FooScreen,
+      },
+      Ddd: {
+        screen: BarScreen,
+      },
+    });
+    const state = router.getStateForAction({ type: NavigationActions.INIT });
+    const state2 = router.getStateForAction(
+      {
+        type: NavigationActions.NAVIGATE,
+        routeName: 'Bbb',
+        params: { name: 'Zoom' },
+      },
+      state
+    );
+    const state3 = router.getStateForAction(
+      {
+        type: NavigationActions.NAVIGATE,
+        routeName: 'Ddd',
+        params: { name: 'Boom' },
+      },
+      state2
+    );
+    const state4 = router.getStateForAction(
+      { type: NavigationActions.BACK, params: { name: 'Doom' } },
+      state3
+    );
+    expect(state4).toEqual({
+      ...state2,
+      routes: [
+        {
+          // $FlowFixMe
+          ...state2.routes[0],
+          params: { name: 'Doom' },
+        },
+      ],
+    });
+  });
 });


### PR DESCRIPTION
It would be very handy, while it might disagree with the navigation concept, if route parameters could be overridden on the dispatch of BACK navigation action where the parameters are used to statefully render the header contents.

This patch adds `params` parameter to `NavigationSetParamsAction` and allows one to do so for StackRouter.
