### PR TITLE
Reduce unnecessary re-rendering by injecting a smart shouldComponentUpdate.

### DIFF
--- a/src/views/CardStack/CardStack.js
+++ b/src/views/CardStack/CardStack.js
@@ -400,6 +400,7 @@ class CardStack extends React.Component<Props> {
               screenProps={screenProps}
               navigation={navigation}
               component={SceneComponent}
+              scene={scene}
             />
           </View>
           {this._renderHeader(scene, headerMode)}
@@ -411,6 +412,7 @@ class CardStack extends React.Component<Props> {
         screenProps={this.props.screenProps}
         navigation={navigation}
         component={SceneComponent}
+        scene={scene}
       />
     );
   }

--- a/src/views/SceneView.js
+++ b/src/views/SceneView.js
@@ -7,12 +7,14 @@ import type {
   NavigationScreenProp,
   NavigationComponent,
   NavigationRoute,
+  NavigationScene,
 } from '../TypeDefinition';
 
 type Props = {
   screenProps?: {},
   navigation: NavigationScreenProp<*>,
   component: NavigationComponent,
+  scene?: NavigationScene,
 };
 
 export default class SceneView extends React.PureComponent<Props> {
@@ -27,8 +29,17 @@ export default class SceneView extends React.PureComponent<Props> {
   }
 
   render() {
-    const { screenProps, navigation, component: Component } = this.props;
+    const { screenProps, navigation, component: Component, scene } = this.props;
 
-    return <Component screenProps={screenProps} navigation={navigation} />;
+    const comp: any = (
+      <Component screenProps={screenProps} navigation={navigation} />
+    );
+    const originalMethod = comp.type.prototype.shouldComponentUpdate;
+    if (originalMethod && scene) {
+      comp.type.prototype.shouldComponentUpdate = function(...args: [*]) {
+        return scene.isActive && originalMethod.apply(this, args);
+      };
+    }
+    return comp;
   }
 }

--- a/src/views/SceneView.js
+++ b/src/views/SceneView.js
@@ -34,10 +34,13 @@ export default class SceneView extends React.PureComponent<Props> {
     const comp: any = (
       <Component screenProps={screenProps} navigation={navigation} />
     );
-    const originalMethod = comp.type.prototype.shouldComponentUpdate;
-    if (originalMethod && scene) {
+    if (scene) {
+      const originalMethod = comp.type.prototype.shouldComponentUpdate;
       comp.type.prototype.shouldComponentUpdate = function(...args: [*]) {
-        return scene.isActive && originalMethod.apply(this, args);
+        return (
+          scene.isActive &&
+          (!originalMethod || originalMethod.apply(this, args))
+        );
       };
     }
     return comp;


### PR DESCRIPTION
Fixes partially #608 (i.e. only for _(point 1)_ described in https://github.com/react-community/react-navigation/issues/608#issuecomment-328635042)

## Motivation

This PR reduces unnecessary re-rendering with Stack Navigator by injecting a smart `shouldComponentUpdate` which judges whether the given scene is active or not.

Please note that I tried to use `StaticContainer` like https://github.com/react-community/react-navigation/issues/608#issuecomment-328689388, but it cannot prevent from re-rendering child components which refers to state managed by Redux.

## Test plan

~I tested this PR in my modified `ReduxExample` project which has a `TextInput` component for updating `state` managed by Redux.~
~I confirmed that only one component was re-rendered when updating state which multiple components refers to by entering texts in the `TextInput`.~
~If needed, I can share my modified `ReduxExample` for testing purpose (but its code is a bit dirty).~

Please see https://github.com/react-community/react-navigation/pull/2942#issuecomment-343527899.