### PR TITLE
Support for Android translucent status bar

### DIFF
--- a/src/views/SafeAreaView.js
+++ b/src/views/SafeAreaView.js
@@ -101,9 +101,18 @@ class SafeView extends Component {
   }
 
   render() {
-    const { forceInset = false, isLandscape, children, style } = this.props;
+    const {
+      forceInset = false,
+      enableOnAndroid,
+      isLandscape,
+      children,
+      style,
+    } = this.props;
 
-    if (Platform.OS !== 'ios') {
+    if (
+      Platform.OS !== 'ios' &&
+      !(enableOnAndroid && Platform.OS === 'android')
+    ) {
       return <View style={style}>{this.props.children}</View>;
     }
 

--- a/src/views/SafeAreaView.js
+++ b/src/views/SafeAreaView.js
@@ -5,8 +5,8 @@ import {
   InteractionManager,
   NativeModules,
   Platform,
-  StatusBar,
   SafeAreaView,
+  StatusBar,
   StyleSheet,
   View,
 } from 'react-native';
@@ -103,7 +103,7 @@ class SafeView extends Component {
   render() {
     const {
       forceInset = false,
-      enableOnAndroid,
+      enableOnAndroid = true,
       isLandscape,
       children,
       style,

--- a/src/views/SafeAreaView.js
+++ b/src/views/SafeAreaView.js
@@ -5,6 +5,7 @@ import {
   InteractionManager,
   NativeModules,
   Platform,
+  StatusBar,
   SafeAreaView,
   StyleSheet,
   View,
@@ -53,6 +54,8 @@ const isIPad = (() => {
 })();
 
 const statusBarHeight = isLandscape => {
+  if (StatusBar.currentHeight) return StatusBar.currentHeight;
+
   if (isIPhoneX) {
     return isLandscape ? 0 : 44;
   }


### PR DESCRIPTION
Android's status bar is translucent by default for Expo and CRNA apps. But current SafeAreaView implementation doesn't support Android. This pull request takes Android's status bar height into consideration for SafeAreaView. And thus fix all the header layouts for Android app with translucent status bar.

See: https://github.com/react-community/react-navigation/issues/12

**Test plan**

Tested with NavigationPlayground app in examples.

Before | After
-- | -- 
![screenshot_20171123-174359](https://user-images.githubusercontent.com/648142/33167383-540a5d76-d078-11e7-8d09-c73ddabc5ed4.png) | ![screenshot_20171123-174142](https://user-images.githubusercontent.com/648142/33167391-5a9fade4-d078-11e7-8e82-8faf73f29d9b.png)

iOS is not affected because `StatusBar.currentHeight` is always `undefined` on React Native iOS.

**Caveats**

This doesn't work with non-translucent Android status bar. React Native currently doesn't provide an API for getting the current translucency of status bar.

