### PR TITLE
Pass pointerEvents through in SafeAreaView

### DIFF
--- a/src/views/SafeAreaView.js
+++ b/src/views/SafeAreaView.js
@@ -111,6 +111,7 @@ class SafeView extends Component {
         ref={c => (this.view = c)}
         onLayout={this._onLayout}
         style={safeAreaStyle}
+        pointerEvents={this.props.pointerEvents}
       >
         {this.props.children}
       </View>


### PR DESCRIPTION
- this was causing us a problem where where `pointerEvents: 'box-none'` wasn't working on a `SafeAreaView` so the view was capturing touches it shouldn't