### PR TITLE
Fix issue with SET_PARAMS causing navigation

### DIFF
--- a/src/routers/TabRouter.js
+++ b/src/routers/TabRouter.js
@@ -190,6 +190,12 @@ export default (
             ...state,
             routes,
           };
+        } else {
+          // Don't navigate on SET_PARAMS
+          // Fix for https://github.com/react-community/react-navigation/issues/1711
+          return {
+            ...state,
+          };
         }
       }
       if (activeTabIndex !== state.index) {


### PR DESCRIPTION
This is a fix for https://github.com/react-community/react-navigation/issues/1711 where setting params on a tap is causing the tab view to go to the that tab even if it was not the current active tab.