### PR TITLE
Fix drawer toggle

### DIFF
--- a/src/views/Drawer/DrawerView.js
+++ b/src/views/Drawer/DrawerView.js
@@ -95,8 +95,7 @@ export default class DrawerView extends React.PureComponent<
       } else if (routes[index].routeName === drawerToggleRoute) {
         if (this.props.navigation.state.index == 0) {
           this.props.navigation.navigate(drawerOpenRoute);
-        }
-        else {
+        } else {
           this.props.navigation.navigate(drawerCloseRoute);
         }
       } else {

--- a/src/views/Drawer/DrawerView.js
+++ b/src/views/Drawer/DrawerView.js
@@ -93,10 +93,11 @@ export default class DrawerView extends React.PureComponent<
       if (routes[index].routeName === drawerOpenRoute) {
         this._drawer.openDrawer();
       } else if (routes[index].routeName === drawerToggleRoute) {
-        if (this._drawer.state.drawerShown) {
-          this.props.navigation.navigate(drawerCloseRoute);
-        } else {
+        if (this.props.navigation.state.index == 0) {
           this.props.navigation.navigate(drawerOpenRoute);
+        }
+        else {
+          this.props.navigation.navigate(drawerCloseRoute);
         }
       } else {
         this._drawer.closeDrawer();

--- a/src/views/Drawer/DrawerView.js
+++ b/src/views/Drawer/DrawerView.js
@@ -93,7 +93,7 @@ export default class DrawerView extends React.PureComponent<
       if (routes[index].routeName === drawerOpenRoute) {
         this._drawer.openDrawer();
       } else if (routes[index].routeName === drawerToggleRoute) {
-        if (this.props.navigation.state.index == 0) {
+        if (this.props.navigation.state.index === 0) {
           this.props.navigation.navigate(drawerOpenRoute);
         } else {
           this.props.navigation.navigate(drawerCloseRoute);


### PR DESCRIPTION
Drawer does not toggle as per [this](https://github.com/react-community/react-navigation/issues/2760) issue. `this._drawer.state.drawerShown` seems to be available only on iOS?

**Test plan (required)**

Works on both iOS and Android (Issue didn't exist in iOS in the first place)