### PR TITLE
Overwrite navigation props only if they are not received as a prop

### DIFF
--- a/src/views/CardStack/CardStack.js
+++ b/src/views/CardStack/CardStack.js
@@ -64,7 +64,7 @@ type Props = {
 
 /**
  * The max duration of the card animation in milliseconds after released gesture.
- * The actual duration should be always less then that because the rest distance 
+ * The actual duration should be always less then that because the rest distance
  * is always less then the full distance of the layout.
  */
 const ANIMATION_DURATION = 500;
@@ -402,7 +402,8 @@ class CardStack extends React.Component<Props> {
     SceneComponent: NavigationComponent,
     scene: NavigationScene
   ): React.Node {
-    const { navigation } = this._getScreenDetails(scene);
+    const navigation =
+      this.props.navigation || this._getScreenDetails(scene).navigation;
     const { screenProps } = this.props;
     const headerMode = this._getHeaderMode();
     if (headerMode === 'screen') {


### PR DESCRIPTION
**Issue**
This refers to: #3206 

[React-navigation documentation on Redux integrations](https://reactnavigation.org/docs/guides/redux) states in point 2 that: 

> Once you pass your own navigation prop to the navigator, the default navigation prop gets destroyed.

I dont think that is what is happening. I tried the redux integration like in the example and when I pass my own navigation prop to top level connected navigator (stacknavigator in my case) without using `addNavigationHelpers` function (I wanted to use custom navigate, goBack functions) these got always overwritten along the way. I was able to log the exact spot and it happened here in `CardStack.js` because `this._getScreenDetails` calls `addNavigationHelpers` internally and creates new navigation prop that gets passed around.

**How this can be replicated?**
Use stacknavigator as in connect to redux example. And insert custom navigation prop (for example with custom navigation, goBack, etc function or for test purposes with entirely new key and value, for example `'test': 'test'` ). Then try to console log received props on the screens and you will find that these custom values are not there.

**How this can be tested**
After this one change the values are correctly propagated in screens