### PR TITLE
If URL is just a scheme:// component without a path, default to root "/" URL

### DIFF
--- a/src/createNavigationContainer.js
+++ b/src/createNavigationContainer.js
@@ -85,6 +85,8 @@ export default function createNavigationContainer<S: NavigationState, O: {}>(
       let path = url.split(delimiter)[1];
       if (typeof path === 'undefined') {
         path = url;
+      } else if (path === '') {
+        path = '/';
       }
       return {
         path,


### PR DESCRIPTION
Fixes issue https://github.com/react-navigation/react-navigation/issues/2599, where an ejected expo app would mount the initial route twice.

The root cause turns out to be as follows:

1. On mount, the navigation container [checks for the initial URL with `Linking.getInitialURL()`](https://github.com/react-navigation/react-navigation/blob/master/src/createNavigationContainer.js#L161-L163)
2. An ejected expo app returns a path-less URI, e.g. `expb91fecbd0fc74b86ab71881fc10189e8://`.
3. This [edge case was not handled in `NavigationContainer#_urlToPathAndParams`](https://github.com/react-navigation/react-navigation/blob/master/src/createNavigationContainer.js#L85-L88) that mistakenly interpreted the url to be a schema-less route name. 
4. The route name [gets passed to `router.getActionForPathAndParams`, which returns a navigation action for the initial screen](https://github.com/react-navigation/react-navigation/blob/master/src/createNavigationContainer.js#L99-L102).
5. The navigation action is dispatched, causing the initial screen to appear twice in the router state

In detail, `Linking.getInitialURL()` behaves as follows:

| App type | Return value |
| --------- | ----- |
| react-native init | null |
| create-react-native-app | exp://localhost:19002 |
| Ejected CRNA/Expo | expb91fecbd0fc74b86ab71881fc10189e8:// |

This fix simply checks that if the URI contains a schema delimiter, but the second part is empty, we default to the root path `/`. This will match the already mounted initial route, and the unwanted navigation action is not dispatched.

The issue can be reproduced with the following app:
```
import React from 'react';
import { Text } from 'react-native';
import { StackNavigator } from 'react-navigation'; // 1.0.0-beta.22

export default StackNavigator({
  Home: { screen: () => <Text>Hello Navigation</Text> }
});
```

In an ejected Expo app, this will result in the initial route stack after mount containing the `Home` route twice. In crna/init apps it will behave as expected. Applying my patch will fix it in the ejected app.

**NOTE:** I don't know if this breaks any use cases folks might have around deep linking. I couldn't figure out any.


  
  