### PR TITLE
Fix #2795 - Not reducing header height in landscape on iPad

### DIFF
--- a/src/views/Header/Header.js
+++ b/src/views/Header/Header.js
@@ -47,9 +47,6 @@ const APPBAR_HEIGHT = Platform.OS === 'ios' ? 44 : 56;
 const STATUSBAR_HEIGHT = Platform.OS === 'ios' ? 20 : 0;
 const TITLE_OFFSET = Platform.OS === 'ios' ? 70 : 56;
 
-const isTablet =
-  Dimensions.get('window').height / Dimensions.get('window').width < 1.6;
-
 type Props = HeaderProps & { isLandscape: boolean };
 class Header extends React.PureComponent<Props, State> {
   static defaultProps = {
@@ -332,7 +329,7 @@ class Header extends React.PureComponent<Props, State> {
     const { headerStyle } = options;
     const viewHeight =
       typeof rest.layout.height === 'number' ? rest.layout.height : null;
-    const isHeightConstrained = viewHeight ? viewHeight < 500 : !isTablet;
+    const isHeightConstrained = viewHeight ? viewHeight < 500 : !Platform.isPad;
     const appBarHeight =
       Platform.OS === 'ios'
         ? isLandscape && isHeightConstrained ? 32 : 44

--- a/src/views/Header/Header.js
+++ b/src/views/Header/Header.js
@@ -327,13 +327,8 @@ class Header extends React.PureComponent<Props, State> {
 
     const { options } = this.props.getScreenDetails(scene);
     const { headerStyle } = options;
-    const viewHeight =
-      typeof rest.layout.height === 'number' ? rest.layout.height : null;
-    const isHeightConstrained = viewHeight ? viewHeight < 500 : !Platform.isPad;
     const appBarHeight =
-      Platform.OS === 'ios'
-        ? isLandscape && isHeightConstrained ? 32 : 44
-        : 56;
+      Platform.OS === 'ios' ? (isLandscape && !Platform.isPad ? 32 : 44) : 56;
     const containerStyles = [
       styles.container,
       {

--- a/src/views/Header/Header.js
+++ b/src/views/Header/Header.js
@@ -47,6 +47,9 @@ const APPBAR_HEIGHT = Platform.OS === 'ios' ? 44 : 56;
 const STATUSBAR_HEIGHT = Platform.OS === 'ios' ? 20 : 0;
 const TITLE_OFFSET = Platform.OS === 'ios' ? 70 : 56;
 
+const isTablet =
+  Dimensions.get('window').height / Dimensions.get('window').width < 1.6;
+
 type Props = HeaderProps & { isLandscape: boolean };
 class Header extends React.PureComponent<Props, State> {
   static defaultProps = {
@@ -327,7 +330,13 @@ class Header extends React.PureComponent<Props, State> {
 
     const { options } = this.props.getScreenDetails(scene);
     const { headerStyle } = options;
-    const appBarHeight = Platform.OS === 'ios' ? (isLandscape ? 32 : 44) : 56;
+    const viewHeight =
+      typeof rest.layout.height === 'number' ? rest.layout.height : null;
+    const isHeightConstrained = viewHeight ? viewHeight < 500 : !isTablet;
+    const appBarHeight =
+      Platform.OS === 'ios'
+        ? isLandscape && isHeightConstrained ? 32 : 44
+        : 56;
     const containerStyles = [
       styles.container,
       {


### PR DESCRIPTION
Resolves #2795.

Due to the changes made post-iOS 11, when any iOS 11 device is in the landscape orientation, the header is shrunk to 32pts height.  Unfortunately, this incorrectly applies to tablets as well.  This simply looks at the layout height and only shrinks if it is landscape and the vertically small (similar to how Apple's Size Classes determine whether the header should be shorter).  On tablets with lots of vertical space, even in landscape, the header is not made smaller.

Before:
<img width="863" alt="screen shot 2018-01-09 at 10 38 37 am" src="https://user-images.githubusercontent.com/10255587/34728978-68363be6-f529-11e7-9a7f-aa7387679483.png">

After:
<img width="892" alt="screen shot 2018-01-09 at 10 39 21 am" src="https://user-images.githubusercontent.com/10255587/34728976-68289c3e-f529-11e7-8c14-fc7c89ef2ae2.png">

Notice the extra space around the right tab bar button in the 44pt version.

Notes:
* This only affects iOS (per the pre-existing platform check).
* This method is similar to how I fixed #2794 in #3041.
* The use of Dimension is platform-detection, and is only used on the initial frame before the layout prop has a valid (non-zero) height.