### PR TITLE
Use stiffness/damping/mass for card stack transition on React Native >= 50

### DIFF
--- a/src/utils/ReactNativeFeatures.js
+++ b/src/utils/ReactNativeFeatures.js
@@ -1,0 +1,12 @@
+/* @flow */
+
+import { NativeModules } from 'react-native';
+const { PlatformConstants } = NativeModules;
+
+export const supportsImprovedSpringAnimation = () => {
+  if (PlatformConstants && PlatformConstants.reactNativeVersion) {
+    const { major, minor } = PlatformConstants.reactNativeVersion;
+    return minor >= 50 || (major === 0 && minor === 0); // `master` has major + minor set to 0
+  }
+  return false;
+};

--- a/src/views/CardStack/TransitionConfigs.js
+++ b/src/views/CardStack/TransitionConfigs.js
@@ -9,12 +9,25 @@ import type {
 } from '../../TypeDefinition';
 
 import CardStackStyleInterpolator from './CardStackStyleInterpolator';
+import * as ReactNativeFeatures from '../../utils/ReactNativeFeatures';
 
-const IOSTransitionSpec = ({
-  duration: 500,
-  easing: Easing.bezier(0.2833, 0.99, 0.31833, 0.99),
-  timing: Animated.timing,
-}: NavigationTransitionSpec);
+let IOSTransitionSpec;
+if (ReactNativeFeatures.supportsImprovedSpringAnimation()) {
+  // These are the exact values from UINavigationController's animation configuration
+  IOSTransitionSpec = ({
+    timing: Animated.spring,
+    stiffness: 1000,
+    damping: 500,
+    mass: 3,
+  }: NavigationTransitionSpec);
+} else {
+  // This is an approximation of the IOS spring animation using a derived bezier curve
+  IOSTransitionSpec = ({
+    duration: 500,
+    easing: Easing.bezier(0.2833, 0.99, 0.31833, 0.99),
+    timing: Animated.timing,
+  }: NavigationTransitionSpec);
+}
 
 // Standard iOS navigation transition
 const SlideFromRightIOS = ({


### PR DESCRIPTION
In RN >= 0.50, I added a new spring implementation that mimics Apple's spring algorithm from CASpringAnimation (commit here: https://github.com/facebook/react-native/commit/26133beda9034d374afb95b3a653353e25c40c84). This PR makes TransitionConfig use this new spring implementation with the exact values that UINavigationController uses for it's animation.

For RN < .50, we'll continue using the old bezier curve.