### PR TITLE
Remove forceInset of SafeAreaView in TabBarTop

### DIFF
--- a/src/views/TabView/TabBarTop.js
+++ b/src/views/TabView/TabBarTop.js
@@ -84,9 +84,7 @@ export default class TabBarTop extends React.PureComponent<Props> {
     const label = this.props.getLabel({ ...scene, tintColor });
     if (typeof label === 'string') {
       return (
-        <SafeAreaView
-          forceInset={{ top: tabBarPosition === 'top' ? 'always' : 'never' }}
-        >
+        <SafeAreaView>
           <Animated.Text
             style={[styles.label, { color }, labelStyle]}
             allowFontScaling={allowFontScaling}


### PR DESCRIPTION
TabBarTop in top position doesn't mean mean it's necessarily  at the top of the screen.
Remove `forceInset` of the SafeAreaView to remove unwanted and unremovable marginTop.

_Example in my app :_ 
First TabBarTop at the top (in red) get the SafeAreaView marginTop for StatusBar, the Second TabBarTop also in top position but not in top of the screen (in blue) shouldn't had a marginTop.

**Current Behavior :** 

<img width="447" alt="capture d ecran 2018-01-16 a 17 54 07" src="https://user-images.githubusercontent.com/1412159/35001069-4aa19c16-fae6-11e7-9818-e6bd776a149d.png">


**Expected Behavior :** 

<img width="447" alt="capture d ecran 2018-01-16 a 17 50 14" src="https://user-images.githubusercontent.com/1412159/35001091-5395d5d0-fae6-11e7-9fb5-96d3f8994169.png">

