### PR TITLE
Export index of scene for navigation state props.js

### DIFF
--- a/src/views/CardStack/CardStack.js
+++ b/src/views/CardStack/CardStack.js
@@ -145,13 +145,13 @@ class CardStack extends React.Component<Props> {
         dispatch: navigation.dispatch,
         state: {
           ...scene.route,
-          index: scene.index
+          index: scene.index,
         },
       });
       screenDetails = {
         state: {
           ...scene.route,
-          index: scene.index
+          index: scene.index,
         },
         navigation: screenNavigation,
         options: router.getScreenOptions(screenNavigation, screenProps),

--- a/src/views/CardStack/CardStack.js
+++ b/src/views/CardStack/CardStack.js
@@ -143,10 +143,16 @@ class CardStack extends React.Component<Props> {
         NavigationRoute
       > = addNavigationHelpers({
         dispatch: navigation.dispatch,
-        state: scene.route,
+        state: {
+          ...scene.route,
+          index: scene.index
+        },
       });
       screenDetails = {
-        state: scene.route,
+        state: {
+          ...scene.route,
+          index: scene.index
+        },
         navigation: screenNavigation,
         options: router.getScreenOptions(screenNavigation, screenProps),
       };


### PR DESCRIPTION
Exporting index of current scene in navigation state props

Sometime we need current route index and based on index we take some decision. In my case, I want to show my custom left component if there is no back route otherwise back button should show. There is no way to find route index inside screen component header navigation props.

This solve our issue by checking current index.
