### PR TITLE
Export UnwrappedHeader so Header can be customized easier

### DIFF
--- a/src/views/Header/Header.js
+++ b/src/views/Header/Header.js
@@ -48,7 +48,7 @@ const STATUSBAR_HEIGHT = Platform.OS === 'ios' ? 20 : 0;
 const TITLE_OFFSET = Platform.OS === 'ios' ? 70 : 56;
 
 type Props = HeaderProps & { isLandscape: boolean };
-class Header extends React.PureComponent<Props, State> {
+export class UnwrappedHeader extends React.PureComponent<Props, State> {
   static defaultProps = {
     leftInterpolator: HeaderStyleInterpolator.forLeft,
     titleInterpolator: HeaderStyleInterpolator.forCenter,
@@ -405,4 +405,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default withOrientation(Header);
+export default withOrientation(UnwrappedHeader);


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

Explain the **motivation** for making this change. What existing problem does the pull request solve?

If an end-user wants to customize the HeaderTitle, this PR exports a Header class that has not had `withOrientation` applied to it.

Example: 
```js
class EditableHeaderTitle extends React.Component {
    constructor(props) {
        super(props)
        this.state = { text: props.initialText }
    }

    render() {
        return (
            <View pointerEvents={'auto'} style={{ height: 30, width: 500 }}>
                <TextInput
                    style={{
                        flex: 1,
                        fontSize: Platform.OS === 'ios' ? 17 : 20,
                        fontWeight: Platform.OS === 'ios' ? '600' : '500',
                        color: '#000',
                        textAlign: Platform.OS === 'ios' ? 'center' : 'left',
                        marginHorizontal: 16,
                        autoCapitalize: 'words',
                    }}
                    onChangeText={(text) => {
                        this.setState({ text })
                        this.props.onChangeText()
                    }}
                    value={this.state.text}
                />
            </View>
        )
    }
}

class EditableHeader extends UnwrappedHeader {
    _renderTitleComponent = (props: SceneProps): ?React.Node => {
        // $FlowFixMe
        const details = this.props.getScreenDetails(props.scene)
        const headerTitle = details.options.headerTitle
        if (React.isValidElement(headerTitle)) {
            return headerTitle
        }
        const titleString = this._getHeaderTitleString(props.scene)

        const titleStyle = details.options.headerTitleStyle
        const color = details.options.headerTintColor
        const allowFontScaling = details.options.headerTitleAllowFontScaling

        // On iOS, width of left/right components depends on the calculated
        // size of the title.
        const onLayoutIOS =
            Platform.OS === 'ios'
                ? (e: LayoutEvent) => {
                    this.setState({
                        widths: {
                            ...this.state.widths,
                            [props.scene.key]: e.nativeEvent.layout.width,
                        },
                    })
                }
                : undefined

        const RenderedHeaderTitle = EditableHeaderTitle
        return (
            <RenderedHeaderTitle
                onLayout={onLayoutIOS}
                allowFontScaling={allowFontScaling == null ? true : allowFontScaling}
                style={[color ? { color } : null, titleStyle]}
            >
            </RenderedHeaderTitle>
        )
    }
}

export default withOrientation(EditableHeader)

// ...

static navigationOptions = {
        header: ((props: *) => <EditableHeader onChangeText={console.warn} {...props} />),
}
```

If we inherit directly off of Header as wrapped by withOrientation, the overridden methods won't be used. 

- [x] Prefer **small pull requests**. 

**Test plan (required)**
The only changes made are:
```diff
-class Header extends React.PureComponent<Props, State> {
+export class UnwrappedHeader extends React.PureComponent<Props, State> {
    static defaultProps = {
      leftInterpolator: HeaderStyleInterpolator.forLeft,
      titleInterpolator: HeaderStyleInterpolator.forCenter,
 @@ -405,4 +405,4 @@ const styles = StyleSheet.create({
    },
  });
  
-export default withOrientation(Header);
+export default withOrientation(UnwrappedHeader);
```

That being said, the example renders:
<img src="https://user-images.githubusercontent.com/2363105/35200968-8a36f180-fee4-11e7-97d7-a2ce4ee95635.jpeg" width=400px/>

I am using the same library without a modified header in the rest of my app, and it doesn't crash elsewhere.

I ran `yarn test`. All tests passed.