### PR TITLE
Remove NavigatorTypes

### DIFF
--- a/src/navigators/DrawerNavigator.js
+++ b/src/navigators/DrawerNavigator.js
@@ -9,8 +9,6 @@ import DrawerView from '../views/Drawer/DrawerView';
 import DrawerItems from '../views/Drawer/DrawerNavigatorItems';
 import SafeAreaView from '../views/SafeAreaView';
 
-import NavigatorTypes from './NavigatorTypes';
-
 // A stack navigators props are the intersection between
 // the base navigator props (navgiation, screenProps, etc)
 // and the view's props
@@ -66,16 +64,12 @@ const DrawerNavigator = (routeConfigs, config = {}) => {
   } = mergedConfig;
 
   const contentRouter = TabRouter(routeConfigs, tabsConfig);
-
   const drawerRouter = TabRouter(
     {
       [drawerCloseRoute]: {
-        screen: createNavigator(
-          contentRouter,
-          routeConfigs,
-          config,
-          NavigatorTypes.DRAWER
-        )(props => <DrawerScreen {...props} />),
+        screen: createNavigator(contentRouter, routeConfigs, config)(props => (
+          <DrawerScreen {...props} />
+        )),
       },
       [drawerOpenRoute]: {
         screen: () => null,
@@ -89,26 +83,23 @@ const DrawerNavigator = (routeConfigs, config = {}) => {
     }
   );
 
-  const navigator = createNavigator(
-    drawerRouter,
-    routeConfigs,
-    config,
-    NavigatorTypes.DRAWER
-  )(props => (
-    <DrawerView
-      {...props}
-      drawerBackgroundColor={drawerBackgroundColor}
-      drawerLockMode={drawerLockMode}
-      useNativeAnimations={useNativeAnimations}
-      drawerWidth={drawerWidth}
-      contentComponent={contentComponent}
-      contentOptions={contentOptions}
-      drawerPosition={drawerPosition}
-      drawerOpenRoute={drawerOpenRoute}
-      drawerCloseRoute={drawerCloseRoute}
-      drawerToggleRoute={drawerToggleRoute}
-    />
-  ));
+  const navigator = createNavigator(drawerRouter, routeConfigs, config)(
+    props => (
+      <DrawerView
+        {...props}
+        drawerBackgroundColor={drawerBackgroundColor}
+        drawerLockMode={drawerLockMode}
+        useNativeAnimations={useNativeAnimations}
+        drawerWidth={drawerWidth}
+        contentComponent={contentComponent}
+        contentOptions={contentOptions}
+        drawerPosition={drawerPosition}
+        drawerOpenRoute={drawerOpenRoute}
+        drawerCloseRoute={drawerCloseRoute}
+        drawerToggleRoute={drawerToggleRoute}
+      />
+    )
+  );
 
   return createNavigationContainer(navigator);
 };

--- a/src/navigators/NavigatorTypes.js
+++ b/src/navigators/NavigatorTypes.js
@@ -1,9 +1,0 @@
-const STACK = 'react-navigation/STACK';
-const TABS = 'react-navigation/TABS';
-const DRAWER = 'react-navigation/DRAWER';
-
-export default {
-  STACK,
-  TABS,
-  DRAWER,
-};

--- a/src/navigators/StackNavigator.js
+++ b/src/navigators/StackNavigator.js
@@ -3,7 +3,6 @@ import createNavigationContainer from '../createNavigationContainer';
 import createNavigator from './createNavigator';
 import CardStackTransitioner from '../views/CardStack/CardStackTransitioner';
 import StackRouter from '../routers/StackRouter';
-import NavigatorTypes from './NavigatorTypes';
 import NavigationActions from '../NavigationActions';
 
 // A stack navigators props are the intersection between
@@ -34,26 +33,23 @@ export default (routeConfigMap, stackConfig = {}) => {
   const router = StackRouter(routeConfigMap, stackRouterConfig);
 
   // Create a navigator with CardStackTransitioner as the view
-  const navigator = createNavigator(
-    router,
-    routeConfigMap,
-    stackConfig,
-    NavigatorTypes.STACK
-  )(props => (
-    <CardStackTransitioner
-      {...props}
-      headerMode={headerMode}
-      mode={mode}
-      cardStyle={cardStyle}
-      transitionConfig={transitionConfig}
-      onTransitionStart={onTransitionStart}
-      onTransitionEnd={(lastTransition, transition) => {
-        const { state, dispatch } = props.navigation;
-        dispatch(NavigationActions.completeTransition());
-        onTransitionEnd && onTransitionEnd();
-      }}
-    />
-  ));
+  const navigator = createNavigator(router, routeConfigMap, stackConfig)(
+    props => (
+      <CardStackTransitioner
+        {...props}
+        headerMode={headerMode}
+        mode={mode}
+        cardStyle={cardStyle}
+        transitionConfig={transitionConfig}
+        onTransitionStart={onTransitionStart}
+        onTransitionEnd={(lastTransition, transition) => {
+          const { state, dispatch } = props.navigation;
+          dispatch(NavigationActions.completeTransition());
+          onTransitionEnd && onTransitionEnd();
+        }}
+      />
+    )
+  );
 
   return createNavigationContainer(navigator);
 };

--- a/src/navigators/TabNavigator.js
+++ b/src/navigators/TabNavigator.js
@@ -8,8 +8,6 @@ import TabView from '../views/TabView/TabView';
 import TabBarTop from '../views/TabView/TabBarTop';
 import TabBarBottom from '../views/TabView/TabBarBottom';
 
-import NavigatorTypes from './NavigatorTypes';
-
 // A tab navigators props are the intersection between
 // the base navigator props (navgiation, screenProps, etc)
 // and the view's props
@@ -30,12 +28,7 @@ const TabNavigator = (routeConfigs, config = {}) => {
 
   const router = TabRouter(routeConfigs, tabsConfig);
 
-  const navigator = createNavigator(
-    router,
-    routeConfigs,
-    config,
-    NavigatorTypes.TABS
-  )(props => (
+  const navigator = createNavigator(router, routeConfigs, config)(props => (
     <TabView
       {...props}
       tabBarComponent={tabBarComponent}

--- a/src/navigators/createNavigator.js
+++ b/src/navigators/createNavigator.js
@@ -3,19 +3,10 @@ import React from 'react';
 /**
  * Creates a navigator based on a router and a view that renders the screens.
  */
-export default function createNavigator(
-  router,
-  routeConfigs,
-  navigatorConfig,
-  navigatorType
-) {
+export default function createNavigator(router, routeConfigs, navigatorConfig) {
   return NavigationView => {
     class Navigator extends React.Component {
       static router = router;
-
-      static routeConfigs = routeConfigs;
-      static navigatorConfig = navigatorConfig;
-      static navigatorType = navigatorType;
       static navigationOptions = null;
 
       render() {


### PR DESCRIPTION
It has some legacy of being potentially necessary to support hybrid case in some situations, but it's no longer used and we don't need it.

**Test plan (required)**

Run tests, run playground app