### PR TITLE
Update repository URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "module": "lib/react-navigation.web.js",
   "webpack": "lib/react-navigation.web.js",
   "repository": {
-    "url": "git@github.com:react-community/react-navigation.git",
+    "url": "git@github.com:react-navigation/react-navigation.git",
     "type": "git"
   },
   "author": "Adam Miskiewicz <adam@sk3vy.com>",


### PR DESCRIPTION
Update repository URL to reflect move from `react-community` to `react-navigation` organization.