### PR TITLE
allow initialRouteParams for TabRouters

### DIFF
--- a/src/TypeDefinition.js
+++ b/src/TypeDefinition.js
@@ -353,6 +353,7 @@ export type StackNavigatorConfig = {
 
 export type NavigationTabRouterConfig = {
   initialRouteName?: string,
+  initialRouteParams?: NavigationParams,
   paths?: NavigationPathsConfig,
   navigationOptions?: NavigationScreenConfig<*>,
   order?: Array<string>, // todo: type these as the real route names rather than 'string'

--- a/src/routers/TabRouter.js
+++ b/src/routers/TabRouter.js
@@ -12,6 +12,7 @@ export default (routeConfigs, config = {}) => {
 
   const order = config.order || Object.keys(routeConfigs);
   const paths = config.paths || {};
+  const initialRouteParams = config.initialRouteParams;
   const initialRouteName = config.initialRouteName || order[0];
   const initialRouteIndex = order.indexOf(initialRouteName);
   const backBehavior = config.backBehavior || 'initialRoute';
@@ -38,6 +39,8 @@ export default (routeConfigs, config = {}) => {
       let state = inputState;
       if (!state) {
         const routes = order.map(routeName => {
+          const params =
+            routeName === initialRouteName ? initialRouteParams : undefined;
           const tabRouter = tabRouters[routeName];
           if (tabRouter) {
             const childAction = NavigationActions.init();
@@ -45,11 +48,13 @@ export default (routeConfigs, config = {}) => {
               ...tabRouter.getStateForAction(childAction),
               key: routeName,
               routeName,
+              params,
             };
           }
           return {
             key: routeName,
             routeName,
+            params,
           };
         });
         state = {
@@ -69,6 +74,9 @@ export default (routeConfigs, config = {}) => {
             params: {
               ...route.params,
               ...params,
+              ...(route.routeName === initialRouteName
+                ? initialRouteParams
+                : null),
             },
           }));
         }

--- a/src/routers/__tests__/TabRouter-test.js
+++ b/src/routers/__tests__/TabRouter-test.js
@@ -107,6 +107,22 @@ describe('TabRouter', () => {
     });
   });
 
+  test('Can set the initial params', () => {
+    const router = TabRouter(
+      { Foo: BareLeafRouteConfig, Bar: BareLeafRouteConfig },
+      { initialRouteName: 'Bar', initialRouteParams: { name: 'Qux' } }
+    );
+    const state = router.getStateForAction({ type: NavigationActions.INIT });
+    expect(state).toEqual({
+      index: 1,
+      routes: [
+        { key: 'Foo', routeName: 'Foo' },
+        { key: 'Bar', routeName: 'Bar', params: { name: 'Qux' } },
+      ],
+      isTransitioning: false,
+    });
+  });
+
   test('Handles the SetParams action', () => {
     const router = TabRouter({
       Foo: {


### PR DESCRIPTION
Allow the passing in of `initialRouteParams` into `TabRouter`'s config since `StackRouter` already has that feature. The request was filed [here](https://github.com/react-navigation/react-navigation/issues/1790).

First PR, please let me know if I've missed something!