### PR TITLE
Simple fix to back button behavior

### DIFF
--- a/src/views/Header/Header.js
+++ b/src/views/Header/Header.js
@@ -72,7 +72,7 @@ class Header extends React.PureComponent {
 
   _navigateBack = () => {
     requestAnimationFrame(() => {
-      this.props.navigation.goBack();
+      this.props.navigation.goBack(this.props.scene.route.key);
     });
   };
 


### PR DESCRIPTION
Back button in simple playground will close the stack example rather than popping within the stack.

This avoids the problem by telling goBack the key to go back FROM