### PR TITLE
rely on defaultProps in TouchableItem

### DIFF
--- a/src/views/TouchableItem.js
+++ b/src/views/TouchableItem.js
@@ -42,8 +42,8 @@ export default class TouchableItem extends React.Component {
           {...rest}
           style={null}
           background={TouchableNativeFeedback.Ripple(
-            this.props.pressColor || '',
-            this.props.borderless || false
+            this.props.pressColor,
+            this.props.borderless
           )}
         >
           <View style={style}>{React.Children.only(this.props.children)}</View>


### PR DESCRIPTION
 Just a minor polishment: TouchableItem.js defines

```
  static defaultProps = {
     borderless: false,
     pressColor: 'rgba(0, 0, 0, .32)',
   };
```

so using eg. `this.props.borderless || false` can be just `this.props.borderless`


**Test plan (required)**

Tried it out with my app, works as before.
