### PR TITLE
Add NavigationPlayground Flow test to CI

### DIFF
--- a/examples/NavigationPlayground/package.json
+++ b/examples/NavigationPlayground/package.json
@@ -8,7 +8,7 @@
     "eject": "react-native-scripts eject",
     "android": "react-native-scripts android",
     "ios": "react-native-scripts ios",
-    "test": "node node_modules/jest/bin/jest.js"
+    "test": "node node_modules/jest/bin/jest.js && flow"
   },
   "dependencies": {
     "expo": "^25.0.0",


### PR DESCRIPTION
In order to make sure that contributors don't making breaking changes to our Flow types without corresponding updates to the libdefs, we should make sure these breaking changes get caught by CI. Right now our libdefs are any-typed, but I'll put up a PR later that will refine the libdef (located at `flow-typed/npm/react-navigation_vx.x.x.js`).