### PR TITLE
fix statusHeight on non-iphoneX devices in landScape

### DIFF
--- a/src/views/SafeAreaView.js
+++ b/src/views/SafeAreaView.js
@@ -76,11 +76,7 @@ const statusBarHeight = isLandscape => {
     return isLandscape ? 0 : 44;
   }
 
-  if (isIPad) {
-    return 20;
-  }
-
-  return isLandscape ? 0 : 20;
+  return 20;
 };
 
 const doubleFromPercentString = percent => {


### PR DESCRIPTION

Problem in landScape on non-iPhoneX devices. There was no statusBar height. In landScape mode it returned 0.

<img width="529" alt="screen shot 2018-01-30 at 11 42 43" src="https://user-images.githubusercontent.com/15018124/35562154-cc65b058-05b2-11e8-94a0-3837d5ba2451.png">
