### PR TITLE
Encapsulate DrawerSidebar in the SafeAreaView.

### DIFF
--- a/src/navigators/__tests__/__snapshots__/DrawerNavigator-test.js.snap
+++ b/src/navigators/__tests__/__snapshots__/DrawerNavigator-test.js.snap
@@ -82,158 +82,172 @@ exports[`DrawerNavigator renders successfully 1`] = `
     }
   >
     <View
+      collapsable={undefined}
+      onLayout={[Function]}
       style={
-        Array [
-          Object {
-            "flex": 1,
-          },
-          undefined,
-        ]
+        Object {
+          "flex": 1,
+          "paddingBottom": 0,
+          "paddingLeft": 0,
+          "paddingRight": 0,
+          "paddingTop": 20,
+        }
       }
     >
-      <RCTScrollView
-        DEPRECATED_sendUpdatedChildFrames={false}
-        alwaysBounceHorizontal={undefined}
-        alwaysBounceVertical={false}
-        onContentSizeChange={null}
-        onMomentumScrollBegin={[Function]}
-        onMomentumScrollEnd={[Function]}
-        onResponderGrant={[Function]}
-        onResponderReject={[Function]}
-        onResponderRelease={[Function]}
-        onResponderTerminate={undefined}
-        onResponderTerminationRequest={[Function]}
-        onScroll={[Function]}
-        onScrollBeginDrag={[Function]}
-        onScrollEndDrag={[Function]}
-        onScrollShouldSetResponder={[Function]}
-        onStartShouldSetResponder={[Function]}
-        onStartShouldSetResponderCapture={[Function]}
-        onTouchCancel={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        scrollEventThrottle={undefined}
-        sendMomentumEvents={false}
+      <View
         style={
           Array [
             Object {
-              "flexDirection": "column",
-              "flexGrow": 1,
-              "flexShrink": 1,
-              "overflow": "scroll",
+              "flex": 1,
             },
             undefined,
           ]
         }
       >
-        <RCTScrollContentView
-          collapsable={false}
-          removeClippedSubviews={undefined}
+        <RCTScrollView
+          DEPRECATED_sendUpdatedChildFrames={false}
+          alwaysBounceHorizontal={undefined}
+          alwaysBounceVertical={false}
+          onContentSizeChange={null}
+          onMomentumScrollBegin={[Function]}
+          onMomentumScrollEnd={[Function]}
+          onResponderGrant={[Function]}
+          onResponderReject={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={undefined}
+          onResponderTerminationRequest={[Function]}
+          onScroll={[Function]}
+          onScrollBeginDrag={[Function]}
+          onScrollEndDrag={[Function]}
+          onScrollShouldSetResponder={[Function]}
+          onStartShouldSetResponder={[Function]}
+          onStartShouldSetResponderCapture={[Function]}
+          onTouchCancel={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          scrollEventThrottle={undefined}
+          sendMomentumEvents={false}
           style={
             Array [
-              undefined,
+              Object {
+                "flexDirection": "column",
+                "flexGrow": 1,
+                "flexShrink": 1,
+                "overflow": "scroll",
+              },
               undefined,
             ]
           }
         >
-          <View
-            collapsable={undefined}
-            onLayout={[Function]}
+          <RCTScrollContentView
+            collapsable={false}
+            removeClippedSubviews={undefined}
             style={
-              Object {
-                "paddingBottom": 0,
-                "paddingLeft": 0,
-                "paddingRight": 0,
-                "paddingTop": 20,
-              }
+              Array [
+                undefined,
+                undefined,
+              ]
             }
           >
             <View
+              collapsable={undefined}
+              onLayout={[Function]}
               style={
-                Array [
-                  Object {
-                    "paddingVertical": 4,
-                  },
-                  undefined,
-                ]
+                Object {
+                  "paddingBottom": 0,
+                  "paddingLeft": 0,
+                  "paddingRight": 0,
+                  "paddingTop": 20,
+                }
               }
             >
               <View
-                accessibilityComponentType={undefined}
-                accessibilityLabel={undefined}
-                accessibilityTraits={undefined}
-                accessible={true}
-                collapsable={undefined}
-                hasTVPreferredFocus={undefined}
-                hitSlop={undefined}
-                isTVSelectable={true}
-                nativeID={undefined}
-                onLayout={undefined}
-                onResponderGrant={[Function]}
-                onResponderMove={[Function]}
-                onResponderRelease={[Function]}
-                onResponderTerminate={[Function]}
-                onResponderTerminationRequest={[Function]}
-                onStartShouldSetResponder={[Function]}
                 style={
-                  Object {
-                    "opacity": 1,
-                  }
+                  Array [
+                    Object {
+                      "paddingVertical": 4,
+                    },
+                    undefined,
+                  ]
                 }
-                testID={undefined}
-                tvParallaxProperties={undefined}
               >
                 <View
+                  accessibilityComponentType={undefined}
+                  accessibilityLabel={undefined}
+                  accessibilityTraits={undefined}
+                  accessible={true}
                   collapsable={undefined}
-                  onLayout={[Function]}
+                  hasTVPreferredFocus={undefined}
+                  hitSlop={undefined}
+                  isTVSelectable={true}
+                  nativeID={undefined}
+                  onLayout={undefined}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
                   style={
                     Object {
-                      "backgroundColor": "rgba(0, 0, 0, .04)",
-                      "paddingBottom": 0,
-                      "paddingLeft": 0,
-                      "paddingRight": 0,
-                      "paddingTop": 0,
+                      "opacity": 1,
                     }
                   }
+                  testID={undefined}
+                  tvParallaxProperties={undefined}
                 >
                   <View
+                    collapsable={undefined}
+                    onLayout={[Function]}
                     style={
-                      Array [
-                        Object {
-                          "alignItems": "center",
-                          "flexDirection": "row",
-                        },
-                        undefined,
-                      ]
+                      Object {
+                        "backgroundColor": "rgba(0, 0, 0, .04)",
+                        "paddingBottom": 0,
+                        "paddingLeft": 0,
+                        "paddingRight": 0,
+                        "paddingTop": 0,
+                      }
                     }
                   >
-                    <Text
-                      accessible={true}
-                      allowFontScaling={true}
-                      ellipsizeMode="tail"
+                    <View
                       style={
                         Array [
                           Object {
-                            "fontWeight": "bold",
-                            "margin": 16,
-                          },
-                          Object {
-                            "color": "#2196f3",
+                            "alignItems": "center",
+                            "flexDirection": "row",
                           },
                           undefined,
                         ]
                       }
                     >
-                      Welcome anonymous
-                    </Text>
+                      <Text
+                        accessible={true}
+                        allowFontScaling={true}
+                        ellipsizeMode="tail"
+                        style={
+                          Array [
+                            Object {
+                              "fontWeight": "bold",
+                              "margin": 16,
+                            },
+                            Object {
+                              "color": "#2196f3",
+                            },
+                            undefined,
+                          ]
+                        }
+                      >
+                        Welcome anonymous
+                      </Text>
+                    </View>
                   </View>
                 </View>
               </View>
             </View>
-          </View>
-        </RCTScrollContentView>
-      </RCTScrollView>
+          </RCTScrollContentView>
+        </RCTScrollView>
+      </View>
     </View>
   </View>
 </View>

--- a/src/views/Drawer/DrawerSidebar.js
+++ b/src/views/Drawer/DrawerSidebar.js
@@ -83,22 +83,24 @@ class DrawerSidebar extends React.PureComponent {
     const { state } = this.props.navigation;
     invariant(typeof state.index === 'number', 'should be set');
     return (
-      <View style={[styles.container, this.props.style]}>
-        <ContentComponent
-          {...this.props.contentOptions}
-          navigation={this.props.navigation}
-          items={state.routes}
-          activeItemKey={
-            state.routes[state.index] ? state.routes[state.index].key : null
-          }
-          screenProps={this.props.screenProps}
-          getLabel={this._getLabel}
-          renderIcon={this._renderIcon}
-          onItemPress={this._onItemPress}
-          router={this.props.router}
-          drawerPosition={this.props.drawerPosition}
-        />
-      </View>
+      <SafeAreaView style={styles.container}>
+        <View style={[styles.container, this.props.style]}>
+          <ContentComponent
+            {...this.props.contentOptions}
+            navigation={this.props.navigation}
+            items={state.routes}
+            activeItemKey={
+              state.routes[state.index] ? state.routes[state.index].key : null
+            }
+            screenProps={this.props.screenProps}
+            getLabel={this._getLabel}
+            renderIcon={this._renderIcon}
+            onItemPress={this._onItemPress}
+            router={this.props.router}
+            drawerPosition={this.props.drawerPosition}
+          />
+        </View>
+      </SafeAreaView>
     );
   }
 }


### PR DESCRIPTION
So that proper padding styles can be applied to the drawer content.

Please provide enough information so that others can review your pull request:

**motivation** 
Without using `SafeAreaView` component in `DrawerView`, proper padding styles are not applied. Thus drawer content was overlapping status bar on iPhone X.

From [this commit](https://github.com/jainkuniya/react-navigation/commit/f2f4e5ce44c76b8273ad6082e8e5866fc8ebe7dd#diff-1ef5b8f9d10c4acbaf92697f3abd0041) I was expecting `SafeAreaView` component in the `DrawerSidebar`, but can't find it. So submitting this PR. 

**Test plan (required)**
Test on iPhone X