### PR TITLE
Handle the navigate action as first action with nested StackRouter

### DIFF
--- a/src/routers/StackRouter.js
+++ b/src/routers/StackRouter.js
@@ -101,23 +101,39 @@ export default (routeConfigs, stackConfig = {}) => {
       // Set up the initial state if needed
       if (!state) {
         let route = {};
-        if (
-          behavesLikePushAction(action) &&
-          childRouters[action.routeName] !== undefined
-        ) {
+        const childRouter = childRouters[action.routeName];
+        if (behavesLikePushAction(action) && childRouter !== undefined) {
+          if (childRouter === null) {
+            return {
+              isTransitioning: false,
+              index: 0,
+              routes: [
+                {
+                  ...action,
+                  type: undefined,
+                  key: `Init-${_getUuid()}`,
+                },
+              ],
+            };
+          }
+
+          const childAction =
+            action.action || NavigationActions.init({ params: action.params });
           return {
             key: 'StackRouterRoot',
             isTransitioning: false,
             index: 0,
             routes: [
               {
-                routeName: action.routeName,
                 params: action.params,
-                key: `Init-${generateKey()}`,
+                ...childRouter.getStateForAction(childAction),
+                routeName: action.routeName,
+                key: `Init-${_getUuid()}`,
               },
             ],
           };
         }
+
         if (initialChildRouter) {
           route = initialChildRouter.getStateForAction(
             NavigationActions.navigate({

--- a/src/routers/__tests__/Routers-test.js
+++ b/src/routers/__tests__/Routers-test.js
@@ -7,6 +7,11 @@ import TabRouter from '../TabRouter';
 
 import NavigationActions from '../../NavigationActions';
 import addNavigationHelpers from '../../addNavigationHelpers';
+import { _TESTING_ONLY_normalize_keys } from '../KeyGenerator';
+
+beforeEach(() => {
+  _TESTING_ONLY_normalize_keys();
+});
 
 const ROUTERS = {
   TabRouter,
@@ -105,8 +110,8 @@ test('Handles no-op actions with tabs within stack router', () => {
     type: NavigationActions.NAVIGATE,
     routeName: 'Qux',
   });
-  expect(state1.routes[0].key).toEqual('Init-id-0-0');
-  expect(state2.routes[0].key).toEqual('Init-id-0-1');
+  expect(state1.routes[0].key).toEqual('Init-id-0');
+  expect(state2.routes[0].key).toEqual('Init-id-1');
   state1.routes[0].key = state2.routes[0].key;
   expect(state1).toEqual(state2);
   const state3 = TestRouter.getStateForAction(
@@ -134,7 +139,7 @@ test('Handles deep action', () => {
     key: 'StackRouterRoot',
     routes: [
       {
-        key: 'Init-id-0-2',
+        key: 'Init-id-0',
         routeName: 'Bar',
       },
     ],
@@ -174,8 +179,8 @@ test('Supports lazily-evaluated getScreen', () => {
     immediate: true,
     routeName: 'Qux',
   });
-  expect(state1.routes[0].key).toEqual('Init-id-0-4');
-  expect(state2.routes[0].key).toEqual('Init-id-0-5');
+  expect(state1.routes[0].key).toEqual('Init-id-0');
+  expect(state2.routes[0].key).toEqual('Init-id-1');
   state1.routes[0].key = state2.routes[0].key;
   expect(state1).toEqual(state2);
   const state3 = TestRouter.getStateForAction(

--- a/src/routers/__tests__/StackRouter-test.js
+++ b/src/routers/__tests__/StackRouter-test.js
@@ -1070,44 +1070,37 @@ describe('StackRouter', () => {
       },
     });
 
-    expect(state && state.index).toEqual(0);
-    expect(state && state.isTransitioning).toEqual(false);
-    /* $FlowFixMe */
-    expect(state && state.routes[0].index).toEqual(0);
-    expect(state && state.routes[0].routeName).toEqual('main');
-    expect(state && state.routes[0].routes[0].index).toEqual(0);
-    expect(state && state.routes[0].routes[0].routeName).toEqual('profile');
-    expect(state && state.routes[0].routes[0].routes[0].routeName).toEqual(
-      'list'
-    );
-    // expect(state).toEqual({
-    //   index: 0,
-    //   isTransitioning: false,
-    //   routes: [
-    //     {
-    //       index: 0,
-    //       key: 'Init-id-0-41',
-    //       params: { code: 'test', foo: 'bar' },
-    //       routeName: 'main',
-    //       routes: [
-    //         {
-    //           index: 0,
-    //           key: 'Init-id-0-40',
-    //           params: { code: 'test', foo: 'bar', id: '4' },
-    //           routeName: 'profile',
-    //           routes: [
-    //             {
-    //               key: 'Init-id-0-39',
-    //               params: { code: 'test', foo: 'bar', id: '10259959195' },
-    //               routeName: 'list',
-    //               type: undefined,
-    //             },
-    //           ],
-    //         },
-    //       ],
-    //     },
-    //   ],
-    // });
+    expect(state).toEqual({
+      index: 0,
+      isTransitioning: false,
+      key: 'StackRouterRoot',
+      routes: [
+        {
+          index: 0,
+          isTransitioning: false,
+          key: 'Init-id-2',
+          params: { code: 'test', foo: 'bar' },
+          routeName: 'main',
+          routes: [
+            {
+              index: 0,
+              isTransitioning: false,
+              key: 'Init-id-1',
+              params: { code: 'test', foo: 'bar', id: '4' },
+              routeName: 'profile',
+              routes: [
+                {
+                  key: 'Init-id-0',
+                  params: { code: 'test', foo: 'bar', id: '10259959195' },
+                  routeName: 'list',
+                  type: undefined,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
 
     const state2 = TestStackRouter.getStateForAction({
       type: NavigationActions.NAVIGATE,
@@ -1135,44 +1128,38 @@ describe('StackRouter', () => {
         },
       },
     });
-    expect(state2 && state2.index).toEqual(0);
-    expect(state2 && state2.isTransitioning).toEqual(false);
-    /* $FlowFixMe */
-    expect(state2 && state2.routes[0].index).toEqual(0);
-    expect(state2 && state2.routes[0].routeName).toEqual('main');
-    expect(state2 && state2.routes[0].routes[0].index).toEqual(0);
-    expect(state2 && state2.routes[0].routes[0].routeName).toEqual('profile');
-    expect(state2 && state2.routes[0].routes[0].routes[0].routeName).toEqual(
-      'list'
-    );
 
-    // expect(state2).toEqual({
-    //   index: 0,
-    //   routes: [
-    //     {
-    //       index: 0,
-    //       key: 'Init-id-0-44',
-    //       params: { code: '', foo: 'bar' },
-    //       routeName: 'main',
-    //       routes: [
-    //         {
-    //           index: 0,
-    //           key: 'Init-id-0-43',
-    //           params: { code: '', foo: 'bar', id: '4' },
-    //           routeName: 'profile',
-    //           routes: [
-    //             {
-    //               key: 'Init-id-0-42',
-    //               params: { code: '', foo: 'bar', id: '10259959195' },
-    //               routeName: 'list',
-    //               type: undefined,
-    //             },
-    //           ],
-    //         },
-    //       ],
-    //     },
-    //   ],
-    // });
+    expect(state2).toEqual({
+      index: 0,
+      isTransitioning: false,
+      key: 'StackRouterRoot',
+      routes: [
+        {
+          index: 0,
+          isTransitioning: false,
+          key: 'Init-id-5',
+          params: { code: '', foo: 'bar' },
+          routeName: 'main',
+          routes: [
+            {
+              index: 0,
+              isTransitioning: false,
+              key: 'Init-id-4',
+              params: { code: '', foo: 'bar', id: '4' },
+              routeName: 'profile',
+              routes: [
+                {
+                  key: 'Init-id-3',
+                  params: { code: '', foo: 'bar', id: '10259959195' },
+                  routeName: 'list',
+                  type: undefined,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
   });
 
   test('Handles the navigate action with params and nested TabRouter', () => {

--- a/src/routers/__tests__/StackRouter-test.js
+++ b/src/routers/__tests__/StackRouter-test.js
@@ -1042,6 +1042,139 @@ describe('StackRouter', () => {
     ]);
   });
 
+  test('Handles the navigate action with params and nested StackRouter as a first action', () => {
+    const state = TestStackRouter.getStateForAction({
+      type: NavigationActions.NAVIGATE,
+      routeName: 'main',
+      params: {
+        code: 'test',
+        foo: 'bar',
+      },
+      action: {
+        type: NavigationActions.NAVIGATE,
+        routeName: 'profile',
+        params: {
+          id: '4',
+          code: 'test',
+          foo: 'bar',
+        },
+        action: {
+          type: NavigationActions.NAVIGATE,
+          routeName: 'list',
+          params: {
+            id: '10259959195',
+            code: 'test',
+            foo: 'bar',
+          },
+        },
+      },
+    });
+
+    expect(state && state.index).toEqual(0);
+    expect(state && state.isTransitioning).toEqual(false);
+    /* $FlowFixMe */
+    expect(state && state.routes[0].index).toEqual(0);
+    expect(state && state.routes[0].routeName).toEqual('main');
+    expect(state && state.routes[0].routes[0].index).toEqual(0);
+    expect(state && state.routes[0].routes[0].routeName).toEqual('profile');
+    expect(state && state.routes[0].routes[0].routes[0].routeName).toEqual(
+      'list'
+    );
+    // expect(state).toEqual({
+    //   index: 0,
+    //   isTransitioning: false,
+    //   routes: [
+    //     {
+    //       index: 0,
+    //       key: 'Init-id-0-41',
+    //       params: { code: 'test', foo: 'bar' },
+    //       routeName: 'main',
+    //       routes: [
+    //         {
+    //           index: 0,
+    //           key: 'Init-id-0-40',
+    //           params: { code: 'test', foo: 'bar', id: '4' },
+    //           routeName: 'profile',
+    //           routes: [
+    //             {
+    //               key: 'Init-id-0-39',
+    //               params: { code: 'test', foo: 'bar', id: '10259959195' },
+    //               routeName: 'list',
+    //               type: undefined,
+    //             },
+    //           ],
+    //         },
+    //       ],
+    //     },
+    //   ],
+    // });
+
+    const state2 = TestStackRouter.getStateForAction({
+      type: NavigationActions.NAVIGATE,
+      routeName: 'main',
+      params: {
+        code: '',
+        foo: 'bar',
+      },
+      action: {
+        type: NavigationActions.NAVIGATE,
+        routeName: 'profile',
+        params: {
+          id: '4',
+          code: '',
+          foo: 'bar',
+        },
+        action: {
+          type: NavigationActions.NAVIGATE,
+          routeName: 'list',
+          params: {
+            id: '10259959195',
+            code: '',
+            foo: 'bar',
+          },
+        },
+      },
+    });
+    expect(state2 && state2.index).toEqual(0);
+    expect(state2 && state2.isTransitioning).toEqual(false);
+    /* $FlowFixMe */
+    expect(state2 && state2.routes[0].index).toEqual(0);
+    expect(state2 && state2.routes[0].routeName).toEqual('main');
+    expect(state2 && state2.routes[0].routes[0].index).toEqual(0);
+    expect(state2 && state2.routes[0].routes[0].routeName).toEqual('profile');
+    expect(state2 && state2.routes[0].routes[0].routes[0].routeName).toEqual(
+      'list'
+    );
+
+    // expect(state2).toEqual({
+    //   index: 0,
+    //   routes: [
+    //     {
+    //       index: 0,
+    //       key: 'Init-id-0-44',
+    //       params: { code: '', foo: 'bar' },
+    //       routeName: 'main',
+    //       routes: [
+    //         {
+    //           index: 0,
+    //           key: 'Init-id-0-43',
+    //           params: { code: '', foo: 'bar', id: '4' },
+    //           routeName: 'profile',
+    //           routes: [
+    //             {
+    //               key: 'Init-id-0-42',
+    //               params: { code: '', foo: 'bar', id: '10259959195' },
+    //               routeName: 'list',
+    //               type: undefined,
+    //             },
+    //           ],
+    //         },
+    //       ],
+    //     },
+    //   ],
+    // });
+  });
+
   test('Handles the navigate action with params and nested TabRouter', () => {
     const ChildNavigator = () => <div />;
     ChildNavigator.router = TabRouter({


### PR DESCRIPTION
Fixes issue discovered when implementing deep linking in an application. Handles the navigate action with params and nested StackRouter as the first action. Thanks to my colleague @muramasa for tracking down the root cause, making a fix, and writing a unit test that reproduces this issue.


**Test plan (required)**
Verified internal application bug was fixed with manual test. Added unit test that failed `jest test` without the fix, and verified new test (and all other tests) pass with the fix in place:
```
Test Suites: 16 passed, 16 total
Tests:       124 passed, 124 total
Snapshots:   6 passed, 6 total
Time:        2.882s
Ran all test suites.
``` 

**Code formatting**

```yarn run test``` and pre-commit hooks passed.