### PR TITLE
StackRouter Reset Action should match state key

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "url": "git@github.com:react-navigation/react-navigation.git",
     "type": "git"
   },
-  "author": "Adam Miskiewicz <adam@sk3vy.com>, Eric Vicenti <ericvicenti@gmail.com>",
+  "author":
+    "Adam Miskiewicz <adam@sk3vy.com>, Eric Vicenti <ericvicenti@gmail.com>",
   "license": "BSD-2-Clause",
   "scripts": {
     "start": "npm run ios",
@@ -21,10 +22,7 @@
     "format": "eslint --fix .",
     "precommit": "lint-staged"
   },
-  "files": [
-    "lib",
-    "src"
-  ],
+  "files": ["lib", "src"],
   "peerDependencies": {
     "react": "*",
     "react-native": "*"
@@ -70,25 +68,15 @@
     "notify": true,
     "preset": "react-native",
     "testRegex": "./src/.*\\-test\\.js$",
-    "setupFiles": [
-      "<rootDir>/jest-setup.js"
-    ],
+    "setupFiles": ["<rootDir>/jest-setup.js"],
     "coverageDirectory": "./coverage/",
     "collectCoverage": true,
-    "collectCoverageFrom": [
-      "src/**/*.js"
-    ],
-    "coveragePathIgnorePatterns": [
-      "jest-setup.js"
-    ],
-    "modulePathIgnorePatterns": [
-      "examples"
-    ]
+    "coverageReporters": ["lcov"],
+    "collectCoverageFrom": ["src/**/*.js"],
+    "coveragePathIgnorePatterns": ["jest-setup.js"],
+    "modulePathIgnorePatterns": ["examples"]
   },
   "lint-staged": {
-    "*.js": [
-      "eslint --fix",
-      "git add"
-    ]
+    "*.js": ["eslint --fix", "git add"]
   }
 }

--- a/src/routers/StackRouter.js
+++ b/src/routers/StackRouter.js
@@ -295,6 +295,12 @@ export default (routeConfigs, stackConfig = {}) => {
       }
 
       if (action.type === NavigationActions.RESET) {
+        // Only handle reset actions that are unspecified or match this state key
+        if (action.key != null && action.key != state.key) {
+          // Deliberately use != instead of !== so we can match null with
+          // undefined on either the state or the action
+          return state;
+        }
         const resetAction = action;
 
         return {

--- a/src/routers/__tests__/StackRouter-test.js
+++ b/src/routers/__tests__/StackRouter-test.js
@@ -768,6 +768,49 @@ describe('StackRouter', () => {
     expect(state2 && state2.routes[1].routeName).toEqual('Bar');
   });
 
+  test('Handles the reset action only with correct key set', () => {
+    const router = StackRouter({
+      Foo: {
+        screen: () => <div />,
+      },
+      Bar: {
+        screen: () => <div />,
+      },
+    });
+    const state1 = router.getStateForAction({ type: NavigationActions.INIT });
+    const resetAction = {
+      type: NavigationActions.RESET,
+      key: 'Bad Key',
+      actions: [
+        {
+          type: NavigationActions.NAVIGATE,
+          routeName: 'Foo',
+          params: { bar: '42' },
+          immediate: true,
+        },
+        {
+          type: NavigationActions.NAVIGATE,
+          routeName: 'Bar',
+          immediate: true,
+        },
+      ],
+      index: 1,
+    };
+    const state2 = router.getStateForAction(resetAction, state1);
+    expect(state2).toEqual(state1);
+    const state3 = router.getStateForAction(
+      {
+        ...resetAction,
+        key: state2.key,
+      },
+      state2
+    );
+    expect(state3 && state3.index).toEqual(1);
+    expect(state3 && state3.routes[0].params).toEqual({ bar: '42' });
+    expect(state3 && state3.routes[0].routeName).toEqual('Foo');
+    expect(state3 && state3.routes[1].routeName).toEqual('Bar');
+  });
+
   test('Handles the reset action with nested Router', () => {
     const ChildRouter = TabRouter({
       baz: {


### PR DESCRIPTION
There are a ton of issues relating to reset, because there is no way to match the key of the state that you are setting. This change makes that possible.

We should also probably add a way to do this from the navigation helpers so that you can do `props.navigation.reset({key, ...`