### PR TITLE
Clean up old build process and Babel config

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,28 +1,3 @@
 {
-  "env": {
-    // For RN example development
-    "development": {
-      "presets": ["react-native"]
-    },
-    // For Jest
-    "test": {
-      "presets": ["react-native"]
-    },
-    // For publishing to NPM for RN
-    "publish-rn": {
-      "presets": ["react-native-syntax"]
-    },
-    // For publishing to NPM for web
-    "publish-web": {
-      "presets": ["es2015", "stage-1", "react"],
-      "plugins": [
-        [
-          "transform-define",
-          {
-            "__DEV__": false
-          }
-        ]
-      ]
-    }
-  }
+  "presets": ["react-native"]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,6 @@ jsconfig.json
 # NodeJS
 npm-debug.log
 node_modules
-lib-rn
-lib
 yarn-error.log
 
 # OS X

--- a/examples/NavigationPlayground/.flowconfig
+++ b/examples/NavigationPlayground/.flowconfig
@@ -34,9 +34,6 @@
 ; Ignore react-native-fbads dependency of the expo sdk
 .*/node_modules/react-native-fbads/*
 
-.*/react-navigation/lib-rn/.*
-.*/react-navigation/lib/.*
-
 .*/react-navigation/examples/ReduxExample/.*
 .*/react-navigation/website/.*
 

--- a/package.json
+++ b/package.json
@@ -21,16 +21,12 @@
     "format": "eslint --fix .",
     "precommit": "lint-staged"
   },
-  "files": [
-    "lib",
-    "src"
-  ],
+  "files": ["src"],
   "peerDependencies": {
     "react": "*",
     "react-native": "*"
   },
   "dependencies": {
-    "babel-plugin-transform-define": "^1.3.0",
     "clamp": "^1.0.1",
     "hoist-non-react-statics": "^2.2.0",
     "path-to-regexp": "^1.7.0",
@@ -43,12 +39,7 @@
     "babel-core": "^6.25.0",
     "babel-eslint": "^7.2.3",
     "babel-jest": "^20.0.3",
-    "babel-preset-es2015": "^6.24.1",
-    "babel-preset-react": "^6.24.1",
     "babel-preset-react-native": "^2.1.0",
-    "babel-preset-react-native-stage-0": "^1.0.1",
-    "babel-preset-react-native-syntax": "^1.0.0",
-    "babel-preset-stage-1": "^6.24.1",
     "codecov": "^2.2.0",
     "eslint": "^4.2.0",
     "eslint-config-prettier": "^2.3.0",


### PR DESCRIPTION
The build scripts were removed in cbd1fee8a440887ca1a4b7cde93ac04f376f7327, but some of the stuff they were using (namely, Babel configurations) were left in place. This PR removes them.