### PR TITLE
Add left-to-right dismiss gesture to modal

### DIFF
--- a/docs/api/navigators/StackNavigator.md
+++ b/docs/api/navigators/StackNavigator.md
@@ -160,7 +160,7 @@ Object to override the distance of touch start from the edge of the screen to re
 
 #### `gestureDirection`
 
-String to override the direction for dismiss gesture. `default` for normal behaviour or `inverted` for right-to-left swipes.
+String to override the direction for dismiss gesture. `default` for normal behaviour or `inverted` for right-to-left swipes, `rotated` for left-to-right swipes on modal.
 
 ### Navigator Props
 

--- a/src/views/CardStack/CardStack.js
+++ b/src/views/CardStack/CardStack.js
@@ -197,9 +197,10 @@ class CardStack extends React.Component {
     }
     const { navigation, position, layout, scene, scenes, mode } = this.props;
     const { index } = navigation.state;
-    const isVertical = mode === 'modal';
     const { options } = this._getScreenDetails(scene);
     const gestureDirectionInverted = options.gestureDirection === 'inverted';
+    const isVertical =
+      mode === 'modal' && options.gestureDirection !== 'rotated';
 
     const responder = PanResponder.create({
       onPanResponderTerminate: () => {


### PR DESCRIPTION
I needed a way to dismiss StackNavigator modal with a left-to-right gesture. Might not be the best way to implement it, but `gestureDirection: inverted` already creates weird bottom-to-top dismiss gesture on modals, so adding `rotated` option looks net positive.