### PR TITLE
[BREAKING] Default to bottom tabs

### DIFF
--- a/src/navigators/TabNavigator.js
+++ b/src/navigators/TabNavigator.js
@@ -45,14 +45,14 @@ const TabNavigator = (routeConfigs, config = {}) => {
 };
 
 const Presets = {
-  iOSBottomTabs: {
+  BottomTabs: {
     tabBarComponent: TabBarBottom,
     tabBarPosition: 'bottom',
     swipeEnabled: false,
     animationEnabled: false,
     initialLayout: undefined,
   },
-  AndroidTopTabs: {
+  TopTabs: {
     tabBarComponent: TabBarTop,
     tabBarPosition: 'top',
     swipeEnabled: true,
@@ -80,10 +80,9 @@ const Presets = {
  *```
  */
 TabNavigator.Presets = {
-  iOSBottomTabs: Presets.iOSBottomTabs,
-  AndroidTopTabs: Presets.AndroidTopTabs,
-  Default:
-    Platform.OS === 'ios' ? Presets.iOSBottomTabs : Presets.AndroidTopTabs,
+  BottomTabs: Presets.BottomTabs,
+  TopTabs: Presets.TopTabs,
+  Default: Presets.BottomTabs,
 };
 
 export default TabNavigator;


### PR DESCRIPTION
It's confusing to have such a significant difference between layouts on iOS and Android when using TabNavigator. Further, the top tabs pattern seems to be becoming increasingly less common (anecdotally, from my experience) and more apps are just using bottom tabs. This PR makes the default behavior the same on iOS and Android.

**Test plan (required)**

Run the playground app.

@satya164 pointed out that we should make the default bottom tab bar look more like the material design guidelines on Android, I agree with this and will add follow-up commits for it.