### PR TITLE
Fix events issue when swiping back

### DIFF
--- a/src/NavigationActions.js
+++ b/src/NavigationActions.js
@@ -17,6 +17,7 @@ const createAction = (type, fn) => {
 const back = createAction(BACK, (payload = {}) => ({
   type: BACK,
   key: payload.key,
+  immediate: payload.immediate,
 }));
 
 const init = createAction(INIT, (payload = {}) => {

--- a/src/views/CardStack/CardStack.js
+++ b/src/views/CardStack/CardStack.js
@@ -183,7 +183,10 @@ class CardStack extends React.Component {
       const backFromScene = scenes.find(s => s.index === toValue + 1);
       if (!this._isResponding && backFromScene) {
         navigation.dispatch(
-          NavigationActions.back({ key: backFromScene.route.key })
+          NavigationActions.back({
+            key: backFromScene.route.key,
+            immediate: true,
+          })
         );
       }
     });


### PR DESCRIPTION
As reported in #3345, the events do not fire properly when swiping back. This causes the completed back swipe to cause `immediate` transition, and the events are correct.