### PR TITLE
Fix Transitioner race condition

### DIFF
--- a/src/views/Transitioner.js
+++ b/src/views/Transitioner.js
@@ -120,15 +120,6 @@ class Transitioner extends React.Component {
           ]
         : [];
 
-    // When there are no animations happening, avoid calling onTransitionStart/End.
-    // This is important because the stack navigator fires the completion prop when
-    // the transition is ended.
-    if (!animations.length) {
-      this._isTransitionRunning = false;
-      this.setState(nextState);
-      return;
-    }
-
     // update scenes and play the transition
     this._isTransitionRunning = true;
     this.setState(nextState, async () => {


### PR DESCRIPTION
This fixes a CardStack gesture regression, as noted in https://github.com/react-navigation/react-navigation/issues/700#issuecomment-362943948

This breaking code was added during the events implementation, but I think we should be able to manage this circumstance from the parent context. In any case, the events bugs that *might* result from this change will be far less insidious than the cardstack transitioner issue that we experience now.