### PR TITLE
Key for completion action, to prevent eager didFocus

### DIFF
--- a/src/NavigationActions.js
+++ b/src/NavigationActions.js
@@ -92,6 +92,7 @@ const uri = createAction(URI, payload => ({
 
 const completeTransition = createAction(COMPLETE_TRANSITION, payload => ({
   type: COMPLETE_TRANSITION,
+  key: payload && payload.key,
 }));
 
 const mapDeprecatedNavigateAction = action => {

--- a/src/navigators/StackNavigator.js
+++ b/src/navigators/StackNavigator.js
@@ -44,7 +44,7 @@ export default (routeConfigMap, stackConfig = {}) => {
         onTransitionStart={onTransitionStart}
         onTransitionEnd={(lastTransition, transition) => {
           const { state, dispatch } = props.navigation;
-          dispatch(NavigationActions.completeTransition());
+          dispatch(NavigationActions.completeTransition({ key: state.key }));
           onTransitionEnd && onTransitionEnd();
         }}
       />

--- a/src/routers/StackRouter.js
+++ b/src/routers/StackRouter.js
@@ -107,13 +107,13 @@ export default (routeConfigs, stackConfig = {}) => {
           childRouters[action.routeName] !== undefined
         ) {
           return {
+            key: 'StackRouterRoot',
             isTransitioning: false,
             index: 0,
             routes: [
               {
                 routeName: action.routeName,
                 params: action.params,
-                type: undefined,
                 key: `Init-${generateKey()}`,
               },
             ],
@@ -142,6 +142,7 @@ export default (routeConfigs, stackConfig = {}) => {
         };
         // eslint-disable-next-line no-param-reassign
         state = {
+          key: 'StackRouterRoot',
           isTransitioning: false,
           index: 0,
           routes: [route],
@@ -254,6 +255,7 @@ export default (routeConfigs, stackConfig = {}) => {
 
       if (
         action.type === NavigationActions.COMPLETE_TRANSITION &&
+        (action.key == null || action.key === state.key) &&
         state.isTransitioning
       ) {
         return {


### PR DESCRIPTION
The completion action would previously change the isTransitioning of any state, but this will ensure that the completing navigator only marks its own state as isTransitioning:false. Now, even when transition completion happens immediately on the parent, the child focus event still waits for the child isTransitioning to go false.
