### PR TITLE
remove $FlowFixMe comments left over, as flow is no longer used

### DIFF
--- a/src/routers/StackRouter.js
+++ b/src/routers/StackRouter.js
@@ -81,7 +81,6 @@ export default (routeConfigs, stackConfig = {}) => {
   });
 
   paths = Object.entries(pathsByRouteNames);
-  /* $FlowFixMe */
   paths.sort((a: [string, *], b: [string, *]) => b[1].priority - a[1].priority);
 
   return {

--- a/src/routers/__tests__/StackRouter-test.js
+++ b/src/routers/__tests__/StackRouter-test.js
@@ -1161,9 +1161,7 @@ describe('StackRouter', () => {
       };
       const { path, params } = router.getPathAndParamsForState(state);
       expect(path).toEqual('baz/321');
-      /* $FlowFixMe: params.id has to exist */
       expect(params.id).toEqual('123');
-      /* $FlowFixMe: params.bazId has to exist */
       expect(params.bazId).toEqual('321');
     }
 
@@ -1323,9 +1321,7 @@ test('Handles deep navigate completion action', () => {
   );
   expect(state2 && state2.index).toEqual(0);
   expect(state2 && state2.isTransitioning).toEqual(false);
-  /* $FlowFixMe */
   expect(state2 && state2.routes[0].index).toEqual(1);
-  /* $FlowFixMe */
   expect(state2 && state2.routes[0].isTransitioning).toEqual(true);
   expect(!!key).toEqual(true);
   const state3 = router.getStateForAction(
@@ -1336,8 +1332,6 @@ test('Handles deep navigate completion action', () => {
   );
   expect(state3 && state3.index).toEqual(0);
   expect(state3 && state3.isTransitioning).toEqual(false);
-  /* $FlowFixMe */
   expect(state3 && state3.routes[0].index).toEqual(1);
-  /* $FlowFixMe */
   expect(state3 && state3.routes[0].isTransitioning).toEqual(false);
 });


### PR DESCRIPTION
#3397 removed flow usage. These $FlowFixMe comments were left over, previously used to have flow ignore those lines.
