### PR TITLE
Fix StackRouter Replace Key Behavior

### DIFF
--- a/src/NavigationActions.js
+++ b/src/NavigationActions.js
@@ -83,6 +83,7 @@ const reset = createAction(RESET, payload => ({
 const replace = createAction(REPLACE, payload => ({
   type: REPLACE,
   key: payload.key,
+  newKey: payload.newKey,
   params: payload.params,
   action: payload.action,
   routeName: payload.routeName,

--- a/src/routers/StackRouter.js
+++ b/src/routers/StackRouter.js
@@ -201,7 +201,7 @@ export default (routeConfigs, stackConfig = {}) => {
             params: action.params,
             // merge the child state in this order to allow params override
             ...childState,
-            key: action.key,
+            key: action.newKey || generateKey(),
             routeName: action.routeName,
           };
           return { ...state, routes };

--- a/src/routers/__tests__/StackRouter-test.js
+++ b/src/routers/__tests__/StackRouter-test.js
@@ -533,8 +533,21 @@ describe('StackRouter', () => {
     );
     expect(replacedState.index).toEqual(0);
     expect(replacedState.routes.length).toEqual(1);
+    expect(replacedState.routes[0].key).not.toEqual(initState.routes[0].key);
     expect(replacedState.routes[0].routeName).toEqual('bar');
     expect(replacedState.routes[0].params.meaning).toEqual(42);
+    const replacedState2 = TestRouter.getStateForAction(
+      NavigationActions.replace({
+        routeName: 'bar',
+        key: initState.routes[0].key,
+        newKey: 'wow',
+      }),
+      initState
+    );
+    expect(replacedState2.index).toEqual(0);
+    expect(replacedState2.routes.length).toEqual(1);
+    expect(replacedState2.routes[0].key).toEqual('wow');
+    expect(replacedState2.routes[0].routeName).toEqual('bar');
   });
 
   test('Handles push transition logic with completion action', () => {


### PR DESCRIPTION
Replace should actually provide new keys on the replaced route, use ‘newKey’ on the action if you want to define the new route key