### PR TITLE
Fix issue with StackRouter popToTop

### DIFF
--- a/examples/NavigationPlayground/js/SimpleStack.js
+++ b/examples/NavigationPlayground/js/SimpleStack.js
@@ -27,6 +27,7 @@ class MyNavScreen extends React.Component<MyNavScreenProps> {
           onPress={() => navigation.navigate('Profile', { name: 'Jane' })}
           title="Go to a profile screen"
         />
+        <Button onPress={() => navigation.popToTop()} title="Pop to top" />
         <Button
           onPress={() => navigation.navigate('Photos', { name: 'Jane' })}
           title="Go to a photos screen"

--- a/src/routers/StackRouter.js
+++ b/src/routers/StackRouter.js
@@ -175,6 +175,7 @@ export default (routeConfigs, stackConfig = {}) => {
       if (action.type === NavigationActions.POP_TO_TOP) {
         if (state.index !== 0) {
           return {
+            ...state,
             isTransitioning: action.immediate !== true,
             index: 0,
             routes: [state.routes[0]],


### PR DESCRIPTION
Previously the state was getting squashed, in this case it would destroy the routeName of the state, which was a route for the parent navigator, who could no longer render properly.