### PR TITLE
[BREAKING] Decode URI encoded string of deep link

### DIFF
--- a/src/routers/StackRouter.js
+++ b/src/routers/StackRouter.js
@@ -521,7 +521,15 @@ export default (routeConfigs, stackConfig = {}) => {
         }
         const nextResult = result || {};
         const paramName = key.name;
-        nextResult[paramName] = matchResult;
+
+        let decodedMatchResult;
+        try {
+          decodedMatchResult = decodeURIComponent(matchResult);
+        } catch (e) {
+          // ignore `URIError: malformed URI`
+        }
+
+        nextResult[paramName] = decodedMatchResult || matchResult;
         return nextResult;
       }, queryParams);
 

--- a/src/routers/__tests__/StackRouter-test.js
+++ b/src/routers/__tests__/StackRouter-test.js
@@ -1355,6 +1355,28 @@ describe('StackRouter', () => {
     );
   });
 
+  test('URI encoded string get passed to deep link', () => {
+    const uri = 'people/2018%2F02%2F07';
+    const action = TestStackRouter.getActionForPathAndParams(uri);
+    expect(action).toEqual({
+      routeName: 'person',
+      params: {
+        id: '2018/02/07',
+      },
+      type: NavigationActions.NAVIGATE,
+    });
+
+    const malformedUri = 'people/%E0%A4%A';
+    const action2 = TestStackRouter.getActionForPathAndParams(malformedUri);
+    expect(action2).toEqual({
+      routeName: 'person',
+      params: {
+        id: '%E0%A4%A',
+      },
+      type: NavigationActions.NAVIGATE,
+    });
+  });
+
   test('Querystring params get passed to nested deep link', () => {
     // uri with two non-empty query param values
     const uri = 'main/p/4/list/10259959195?code=test&foo=bar';


### PR DESCRIPTION
# problem
example:

```js
StackNavigator({
  search: {
    screen: SearchScreen,
    path: 'search/:keyword'
  }
})
```

When you pass encoded URI like `app://search/2018%2F02%2F07` for deep link, it passes raw value `params: { keyword: '2018%2F02%2F07' }`  to `SearchScreen`. 

It's not consistent with the behavior when calling `.navigate('search', { keyword: '2018/02/07' })` from JavaScript. 

Also, it has trouble when you use multi-byte language characters such as Japanese.
(ex:  https://ja.wikipedia.org/wiki/%E3%82%A6%E3%82%A3%E3%82%AD%E3%83%9A%E3%83%87%E3%82%A3%E3%82%A2 )

I think it would be better to pass decoded params to screen.
