### PR TITLE
Add iconStyle property to tabBarOptions for iOS

### DIFF
--- a/src/views/TabView/TabBarBottom.js
+++ b/src/views/TabView/TabBarBottom.js
@@ -93,6 +93,7 @@ class TabBarBottom extends React.PureComponent {
       renderIcon,
       showIcon,
       showLabel,
+      iconStyle,
     } = this.props;
     if (showIcon === false) {
       return null;
@@ -105,7 +106,7 @@ class TabBarBottom extends React.PureComponent {
         inactiveTintColor={inactiveTintColor}
         renderIcon={renderIcon}
         scene={scene}
-        style={showLabel && this._shouldUseHorizontalTabs() ? {} : styles.icon}
+        style={showLabel && useHorizontalTabs ? {} : [styles.icon, iconStyle]}
       />
     );
   };

--- a/src/views/TabView/TabBarBottom.js
+++ b/src/views/TabView/TabBarBottom.js
@@ -108,7 +108,7 @@ class TabBarBottom extends React.PureComponent {
         scene={scene}
         style={[
           showLabel && this._shouldUseHorizontalTabs() ? styles.icon : null,
-          iconStyle
+          iconStyle,
         ]}
       />
     );

--- a/src/views/TabView/TabBarBottom.js
+++ b/src/views/TabView/TabBarBottom.js
@@ -106,7 +106,11 @@ class TabBarBottom extends React.PureComponent {
         inactiveTintColor={inactiveTintColor}
         renderIcon={renderIcon}
         scene={scene}
-        style={showLabel && this._shouldUseHorizontalTabs() ? {} : [styles.icon, iconStyle]}
+        style={
+          showLabel && this._shouldUseHorizontalTabs()
+            ? {}
+            : [styles.icon, iconStyle]
+        }
       />
     );
   };

--- a/src/views/TabView/TabBarBottom.js
+++ b/src/views/TabView/TabBarBottom.js
@@ -106,7 +106,7 @@ class TabBarBottom extends React.PureComponent {
         inactiveTintColor={inactiveTintColor}
         renderIcon={renderIcon}
         scene={scene}
-        style={showLabel && useHorizontalTabs ? {} : [styles.icon, iconStyle]}
+        style={showLabel && this._shouldUseHorizontalTabs() ? {} : [styles.icon, iconStyle]}
       />
     );
   };

--- a/src/views/TabView/TabBarBottom.js
+++ b/src/views/TabView/TabBarBottom.js
@@ -106,11 +106,7 @@ class TabBarBottom extends React.PureComponent {
         inactiveTintColor={inactiveTintColor}
         renderIcon={renderIcon}
         scene={scene}
-        style={
-          showLabel && this._shouldUseHorizontalTabs()
-            ? {}
-            : [styles.icon, iconStyle]
-        }
+        style={[showLabel && this._shouldUseHorizontalTabs() ? styles.icon : null, iconStyle]}
       />
     );
   };

--- a/src/views/TabView/TabBarBottom.js
+++ b/src/views/TabView/TabBarBottom.js
@@ -106,7 +106,10 @@ class TabBarBottom extends React.PureComponent {
         inactiveTintColor={inactiveTintColor}
         renderIcon={renderIcon}
         scene={scene}
-        style={[showLabel && this._shouldUseHorizontalTabs() ? styles.icon : null, iconStyle]}
+        style={[
+          showLabel && this._shouldUseHorizontalTabs() ? styles.icon : null,
+          iconStyle
+        ]}
       />
     );
   };


### PR DESCRIPTION
This property is Android-only now, but is very useful for styling icons.

I need a same look of TabBar on both platforms, but without this changes I can not do it. Also this changes provide a more consistent and solid API for customising TabBar.
