### PR TITLE
Remove Linking/BackHandler from PlatformHelpers.

### DIFF
--- a/src/PlatformHelpers.native.js
+++ b/src/PlatformHelpers.native.js
@@ -1,9 +1,8 @@
 import {
   BackAndroid as DeprecatedBackAndroid,
   BackHandler as ModernBackHandler,
-  Linking,
 } from 'react-native';
 
 const BackHandler = ModernBackHandler || DeprecatedBackAndroid;
 
-export { BackHandler, Linking };
+export { BackHandler };

--- a/src/PlatformHelpers.web.js
+++ b/src/PlatformHelpers.web.js
@@ -1,9 +1,3 @@
-export const Linking = {
-  addEventListener: () => {},
-  removeEventListener: () => {},
-  getInitialURL: () => Promise.reject('Unsupported platform'),
-};
+import { BackHandler } from 'react-native';
 
-export const BackHandler = {
-  addEventListener: () => {},
-};
+export { BackHandler };

--- a/src/createNavigationContainer.js
+++ b/src/createNavigationContainer.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { BackHandler, Linking } from './PlatformHelpers';
+import { Linking } from 'react-native';
+import { BackHandler } from './PlatformHelpers';
 import NavigationActions from './NavigationActions';
 import addNavigationHelpers from './addNavigationHelpers';
 import invariant from './utils/invariant';


### PR DESCRIPTION
The Linking component is now supported by react-native-web. It also provider BackHandler as a dummy components, so there's no need to supply dummy replacements ourselves.

So this fixes the warning, and React Navigation on react-native-web should now be able to pick up the initialUrl too.

