### PR TITLE
Run Prettier on Flow libdef on precommit

### DIFF
--- a/flow/react-navigation.js
+++ b/flow/react-navigation.js
@@ -332,12 +332,12 @@ declare module 'react-navigation' {
     navigationOptions?: ?NavigationScreenConfig<Options>,
   };
 
-  declare export type NavigationRouteConfig = 
-  | NavigationComponent
-  | {
-    navigationOptions?: NavigationScreenConfig<*>,
-    path?: string,
-  } & NavigationScreenRouteConfig;
+  declare export type NavigationRouteConfig =
+    | NavigationComponent
+    | ({
+        navigationOptions?: NavigationScreenConfig<*>,
+        path?: string,
+      } & NavigationScreenRouteConfig);
 
   declare export type NavigationScreenRouteConfig =
     | NavigationComponent

--- a/package.json
+++ b/package.json
@@ -72,6 +72,10 @@
     "modulePathIgnorePatterns": ["examples"]
   },
   "lint-staged": {
-    "*.js": ["eslint --fix", "git add"]
+    "*.js": [
+      "eslint --fix",
+      "prettier --write flow/react-navigation.js",
+      "git add"
+    ]
   }
 }


### PR DESCRIPTION
My first thought was to do it through `eslint`, which already runs on `precommit`. However, `eslint` has a custom parser, and the only way to get it to process flow-typed files is with `babel-eslint`, but `babel-plugin-transform-flow-strip-types` can't handle the libdef-specific syntax `declare export type`.

Since we can't get `eslint` to run Prettier for us, I just set up `lint-staged` to call it on the libdef file separately. I'm don't feel too strongly about running Prettier on the libdef, so if this approach is too messy/brittle let me know and we can scuttle it.