### PR TITLE
Add getParam navigation helper

### DIFF
--- a/src/__tests__/addNavigationHelpers-test.js
+++ b/src/__tests__/addNavigationHelpers-test.js
@@ -102,4 +102,17 @@ describe('addNavigationHelpers', () => {
       }).getParam('name', 'Brent')
     ).toEqual('Brent');
   });
+
+  it('handles GetParams action with param value as null', () => {
+    const mockedDispatch = jest
+      .fn(() => false)
+      .mockImplementationOnce(() => true);
+    expect(
+      addNavigationHelpers({
+        state: { key: 'B', routeName: 'Settings', params: { name: null } },
+        dispatch: mockedDispatch,
+        addListener: dummyEventSubscriber,
+      }).getParam('name')
+    ).toEqual(null);
+  });
 });

--- a/src/__tests__/addNavigationHelpers-test.js
+++ b/src/__tests__/addNavigationHelpers-test.js
@@ -76,4 +76,30 @@ describe('addNavigationHelpers', () => {
     });
     expect(mockedDispatch.mock.calls.length).toBe(1);
   });
+
+  it('handles GetParams action', () => {
+    const mockedDispatch = jest
+      .fn(() => false)
+      .mockImplementationOnce(() => true);
+    expect(
+      addNavigationHelpers({
+        state: { key: 'B', routeName: 'Settings', params: { name: 'Peter' } },
+        dispatch: mockedDispatch,
+        addListener: dummyEventSubscriber,
+      }).getParam('name', 'Brent')
+    ).toEqual('Peter');
+  });
+
+  it('handles GetParams action with default param', () => {
+    const mockedDispatch = jest
+      .fn(() => false)
+      .mockImplementationOnce(() => true);
+    expect(
+      addNavigationHelpers({
+        state: { key: 'B', routeName: 'Settings' },
+        dispatch: mockedDispatch,
+        addListener: dummyEventSubscriber,
+      }).getParam('name', 'Brent')
+    ).toEqual('Brent');
+  });
 });

--- a/src/addNavigationHelpers.js
+++ b/src/addNavigationHelpers.js
@@ -62,11 +62,10 @@ export default function(navigation) {
     },
 
     getParam: (paramName, defaultValue) => {
-      const param =
-        navigation.state.params && navigation.state.params[paramName];
+      const params = navigation.state.params;
 
-      if (param != null) {
-        return param;
+      if (params && paramName in params) {
+        return params[paramName];
       }
 
       return defaultValue;

--- a/src/addNavigationHelpers.js
+++ b/src/addNavigationHelpers.js
@@ -61,6 +61,12 @@ export default function(navigation) {
       return navigation.dispatch(NavigationActions.setParams({ params, key }));
     },
 
+    getParam: (paramName, defaultValue) => {
+      const param =
+        navigation.state.params && navigation.state.params[paramName];
+      return param || defaultValue;
+    },
+
     push: (routeName, params, action) =>
       navigation.dispatch(
         NavigationActions.push({ routeName, params, action })

--- a/src/addNavigationHelpers.js
+++ b/src/addNavigationHelpers.js
@@ -64,11 +64,11 @@ export default function(navigation) {
     getParam: (paramName, defaultValue) => {
       const param =
         navigation.state.params && navigation.state.params[paramName];
-      
+
       if (param != null) {
         return param;
       }
-      
+
       return defaultValue;
     },
 

--- a/src/addNavigationHelpers.js
+++ b/src/addNavigationHelpers.js
@@ -64,7 +64,12 @@ export default function(navigation) {
     getParam: (paramName, defaultValue) => {
       const param =
         navigation.state.params && navigation.state.params[paramName];
-      return param || defaultValue;
+      
+      if (param != null) {
+        return param;
+      }
+      
+      return defaultValue;
     },
 
     push: (routeName, params, action) =>

--- a/src/navigators/__tests__/__snapshots__/StackNavigator-test.js.snap
+++ b/src/navigators/__tests__/__snapshots__/StackNavigator-test.js.snap
@@ -95,6 +95,7 @@ exports[`StackNavigator applies correct values when headerRight is present 1`] =
         Object {
           "addListener": [Function],
           "dispatch": [Function],
+          "getParam": [Function],
           "goBack": [Function],
           "navigate": [Function],
           "pop": [Function],
@@ -334,6 +335,7 @@ exports[`StackNavigator renders successfully 1`] = `
         Object {
           "addListener": [Function],
           "dispatch": [Function],
+          "getParam": [Function],
           "goBack": [Function],
           "navigate": [Function],
           "pop": [Function],

--- a/src/views/__tests__/__snapshots__/TabView-test.js.snap
+++ b/src/views/__tests__/__snapshots__/TabView-test.js.snap
@@ -237,6 +237,7 @@ exports[`TabBarBottom renders successfully 1`] = `
               Object {
                 "addListener": [Function],
                 "dispatch": undefined,
+                "getParam": [Function],
                 "goBack": [Function],
                 "navigate": [Function],
                 "pop": [Function],


### PR DESCRIPTION
Handling `navigation.state.params.name` when `params` doesn't exist results in an error. 

Initially, I was going to create an empty object.
After reading #2046, I went with the suggestion of creating a `getParam` helper instead.

**Test plan (required)**
- Set a parameter
- Get the parameter

- Get an undefined parameter