### PR TITLE
add withNavigationFocus HOC

### DIFF
--- a/examples/NavigationPlayground/js/App.js
+++ b/examples/NavigationPlayground/js/App.js
@@ -30,6 +30,7 @@ import StacksWithKeys from './StacksWithKeys';
 import SimpleStack from './SimpleStack';
 import SimpleTabs from './SimpleTabs';
 import TabAnimations from './TabAnimations';
+import TabsWithNavigationFocus from './TabsWithNavigationFocus';
 
 const ExampleInfo = {
   SimpleStack: {
@@ -94,7 +95,12 @@ const ExampleInfo = {
     name: 'Animated Tabs Example',
     description: 'Tab transitions have custom animations',
   },
+  TabsWithNavigationFocus: {
+    name: 'Tabs using withNavigationFocus HOC',
+    description: 'Tab views will receive isFocused prop from HOC',
+  },
 };
+
 const ExampleRoutes = {
   SimpleStack: SimpleStack,
   SimpleTabs: SimpleTabs,
@@ -118,6 +124,7 @@ const ExampleRoutes = {
     path: 'settings',
   },
   TabAnimations: TabAnimations,
+  TabsWithNavigationFocus: TabsWithNavigationFocus,
 };
 
 type State = {

--- a/examples/NavigationPlayground/js/TabsWithNavigationFocus.js
+++ b/examples/NavigationPlayground/js/TabsWithNavigationFocus.js
@@ -1,0 +1,48 @@
+/**
+ * @flow
+ */
+
+import React from 'react';
+import { SafeAreaView } from 'react-native';
+import { TabNavigator, withNavigationFocus } from 'react-navigation';
+
+import SampleText from './SampleText';
+
+const createTabScreen = name => {
+  const TabScreen = ({ isFocused }) => (
+    <SafeAreaView
+      forceInset={{ horizontal: 'always', top: 'always' }}
+      style={{
+        flex: 1,
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <SampleText>Tab {name}</SampleText>
+      <SampleText>IsFocused={isFocused ? 'true' : 'false'}</SampleText>
+    </SafeAreaView>
+  );
+
+  return withNavigationFocus(TabScreen);
+};
+
+const TabsWithNavigationFocus = TabNavigator(
+  {
+    One: {
+      screen: createTabScreen('One'),
+    },
+    Two: {
+      screen: createTabScreen('Two'),
+    },
+    Three: {
+      screen: createTabScreen('Three'),
+    },
+  },
+  {
+    tabBarPosition: 'bottom',
+    animationEnabled: true,
+    swipeEnabled: true,
+  }
+);
+
+export default TabsWithNavigationFocus;

--- a/examples/NavigationPlayground/js/TabsWithNavigationFocus.js
+++ b/examples/NavigationPlayground/js/TabsWithNavigationFocus.js
@@ -18,8 +18,8 @@ const createTabScreen = name => {
         justifyContent: 'center',
       }}
     >
-      <SampleText>Tab {name}</SampleText>
-      <SampleText>IsFocused={isFocused ? 'true' : 'false'}</SampleText>
+      <SampleText>{'Tab=' + name}</SampleText>
+      <SampleText>{'IsFocused=' + isFocused ? 'true' : 'false'}</SampleText>
     </SafeAreaView>
   );
 

--- a/flow/react-navigation.js
+++ b/flow/react-navigation.js
@@ -1102,4 +1102,7 @@ declare module 'react-navigation' {
   declare export function withNavigation<T: {}>(
     Component: React$ComponentType<T & _NavigationInjectedProps>
   ): React$ComponentType<T>;
+  declare export function withNavigationFocus<T: {}>(
+    Component: React$ComponentType<T & _NavigationInjectedProps>
+  ): React$ComponentType<T>;
 }

--- a/src/react-navigation.js
+++ b/src/react-navigation.js
@@ -88,4 +88,7 @@ module.exports = {
   get withNavigation() {
     return require('./views/withNavigation').default;
   },
+  get withNavigationFocus() {
+    return require('./views/withNavigationFocus').default;
+  },
 };

--- a/src/react-navigation.web.js
+++ b/src/react-navigation.web.js
@@ -32,4 +32,7 @@ module.exports = {
   get withNavigation() {
     return require('./views/withNavigation').default;
   },
+  get withNavigationFocus() {
+    return require('./views/withNavigationFocus').default;
+  },
 };

--- a/src/views/withIsFocused.js
+++ b/src/views/withIsFocused.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import propTypes from 'prop-types';
+import hoistStatics from 'hoist-non-react-statics';
+
+export default function withNavigationFocus(Component) {
+  class ComponentWithNavigationFocus extends React.Component {
+    static displayName = `withNavigationFocus(${Component.displayName ||
+      Component.name})`;
+
+    state = {
+      isFocused: false,
+    };
+
+    componentDidMount() {
+      if (this.props.navigation) {
+        this.subs = [
+          this.props.navigation.addListener('didFocus', () =>
+            this.setState({ isFocused: true })
+          ),
+          this.props.navigation.addListener('willBlur', () =>
+            this.setState({ isFocused: false })
+          ),
+        ];
+      } else {
+        console.warn(
+          'withIsFocused wrapped component did not receive navigation from props, so isFocused prop swill remain false'
+        );
+      }
+    }
+
+    componentWillUnmount() {
+      this.subs && this.subs.forEach(sub => sub.remove());
+    }
+
+    render() {
+      return (
+        <Component
+          {...this.props}
+          isFocused={this.state.isFocused}
+          ref={this.props.onRef}
+        />
+      );
+    }
+  }
+
+  return hoistStatics(ComponentWithNavigationFocus, Component);
+}

--- a/src/views/withNavigationFocus.js
+++ b/src/views/withNavigationFocus.js
@@ -23,7 +23,7 @@ export default function withNavigationFocus(Component) {
         ];
       } else {
         console.warn(
-          'withIsFocused wrapped component did not receive navigation from props, so isFocused prop swill remain false'
+          'withNavigationFocus wrapped component did not receive navigation from props, so isFocused prop will remain false'
         );
       }
     }

--- a/src/views/withNavigationFocus.js
+++ b/src/views/withNavigationFocus.js
@@ -1,35 +1,45 @@
 import React from 'react';
+import propTypes from 'prop-types';
 import hoistStatics from 'hoist-non-react-statics';
+import invariant from '../utils/invariant';
 
 export default function withNavigationFocus(Component) {
   class ComponentWithNavigationFocus extends React.Component {
     static displayName = `withNavigationFocus(${Component.displayName ||
       Component.name})`;
 
+    static contextTypes = {
+      navigation: propTypes.object.isRequired,
+    };
+
     state = {
       isFocused: false,
     };
 
     componentDidMount() {
-      if (this.props.navigation) {
-        this.subs = [
-          this.props.navigation.addListener('didFocus', () =>
-            this.setState({ isFocused: true })
-          ),
-          this.props.navigation.addListener('willBlur', () =>
-            this.setState({ isFocused: false })
-          ),
-        ];
-      } else {
-        console.warn(
-          'withNavigationFocus wrapped component did not receive navigation from props, so isFocused prop will remain false'
-        );
-      }
+      const navigation = this.getNavigation();
+      this.subs = [
+        navigation.addListener('didFocus', () =>
+          this.setState({ isFocused: true })
+        ),
+        navigation.addListener('willBlur', () =>
+          this.setState({ isFocused: false })
+        ),
+      ];
     }
 
     componentWillUnmount() {
-      this.subs && this.subs.forEach(sub => sub.remove());
+      this.subs.forEach(sub => sub.remove());
     }
+
+    getNavigation = () => {
+      const navigation = this.props.navigation || this.context.navigation;
+      invariant(
+        !!navigation,
+        'withNavigationFocus can only be used on a view hierarchy of a navigator. The wrapped component is unable to get access to navigation from props or context.'
+      );
+      return navigation;
+    };
 
     render() {
       return (

--- a/src/views/withNavigationFocus.js
+++ b/src/views/withNavigationFocus.js
@@ -18,7 +18,7 @@ export default function withNavigationFocus(Component) {
 
     componentDidMount() {
       const navigation = this.getNavigation();
-      this.subs = [
+      this.subscriptions = [
         navigation.addListener('didFocus', () =>
           this.setState({ isFocused: true })
         ),
@@ -29,7 +29,7 @@ export default function withNavigationFocus(Component) {
     }
 
     componentWillUnmount() {
-      this.subs.forEach(sub => sub.remove());
+      this.subscriptions.forEach(sub => sub.remove());
     }
 
     getNavigation = () => {

--- a/src/views/withNavigationFocus.js
+++ b/src/views/withNavigationFocus.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import propTypes from 'prop-types';
 import hoistStatics from 'hoist-non-react-statics';
 
 export default function withNavigationFocus(Component) {


### PR DESCRIPTION
As discussed in other issues, we should be able to know easily which screen has the focus.

This HOC idea has been mentioned here by @satya164 and @ericvicenti 
- https://github.com/react-navigation/react-navigation/issues/51#issuecomment-276003658
- https://github.com/react-navigation/react-navigation/issues/51#issuecomment-278761705
- https://github.com/react-navigation/react-navigation/pull/3345#issuecomment-360260067


Here is a basic implementation using the new lifecycle hooks to provide this feature
