### PR TITLE
Also accept numbers as navigate action key

### DIFF
--- a/src/addNavigationHelpers.js
+++ b/src/addNavigationHelpers.js
@@ -54,7 +54,9 @@ export default function(navigation) {
      */
     setParams: params => {
       invariant(
-        navigation.state.key && typeof navigation.state.key === 'string',
+        navigation.state.key &&
+          (typeof navigation.state.key === 'string' ||
+            typeof navigation.state.key === 'number'),
         'setParams cannot be called by root navigator'
       );
       const key = navigation.state.key;


### PR DESCRIPTION
This is convenient when using numerical id's as keys. For now I'm using `key: item.id.toString()`.