### PR TITLE
use initialRouteName as key when initializing StackRouter

### DIFF
--- a/src/routers/StackRouter.js
+++ b/src/routers/StackRouter.js
@@ -146,7 +146,7 @@ export default (routeConfigs, stackConfig = {}) => {
           ...route,
           ...(params ? { params } : {}),
           routeName: initialRouteName,
-          key: action.key || generateKey(),
+          key: action.key || initialRouteName,
         };
         state = {
           key: 'StackRouterRoot',


### PR DESCRIPTION
When initializing the state for a StackRouter the keys for the inital routes are generated instead of using the routeName like it is done in the TabRouter https://github.com/react-navigation/react-navigation/blob/9beb32ecaca56f7a8df3443002b5b73ee6a415a2/src/routers/TabRouter.js#L61-L65. This makes it impossible to navigate to an exisiting (the initial one) screen with the newly added [key](https://github.com/react-navigation/react-navigation/pull/3393) property without pushing a new screen. 