### PR TITLE
add possibility to specify navigation key also for navigationHelpers …

### DIFF
--- a/flow/react-navigation.js
+++ b/flow/react-navigation.js
@@ -517,7 +517,8 @@ declare module 'react-navigation' {
     navigate: (
       routeName: string,
       params?: NavigationParams,
-      action?: NavigationNavigateAction
+      action?: NavigationNavigateAction,
+      key?: string
     ) => boolean,
     setParams: (newParams: NavigationParams) => boolean,
     addListener: (

--- a/src/addNavigationHelpers.js
+++ b/src/addNavigationHelpers.js
@@ -19,10 +19,10 @@ export default function(navigation) {
         NavigationActions.back({ key: actualizedKey })
       );
     },
-    navigate: (navigateTo, params, action) => {
+    navigate: (navigateTo, params, action, key) => {
       if (typeof navigateTo === 'string') {
         return navigation.dispatch(
-          NavigationActions.navigate({ routeName: navigateTo, params, action })
+          NavigationActions.navigate({ routeName: navigateTo, params, action, key })
         );
       }
       invariant(


### PR DESCRIPTION
Since https://github.com/react-navigation/react-navigation/pull/3393 was merged a Navigate action allows to pass a key. This PR just updates the navigate helper function to allow this too.