### PR TITLE
Move the back button handler subscription to the NavigationContainer constructor

### DIFF
--- a/src/createNavigationContainer.js
+++ b/src/createNavigationContainer.js
@@ -26,6 +26,17 @@ export default function createNavigationContainer(Component) {
       this._validateProps(props);
 
       this._initialAction = NavigationActions.init();
+
+      if (this._isStateful()) {
+        this.subs = BackHandler.addEventListener('hardwareBackPress', () => {
+          if (!this._isMounted) {
+            this.subs && this.subs.remove();
+          } else {
+            this.dispatch(NavigationActions.back());
+          }
+        });
+      }
+
       this.state = {
         nav: this._isStateful()
           ? Component.router.getStateForAction(this._initialAction)
@@ -125,13 +136,10 @@ export default function createNavigationContainer(Component) {
     }
 
     componentDidMount() {
+      this._isMounted = true;
       if (!this._isStateful()) {
         return;
       }
-
-      this.subs = BackHandler.addEventListener('hardwareBackPress', () =>
-        this.dispatch(NavigationActions.back())
-      );
 
       Linking.addEventListener('url', this._handleOpenURL);
 
@@ -148,6 +156,7 @@ export default function createNavigationContainer(Component) {
     }
 
     componentWillUnmount() {
+      this._isMounted = false;
       Linking.removeEventListener('url', this._handleOpenURL);
       this.subs && this.subs.remove();
     }

--- a/src/createNavigationContainer.js
+++ b/src/createNavigationContainer.js
@@ -32,7 +32,10 @@ export default function createNavigationContainer(Component) {
           if (!this._isMounted) {
             this.subs && this.subs.remove();
           } else {
-            this.dispatch(NavigationActions.back());
+            // dispatch returns true if the action results in a state change,
+            // and false otherwise. This maps well to what BackHandler expects
+            // from a callback -- true if handled, false if not handled
+            return this.dispatch(NavigationActions.back());
           }
         });
       }


### PR DESCRIPTION
# Motivation

Back button handlers added in children of the NavigationContainer would register before the NavigationContainer's global handler. This resulted in the need for an awkward workaround to get a handler to fire before the global handler from a navigation view: https://github.com/nodevember/nodevember-2017-mobile/blob/07d92947a1295bf1ea3365d9e09690c923c5f4dd/src/Navigation.js#L190-L193

# Test plan

I tested it in the Nodevember app linked to above.