### PR TITLE
Fix react-native-web support for #3526

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-navigation",
-  "version": "1.1.0-rc.3",
+  "version": "1.1.0-rc.4",
   "description": "Routing and navigation for your React Native apps",
   "main": "src/react-navigation.js",
   "repository": {

--- a/src/PlatformHelpers.native.js
+++ b/src/PlatformHelpers.native.js
@@ -1,8 +1,9 @@
 import {
   BackAndroid as DeprecatedBackAndroid,
   BackHandler as ModernBackHandler,
+  MaskedViewIOS,
 } from 'react-native';
 
 const BackHandler = ModernBackHandler || DeprecatedBackAndroid;
 
-export { BackHandler };
+export { BackHandler, MaskedViewIOS };

--- a/src/PlatformHelpers.web.js
+++ b/src/PlatformHelpers.web.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import { BackHandler, Text } from 'react-native';
+import { BackHandler, View } from 'react-native';
 
 const MaskedViewIOS = () => {
-  <Text>MaskedViewIOS not available on Reacht Native Web</Text>;
+  <View>{this.props.children}</View>;
 };
 
 export { BackHandler, MaskedViewIOS };

--- a/src/PlatformHelpers.web.js
+++ b/src/PlatformHelpers.web.js
@@ -1,3 +1,8 @@
-import { BackHandler } from 'react-native';
+import React from 'react';
+import { BackHandler, Text } from 'react-native';
 
-export { BackHandler };
+const MaskedViewIOS = () => {
+  <Text>MaskedViewIOS not available on Reacht Native Web</Text>;
+};
+
+export { BackHandler, MaskedViewIOS };

--- a/src/PlatformHelpers.web.js
+++ b/src/PlatformHelpers.web.js
@@ -1,8 +1,6 @@
 import React from 'react';
 import { BackHandler, View } from 'react-native';
 
-const MaskedViewIOS = () => {
-  <View>{this.props.children}</View>;
-};
+const MaskedViewIOS = () => <View>{this.props.children}</View>;
 
 export { BackHandler, MaskedViewIOS };

--- a/src/views/Header/Header.js
+++ b/src/views/Header/Header.js
@@ -6,10 +6,10 @@ import {
   Image,
   Platform,
   StyleSheet,
-  MaskedViewIOS,
   View,
   ViewPropTypes,
 } from 'react-native';
+import { MaskedViewIOS } from '../../PlatformHelpers';
 import SafeAreaView from 'react-native-safe-area-view';
 
 import HeaderTitle from './HeaderTitle';
@@ -379,7 +379,7 @@ class Header extends React.PureComponent {
     if (
       options.headerLeft ||
       options.headerBackImage ||
-      Platform.OS === 'android' ||
+      Platform.OS !== 'ios' ||
       transitionPreset !== 'uikit'
     ) {
       return (


### PR DESCRIPTION
https://github.com/react-navigation/react-navigation/pull/3526 introduced use of MaskedViewIOS component. I created a stub in PlatformHelpers.web.js for it, and inverted a Platform test in the code.

**Test plan (required)**

No UI changes, code passes tests.
