### PR TITLE
fix typespec of `init` action creator

### DIFF
--- a/flow/react-navigation.js
+++ b/flow/react-navigation.js
@@ -759,7 +759,7 @@ declare module 'react-navigation' {
       toString: () => string,
     },
     init: {
-      (payload: { params?: NavigationParams }): NavigationInitAction,
+      (payload?: { params?: NavigationParams }): NavigationInitAction,
       toString: () => string,
     },
     navigate: {


### PR DESCRIPTION
The `init` action creator doesn't not required `payload` parameter.

https://github.com/react-navigation/react-navigation/blob/2bb91a6740e2f1ade012906dc03c972ba6375cc3/src/NavigationActions.js#L24

Notice the `default` value