### PR TITLE
Pop to top on TabNavigator when tapping already focused tab icon

### DIFF
--- a/src/NavigationActions.js
+++ b/src/NavigationActions.js
@@ -57,6 +57,7 @@ const pop = createAction(POP, payload => ({
 const popToTop = createAction(POP_TO_TOP, payload => ({
   type: POP_TO_TOP,
   immediate: payload && payload.immediate,
+  key: payload && payload.key,
 }));
 
 const push = createAction(PUSH, payload => {

--- a/src/routers/StackRouter.js
+++ b/src/routers/StackRouter.js
@@ -305,6 +305,12 @@ export default (routeConfigs, stackConfig = {}) => {
 
       // Handle pop-to-top behavior. Make sure this happens after children have had a chance to handle the action, so that the inner stack pops to top first.
       if (action.type === NavigationActions.POP_TO_TOP) {
+        // Refuse to handle pop to top if a key is given that doesn't correspond
+        // to this router
+        if (action.key && state.key !== action.key) {
+          return state;
+        }
+
         // If we're already at the top, then we return the state with a new
         // identity so that the action is handled by this router.
         if (state.index === 0) {

--- a/src/routers/__tests__/StackRouter-test.js
+++ b/src/routers/__tests__/StackRouter-test.js
@@ -457,6 +457,35 @@ describe('StackRouter', () => {
     expect(state3 && state3.routes[1].index).toEqual(0);
   });
 
+  test('popToTop targets StackRouter by key if specified', () => {
+    const ChildNavigator = () => <div />;
+    ChildNavigator.router = StackRouter({
+      Baz: { screen: () => <div /> },
+      Qux: { screen: () => <div /> },
+    });
+    const router = StackRouter({
+      Foo: { screen: () => <div /> },
+      Bar: { screen: ChildNavigator },
+    });
+    const state = router.getStateForAction({ type: NavigationActions.INIT });
+    const state2 = router.getStateForAction(
+      {
+        type: NavigationActions.NAVIGATE,
+        routeName: 'Bar',
+      },
+      state
+    );
+    const barKey = state2.routes[1].routes[0].key;
+    const state3 = router.getStateForAction(
+      {
+        type: NavigationActions.POP_TO_TOP,
+        key: state2.key,
+      },
+      state2
+    );
+    expect(state3 && state3.index).toEqual(0);
+  });
+
   test('popToTop works as expected', () => {
     const TestRouter = StackRouter({
       foo: { screen: () => <div /> },

--- a/src/views/TabView/TabBarBottom.js
+++ b/src/views/TabView/TabBarBottom.js
@@ -10,6 +10,7 @@ import {
 import SafeAreaView from 'react-native-safe-area-view';
 
 import TabBarIcon from './TabBarIcon';
+import NavigationActions from '../../NavigationActions';
 import withOrientation from '../withOrientation';
 
 const majorVersion = parseInt(Platform.Version, 10);
@@ -176,6 +177,19 @@ class TabBarBottom extends React.PureComponent {
     }
   }
 
+  _handleTabPress = index => {
+    const { jumpToIndex, navigation } = this.props;
+    const currentIndex = navigation.state.index;
+
+    if (currentIndex === index) {
+      // TODO: determine if we already dispatched popToTop, and if so then emit
+      // some event for route so it can scroll to top if there is a ScrollView
+      navigation.dispatch(NavigationActions.popToTop());
+    } else {
+      jumpToIndex(index);
+    }
+  };
+
   render() {
     const {
       position,
@@ -235,8 +249,13 @@ class TabBarBottom extends React.PureComponent {
                 accessibilityLabel={accessibilityLabel}
                 onPress={() =>
                   onPress
-                    ? onPress({ previousScene, scene, jumpToIndex })
-                    : jumpToIndex(index)
+                    ? onPress({
+                        previousScene,
+                        scene,
+                        jumpToIndex,
+                        defaultHandler: this._handleTabPress,
+                      })
+                    : this._handleTabPress(index)
                 }
               >
                 <Animated.View style={[styles.tab, { backgroundColor }]}>

--- a/src/views/TabView/TabBarBottom.js
+++ b/src/views/TabView/TabBarBottom.js
@@ -182,9 +182,14 @@ class TabBarBottom extends React.PureComponent {
     const currentIndex = navigation.state.index;
 
     if (currentIndex === index) {
-      // TODO: determine if we already dispatched popToTop, and if so then emit
-      // some event for route so it can scroll to top if there is a ScrollView
-      navigation.dispatch(NavigationActions.popToTop());
+      let childRoute = navigation.state.routes[index];
+      if (childRoute.hasOwnProperty('index') && childRoute.index > 0) {
+        navigation.dispatch(
+          NavigationActions.popToTop({ key: childRoute.key })
+        );
+      } else {
+        // TODO: do something to scroll to top
+      }
     } else {
       jumpToIndex(index);
     }

--- a/src/views/TabView/TabBarTop.js
+++ b/src/views/TabView/TabBarTop.js
@@ -91,7 +91,15 @@ export default class TabBarTop extends React.PureComponent {
     const onPress = getOnPress(previousScene, scene);
 
     if (onPress) {
-      onPress({ previousScene, scene, jumpToIndex });
+      // To maintain the same API as `TabbarBottom`, we pass in a `defaultHandler`
+      // even though I don't believe in this case it should be any different
+      // than `jumpToIndex`.
+      onPress({
+        previousScene,
+        scene,
+        jumpToIndex,
+        defaultHandler: jumpToIndex,
+      });
     } else {
       jumpToIndex(scene.index);
     }


### PR DESCRIPTION
# Motivation

The expected behavior for tab bars is that when you have a stack within them and tab the icon for the active tab, then it should pop that stack to the top. This adds that behavior, partially solving https://github.com/react-navigation/react-navigation/issues/3588. The next step is to scroll a scrollview to top if the user taps again after popping to top.

# Test plan

Try out navigation playground Stacks in Tabs.

# Concerns

- ~I don't think this is actually a shippable solution in its current form due to the following edge case: if there are no stacks within the TabNavigator, but the TabNavigator is nested within another StackNavigator, then the pop to top action would be handled by the parent. I think we need to change `popToTop` to optionally accept a key.~ &mdash; I updated popToTop to accept a key and StackRouter to respect it.
- Maybe there's too much router logic in the view?
- Should there be an option to disable this? Or should people just override the onTabPress (or whatever) option and make it call jumpToIndex directly?