### PR TITLE
Fix bug #3279 “Action within RESET doesn't trigger”

### DIFF
--- a/src/routers/StackRouter.js
+++ b/src/routers/StackRouter.js
@@ -386,21 +386,28 @@ export default (routeConfigs, stackConfig = {}) => {
           // undefined on either the state or the action
           return state;
         }
-        const resetAction = action;
+        const newStackActions = action.actions;
 
         return {
           ...state,
-          routes: resetAction.actions.map(childAction => {
-            const router = childRouters[childAction.routeName];
+          routes: newStackActions.map(newStackAction => {
+            const router = childRouters[newStackAction.routeName];
+
             let childState = {};
+
             if (router) {
+              const childAction =
+                newStackAction.action ||
+                NavigationActions.init({ params: newStackAction.params });
+
               childState = router.getStateForAction(childAction);
             }
+
             return {
-              params: childAction.params,
+              params: newStackAction.params,
               ...childState,
-              routeName: childAction.routeName,
-              key: childAction.key || generateKey(),
+              routeName: newStackAction.routeName,
+              key: newStackAction.key || generateKey(),
             };
           }),
           index: action.index,


### PR DESCRIPTION
https://github.com/react-navigation/react-navigation/issues/3279

If you pass nested action within reset actions it has no effect.

| software         | version
| ---------------- | -------
| react-navigation | 1.1.2
| react-native     | 0.52

<img width="677" alt="screen shot 2018-02-24 at 12 20 38 pm" src="https://user-images.githubusercontent.com/14208343/36629352-7bee4f7c-195d-11e8-894b-ba1979edc547.png">

Bug examples:
snack: https://snack.expo.io/H11t9nRvz
repo: https://github.com/serhiipalash/react-navigation-bug-3279-example

Bug screenshots:
when you press "Reset with nested action"

<img width="350" alt="screen shot 2018-02-24 at 12 26 01 pm" src="https://user-images.githubusercontent.com/14208343/36629404-10146326-195e-11e8-85e4-38f8124cc463.png">

you see new stack like there was no nested action

<img width="351" alt="screen shot 2018-02-24 at 12 23 44 pm" src="https://user-images.githubusercontent.com/14208343/36629422-411e3bae-195e-11e8-8d6d-6e461063ea1d.png">

Expected behaviour:
If I pass nested action within reset actions it should trigger changes in child router.

<img width="353" alt="screen shot 2018-02-24 at 12 34 56 pm" src="https://user-images.githubusercontent.com/14208343/36629524-756b3334-195f-11e8-91af-424ae8ebf9b8.png">

Fix:

<img width="1012" alt="screen shot 2018-02-24 at 12 31 22 pm" src="https://user-images.githubusercontent.com/14208343/36629460-a8c42034-195e-11e8-9fef-5d6f3786808c.png">

Go to `fix-3279` branch in bug example repo to test this fix
https://github.com/serhiipalash/react-navigation-bug-3279-example/tree/fix-3279