### PR TITLE
remove support for deprecated navigation actions

### DIFF
--- a/flow/react-navigation.js
+++ b/flow/react-navigation.js
@@ -71,22 +71,8 @@ declare module 'react-navigation' {
     key?: string,
   |};
 
-  declare type DeprecatedNavigationNavigateAction = {|
-    type: 'Navigate',
-    routeName: string,
-    params?: NavigationParams,
-
-    // The action to run inside the sub-router
-    action?: NavigationNavigateAction | DeprecatedNavigationNavigateAction,
-  |};
-
   declare export type NavigationBackAction = {|
     type: 'Navigation/BACK',
-    key?: ?string,
-  |};
-
-  declare type DeprecatedNavigationBackAction = {|
-    type: 'Back',
     key?: ?string,
   |};
 
@@ -100,23 +86,8 @@ declare module 'react-navigation' {
     params: NavigationParams,
   |};
 
-  declare type DeprecatedNavigationSetParamsAction = {|
-    type: 'SetParams',
-
-    // The key of the route where the params should be set
-    key: string,
-
-    // The new params to merge into the existing route params
-    params: NavigationParams,
-  |};
-
   declare export type NavigationInitAction = {|
     type: 'Navigation/INIT',
-    params?: NavigationParams,
-  |};
-
-  declare type DeprecatedNavigationInitAction = {|
-    type: 'Init',
     params?: NavigationParams,
   |};
 
@@ -127,22 +98,8 @@ declare module 'react-navigation' {
     actions: Array<NavigationNavigateAction>,
   |};
 
-  declare type DeprecatedNavigationResetAction = {|
-    type: 'Reset',
-    index: number,
-    key?: ?string,
-    actions: Array<
-      NavigationNavigateAction | DeprecatedNavigationNavigateAction
-    >,
-  |};
-
   declare export type NavigationUriAction = {|
     type: 'Navigation/URI',
-    uri: string,
-  |};
-
-  declare type DeprecatedNavigationUriAction = {|
-    type: 'Uri',
     uri: string,
   |};
 
@@ -180,17 +137,6 @@ declare module 'react-navigation' {
     | NavigationBackAction
     | NavigationSetParamsAction
     | NavigationResetAction;
-
-  declare type DeprecatedNavigationAction =
-    | DeprecatedNavigationInitAction
-    | DeprecatedNavigationNavigateAction
-    | DeprecatedNavigationBackAction
-    | DeprecatedNavigationSetParamsAction
-    | DeprecatedNavigationResetAction;
-
-  declare export type PossiblyDeprecatedNavigationAction =
-    | NavigationAction
-    | DeprecatedNavigationAction;
 
   /**
    * NavigationState is a tree of routes for a single navigator, where each
@@ -482,7 +428,7 @@ declare module 'react-navigation' {
    */
 
   declare export type NavigationDispatch = (
-    action: PossiblyDeprecatedNavigationAction
+    action: NavigationAction
   ) => boolean;
 
   declare export type NavigationProp<S> = {
@@ -789,9 +735,6 @@ declare module 'react-navigation' {
       (payload: { uri: string }): NavigationUriAction,
       toString: () => string,
     },
-    mapDeprecatedActionAndWarn: (
-      action: PossiblyDeprecatedNavigationAction
-    ) => NavigationAction,
   };
 
   declare type _RouterProp<S: NavigationState, O: {}> = {

--- a/src/NavigationActions.js
+++ b/src/NavigationActions.js
@@ -106,59 +106,6 @@ const completeTransition = createAction(COMPLETE_TRANSITION, payload => ({
   key: payload && payload.key,
 }));
 
-const mapDeprecatedNavigateAction = action => {
-  if (action.type === 'Navigate') {
-    const payload = {
-      routeName: action.routeName,
-      params: action.params,
-    };
-    if (action.action) {
-      payload.action = mapDeprecatedNavigateAction(action.action);
-    }
-    return navigate(payload);
-  }
-  return action;
-};
-
-const mapDeprecatedAction = action => {
-  if (action.type === 'Back') {
-    return back(action);
-  } else if (action.type === 'Init') {
-    return init(action);
-  } else if (action.type === 'Navigate') {
-    return mapDeprecatedNavigateAction(action);
-  } else if (action.type === 'Reset') {
-    return reset({
-      index: action.index,
-      key: action.key,
-      actions: action.actions.map(mapDeprecatedNavigateAction),
-    });
-  } else if (action.type === 'SetParams') {
-    return setParams(action);
-  }
-  return action;
-};
-
-const mapDeprecatedActionAndWarn = action => {
-  const newAction = mapDeprecatedAction(action);
-  if (newAction !== action) {
-    const oldType = action.type;
-    const newType = newAction.type;
-    console.warn(
-      [
-        `The action type '${oldType}' has been renamed to '${newType}'.`,
-        `'${oldType}' will continue to work while in beta but will be removed`,
-        'in the first major release. Moving forward, you should use the',
-        'action constants and action creators exported by this library in',
-        "the 'actions' object.",
-        'See https://github.com/react-community/react-navigation/pull/120 for',
-        'more details.',
-      ].join(' ')
-    );
-  }
-  return newAction;
-};
-
 export default {
   // Action constants
   BACK,
@@ -185,7 +132,4 @@ export default {
   setParams,
   uri,
   completeTransition,
-
-  // TODO: Remove once old actions are deprecated
-  mapDeprecatedActionAndWarn,
 };

--- a/src/createNavigationContainer.js
+++ b/src/createNavigationContainer.js
@@ -166,8 +166,7 @@ export default function createNavigationContainer(Component) {
 
     // Per-tick temporary storage for state.nav
 
-    dispatch = inputAction => {
-      const action = NavigationActions.mapDeprecatedActionAndWarn(inputAction);
+    dispatch = action => {
       if (!this._isStateful()) {
         return false;
       }

--- a/src/routers/__tests__/StackRouter-test.js
+++ b/src/routers/__tests__/StackRouter-test.js
@@ -1506,40 +1506,6 @@ describe('StackRouter', () => {
     }
   });
 
-  test('Maps old actions (uses "Handles the reset action" test)', () => {
-    global.console.warn = jest.fn();
-    const router = StackRouter({
-      Foo: {
-        screen: () => <div />,
-      },
-      Bar: {
-        screen: () => <div />,
-      },
-    });
-    const initAction = NavigationActions.mapDeprecatedActionAndWarn({
-      type: 'Init',
-    });
-    const state = router.getStateForAction(initAction);
-    const resetAction = NavigationActions.mapDeprecatedActionAndWarn({
-      type: 'Reset',
-      actions: [
-        { type: 'Navigate', routeName: 'Foo', params: { bar: '42' } },
-        { type: 'Navigate', routeName: 'Bar' },
-      ],
-      index: 1,
-    });
-    const state2 = router.getStateForAction(resetAction, state);
-    expect(state2 && state2.index).toEqual(1);
-    expect(state2 && state2.routes[0].params).toEqual({ bar: '42' });
-    expect(state2 && state2.routes[0].routeName).toEqual('Foo');
-    expect(state2 && state2.routes[1].routeName).toEqual('Bar');
-    expect(console.warn).toBeCalledWith(
-      expect.stringContaining(
-        "The action type 'Init' has been renamed to 'Navigation/INIT'"
-      )
-    );
-  });
-
   test('URI encoded string get passed to deep link', () => {
     const uri = 'people/2018%2F02%2F07';
     const action = TestStackRouter.getActionForPathAndParams(uri);

--- a/src/routers/__tests__/TabRouter-test.js
+++ b/src/routers/__tests__/TabRouter-test.js
@@ -593,29 +593,6 @@ describe('TabRouter', () => {
     expect(path).toEqual('f/Baz');
   });
 
-  test('Maps old actions (uses "getStateForAction returns null when navigating to same tab" test)', () => {
-    global.console.warn = jest.fn();
-    const router = TabRouter(
-      { Foo: BareLeafRouteConfig, Bar: BareLeafRouteConfig },
-      { initialRouteName: 'Bar' }
-    );
-    const initAction = NavigationActions.mapDeprecatedActionAndWarn({
-      type: 'Init',
-    });
-    const state = router.getStateForAction(initAction);
-    const navigateAction = NavigationActions.mapDeprecatedActionAndWarn({
-      type: 'Navigate',
-      routeName: 'Bar',
-    });
-    const state2 = router.getStateForAction(navigateAction, state);
-    expect(state2).toEqual(null);
-    expect(console.warn).toBeCalledWith(
-      expect.stringContaining(
-        "The action type 'Init' has been renamed to 'Navigation/INIT'"
-      )
-    );
-  });
-
   test('Can navigate to other tab (no router) with params', () => {
     const ScreenA = () => <div />;
     const ScreenB = () => <div />;


### PR DESCRIPTION
About a year ago, https://github.com/react-community/react-navigation/pull/120 was merged, renaming the old navigation actions to new ones, eg. `Init` renamed to `'Navigation/INIT'`. Along with that change, `mapDeprecatedActionAndWarn` was introduced so that things wouldn't break for people using the old navigation actions. The warning informed users that 

> The action type '${oldType}' has been renamed to '${newType}'.`, '${oldType}' will continue to work while in beta but will be removed, in the first major release.

So I figured it's a good time to remove the `mapDeprecatedActionAndWarn` from the code base. Given the warning and the amount of time it was there, I do not think it will affect library users. It also makes the code slightly more straightforward, which is always a good thing.

**Test plan (required)**
The only place with a significant change in the `dispatch` call in `createNavigationContainer.js`. As demonstrated by the passing tests, dispatch is called with the non-deprecated actions, whose correct `type` can be seen in [NavigationActions-test.js](https://github.com/react-navigation/react-navigation/blob/ac741a703b32047dfa85cb33f8d17a1230e7f89a/src/__tests__/NavigationActions-test.js#L17). Also the example apps use the mentioned `NavigationActions` and not the deprecated ones, and the NavigationPlayground provided by the react-navigation-ci bot works well for me.