### PR TITLE
Remove hard-coded forceInset from `SafeAreaView` in `Header`

### DIFF
--- a/src/views/Header/Header.js
+++ b/src/views/Header/Header.js
@@ -474,9 +474,7 @@ class Header extends React.PureComponent {
     ];
 
     return (
-      <SafeAreaView
-        style={containerStyles}
-      >
+      <SafeAreaView style={containerStyles}>
         <View style={StyleSheet.absoluteFill}>{options.headerBackground}</View>
         <View style={{ flex: 1 }}>{appBar}</View>
       </SafeAreaView>

--- a/src/views/Header/Header.js
+++ b/src/views/Header/Header.js
@@ -475,7 +475,6 @@ class Header extends React.PureComponent {
 
     return (
       <SafeAreaView
-        forceInset={{ top: 'always', bottom: 'never' }}
         style={containerStyles}
       >
         <View style={StyleSheet.absoluteFill}>{options.headerBackground}</View>


### PR DESCRIPTION
Since `SafeAreaView` is contex aware with regards to its position, hard coding `forceInset` will cause unremovable padding in some insances.

# Context
[`react-community/react-native-safe-area-view`](https://github.com/react-community/react-native-safe-area-view)'s`SafeAreaView` determines the View's location in relation to the device's viewport in order to determine wether or not to add padding based upon `touchesTop`, … `touchesRight` within [`measureInWindow`](https://github.com/react-community/react-native-safe-area-view/blob/b84d241a8bc215ef956ff3b3a56875e2a04667c5/index.js#L152).

# Motivation
Given this context, `Header.js`'s hard-coding of a `forceInset` `top` value of `always` will cause `SafeAreaView`'s padding to be applied to all instances of `Header`. This leads to additional padding being added to instances of Header, even if they have an offset applied, such as `marginTop`.

While [#3184](https://github.com/react-navigation/react-navigation/issues/3184) was flagged as a duplicate and closed (I believe in error), this PR attempts to fix this rendering problem.


# Test Plan
This bug can be replicated by adding a `marginTop` value of > 0 to `navigationOption`'s `headerStyle`. Expected behavior would be the removal of `SafeAreaView`'s top padding. Encountered behavior is the application of `SafeAreaView`'s top padding, even overriding instances where a different padding is applied. This breaks from the anticipated behavior of inheriting padding when supplied, as mentioned in the comments of PR [#2889](https://github.com/react-navigation/react-navigation/pull/2889). Once applied, `paddingTop` values supplied to `headerStyles` for screens that do not touch the top of the viewport should be properly inherited.

## Bugged View Before Modification: (MarginTop of 36px applied)
<img width="559" alt="screen shot 2018-03-01 at 1 38 36 pm" src="https://user-images.githubusercontent.com/5562161/36865267-0595da76-1d5d-11e8-9c6c-1c4398c80d6e.png">

## Bugged View After Modification: (MarginTop of 36px applied)
<img width="559" alt="screen shot 2018-03-01 at 2 27 43 pm" src="https://user-images.githubusercontent.com/5562161/36865302-21e806a4-1d5d-11e8-88b0-a3d351566c30.png">

## Control View Before Modification: (No MarginTop applied)
<img width="531" alt="screen shot 2018-03-01 at 2 33 25 pm" src="https://user-images.githubusercontent.com/5562161/36865452-95447b6e-1d5d-11e8-88a0-4bce3714e0cb.png">

## Control View After Modification: (No MarginTop applied)
<img width="559" alt="screen shot 2018-03-01 at 2 31 42 pm" src="https://user-images.githubusercontent.com/5562161/36865402-69e8272c-1d5d-11e8-8c13-b47075c1526c.png">
