### PR TITLE
More specific injected Navigation props in Flow definition

### DIFF
--- a/flow/react-navigation.js
+++ b/flow/react-navigation.js
@@ -1024,7 +1024,7 @@ declare module 'react-navigation' {
   declare export var TabBarBottom: React$ComponentType<_TabBarBottomProps>;
 
   declare type _NavigationInjectedProps = {
-    navigation: NavigationScreenProp<NavigationState>,
+    navigation: NavigationScreenProp<NavigationStateRoute>,
   };
   declare export function withNavigation<T: {}>(
     Component: React$ComponentType<T & _NavigationInjectedProps>


### PR DESCRIPTION
Fixed the navigation props type to be a tad more specific since it leaving it as just NavigationState created a seemingly-impossible-to-resolve situation with type parameters.