### PR TITLE
Cache child event subscriptions (1.x branch)

### DIFF
--- a/src/getChildEventSubscriber.js
+++ b/src/getChildEventSubscriber.js
@@ -4,6 +4,7 @@
  * Based on the 'action' events that get fired for this navigation state, this utility will fire
  * focus and blur events for this child
  */
+
 export default function getChildEventSubscriber(addListener, key) {
   const actionSubscribers = new Set();
   const willFocusSubscribers = new Set();


### PR DESCRIPTION
# Motivation

I tracked down the memory leak reported in https://github.com/react-navigation/react-navigation/issues/3636 using Chrome memory tab and found that it was a result of creating new subscribers anytime a `StackNavigator` state changes. ~This PR only fixes it in `StackNavigator`, it is likely also a problem with other navigators but I don't want to invest too much time into those because I've already fixed it for all of them on master (for the upcoming 2.0 release, see: https://github.com/react-navigation/react-navigation/pull/3648). It would be nice for someone to follow up a PR to apply these same changes to other navigators.~ I believe this also applies to other navigators and made the appropriate changes here. This PR does not clean up upstream subscribers when a navigator unmounts, however, but that is an existing issue with minimal impact and which is fixed in https://github.com/react-navigation/react-navigation/pull/3648.

# Test plan

Try running the example code from https://github.com/react-navigation/react-navigation/issues/3636 with this branch and you will see that memory usage does not simply climb forever as you scroll up and down.