### PR TITLE
Fix: tabBar icons are not visible.

### DIFF
--- a/src/views/TabView/TabBarIcon.js
+++ b/src/views/TabView/TabBarIcon.js
@@ -53,12 +53,11 @@ const styles = StyleSheet.create({
     // We render the icon twice at the same position on top of each other:
     // active and inactive one, so we can fade between them:
     // Cover the whole iconContainer:
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    right: 0,
-    bottom: 0,
     alignItems: 'center',
+    alignSelf: 'center',
+    height: '100%',
     justifyContent: 'center',
+    position: 'absolute',
+    width: '100%',
   },
 });


### PR DESCRIPTION
**Motivation** for making this change. 

Icons in tabBar are not visible. So I took this as challenge and find this quick fix. :)
In our project we have updated to `"react-navigation": "1.3.2"` and facing this issue, so I thought of fixing it in the library itself. 
Let me know changes :)

**Test plan (required)**

Clone this https://github.com/jainkuniya/sample-tab-navigation.git and run `yarn install` or `npm install`, and run app.

With 
```
    "react": "16.2.0",
    "react-native": "^0.54.0",
    "react-native-vector-icons": "^4.5.0",
    "react-navigation": "1.3.2"
```

app will look like this
<img width="350" alt="screen shot 2018-03-03 at 5 41 25 pm" src="https://user-images.githubusercontent.com/18511177/36934118-4f73161e-1f0a-11e8-95b3-c89d2264495a.png">

icons are not visible

**On this PR**
<img width="320" alt="screen shot 2018-03-03 at 5 42 36 pm" src="https://user-images.githubusercontent.com/18511177/36934119-4fa52c3a-1f0a-11e8-9865-392695fb834c.png">
