### PR TITLE
Add isFocused helper to navigation and fix withNavigationFocus (1.x branch)

### DIFF
--- a/examples/NavigationPlayground/js/App.js
+++ b/examples/NavigationPlayground/js/App.js
@@ -114,10 +114,10 @@ const ExampleInfo = {
     name: 'Animated Tabs Example',
     description: 'Tab transitions have custom animations',
   },
-  // TabsWithNavigationFocus: {
-  //   name: 'withNavigationFocus',
-  //   description: 'Receive the focus prop to know when a screen is focused',
-  // },
+  TabsWithNavigationFocus: {
+    name: 'withNavigationFocus',
+    description: 'Receive the focus prop to know when a screen is focused',
+  },
 };
 
 const ExampleRoutes = {
@@ -146,7 +146,7 @@ const ExampleRoutes = {
     path: 'settings',
   },
   TabAnimations,
-  // TabsWithNavigationFocus: TabsWithNavigationFocus,
+  TabsWithNavigationFocus,
 };
 
 type State = {

--- a/examples/NavigationPlayground/js/TabsWithNavigationFocus.js
+++ b/examples/NavigationPlayground/js/TabsWithNavigationFocus.js
@@ -3,40 +3,75 @@
  */
 
 import React from 'react';
-import { SafeAreaView, Text } from 'react-native';
+import { Button, SafeAreaView, Text } from 'react-native';
 import { TabNavigator, withNavigationFocus } from 'react-navigation';
 import MaterialCommunityIcons from 'react-native-vector-icons/MaterialCommunityIcons';
 
 import SampleText from './SampleText';
 
-const createTabScreen = (name, icon, focusedIcon, tintColor = '#673ab7') => {
-  const TabScreen = ({ isFocused }) => (
-    <SafeAreaView
-      forceInset={{ horizontal: 'always', top: 'always' }}
-      style={{
-        flex: 1,
-        alignItems: 'center',
-        justifyContent: 'center',
-      }}
-    >
-      <Text style={{ fontWeight: '700', fontSize: 16, marginBottom: 5 }}>
-        {'Tab ' + name.toLowerCase()}
+class Child extends React.Component {
+  render() {
+    return (
+      <Text style={{ color: this.props.isFocused ? 'green' : 'maroon' }}>
+        {this.props.isFocused
+          ? 'I know that my parent is focused!'
+          : 'My parent is not focused! :O'}
       </Text>
-      <Text>{'props.isFocused: ' + (isFocused ? ' true' : 'false')}</Text>
-    </SafeAreaView>
-  );
+    );
+  }
+}
 
-  TabScreen.navigationOptions = {
-    tabBarLabel: name,
-    tabBarIcon: ({ tintColor, focused }) => (
-      <MaterialCommunityIcons
-        name={focused ? focusedIcon : icon}
-        size={26}
-        style={{ color: focused ? tintColor : '#ccc' }}
-      />
-    ),
-  };
+const ChildWithNavigationFocus = withNavigationFocus(Child);
 
+const createTabScreen = (name, icon, focusedIcon, tintColor = '#673ab7') => {
+  class TabScreen extends React.Component {
+    static navigationOptions = {
+      tabBarLabel: name,
+      tabBarIcon: ({ tintColor, focused }) => (
+        <MaterialCommunityIcons
+          name={focused ? focusedIcon : icon}
+          size={26}
+          style={{ color: focused ? tintColor : '#ccc' }}
+        />
+      ),
+    };
+
+    state = { showChild: false };
+
+    render() {
+      const { isFocused } = this.props;
+
+      return (
+        <SafeAreaView
+          forceInset={{ horizontal: 'always', top: 'always' }}
+          style={{
+            flex: 1,
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          <Text style={{ fontWeight: '700', fontSize: 16, marginBottom: 5 }}>
+            {'Tab ' + name.toLowerCase()}
+          </Text>
+          <Text style={{ marginBottom: 20 }}>
+            {'props.isFocused: ' + (isFocused ? ' true' : 'false')}
+          </Text>
+          {this.state.showChild ? (
+            <ChildWithNavigationFocus />
+          ) : (
+            <Button
+              title="Press me"
+              onPress={() => this.setState({ showChild: true })}
+            />
+          )}
+          <Button
+            onPress={() => this.props.navigation.goBack(null)}
+            title="Back to other examples"
+          />
+        </SafeAreaView>
+      );
+    }
+  }
   return withNavigationFocus(TabScreen);
 };
 

--- a/examples/NavigationPlayground/js/TabsWithNavigationFocus.js
+++ b/examples/NavigationPlayground/js/TabsWithNavigationFocus.js
@@ -9,7 +9,7 @@ import MaterialCommunityIcons from 'react-native-vector-icons/MaterialCommunityI
 
 import SampleText from './SampleText';
 
-class Child extends React.Component {
+class Child extends React.Component<any, any> {
   render() {
     return (
       <Text style={{ color: this.props.isFocused ? 'green' : 'maroon' }}>
@@ -24,7 +24,7 @@ class Child extends React.Component {
 const ChildWithNavigationFocus = withNavigationFocus(Child);
 
 const createTabScreen = (name, icon, focusedIcon, tintColor = '#673ab7') => {
-  class TabScreen extends React.Component {
+  class TabScreen extends React.Component<any, any> {
     static navigationOptions = {
       tabBarLabel: name,
       tabBarIcon: ({ tintColor, focused }) => (

--- a/src/views/CardStack/CardStack.js
+++ b/src/views/CardStack/CardStack.js
@@ -109,6 +109,12 @@ class CardStack extends React.Component {
     });
   }
 
+  _isRouteFocused = route => {
+    const { state } = this.props.navigation;
+    const focusedRoute = state.routes[state.index];
+    return route === focusedRoute;
+  };
+
   _getScreenDetails = scene => {
     const { screenProps, transitionProps: { navigation }, router } = this.props;
     let screenDetails = this._screenDetails[scene.key];
@@ -123,6 +129,7 @@ class CardStack extends React.Component {
       const screenNavigation = addNavigationHelpers({
         dispatch: navigation.dispatch,
         state: scene.route,
+        isFocused: this._isRouteFocused.bind(this, scene.route),
         addListener: this._childEventSubscribers[scene.route.key],
       });
       screenDetails = {

--- a/src/views/Drawer/DrawerView.js
+++ b/src/views/Drawer/DrawerView.js
@@ -81,6 +81,12 @@ export default class DrawerView extends React.PureComponent {
     }
   };
 
+  _isRouteFocused = route => () => {
+    const { state } = this.props.navigation;
+    const focusedRoute = state.routes[state.index];
+    return route === focusedRoute;
+  };
+
   _updateScreenNavigation = navigation => {
     const { drawerCloseRoute } = this.props;
     const navigationState = navigation.state.routes.find(
@@ -102,6 +108,7 @@ export default class DrawerView extends React.PureComponent {
     this._screenNavigationProp = addNavigationHelpers({
       dispatch: navigation.dispatch,
       state: navigationState,
+      isFocused: this._isRouteFocused.bind(this, navigationState),
       addListener: this._childEventSubscribers[navigationState.key],
     });
   };

--- a/src/views/__tests__/__snapshots__/TabView-test.js.snap
+++ b/src/views/__tests__/__snapshots__/TabView-test.js.snap
@@ -248,6 +248,7 @@ exports[`TabBarBottom renders successfully 1`] = `
                   "dispatch": undefined,
                   "getParam": [Function],
                   "goBack": [Function],
+                  "isFocused": [Function],
                   "navigate": [Function],
                   "pop": [Function],
                   "popToTop": [Function],

--- a/src/views/withNavigationFocus.js
+++ b/src/views/withNavigationFocus.js
@@ -12,9 +12,13 @@ export default function withNavigationFocus(Component) {
       navigation: propTypes.object.isRequired,
     };
 
-    state = {
-      isFocused: false,
-    };
+    constructor(props, context) {
+      super();
+
+      this.state = {
+        isFocused: this.getNavigation(props, context).isFocused(),
+      };
+    }
 
     componentDidMount() {
       const navigation = this.getNavigation();
@@ -32,8 +36,8 @@ export default function withNavigationFocus(Component) {
       this.subscriptions.forEach(sub => sub.remove());
     }
 
-    getNavigation = () => {
-      const navigation = this.props.navigation || this.context.navigation;
+    getNavigation = (props = this.props, context = this.context) => {
+      const navigation = props.navigation || context.navigation;
       invariant(
         !!navigation,
         'withNavigationFocus can only be used on a view hierarchy of a navigator. The wrapped component is unable to get access to navigation from props or context.'

--- a/src/withCachedChildNavigation.js
+++ b/src/withCachedChildNavigation.js
@@ -31,6 +31,12 @@ export default function withCachedChildNavigation(Comp) {
       });
     }
 
+    _isRouteFocused = route => () => {
+      const { state } = this.props.navigation;
+      const focusedRoute = state.routes[state.index];
+      return route === focusedRoute;
+    };
+
     _updateNavigationProps = navigation => {
       // Update props for each child route
       if (!this._childNavigationProps) {
@@ -52,6 +58,7 @@ export default function withCachedChildNavigation(Comp) {
         this._childNavigationProps[route.key] = addNavigationHelpers({
           dispatch: navigation.dispatch,
           state: route,
+          isFocused: this._isRouteFocused.bind(this, route),
           addListener: this._childEventSubscribers[route.key],
         });
       });


### PR DESCRIPTION
# Motivation

`withNavigationFocus` didn't initialize with the correct state, it always assumed not focused. This PR adds a helper to get the focused state and uses that to properly initialize the state in `withNavigationFocus`. More discussion in https://github.com/react-navigation/react-navigation/pull/3512

In a follow-up PR I'll port this to master (the 2.0-track branch), which should be a good amount less code thanks to only adding navigation helpers in one place.

# Test plan

Run playground example. Tests pass. 