### PR TITLE
Fix typespec of back action creator

### DIFF
--- a/flow/react-navigation.js
+++ b/flow/react-navigation.js
@@ -686,7 +686,7 @@ declare module 'react-navigation' {
     SET_PARAMS: 'Navigation/SET_PARAMS',
     URI: 'Navigation/URI',
     back: {
-      (payload: { key?: ?string }): NavigationBackAction,
+      (payload?: { key?: ?string }): NavigationBackAction,
       toString: () => string,
     },
     init: {


### PR DESCRIPTION
https://github.com/react-navigation/react-navigation/blob/c6301abaed51ef7ac2aa370ed18d66e39ca9e15d/src/NavigationActions.js#L21 doesn't required `params`