### PR TITLE
Fix NavigationEventPayload.lastState type

### DIFF
--- a/flow/react-navigation.js
+++ b/flow/react-navigation.js
@@ -459,7 +459,7 @@ declare module 'react-navigation' {
     type: EventType,
     action: NavigationAction,
     state: NavigationState,
-    lastState: NavigationState,
+    lastState: ?NavigationState,
   };
 
   declare export type NavigationEventCallback = (


### PR DESCRIPTION
Should be nullable, since it is initially called as `null` in `src/createNavigationContainer.js` (and in `react-navigation-redux-helpers`, where it is causing a Flow error).