### PR TITLE
Update ReduxExample so that the first nav click works with nested TabNavigators

### DIFF
--- a/examples/ReduxExample/package.json
+++ b/examples/ReduxExample/package.json
@@ -26,7 +26,7 @@
     "react": "16.2.0",
     "react-native": "^0.52.0",
     "react-navigation": "link:../..",
-    "react-navigation-redux-helpers": "^1.0.0",
+    "react-navigation-redux-helpers": "^1.0.3",
     "react-redux": "^5.0.6",
     "redux": "^3.7.2"
   },

--- a/examples/ReduxExample/src/navigators/AppNavigator.js
+++ b/examples/ReduxExample/src/navigators/AppNavigator.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { addNavigationHelpers, StackNavigator } from 'react-navigation';
+import { initializeListeners } from 'react-navigation-redux-helpers';
 
 import LoginScreen from '../components/LoginScreen';
 import MainScreen from '../components/MainScreen';
@@ -19,6 +20,10 @@ class AppWithNavigationState extends React.Component {
     dispatch: PropTypes.func.isRequired,
     nav: PropTypes.object.isRequired,
   };
+
+  componentDidMount() {
+    initializeListeners('root', this.props.nav);
+  }
 
   render() {
     const { dispatch, nav } = this.props;


### PR DESCRIPTION
I.e. call react-navigation-redux-helpers's initializeListeners() when mounting app
per https://github.com/react-navigation/react-navigation-redux-helpers/issues/7