### PR TITLE
Add dismiss helper, made possible by also adding carefullyGetParent

### DIFF
--- a/examples/NavigationPlayground/js/SimpleStack.js
+++ b/examples/NavigationPlayground/js/SimpleStack.js
@@ -49,7 +49,8 @@ class MyNavScreen extends React.Component<MyNavScreenProps> {
         />
         <Button onPress={() => navigation.popToTop()} title="Pop to top" />
         <Button onPress={() => navigation.pop()} title="Pop" />
-        <Button onPress={() => navigation.goBack(null)} title="Go back" />
+        <Button onPress={() => navigation.goBack()} title="Go back" />
+        <Button onPress={() => navigation.dismiss()} title="Dismiss" />
         <StatusBar barStyle="default" />
       </SafeAreaView>
     );

--- a/flow/react-navigation.js
+++ b/flow/react-navigation.js
@@ -486,6 +486,7 @@ declare module 'react-navigation' {
     +state: S,
     dispatch: NavigationDispatch,
     goBack: (routeKey?: ?string) => boolean,
+    dismiss: () => boolean,
     navigate: (
       routeName: string,
       params?: NavigationParams,

--- a/src/__tests__/addNavigationHelpers-test.js
+++ b/src/__tests__/addNavigationHelpers-test.js
@@ -6,6 +6,30 @@ const dummyEventSubscriber = (name: string, handler: (*) => void) => ({
 });
 
 describe('addNavigationHelpers', () => {
+  it('handles dismiss action', () => {
+    const mockedDispatch = jest
+      .fn(() => false)
+      .mockImplementationOnce(() => true);
+    const child = { key: 'A', routeName: 'Home' };
+    expect(
+      addNavigationHelpers({
+        state: child,
+        dispatch: mockedDispatch,
+        addListener: dummyEventSubscriber,
+        getParentState: () => ({
+          key: 'P',
+          routeName: 'Parent',
+          routes: [child],
+        }),
+      }).dismiss()
+    ).toEqual(true);
+    expect(mockedDispatch).toBeCalledWith({
+      type: NavigationActions.BACK,
+      key: 'P',
+    });
+    expect(mockedDispatch.mock.calls.length).toBe(1);
+  });
+
   it('handles Back action', () => {
     const mockedDispatch = jest
       .fn(() => false)

--- a/src/__tests__/addNavigationHelpers-test.js
+++ b/src/__tests__/addNavigationHelpers-test.js
@@ -16,10 +16,12 @@ describe('addNavigationHelpers', () => {
         state: child,
         dispatch: mockedDispatch,
         addListener: dummyEventSubscriber,
-        getParentState: () => ({
-          key: 'P',
-          routeName: 'Parent',
-          routes: [child],
+        carefullyGetParent: () => ({
+          state: {
+            key: 'P',
+            routeName: 'Parent',
+            routes: [child],
+          },
         }),
       }).dismiss()
     ).toEqual(true);

--- a/src/addNavigationHelpers.js
+++ b/src/addNavigationHelpers.js
@@ -6,6 +6,7 @@ import invariant from './utils/invariant';
 export default function(navigation) {
   return {
     ...navigation,
+    // Go back from the given key, default to active key
     goBack: key => {
       let actualizedKey = key;
       if (key === undefined && navigation.state.key) {
@@ -18,6 +19,12 @@ export default function(navigation) {
       return navigation.dispatch(
         NavigationActions.back({ key: actualizedKey })
       );
+    },
+    // Go back from the parent key. If this is a nested stack, the entire
+    // stack will be dismissed.
+    dismiss: () => {
+      let { key } = navigation.getParentState();
+      return navigation.dispatch(NavigationActions.back({ key }));
     },
     navigate: (navigateTo, params, action) => {
       if (typeof navigateTo === 'string') {

--- a/src/addNavigationHelpers.js
+++ b/src/addNavigationHelpers.js
@@ -2,7 +2,6 @@
 
 import NavigationActions from './NavigationActions';
 import invariant from './utils/invariant';
-
 export default function(navigation) {
   return {
     ...navigation,
@@ -23,8 +22,14 @@ export default function(navigation) {
     // Go back from the parent key. If this is a nested stack, the entire
     // stack will be dismissed.
     dismiss: () => {
-      let { key } = navigation.getParentState();
-      return navigation.dispatch(NavigationActions.back({ key }));
+      let parentState = navigation.getParentState();
+      if (parentState && parentState.key) {
+        return navigation.dispatch(
+          NavigationActions.back({ key: parentState.key })
+        );
+      } else {
+        return false;
+      }
     },
     navigate: (navigateTo, params, action) => {
       if (typeof navigateTo === 'string') {

--- a/src/addNavigationHelpers.js
+++ b/src/addNavigationHelpers.js
@@ -22,10 +22,10 @@ export default function(navigation) {
     // Go back from the parent key. If this is a nested stack, the entire
     // stack will be dismissed.
     dismiss: () => {
-      let parentState = navigation.getParentState();
-      if (parentState && parentState.key) {
+      let parent = navigation.carefullyGetParent();
+      if (parent && parent.state) {
         return navigation.dispatch(
-          NavigationActions.back({ key: parentState.key })
+          NavigationActions.back({ key: parent.state.key })
         );
       } else {
         return false;

--- a/src/navigators/createNavigator.js
+++ b/src/navigators/createNavigator.js
@@ -32,8 +32,8 @@ function createNavigator(NavigatorView, router, navigationConfig) {
       return route === focusedRoute;
     };
 
-    _getParentState = () => {
-      return this.props.navigation.state;
+    _carefullyGetParent = () => {
+      return this.props.navigation;
     };
 
     render() {
@@ -56,7 +56,7 @@ function createNavigator(NavigatorView, router, navigationConfig) {
         const childNavigation = addNavigationHelpers({
           dispatch,
           state: route,
-          getParentState: this._getParentState,
+          carefullyGetParent: this._carefullyGetParent,
           addListener: this.childEventSubscribers[route.key].addListener,
           isFocused: () => this._isRouteFocused(route),
         });

--- a/src/navigators/createNavigator.js
+++ b/src/navigators/createNavigator.js
@@ -32,6 +32,10 @@ function createNavigator(NavigatorView, router, navigationConfig) {
       return route === focusedRoute;
     };
 
+    _getParentState = () => {
+      return this.props.navigation.state;
+    };
+
     render() {
       const { navigation, screenProps } = this.props;
       const { dispatch, state, addListener } = navigation;
@@ -52,9 +56,11 @@ function createNavigator(NavigatorView, router, navigationConfig) {
         const childNavigation = addNavigationHelpers({
           dispatch,
           state: route,
+          getParentState: this._getParentState,
           addListener: this.childEventSubscribers[route.key].addListener,
           isFocused: () => this._isRouteFocused(route),
         });
+
         const options = router.getScreenOptions(childNavigation, screenProps);
         descriptors[route.key] = {
           key: route.key,


### PR DESCRIPTION
# Motivation

Sometimes you want to be able to dismiss a nested stack, for example if you have a root stack that goes from your main app to a modal stack, you might want to go back to the main app when you're n screens deep in the modal stack. People came up with a pretty good solution for this in a previous discussion on the issues here: https://github.com/react-navigation/react-navigation/issues/686#issuecomment-292225313 - I just adapted this to `addNavigationHelpers`.

As for `navigation.carefullyGetParent`, we dicussed it on https://github.com/react-navigation/rfcs/issues/27.

# Test plan

Run tests, try it in playground.
