### PR TITLE
Flow type: SafeAreaView doesn't require children

### DIFF
--- a/flow/react-navigation.js
+++ b/flow/react-navigation.js
@@ -878,7 +878,7 @@ declare module 'react-navigation' {
       vertical?: _SafeAreaViewForceInsetValue,
       horizontal?: _SafeAreaViewForceInsetValue,
     },
-    children: React$Node,
+    children?: React$Node,
     style?: AnimatedViewStyleProp,
   };
   declare export var SafeAreaView: React$ComponentType<_SafeAreaViewProps>;


### PR DESCRIPTION
`children` prop should be optional.

See https://github.com/flowtype/flow-typed/commit/4ec24a5b93eb832b5879b239900174029d92d13b#commitcomment-27932697