### PR TITLE
Allow passing null to onNavigationStateChange prop

### DIFF
--- a/flow/react-navigation.js
+++ b/flow/react-navigation.js
@@ -519,7 +519,7 @@ declare module 'react-navigation' {
 
   declare export type NavigationContainerProps<S: {}, O: {}> = $Shape<{
     uriPrefix?: string | RegExp,
-    onNavigationStateChange?: (
+    onNavigationStateChange?: ?(
       NavigationState,
       NavigationState,
       NavigationAction


### PR DESCRIPTION
As seen here: react-navigation/react-navigation#360, we need to be able to pass null to turn off logging.

This PR mirrors https://github.com/flowtype/flow-typed/pull/1912, which will be overridden when this repo is merged into flow-typed.