### PR TITLE
Add Back Image Style props

### DIFF
--- a/src/views/Header/Header.js
+++ b/src/views/Header/Header.js
@@ -155,6 +155,7 @@ class Header extends React.PureComponent {
         title={backButtonTitle}
         truncatedTitle={truncatedBackButtonTitle}
         titleStyle={options.headerBackTitleStyle}
+        imageStyle={options.headerBackImageStyle}
         width={width}
       />
     );

--- a/src/views/Header/HeaderBackButton.js
+++ b/src/views/Header/HeaderBackButton.js
@@ -40,6 +40,7 @@ class HeaderBackButton extends React.PureComponent {
       width,
       title,
       titleStyle,
+      imageStyle,
       tintColor,
       truncatedTitle,
     } = this.props;
@@ -69,6 +70,7 @@ class HeaderBackButton extends React.PureComponent {
               styles.icon,
               !!title && styles.iconWithTitle,
               !!tintColor && { tintColor },
+              imageStyle
             ]}
             source={buttonImage}
           />


### PR DESCRIPTION
Adding a style prop for Back Image. I wasn't able to style my custom `backImage`, so I modified to accept it. You can change by using this:

```
...navigationOptions = {
  headerBackImageStyle: {
    borderWidth: 1,
    width: 21
  }
}
```