### PR TITLE
Pass initialRouteKey into StackRouter (#3540)

### DIFF
--- a/src/navigators/StackNavigator.js
+++ b/src/navigators/StackNavigator.js
@@ -11,6 +11,7 @@ import NavigationActions from '../NavigationActions';
 
 export default (routeConfigMap, stackConfig = {}) => {
   const {
+    initialRouteKey,
     initialRouteName,
     initialRouteParams,
     paths,
@@ -25,6 +26,7 @@ export default (routeConfigMap, stackConfig = {}) => {
   } = stackConfig;
 
   const stackRouterConfig = {
+    initialRouteKey,
     initialRouteName,
     initialRouteParams,
     paths,


### PR DESCRIPTION
The `initialRouteKey` stack config option was introduced in 1.5.0 in the `StackRouter`. However, it is not being passed into `StackRouter` from `StackNavigator`.