### PR TITLE
Fix isFocused from withNavigationFocus is a function

### DIFF
--- a/src/withCachedChildNavigation.js
+++ b/src/withCachedChildNavigation.js
@@ -31,7 +31,7 @@ export default function withCachedChildNavigation(Comp) {
       });
     }
 
-    _isRouteFocused = route => () => {
+    _isRouteFocused = route => {
       const { state } = this.props.navigation;
       const focusedRoute = state.routes[state.index];
       return route === focusedRoute;

--- a/src/withCachedChildNavigation.js
+++ b/src/withCachedChildNavigation.js
@@ -58,7 +58,7 @@ export default function withCachedChildNavigation(Comp) {
         this._childNavigationProps[route.key] = addNavigationHelpers({
           dispatch: navigation.dispatch,
           state: route,
-          isFocused: this._isRouteFocused.bind(this, route),
+          isFocused: () => this._isRouteFocused(route),
           addListener: this._childEventSubscribers[route.key],
         });
       });


### PR DESCRIPTION
- when in a tab container, isFocused is a function on first render an boolean afterwards
- closes #3709

---

I think this is the culprit. I made a pr to make it simpler to fix. If you think the issue should be fix in another way, just close this! 3709 is still valid :) 