### PR TITLE
Fix memory leak in TabView-test.js

### DIFF
--- a/src/views/__tests__/TabView-test.js
+++ b/src/views/__tests__/TabView-test.js
@@ -10,6 +10,8 @@ const dummyEventSubscriber = (name, handler) => ({
 });
 
 describe('TabBarBottom', () => {
+  jest.useFakeTimers();
+
   it('renders successfully', () => {
     const route = { key: 's1', routeName: 's1' };
     const navigation = {


### PR DESCRIPTION
**Summary**

I've noticed there's a leak in the test suite (process hanging) caused by not mocked timer in TabViewPagerScroll used by default on iOS. 
FYI, the leak was detected by running `jest --detectLeaks` flag.

**Test plan (required)**

Tests are green.
