### PR TITLE
Experiment: use react-native-gesture-handler/DrawerLayout

### DIFF
--- a/examples/NavigationPlayground/js/App.js
+++ b/examples/NavigationPlayground/js/App.js
@@ -21,6 +21,7 @@ import { SafeAreaView, createStackNavigator } from 'react-navigation';
 import CustomTabs from './CustomTabs';
 import CustomTransitioner from './CustomTransitioner';
 import Drawer from './Drawer';
+import StyledDrawer from './StyledDrawer';
 import MultipleDrawer from './MultipleDrawer';
 import TabsInDrawer from './TabsInDrawer';
 import ModalStack from './ModalStack';
@@ -62,6 +63,10 @@ const ExampleInfo = {
   Drawer: {
     name: 'Drawer Example',
     description: 'Android-style drawer navigation',
+  },
+  StyledDrawer: {
+    name: 'Styled Drawer Example',
+    description: 'Drawer navigation using extra styling',
   },
   StackWithHeaderPreset: {
     name: 'UIKit-style Header Transitions',
@@ -133,6 +138,7 @@ const ExampleRoutes = {
   SwitchWithStacks,
   SimpleTabs: SimpleTabs,
   Drawer: Drawer,
+  StyledDrawer: StyledDrawer,
   // MultipleDrawer: {
   //   screen: MultipleDrawer,
   // },

--- a/examples/NavigationPlayground/js/StyledDrawer.js
+++ b/examples/NavigationPlayground/js/StyledDrawer.js
@@ -1,0 +1,91 @@
+/**
+ * @flow
+ */
+
+import React from 'react';
+import { Platform, ScrollView, StatusBar } from 'react-native';
+import {
+  StackNavigator,
+  DrawerNavigator,
+  SafeAreaView,
+} from 'react-navigation';
+import MaterialIcons from 'react-native-vector-icons/MaterialIcons';
+import SampleText from './SampleText';
+import { Button } from './commonComponents/ButtonWithMargin';
+
+const MyNavScreen = ({ navigation, banner }) => (
+  <ScrollView>
+    <SafeAreaView forceInset={{ top: 'always' }}>
+      <SampleText>{banner}</SampleText>
+      <Button onPress={() => navigation.openDrawer()} title="Open drawer" />
+      <Button
+        onPress={() => navigation.navigate('Email')}
+        title="Open other screen"
+      />
+      <Button onPress={() => navigation.goBack(null)} title="Go back" />
+    </SafeAreaView>
+    <StatusBar barStyle="default" />
+  </ScrollView>
+);
+
+const InboxScreen = ({ navigation }) => (
+  <MyNavScreen banner={'Inbox Screen'} navigation={navigation} />
+);
+InboxScreen.navigationOptions = {
+  drawerLabel: 'Inbox',
+  drawerIcon: ({ tintColor }) => (
+    <MaterialIcons
+      name="move-to-inbox"
+      size={24}
+      style={{ color: tintColor }}
+    />
+  ),
+};
+
+const EmailScreen = ({ navigation }) => (
+  <MyNavScreen banner={'Email Screen'} navigation={navigation} />
+);
+
+const DraftsScreen = ({ navigation }) => (
+  <MyNavScreen banner={'Drafts Screen'} navigation={navigation} />
+);
+DraftsScreen.navigationOptions = {
+  drawerLabel: 'Drafts',
+  drawerIcon: ({ tintColor }) => (
+    <MaterialIcons name="drafts" size={24} style={{ color: tintColor }} />
+  ),
+};
+
+const InboxStack = StackNavigator({
+  Inbox: { screen: InboxScreen },
+  Email: { screen: EmailScreen },
+});
+
+const DraftsStack = StackNavigator({
+  Drafts: { screen: DraftsScreen },
+  Email: { screen: EmailScreen },
+});
+
+const StyledDrawer = DrawerNavigator(
+  {
+    Inbox: {
+      path: '/',
+      screen: InboxStack,
+    },
+    Drafts: {
+      path: '/sent',
+      screen: DraftsStack,
+    },
+  },
+  {
+    initialRouteName: 'Drafts',
+    contentOptions: {
+      activeTintColor: '#e91e63',
+    },
+    drawerType: 'back',
+    overlayColor: '#00000000',
+    hideStatusBar: true,
+  }
+);
+
+export default StyledDrawer;

--- a/flow/react-navigation.js
+++ b/flow/react-navigation.js
@@ -835,6 +835,11 @@ declare module 'react-navigation' {
     useNativeAnimations?: boolean,
     drawerBackgroundColor?: string,
     screenProps?: {},
+    drawerType?: string,
+    edgeWidth?: number,
+    hideStatusBar?: boolean,
+    statusBarAnimation?: string,
+    overlayColor?: string,
   |};
   declare type _DrawerNavigatorConfig = $Exact<{
     ...NavigationTabRouterConfig,
@@ -975,6 +980,11 @@ declare module 'react-navigation' {
     screenProps?: {},
     navigation: NavigationScreenProp<NavigationState>,
     router: NavigationRouter<NavigationState, NavigationDrawerScreenOptions>,
+    drawerType: string,
+    edgeWidth?: number,
+    hideStatusBar: boolean,
+    statusBarAnimation: string,
+    overlayColor: string,
   };
   declare export var DrawerView: React$ComponentType<_DrawerViewProps>;
 

--- a/jest-setup.js
+++ b/jest-setup.js
@@ -29,6 +29,7 @@ jest.mock('ScrollView', () => {
 // tests don't test the native bits, so just substitute the JS-only
 // polyfill for now
 jest.mock('react-native-gesture-handler/DrawerLayout', () => {
+  // $FlowExpectedError
   return require.requireActual('react-native-drawer-layout-polyfill');
 });
 

--- a/jest-setup.js
+++ b/jest-setup.js
@@ -26,6 +26,12 @@ jest.mock('ScrollView', () => {
   return ScrollView;
 });
 
+// tests don't test the native bits, so just substitute the JS-only
+// polyfill for now
+jest.mock('react-native-gesture-handler/DrawerLayout', () => {
+  return require.requireActual('react-native-drawer-layout-polyfill');
+});
+
 // Mock setState so it waits using setImmediate before actually being called,
 // so we can use jest's mock timers to control it.
 // setState in the test renderer is sync instead of async like react and react-native.

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   ],
   "peerDependencies": {
     "react": "*",
-    "react-native": "*"
+    "react-native": "*",
+    "react-native-gesture-handler": "^1.0.0"
   },
   "dependencies": {
     "clamp": "^1.0.1",
@@ -36,7 +37,6 @@
     "prop-types": "^15.5.10",
     "react-lifecycles-compat": "^3",
     "react-native-drawer-layout-polyfill": "^1.3.2",
-    "react-native-gesture-handler": "^1.0.0-alpha.41",
     "react-native-safe-area-view": "^0.7.0",
     "react-navigation-deprecated-tab-navigator": "1.2.0",
     "react-navigation-tabs": "0.2.0"

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "prop-types": "^15.5.10",
     "react-lifecycles-compat": "^3",
     "react-native-drawer-layout-polyfill": "^1.3.2",
+    "react-native-gesture-handler": "^1.0.0-alpha.41",
     "react-native-safe-area-view": "^0.7.0",
     "react-navigation-deprecated-tab-navigator": "1.2.0",
     "react-navigation-tabs": "0.2.0"

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "prettier-eslint": "^8.8.1",
     "react": "16.2.0",
     "react-native": "^0.52.0",
+    "react-native-gesture-handler": "^1.0.0",
     "react-native-vector-icons": "^4.2.0",
     "react-test-renderer": "^16.0.0"
   },

--- a/src/navigators/createDrawerNavigator.js
+++ b/src/navigators/createDrawerNavigator.js
@@ -41,6 +41,10 @@ const DefaultDrawerConfig = {
   drawerPosition: 'left',
   drawerBackgroundColor: 'white',
   useNativeAnimations: true,
+  drawerType: 'front',
+  hideStatusBar: false,
+  statusBarAnimation: 'slide',
+  overlayColor: 'black',
 };
 
 const DrawerNavigator = (routeConfigs, config = {}) => {

--- a/src/routers/DrawerActions.js
+++ b/src/routers/DrawerActions.js
@@ -5,16 +5,19 @@ const TOGGLE_DRAWER = 'Navigation/TOGGLE_DRAWER';
 const openDrawer = payload => ({
   type: OPEN_DRAWER,
   ...payload,
+  suppressAnimation: false,
 });
 
 const closeDrawer = payload => ({
   type: CLOSE_DRAWER,
   ...payload,
+  suppressAnimation: false,
 });
 
 const toggleDrawer = payload => ({
   type: TOGGLE_DRAWER,
   ...payload,
+  suppressAnimation: false,
 });
 
 export default {

--- a/src/routers/DrawerRouter.js
+++ b/src/routers/DrawerRouter.js
@@ -40,6 +40,7 @@ export default (routeConfigs, config = {}) => {
           return {
             ...state,
             isDrawerOpen: false,
+            suppressAnimation: action.suppressAnimation,
           };
         }
 
@@ -47,6 +48,7 @@ export default (routeConfigs, config = {}) => {
           return {
             ...state,
             isDrawerOpen: true,
+            suppressAnimation: action.suppressAnimation,
           };
         }
 
@@ -54,6 +56,7 @@ export default (routeConfigs, config = {}) => {
           return {
             ...state,
             isDrawerOpen: !state.isDrawerOpen,
+            suppressAnimation: action.suppressAnimation,
           };
         }
       }
@@ -72,6 +75,7 @@ export default (routeConfigs, config = {}) => {
           return {
             ...switchedState,
             isDrawerOpen: false,
+            suppressAnimation: false,
           };
         }
         // Return the state new state, as returned by the switch router.

--- a/src/routers/__tests__/DrawerRouter-test.js
+++ b/src/routers/__tests__/DrawerRouter-test.js
@@ -39,6 +39,7 @@ describe('DrawerRouter', () => {
         { key: 'Bar', routeName: 'Bar', params: undefined },
       ],
       isDrawerOpen: false,
+      suppressAnimation: false,
     };
     expect(state2).toEqual(expectedState2);
     expect(router.getComponentForState(expectedState)).toEqual(ScreenA);

--- a/src/views/Drawer/DrawerView.js
+++ b/src/views/Drawer/DrawerView.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Dimensions } from 'react-native';
-import DrawerLayout from 'react-native-drawer-layout-polyfill';
+import DrawerLayout from 'react-native-gesture-handler/DrawerLayout';
 
 import DrawerSidebar from './DrawerSidebar';
 import NavigationActions from '../../NavigationActions';
@@ -26,29 +26,25 @@ export default class DrawerView extends React.PureComponent {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    const { isDrawerOpen } = this.props.navigation.state;
+    const { isDrawerOpen, suppressAnimation } = this.props.navigation.state;
     const wasDrawerOpen = prevProps.navigation.state.isDrawerOpen;
 
-    if (isDrawerOpen && !wasDrawerOpen) {
-      this._drawer.openDrawer();
-    } else if (wasDrawerOpen && !isDrawerOpen) {
-      this._drawer.closeDrawer();
+    if (!suppressAnimation) {
+      if (isDrawerOpen && !wasDrawerOpen) {
+        this._drawer.openDrawer();
+      } else if (wasDrawerOpen && !isDrawerOpen) {
+        this._drawer.closeDrawer();
+      }
     }
   }
 
-  _handleDrawerOpen = () => {
-    const { navigation } = this.props;
-    const { isDrawerOpen } = navigation.state;
-    if (!isDrawerOpen) {
-      navigation.dispatch({ type: DrawerActions.OPEN_DRAWER });
-    }
-  };
-
-  _handleDrawerClose = () => {
-    const { navigation } = this.props;
-    const { isDrawerOpen } = navigation.state;
-    if (isDrawerOpen) {
-      navigation.dispatch({ type: DrawerActions.CLOSE_DRAWER });
+  _handleDrawerStateChanged = (state, opening) => {
+    if (state === 'Settling') {
+      const { navigation } = this.props;
+      navigation.dispatch({
+        type: opening ? DrawerActions.OPEN_DRAWER : DrawerActions.CLOSE_DRAWER,
+        suppressAnimation: true,
+      });
     }
   };
 
@@ -100,8 +96,7 @@ export default class DrawerView extends React.PureComponent {
           this.props.navigationConfig.drawerBackgroundColor
         }
         drawerWidth={this.state.drawerWidth}
-        onDrawerOpen={this._handleDrawerOpen}
-        onDrawerClose={this._handleDrawerClose}
+        onDrawerStateChanged={this._handleDrawerStateChanged}
         useNativeAnimations={this.props.navigationConfig.useNativeAnimations}
         renderNavigationView={this._renderNavigationView}
         drawerPosition={
@@ -109,6 +104,12 @@ export default class DrawerView extends React.PureComponent {
             ? DrawerLayout.positions.Right
             : DrawerLayout.positions.Left
         }
+        /* props specific to react-nativre-gesture-handler/DrawerLayout */
+        drawerType={this.props.navigationConfig.drawerType}
+        edgeWidth={this.props.navigationConfig.edgeWidth}
+        hideStatusBar={this.props.navigationConfig.hideStatusBar}
+        statusBarAnimation={this.props.navigationConfig.statusBarAnimation}
+        overlayColor={this.props.navigationConfig.overlayColor}
       >
         <DrawerScreen
           screenProps={this.props.screenProps}

--- a/src/views/Drawer/DrawerView.js
+++ b/src/views/Drawer/DrawerView.js
@@ -104,7 +104,7 @@ export default class DrawerView extends React.PureComponent {
             ? DrawerLayout.positions.Right
             : DrawerLayout.positions.Left
         }
-        /* props specific to react-nativre-gesture-handler/DrawerLayout */
+        /* props specific to react-native-gesture-handler/DrawerLayout */
         drawerType={this.props.navigationConfig.drawerType}
         edgeWidth={this.props.navigationConfig.edgeWidth}
         hideStatusBar={this.props.navigationConfig.hideStatusBar}

--- a/src/views/Drawer/DrawerView.js
+++ b/src/views/Drawer/DrawerView.js
@@ -41,10 +41,15 @@ export default class DrawerView extends React.PureComponent {
   _handleDrawerStateChanged = (state, opening) => {
     if (state === 'Settling') {
       const { navigation } = this.props;
-      navigation.dispatch({
-        type: opening ? DrawerActions.OPEN_DRAWER : DrawerActions.CLOSE_DRAWER,
-        suppressAnimation: true,
-      });
+      const { isDrawerOpen } = navigation.state;
+      if (opening !== isDrawerOpen) {
+        navigation.dispatch({
+          type: opening
+            ? DrawerActions.OPEN_DRAWER
+            : DrawerActions.CLOSE_DRAWER,
+          suppressAnimation: true,
+        });
+      }
     }
   };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4881,6 +4881,14 @@ react-native-drawer-layout@1.3.2:
   dependencies:
     react-native-dismiss-keyboard "1.0.0"
 
+react-native-gesture-handler@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-1.0.0.tgz#442c9da5190a9fceb982489f235e889214312e95"
+  dependencies:
+    hoist-non-react-statics "^2.3.1"
+    invariant "^2.2.2"
+    prop-types "^15.5.10"
+
 react-native-safe-area-view@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/react-native-safe-area-view/-/react-native-safe-area-view-0.7.0.tgz#38f5ab9368d6ef9e5d18ab64212938af3ec39421"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4882,8 +4882,8 @@ react-native-drawer-layout@1.3.2:
     react-native-dismiss-keyboard "1.0.0"
 
 react-native-gesture-handler@^1.0.0-alpha.41:
-  version "1.0.0-alpha.41"
-  resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-1.0.0-alpha.41.tgz#5667a1977ab148339ec2e7b0a94ad4b959cf09e5"
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-1.0.0.tgz#442c9da5190a9fceb982489f235e889214312e95"
   dependencies:
     hoist-non-react-statics "^2.3.1"
     invariant "^2.2.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4881,14 +4881,6 @@ react-native-drawer-layout@1.3.2:
   dependencies:
     react-native-dismiss-keyboard "1.0.0"
 
-react-native-gesture-handler@^1.0.0-alpha.41:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-1.0.0.tgz#442c9da5190a9fceb982489f235e889214312e95"
-  dependencies:
-    hoist-non-react-statics "^2.3.1"
-    invariant "^2.2.2"
-    prop-types "^15.5.10"
-
 react-native-safe-area-view@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/react-native-safe-area-view/-/react-native-safe-area-view-0.7.0.tgz#38f5ab9368d6ef9e5d18ab64212938af3ec39421"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4881,6 +4881,14 @@ react-native-drawer-layout@1.3.2:
   dependencies:
     react-native-dismiss-keyboard "1.0.0"
 
+react-native-gesture-handler@^1.0.0-alpha.41:
+  version "1.0.0-alpha.41"
+  resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-1.0.0-alpha.41.tgz#5667a1977ab148339ec2e7b0a94ad4b959cf09e5"
+  dependencies:
+    hoist-non-react-statics "^2.3.1"
+    invariant "^2.2.2"
+    prop-types "^15.5.10"
+
 react-native-safe-area-view@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/react-native-safe-area-view/-/react-native-safe-area-view-0.7.0.tgz#38f5ab9368d6ef9e5d18ab64212938af3ec39421"


### PR DESCRIPTION
**Motivation**

I found myself wanting to create a `DrawerNavigator` with some custom styling:
- Make it appear that the drawer is underneath the view, rather than on top of it
- Style the overlay that hides the non-drawer content
  - Specifically, set it to a color with alpha zero so as to remove it entirely

I found that `react-native-gesture-handler`'s `DrawerLayout` component supports exactly these features, as props. I was about to attempt to create my own custom drawer navigator with this `DrawerLayout`, when I noticed a few things:
- The 3.0 Roadmap (and a handful of other issues) mention a plan to move to using `react-native-gesture-handler/DrawerLayout` in place of the current polyfill. 
- After looking at the source for the existing `DrawerNavigator`, I surmised that it would be very simple to swap out `DrawerLayout`, since the API only contains additions.

However, I didn't see a clear place to discuss my intention here, since:
- The roadmap issue is limited to collaborators
- I couldn't find any other issues PRs discussing this plan
- I didn't see any existing branches going down this road
- It could be an RFC, but the code changes are so small that it seems easier to discuss as a PR

Feel free to close this PR and redirect me to a more appropriate avenue, or reject in favor of an implementation that's already in the works, or something else. I just wanted to start the conversation, and it turned out to be nearly as simple a change as I expected. (I was also hoping that this might help this functionality to be released sooner, since I would really like to use it 🙂)

**Implementation Notes**

Besides swapping out the `DrawerLayout` component, I made these notable changes:
- Don't call `_drawer.{open,close}Drawer()` when the drawer is already {open, closed}
  - If the drawer opens or closes because of non-programmatic user action (e.g. swipe from left, or tap outside drawer), the `onDrawer{Open,Close}` event would cause the drawer to animate a second time with no user action.
  - The `suppressAnimation` approach here feels a bit hacky; I welcome suggestions for another way to make an action only update the nav state without subsequently calling `openDrawer()` or `closeDrawer()`; i.e. distinguishing between.
- Use `onDrawerStateChanged` instead of `onDrawer{Open,Close}`
  - Previously, the navigation state was not being updated until the drawer animation finished
  - This prevented e.g. reopening the drawer while the close animation was still happening
  - Changed to update nav state on the `Settling` state

**Test plan (required)**

- Tests pass
  - I haven't yet updated the `DrawerNavigator` test, because I wasn't sure how to let Jest use a native module - or mock the right subsets of it to make the test still meaningful.
- NavigationPlayground looks good on iOS/Android
  - Behaves same as before
- New props are passed down correctly and have the desired effect
  - Not tested exhaustively; tested with `drawerType`, `hideStatusBar`, and `overlayColor`