### PR TITLE
Rename exports for navigators from XNavigator to createXNavigator

### DIFF
--- a/examples/NavigationPlayground/flow-typed/npm/react-native_vx.x.x.js
+++ b/examples/NavigationPlayground/flow-typed/npm/react-native_vx.x.x.js
@@ -2638,7 +2638,7 @@ declare module 'react-native/local-cli/templates/HelloNavigation/views/chat/Chat
   declare module.exports: any;
 }
 
-declare module 'react-native/local-cli/templates/HelloNavigation/views/HomeScreenTabNavigator' {
+declare module 'react-native/local-cli/templates/HelloNavigation/views/HomeScreencreateTabNavigator' {
   declare module.exports: any;
 }
 
@@ -3609,22 +3609,30 @@ declare module 'react-native/babel-preset/index.js' {
   declare module.exports: $Exports<'react-native/babel-preset/index'>;
 }
 declare module 'react-native/babel-preset/lib/resolvePlugins.js' {
-  declare module.exports: $Exports<'react-native/babel-preset/lib/resolvePlugins'>;
+  declare module.exports: $Exports<
+    'react-native/babel-preset/lib/resolvePlugins'
+  >;
 }
 declare module 'react-native/babel-preset/plugins.js' {
   declare module.exports: $Exports<'react-native/babel-preset/plugins'>;
 }
 declare module 'react-native/babel-preset/transforms/transform-dynamic-import.js' {
-  declare module.exports: $Exports<'react-native/babel-preset/transforms/transform-dynamic-import'>;
+  declare module.exports: $Exports<
+    'react-native/babel-preset/transforms/transform-dynamic-import'
+  >;
 }
 declare module 'react-native/babel-preset/transforms/transform-symbol-member.js' {
-  declare module.exports: $Exports<'react-native/babel-preset/transforms/transform-symbol-member'>;
+  declare module.exports: $Exports<
+    'react-native/babel-preset/transforms/transform-symbol-member'
+  >;
 }
 declare module 'react-native/bots/code-analysis-bot.js' {
   declare module.exports: $Exports<'react-native/bots/code-analysis-bot'>;
 }
 declare module 'react-native/bots/pr-inactivity-bookmarklet.js' {
-  declare module.exports: $Exports<'react-native/bots/pr-inactivity-bookmarklet'>;
+  declare module.exports: $Exports<
+    'react-native/bots/pr-inactivity-bookmarklet'
+  >;
 }
 declare module 'react-native/bots/question-bookmarklet.js' {
   declare module.exports: $Exports<'react-native/bots/question-bookmarklet'>;
@@ -3633,7 +3641,9 @@ declare module 'react-native/cli.js' {
   declare module.exports: $Exports<'react-native/cli'>;
 }
 declare module 'react-native/ContainerShip/scripts/run-android-ci-instrumentation-tests.js' {
-  declare module.exports: $Exports<'react-native/ContainerShip/scripts/run-android-ci-instrumentation-tests'>;
+  declare module.exports: $Exports<
+    'react-native/ContainerShip/scripts/run-android-ci-instrumentation-tests'
+  >;
 }
 declare module 'react-native/danger/dangerfile.js' {
   declare module.exports: $Exports<'react-native/danger/dangerfile'>;
@@ -3663,61 +3673,95 @@ declare module 'react-native/flow/Set.js' {
   declare module.exports: $Exports<'react-native/flow/Set'>;
 }
 declare module 'react-native/IntegrationTests/AccessibilityManagerTest.js' {
-  declare module.exports: $Exports<'react-native/IntegrationTests/AccessibilityManagerTest'>;
+  declare module.exports: $Exports<
+    'react-native/IntegrationTests/AccessibilityManagerTest'
+  >;
 }
 declare module 'react-native/IntegrationTests/AppEventsTest.js' {
-  declare module.exports: $Exports<'react-native/IntegrationTests/AppEventsTest'>;
+  declare module.exports: $Exports<
+    'react-native/IntegrationTests/AppEventsTest'
+  >;
 }
 declare module 'react-native/IntegrationTests/AsyncStorageTest.js' {
-  declare module.exports: $Exports<'react-native/IntegrationTests/AsyncStorageTest'>;
+  declare module.exports: $Exports<
+    'react-native/IntegrationTests/AsyncStorageTest'
+  >;
 }
 declare module 'react-native/IntegrationTests/ImageCachePolicyTest.js' {
-  declare module.exports: $Exports<'react-native/IntegrationTests/ImageCachePolicyTest'>;
+  declare module.exports: $Exports<
+    'react-native/IntegrationTests/ImageCachePolicyTest'
+  >;
 }
 declare module 'react-native/IntegrationTests/ImageSnapshotTest.js' {
-  declare module.exports: $Exports<'react-native/IntegrationTests/ImageSnapshotTest'>;
+  declare module.exports: $Exports<
+    'react-native/IntegrationTests/ImageSnapshotTest'
+  >;
 }
 declare module 'react-native/IntegrationTests/IntegrationTestHarnessTest.js' {
-  declare module.exports: $Exports<'react-native/IntegrationTests/IntegrationTestHarnessTest'>;
+  declare module.exports: $Exports<
+    'react-native/IntegrationTests/IntegrationTestHarnessTest'
+  >;
 }
 declare module 'react-native/IntegrationTests/IntegrationTestsApp.js' {
-  declare module.exports: $Exports<'react-native/IntegrationTests/IntegrationTestsApp'>;
+  declare module.exports: $Exports<
+    'react-native/IntegrationTests/IntegrationTestsApp'
+  >;
 }
 declare module 'react-native/IntegrationTests/LayoutEventsTest.js' {
-  declare module.exports: $Exports<'react-native/IntegrationTests/LayoutEventsTest'>;
+  declare module.exports: $Exports<
+    'react-native/IntegrationTests/LayoutEventsTest'
+  >;
 }
 declare module 'react-native/IntegrationTests/LoggingTestModule.js' {
-  declare module.exports: $Exports<'react-native/IntegrationTests/LoggingTestModule'>;
+  declare module.exports: $Exports<
+    'react-native/IntegrationTests/LoggingTestModule'
+  >;
 }
 declare module 'react-native/IntegrationTests/PromiseTest.js' {
   declare module.exports: $Exports<'react-native/IntegrationTests/PromiseTest'>;
 }
 declare module 'react-native/IntegrationTests/PropertiesUpdateTest.js' {
-  declare module.exports: $Exports<'react-native/IntegrationTests/PropertiesUpdateTest'>;
+  declare module.exports: $Exports<
+    'react-native/IntegrationTests/PropertiesUpdateTest'
+  >;
 }
 declare module 'react-native/IntegrationTests/RCTRootViewIntegrationTestApp.js' {
-  declare module.exports: $Exports<'react-native/IntegrationTests/RCTRootViewIntegrationTestApp'>;
+  declare module.exports: $Exports<
+    'react-native/IntegrationTests/RCTRootViewIntegrationTestApp'
+  >;
 }
 declare module 'react-native/IntegrationTests/ReactContentSizeUpdateTest.js' {
-  declare module.exports: $Exports<'react-native/IntegrationTests/ReactContentSizeUpdateTest'>;
+  declare module.exports: $Exports<
+    'react-native/IntegrationTests/ReactContentSizeUpdateTest'
+  >;
 }
 declare module 'react-native/IntegrationTests/SimpleSnapshotTest.js' {
-  declare module.exports: $Exports<'react-native/IntegrationTests/SimpleSnapshotTest'>;
+  declare module.exports: $Exports<
+    'react-native/IntegrationTests/SimpleSnapshotTest'
+  >;
 }
 declare module 'react-native/IntegrationTests/SizeFlexibilityUpdateTest.js' {
-  declare module.exports: $Exports<'react-native/IntegrationTests/SizeFlexibilityUpdateTest'>;
+  declare module.exports: $Exports<
+    'react-native/IntegrationTests/SizeFlexibilityUpdateTest'
+  >;
 }
 declare module 'react-native/IntegrationTests/SyncMethodTest.js' {
-  declare module.exports: $Exports<'react-native/IntegrationTests/SyncMethodTest'>;
+  declare module.exports: $Exports<
+    'react-native/IntegrationTests/SyncMethodTest'
+  >;
 }
 declare module 'react-native/IntegrationTests/TimersTest.js' {
   declare module.exports: $Exports<'react-native/IntegrationTests/TimersTest'>;
 }
 declare module 'react-native/IntegrationTests/websocket_integration_test_server.js' {
-  declare module.exports: $Exports<'react-native/IntegrationTests/websocket_integration_test_server'>;
+  declare module.exports: $Exports<
+    'react-native/IntegrationTests/websocket_integration_test_server'
+  >;
 }
 declare module 'react-native/IntegrationTests/WebSocketTest.js' {
-  declare module.exports: $Exports<'react-native/IntegrationTests/WebSocketTest'>;
+  declare module.exports: $Exports<
+    'react-native/IntegrationTests/WebSocketTest'
+  >;
 }
 declare module 'react-native/IntegrationTests/WebViewTest.js' {
   declare module.exports: $Exports<'react-native/IntegrationTests/WebViewTest'>;
@@ -3735,13 +3779,17 @@ declare module 'react-native/lib/deepDiffer.js' {
   declare module.exports: $Exports<'react-native/lib/deepDiffer'>;
 }
 declare module 'react-native/lib/deepFreezeAndThrowOnMutationInDev.js' {
-  declare module.exports: $Exports<'react-native/lib/deepFreezeAndThrowOnMutationInDev'>;
+  declare module.exports: $Exports<
+    'react-native/lib/deepFreezeAndThrowOnMutationInDev'
+  >;
 }
 declare module 'react-native/lib/flattenStyle.js' {
   declare module.exports: $Exports<'react-native/lib/flattenStyle'>;
 }
 declare module 'react-native/lib/InitializeJavaScriptAppEngine.js' {
-  declare module.exports: $Exports<'react-native/lib/InitializeJavaScriptAppEngine'>;
+  declare module.exports: $Exports<
+    'react-native/lib/InitializeJavaScriptAppEngine'
+  >;
 }
 declare module 'react-native/lib/RCTEventEmitter.js' {
   declare module.exports: $Exports<'react-native/lib/RCTEventEmitter'>;
@@ -3759,7 +3807,9 @@ declare module 'react-native/lib/View.js' {
   declare module.exports: $Exports<'react-native/lib/View'>;
 }
 declare module 'react-native/Libraries/ActionSheetIOS/ActionSheetIOS.js' {
-  declare module.exports: $Exports<'react-native/Libraries/ActionSheetIOS/ActionSheetIOS'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/ActionSheetIOS/ActionSheetIOS'
+  >;
 }
 declare module 'react-native/Libraries/Alert/Alert.js' {
   declare module.exports: $Exports<'react-native/Libraries/Alert/Alert'>;
@@ -3768,148 +3818,240 @@ declare module 'react-native/Libraries/Alert/AlertIOS.js' {
   declare module.exports: $Exports<'react-native/Libraries/Alert/AlertIOS'>;
 }
 declare module 'react-native/Libraries/Alert/RCTAlertManager.android.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Alert/RCTAlertManager.android'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Alert/RCTAlertManager.android'
+  >;
 }
 declare module 'react-native/Libraries/Alert/RCTAlertManager.ios.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Alert/RCTAlertManager.ios'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Alert/RCTAlertManager.ios'
+  >;
 }
 declare module 'react-native/Libraries/Animated/release/gulpfile.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Animated/release/gulpfile'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Animated/release/gulpfile'
+  >;
 }
 declare module 'react-native/Libraries/Animated/src/__tests__/Animated-test.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Animated/src/__tests__/Animated-test'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Animated/src/__tests__/Animated-test'
+  >;
 }
 declare module 'react-native/Libraries/Animated/src/__tests__/AnimatedNative-test.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Animated/src/__tests__/AnimatedNative-test'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Animated/src/__tests__/AnimatedNative-test'
+  >;
 }
 declare module 'react-native/Libraries/Animated/src/__tests__/bezier-test.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Animated/src/__tests__/bezier-test'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Animated/src/__tests__/bezier-test'
+  >;
 }
 declare module 'react-native/Libraries/Animated/src/__tests__/Easing-test.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Animated/src/__tests__/Easing-test'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Animated/src/__tests__/Easing-test'
+  >;
 }
 declare module 'react-native/Libraries/Animated/src/__tests__/Interpolation-test.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Animated/src/__tests__/Interpolation-test'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Animated/src/__tests__/Interpolation-test'
+  >;
 }
 declare module 'react-native/Libraries/Animated/src/Animated.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Animated/src/Animated'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Animated/src/Animated'
+  >;
 }
 declare module 'react-native/Libraries/Animated/src/AnimatedEvent.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Animated/src/AnimatedEvent'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Animated/src/AnimatedEvent'
+  >;
 }
 declare module 'react-native/Libraries/Animated/src/AnimatedImplementation.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Animated/src/AnimatedImplementation'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Animated/src/AnimatedImplementation'
+  >;
 }
 declare module 'react-native/Libraries/Animated/src/AnimatedWeb.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Animated/src/AnimatedWeb'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Animated/src/AnimatedWeb'
+  >;
 }
 declare module 'react-native/Libraries/Animated/src/animations/Animation.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Animated/src/animations/Animation'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Animated/src/animations/Animation'
+  >;
 }
 declare module 'react-native/Libraries/Animated/src/animations/DecayAnimation.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Animated/src/animations/DecayAnimation'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Animated/src/animations/DecayAnimation'
+  >;
 }
 declare module 'react-native/Libraries/Animated/src/animations/SpringAnimation.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Animated/src/animations/SpringAnimation'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Animated/src/animations/SpringAnimation'
+  >;
 }
 declare module 'react-native/Libraries/Animated/src/animations/TimingAnimation.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Animated/src/animations/TimingAnimation'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Animated/src/animations/TimingAnimation'
+  >;
 }
 declare module 'react-native/Libraries/Animated/src/bezier.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Animated/src/bezier'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Animated/src/bezier'
+  >;
 }
 declare module 'react-native/Libraries/Animated/src/createAnimatedComponent.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Animated/src/createAnimatedComponent'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Animated/src/createAnimatedComponent'
+  >;
 }
 declare module 'react-native/Libraries/Animated/src/Easing.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Animated/src/Easing'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Animated/src/Easing'
+  >;
 }
 declare module 'react-native/Libraries/Animated/src/NativeAnimatedHelper.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Animated/src/NativeAnimatedHelper'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Animated/src/NativeAnimatedHelper'
+  >;
 }
 declare module 'react-native/Libraries/Animated/src/nodes/AnimatedAddition.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Animated/src/nodes/AnimatedAddition'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Animated/src/nodes/AnimatedAddition'
+  >;
 }
 declare module 'react-native/Libraries/Animated/src/nodes/AnimatedDiffClamp.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Animated/src/nodes/AnimatedDiffClamp'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Animated/src/nodes/AnimatedDiffClamp'
+  >;
 }
 declare module 'react-native/Libraries/Animated/src/nodes/AnimatedDivision.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Animated/src/nodes/AnimatedDivision'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Animated/src/nodes/AnimatedDivision'
+  >;
 }
 declare module 'react-native/Libraries/Animated/src/nodes/AnimatedInterpolation.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Animated/src/nodes/AnimatedInterpolation'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Animated/src/nodes/AnimatedInterpolation'
+  >;
 }
 declare module 'react-native/Libraries/Animated/src/nodes/AnimatedModulo.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Animated/src/nodes/AnimatedModulo'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Animated/src/nodes/AnimatedModulo'
+  >;
 }
 declare module 'react-native/Libraries/Animated/src/nodes/AnimatedMultiplication.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Animated/src/nodes/AnimatedMultiplication'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Animated/src/nodes/AnimatedMultiplication'
+  >;
 }
 declare module 'react-native/Libraries/Animated/src/nodes/AnimatedNode.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Animated/src/nodes/AnimatedNode'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Animated/src/nodes/AnimatedNode'
+  >;
 }
 declare module 'react-native/Libraries/Animated/src/nodes/AnimatedProps.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Animated/src/nodes/AnimatedProps'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Animated/src/nodes/AnimatedProps'
+  >;
 }
 declare module 'react-native/Libraries/Animated/src/nodes/AnimatedStyle.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Animated/src/nodes/AnimatedStyle'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Animated/src/nodes/AnimatedStyle'
+  >;
 }
 declare module 'react-native/Libraries/Animated/src/nodes/AnimatedTracking.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Animated/src/nodes/AnimatedTracking'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Animated/src/nodes/AnimatedTracking'
+  >;
 }
 declare module 'react-native/Libraries/Animated/src/nodes/AnimatedTransform.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Animated/src/nodes/AnimatedTransform'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Animated/src/nodes/AnimatedTransform'
+  >;
 }
 declare module 'react-native/Libraries/Animated/src/nodes/AnimatedValue.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Animated/src/nodes/AnimatedValue'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Animated/src/nodes/AnimatedValue'
+  >;
 }
 declare module 'react-native/Libraries/Animated/src/nodes/AnimatedValueXY.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Animated/src/nodes/AnimatedValueXY'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Animated/src/nodes/AnimatedValueXY'
+  >;
 }
 declare module 'react-native/Libraries/Animated/src/nodes/AnimatedWithChildren.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Animated/src/nodes/AnimatedWithChildren'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Animated/src/nodes/AnimatedWithChildren'
+  >;
 }
 declare module 'react-native/Libraries/Animated/src/polyfills/flattenStyle.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Animated/src/polyfills/flattenStyle'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Animated/src/polyfills/flattenStyle'
+  >;
 }
 declare module 'react-native/Libraries/Animated/src/polyfills/InteractionManager.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Animated/src/polyfills/InteractionManager'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Animated/src/polyfills/InteractionManager'
+  >;
 }
 declare module 'react-native/Libraries/Animated/src/polyfills/Set.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Animated/src/polyfills/Set'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Animated/src/polyfills/Set'
+  >;
 }
 declare module 'react-native/Libraries/Animated/src/SpringConfig.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Animated/src/SpringConfig'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Animated/src/SpringConfig'
+  >;
 }
 declare module 'react-native/Libraries/AppState/AppState.js' {
   declare module.exports: $Exports<'react-native/Libraries/AppState/AppState'>;
 }
 declare module 'react-native/Libraries/ART/ARTSerializablePath.js' {
-  declare module.exports: $Exports<'react-native/Libraries/ART/ARTSerializablePath'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/ART/ARTSerializablePath'
+  >;
 }
 declare module 'react-native/Libraries/ART/ReactNativeART.js' {
   declare module.exports: $Exports<'react-native/Libraries/ART/ReactNativeART'>;
 }
 declare module 'react-native/Libraries/BatchedBridge/__mocks__/MessageQueueTestConfig.js' {
-  declare module.exports: $Exports<'react-native/Libraries/BatchedBridge/__mocks__/MessageQueueTestConfig'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/BatchedBridge/__mocks__/MessageQueueTestConfig'
+  >;
 }
 declare module 'react-native/Libraries/BatchedBridge/__mocks__/MessageQueueTestModule.js' {
-  declare module.exports: $Exports<'react-native/Libraries/BatchedBridge/__mocks__/MessageQueueTestModule'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/BatchedBridge/__mocks__/MessageQueueTestModule'
+  >;
 }
 declare module 'react-native/Libraries/BatchedBridge/__tests__/MessageQueue-test.js' {
-  declare module.exports: $Exports<'react-native/Libraries/BatchedBridge/__tests__/MessageQueue-test'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/BatchedBridge/__tests__/MessageQueue-test'
+  >;
 }
 declare module 'react-native/Libraries/BatchedBridge/__tests__/NativeModules-test.js' {
-  declare module.exports: $Exports<'react-native/Libraries/BatchedBridge/__tests__/NativeModules-test'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/BatchedBridge/__tests__/NativeModules-test'
+  >;
 }
 declare module 'react-native/Libraries/BatchedBridge/BatchedBridge.js' {
-  declare module.exports: $Exports<'react-native/Libraries/BatchedBridge/BatchedBridge'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/BatchedBridge/BatchedBridge'
+  >;
 }
 declare module 'react-native/Libraries/BatchedBridge/MessageQueue.js' {
-  declare module.exports: $Exports<'react-native/Libraries/BatchedBridge/MessageQueue'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/BatchedBridge/MessageQueue'
+  >;
 }
 declare module 'react-native/Libraries/BatchedBridge/NativeModules.js' {
-  declare module.exports: $Exports<'react-native/Libraries/BatchedBridge/NativeModules'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/BatchedBridge/NativeModules'
+  >;
 }
 declare module 'react-native/Libraries/Blob/Blob.js' {
   declare module.exports: $Exports<'react-native/Libraries/Blob/Blob'>;
@@ -3921,568 +4063,926 @@ declare module 'react-native/Libraries/Blob/URL.js' {
   declare module.exports: $Exports<'react-native/Libraries/Blob/URL'>;
 }
 declare module 'react-native/Libraries/BugReporting/BugReporting.js' {
-  declare module.exports: $Exports<'react-native/Libraries/BugReporting/BugReporting'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/BugReporting/BugReporting'
+  >;
 }
 declare module 'react-native/Libraries/BugReporting/dumpReactTree.js' {
-  declare module.exports: $Exports<'react-native/Libraries/BugReporting/dumpReactTree'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/BugReporting/dumpReactTree'
+  >;
 }
 declare module 'react-native/Libraries/BugReporting/getReactData.js' {
-  declare module.exports: $Exports<'react-native/Libraries/BugReporting/getReactData'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/BugReporting/getReactData'
+  >;
 }
 declare module 'react-native/Libraries/CameraRoll/CameraRoll.js' {
-  declare module.exports: $Exports<'react-native/Libraries/CameraRoll/CameraRoll'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/CameraRoll/CameraRoll'
+  >;
 }
 declare module 'react-native/Libraries/CameraRoll/ImagePickerIOS.js' {
-  declare module.exports: $Exports<'react-native/Libraries/CameraRoll/ImagePickerIOS'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/CameraRoll/ImagePickerIOS'
+  >;
 }
 declare module 'react-native/Libraries/Components/AccessibilityInfo/AccessibilityInfo.android.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/AccessibilityInfo/AccessibilityInfo.android'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/AccessibilityInfo/AccessibilityInfo.android'
+  >;
 }
 declare module 'react-native/Libraries/Components/AccessibilityInfo/AccessibilityInfo.ios.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/AccessibilityInfo/AccessibilityInfo.ios'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/AccessibilityInfo/AccessibilityInfo.ios'
+  >;
 }
 declare module 'react-native/Libraries/Components/ActivityIndicator/ActivityIndicator.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/ActivityIndicator/ActivityIndicator'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/ActivityIndicator/ActivityIndicator'
+  >;
 }
 declare module 'react-native/Libraries/Components/AppleTV/TVEventHandler.android.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/AppleTV/TVEventHandler.android'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/AppleTV/TVEventHandler.android'
+  >;
 }
 declare module 'react-native/Libraries/Components/AppleTV/TVEventHandler.ios.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/AppleTV/TVEventHandler.ios'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/AppleTV/TVEventHandler.ios'
+  >;
 }
 declare module 'react-native/Libraries/Components/AppleTV/TVViewPropTypes.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/AppleTV/TVViewPropTypes'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/AppleTV/TVViewPropTypes'
+  >;
 }
 declare module 'react-native/Libraries/Components/Button.js' {
   declare module.exports: $Exports<'react-native/Libraries/Components/Button'>;
 }
 declare module 'react-native/Libraries/Components/CheckBox/CheckBox.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/CheckBox/CheckBox'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/CheckBox/CheckBox'
+  >;
 }
 declare module 'react-native/Libraries/Components/Clipboard/Clipboard.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/Clipboard/Clipboard'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/Clipboard/Clipboard'
+  >;
 }
 declare module 'react-native/Libraries/Components/DatePicker/DatePickerIOS.android.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/DatePicker/DatePickerIOS.android'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/DatePicker/DatePickerIOS.android'
+  >;
 }
 declare module 'react-native/Libraries/Components/DatePicker/DatePickerIOS.ios.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/DatePicker/DatePickerIOS.ios'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/DatePicker/DatePickerIOS.ios'
+  >;
 }
 declare module 'react-native/Libraries/Components/DatePickerAndroid/DatePickerAndroid.android.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/DatePickerAndroid/DatePickerAndroid.android'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/DatePickerAndroid/DatePickerAndroid.android'
+  >;
 }
 declare module 'react-native/Libraries/Components/DatePickerAndroid/DatePickerAndroid.ios.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/DatePickerAndroid/DatePickerAndroid.ios'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/DatePickerAndroid/DatePickerAndroid.ios'
+  >;
 }
 declare module 'react-native/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.android.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.android'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.android'
+  >;
 }
 declare module 'react-native/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.ios.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.ios'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.ios'
+  >;
 }
 declare module 'react-native/Libraries/Components/Keyboard/Keyboard.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/Keyboard/Keyboard'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/Keyboard/Keyboard'
+  >;
 }
 declare module 'react-native/Libraries/Components/Keyboard/KeyboardAvoidingView.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/Keyboard/KeyboardAvoidingView'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/Keyboard/KeyboardAvoidingView'
+  >;
 }
 declare module 'react-native/Libraries/Components/LazyRenderer.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/LazyRenderer'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/LazyRenderer'
+  >;
 }
 declare module 'react-native/Libraries/Components/MaskedView/MaskedViewIOS.android.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/MaskedView/MaskedViewIOS.android'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/MaskedView/MaskedViewIOS.android'
+  >;
 }
 declare module 'react-native/Libraries/Components/MaskedView/MaskedViewIOS.ios.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/MaskedView/MaskedViewIOS.ios'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/MaskedView/MaskedViewIOS.ios'
+  >;
 }
 declare module 'react-native/Libraries/Components/Navigation/NavigatorIOS.android.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/Navigation/NavigatorIOS.android'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/Navigation/NavigatorIOS.android'
+  >;
 }
 declare module 'react-native/Libraries/Components/Navigation/NavigatorIOS.ios.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/Navigation/NavigatorIOS.ios'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/Navigation/NavigatorIOS.ios'
+  >;
 }
 declare module 'react-native/Libraries/Components/Picker/Picker.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/Picker/Picker'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/Picker/Picker'
+  >;
 }
 declare module 'react-native/Libraries/Components/Picker/PickerAndroid.android.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/Picker/PickerAndroid.android'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/Picker/PickerAndroid.android'
+  >;
 }
 declare module 'react-native/Libraries/Components/Picker/PickerAndroid.ios.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/Picker/PickerAndroid.ios'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/Picker/PickerAndroid.ios'
+  >;
 }
 declare module 'react-native/Libraries/Components/Picker/PickerIOS.android.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/Picker/PickerIOS.android'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/Picker/PickerIOS.android'
+  >;
 }
 declare module 'react-native/Libraries/Components/Picker/PickerIOS.ios.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/Picker/PickerIOS.ios'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/Picker/PickerIOS.ios'
+  >;
 }
 declare module 'react-native/Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.android.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.android'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.android'
+  >;
 }
 declare module 'react-native/Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.ios.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.ios'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.ios'
+  >;
 }
 declare module 'react-native/Libraries/Components/ProgressViewIOS/ProgressViewIOS.android.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/ProgressViewIOS/ProgressViewIOS.android'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/ProgressViewIOS/ProgressViewIOS.android'
+  >;
 }
 declare module 'react-native/Libraries/Components/ProgressViewIOS/ProgressViewIOS.ios.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/ProgressViewIOS/ProgressViewIOS.ios'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/ProgressViewIOS/ProgressViewIOS.ios'
+  >;
 }
 declare module 'react-native/Libraries/Components/RefreshControl/__mocks__/RefreshControlMock.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/RefreshControl/__mocks__/RefreshControlMock'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/RefreshControl/__mocks__/RefreshControlMock'
+  >;
 }
 declare module 'react-native/Libraries/Components/RefreshControl/RefreshControl.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/RefreshControl/RefreshControl'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/RefreshControl/RefreshControl'
+  >;
 }
 declare module 'react-native/Libraries/Components/ScrollResponder.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/ScrollResponder'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/ScrollResponder'
+  >;
 }
 declare module 'react-native/Libraries/Components/ScrollView/__mocks__/ScrollViewMock.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/ScrollView/__mocks__/ScrollViewMock'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/ScrollView/__mocks__/ScrollViewMock'
+  >;
 }
 declare module 'react-native/Libraries/Components/ScrollView/processDecelerationRate.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/ScrollView/processDecelerationRate'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/ScrollView/processDecelerationRate'
+  >;
 }
 declare module 'react-native/Libraries/Components/ScrollView/ScrollView.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/ScrollView/ScrollView'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/ScrollView/ScrollView'
+  >;
 }
 declare module 'react-native/Libraries/Components/ScrollView/ScrollViewStickyHeader.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/ScrollView/ScrollViewStickyHeader'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/ScrollView/ScrollViewStickyHeader'
+  >;
 }
 declare module 'react-native/Libraries/Components/SegmentedControlIOS/SegmentedControlIOS.android.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/SegmentedControlIOS/SegmentedControlIOS.android'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/SegmentedControlIOS/SegmentedControlIOS.android'
+  >;
 }
 declare module 'react-native/Libraries/Components/SegmentedControlIOS/SegmentedControlIOS.ios.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/SegmentedControlIOS/SegmentedControlIOS.ios'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/SegmentedControlIOS/SegmentedControlIOS.ios'
+  >;
 }
 declare module 'react-native/Libraries/Components/Slider/Slider.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/Slider/Slider'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/Slider/Slider'
+  >;
 }
 declare module 'react-native/Libraries/Components/StaticContainer.react.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/StaticContainer.react'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/StaticContainer.react'
+  >;
 }
 declare module 'react-native/Libraries/Components/StaticRenderer.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/StaticRenderer'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/StaticRenderer'
+  >;
 }
 declare module 'react-native/Libraries/Components/StatusBar/StatusBar.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/StatusBar/StatusBar'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/StatusBar/StatusBar'
+  >;
 }
 declare module 'react-native/Libraries/Components/StatusBar/StatusBarIOS.android.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/StatusBar/StatusBarIOS.android'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/StatusBar/StatusBarIOS.android'
+  >;
 }
 declare module 'react-native/Libraries/Components/StatusBar/StatusBarIOS.ios.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/StatusBar/StatusBarIOS.ios'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/StatusBar/StatusBarIOS.ios'
+  >;
 }
 declare module 'react-native/Libraries/Components/Subscribable.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/Subscribable'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/Subscribable'
+  >;
 }
 declare module 'react-native/Libraries/Components/Switch/Switch.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/Switch/Switch'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/Switch/Switch'
+  >;
 }
 declare module 'react-native/Libraries/Components/TabBarIOS/TabBarIOS.android.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/TabBarIOS/TabBarIOS.android'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/TabBarIOS/TabBarIOS.android'
+  >;
 }
 declare module 'react-native/Libraries/Components/TabBarIOS/TabBarIOS.ios.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/TabBarIOS/TabBarIOS.ios'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/TabBarIOS/TabBarIOS.ios'
+  >;
 }
 declare module 'react-native/Libraries/Components/TabBarIOS/TabBarItemIOS.android.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/TabBarIOS/TabBarItemIOS.android'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/TabBarIOS/TabBarItemIOS.android'
+  >;
 }
 declare module 'react-native/Libraries/Components/TabBarIOS/TabBarItemIOS.ios.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/TabBarIOS/TabBarItemIOS.ios'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/TabBarIOS/TabBarItemIOS.ios'
+  >;
 }
 declare module 'react-native/Libraries/Components/TextInput/TextInput.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/TextInput/TextInput'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/TextInput/TextInput'
+  >;
 }
 declare module 'react-native/Libraries/Components/TextInput/TextInputState.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/TextInput/TextInputState'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/TextInput/TextInputState'
+  >;
 }
 declare module 'react-native/Libraries/Components/TimePickerAndroid/TimePickerAndroid.android.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/TimePickerAndroid/TimePickerAndroid.android'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/TimePickerAndroid/TimePickerAndroid.android'
+  >;
 }
 declare module 'react-native/Libraries/Components/TimePickerAndroid/TimePickerAndroid.ios.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/TimePickerAndroid/TimePickerAndroid.ios'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/TimePickerAndroid/TimePickerAndroid.ios'
+  >;
 }
 declare module 'react-native/Libraries/Components/ToastAndroid/ToastAndroid.android.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/ToastAndroid/ToastAndroid.android'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/ToastAndroid/ToastAndroid.android'
+  >;
 }
 declare module 'react-native/Libraries/Components/ToastAndroid/ToastAndroid.ios.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/ToastAndroid/ToastAndroid.ios'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/ToastAndroid/ToastAndroid.ios'
+  >;
 }
 declare module 'react-native/Libraries/Components/ToolbarAndroid/ToolbarAndroid.android.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/ToolbarAndroid/ToolbarAndroid.android'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/ToolbarAndroid/ToolbarAndroid.android'
+  >;
 }
 declare module 'react-native/Libraries/Components/ToolbarAndroid/ToolbarAndroid.ios.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/ToolbarAndroid/ToolbarAndroid.ios'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/ToolbarAndroid/ToolbarAndroid.ios'
+  >;
 }
 declare module 'react-native/Libraries/Components/Touchable/__mocks__/ensureComponentIsNative.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/Touchable/__mocks__/ensureComponentIsNative'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/Touchable/__mocks__/ensureComponentIsNative'
+  >;
 }
 declare module 'react-native/Libraries/Components/Touchable/__tests__/TouchableHighlight-test.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/Touchable/__tests__/TouchableHighlight-test'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/Touchable/__tests__/TouchableHighlight-test'
+  >;
 }
 declare module 'react-native/Libraries/Components/Touchable/BoundingDimensions.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/Touchable/BoundingDimensions'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/Touchable/BoundingDimensions'
+  >;
 }
 declare module 'react-native/Libraries/Components/Touchable/ensureComponentIsNative.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/Touchable/ensureComponentIsNative'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/Touchable/ensureComponentIsNative'
+  >;
 }
 declare module 'react-native/Libraries/Components/Touchable/ensurePositiveDelayProps.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/Touchable/ensurePositiveDelayProps'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/Touchable/ensurePositiveDelayProps'
+  >;
 }
 declare module 'react-native/Libraries/Components/Touchable/Position.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/Touchable/Position'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/Touchable/Position'
+  >;
 }
 declare module 'react-native/Libraries/Components/Touchable/Touchable.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/Touchable/Touchable'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/Touchable/Touchable'
+  >;
 }
 declare module 'react-native/Libraries/Components/Touchable/TouchableBounce.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/Touchable/TouchableBounce'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/Touchable/TouchableBounce'
+  >;
 }
 declare module 'react-native/Libraries/Components/Touchable/TouchableHighlight.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/Touchable/TouchableHighlight'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/Touchable/TouchableHighlight'
+  >;
 }
 declare module 'react-native/Libraries/Components/Touchable/TouchableNativeFeedback.android.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/Touchable/TouchableNativeFeedback.android'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/Touchable/TouchableNativeFeedback.android'
+  >;
 }
 declare module 'react-native/Libraries/Components/Touchable/TouchableNativeFeedback.ios.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/Touchable/TouchableNativeFeedback.ios'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/Touchable/TouchableNativeFeedback.ios'
+  >;
 }
 declare module 'react-native/Libraries/Components/Touchable/TouchableOpacity.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/Touchable/TouchableOpacity'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/Touchable/TouchableOpacity'
+  >;
 }
 declare module 'react-native/Libraries/Components/Touchable/TouchableWithoutFeedback.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/Touchable/TouchableWithoutFeedback'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/Touchable/TouchableWithoutFeedback'
+  >;
 }
 declare module 'react-native/Libraries/Components/UnimplementedViews/UnimplementedView.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/UnimplementedViews/UnimplementedView'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/UnimplementedViews/UnimplementedView'
+  >;
 }
 declare module 'react-native/Libraries/Components/View/PlatformViewPropTypes.android.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/View/PlatformViewPropTypes.android'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/View/PlatformViewPropTypes.android'
+  >;
 }
 declare module 'react-native/Libraries/Components/View/PlatformViewPropTypes.ios.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/View/PlatformViewPropTypes.ios'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/View/PlatformViewPropTypes.ios'
+  >;
 }
 declare module 'react-native/Libraries/Components/View/ReactNativeStyleAttributes.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/View/ReactNativeStyleAttributes'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/View/ReactNativeStyleAttributes'
+  >;
 }
 declare module 'react-native/Libraries/Components/View/ReactNativeViewAttributes.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/View/ReactNativeViewAttributes'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/View/ReactNativeViewAttributes'
+  >;
 }
 declare module 'react-native/Libraries/Components/View/ShadowPropTypesIOS.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/View/ShadowPropTypesIOS'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/View/ShadowPropTypesIOS'
+  >;
 }
 declare module 'react-native/Libraries/Components/View/View.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/View/View'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/View/View'
+  >;
 }
 declare module 'react-native/Libraries/Components/View/ViewAccessibility.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/View/ViewAccessibility'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/View/ViewAccessibility'
+  >;
 }
 declare module 'react-native/Libraries/Components/View/ViewPropTypes.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/View/ViewPropTypes'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/View/ViewPropTypes'
+  >;
 }
 declare module 'react-native/Libraries/Components/View/ViewStylePropTypes.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/View/ViewStylePropTypes'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/View/ViewStylePropTypes'
+  >;
 }
 declare module 'react-native/Libraries/Components/ViewPager/ViewPagerAndroid.android.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/ViewPager/ViewPagerAndroid.android'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/ViewPager/ViewPagerAndroid.android'
+  >;
 }
 declare module 'react-native/Libraries/Components/ViewPager/ViewPagerAndroid.ios.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/ViewPager/ViewPagerAndroid.ios'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/ViewPager/ViewPagerAndroid.ios'
+  >;
 }
 declare module 'react-native/Libraries/Components/WebView/WebView.android.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/WebView/WebView.android'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/WebView/WebView.android'
+  >;
 }
 declare module 'react-native/Libraries/Components/WebView/WebView.ios.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Components/WebView/WebView.ios'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Components/WebView/WebView.ios'
+  >;
 }
 declare module 'react-native/Libraries/Core/__mocks__/ErrorUtils.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Core/__mocks__/ErrorUtils'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Core/__mocks__/ErrorUtils'
+  >;
 }
 declare module 'react-native/Libraries/Core/Devtools/__tests__/parseErrorStack-test.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Core/Devtools/__tests__/parseErrorStack-test'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Core/Devtools/__tests__/parseErrorStack-test'
+  >;
 }
 declare module 'react-native/Libraries/Core/Devtools/getDevServer.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Core/Devtools/getDevServer'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Core/Devtools/getDevServer'
+  >;
 }
 declare module 'react-native/Libraries/Core/Devtools/openFileInEditor.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Core/Devtools/openFileInEditor'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Core/Devtools/openFileInEditor'
+  >;
 }
 declare module 'react-native/Libraries/Core/Devtools/parseErrorStack.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Core/Devtools/parseErrorStack'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Core/Devtools/parseErrorStack'
+  >;
 }
 declare module 'react-native/Libraries/Core/Devtools/setupDevtools.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Core/Devtools/setupDevtools'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Core/Devtools/setupDevtools'
+  >;
 }
 declare module 'react-native/Libraries/Core/Devtools/symbolicateStackTrace.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Core/Devtools/symbolicateStackTrace'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Core/Devtools/symbolicateStackTrace'
+  >;
 }
 declare module 'react-native/Libraries/Core/ExceptionsManager.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Core/ExceptionsManager'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Core/ExceptionsManager'
+  >;
 }
 declare module 'react-native/Libraries/Core/InitializeCore.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Core/InitializeCore'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Core/InitializeCore'
+  >;
 }
 declare module 'react-native/Libraries/Core/ReactNativeVersion.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Core/ReactNativeVersion'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Core/ReactNativeVersion'
+  >;
 }
 declare module 'react-native/Libraries/Core/Timers/JSTimers.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Core/Timers/JSTimers'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Core/Timers/JSTimers'
+  >;
 }
 declare module 'react-native/Libraries/EventEmitter/__mocks__/NativeEventEmitter.js' {
-  declare module.exports: $Exports<'react-native/Libraries/EventEmitter/__mocks__/NativeEventEmitter'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/EventEmitter/__mocks__/NativeEventEmitter'
+  >;
 }
 declare module 'react-native/Libraries/EventEmitter/MissingNativeEventEmitterShim.js' {
-  declare module.exports: $Exports<'react-native/Libraries/EventEmitter/MissingNativeEventEmitterShim'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/EventEmitter/MissingNativeEventEmitterShim'
+  >;
 }
 declare module 'react-native/Libraries/EventEmitter/NativeEventEmitter.js' {
-  declare module.exports: $Exports<'react-native/Libraries/EventEmitter/NativeEventEmitter'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/EventEmitter/NativeEventEmitter'
+  >;
 }
 declare module 'react-native/Libraries/EventEmitter/RCTDeviceEventEmitter.js' {
-  declare module.exports: $Exports<'react-native/Libraries/EventEmitter/RCTDeviceEventEmitter'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/EventEmitter/RCTDeviceEventEmitter'
+  >;
 }
 declare module 'react-native/Libraries/EventEmitter/RCTEventEmitter.js' {
-  declare module.exports: $Exports<'react-native/Libraries/EventEmitter/RCTEventEmitter'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/EventEmitter/RCTEventEmitter'
+  >;
 }
 declare module 'react-native/Libraries/EventEmitter/RCTNativeAppEventEmitter.js' {
-  declare module.exports: $Exports<'react-native/Libraries/EventEmitter/RCTNativeAppEventEmitter'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/EventEmitter/RCTNativeAppEventEmitter'
+  >;
 }
 declare module 'react-native/Libraries/Experimental/Incremental.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Experimental/Incremental'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Experimental/Incremental'
+  >;
 }
 declare module 'react-native/Libraries/Experimental/IncrementalExample.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Experimental/IncrementalExample'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Experimental/IncrementalExample'
+  >;
 }
 declare module 'react-native/Libraries/Experimental/IncrementalGroup.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Experimental/IncrementalGroup'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Experimental/IncrementalGroup'
+  >;
 }
 declare module 'react-native/Libraries/Experimental/IncrementalPresenter.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Experimental/IncrementalPresenter'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Experimental/IncrementalPresenter'
+  >;
 }
 declare module 'react-native/Libraries/Experimental/SwipeableRow/SwipeableListView.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Experimental/SwipeableRow/SwipeableListView'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Experimental/SwipeableRow/SwipeableListView'
+  >;
 }
 declare module 'react-native/Libraries/Experimental/SwipeableRow/SwipeableListViewDataSource.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Experimental/SwipeableRow/SwipeableListViewDataSource'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Experimental/SwipeableRow/SwipeableListViewDataSource'
+  >;
 }
 declare module 'react-native/Libraries/Experimental/SwipeableRow/SwipeableQuickActionButton.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Experimental/SwipeableRow/SwipeableQuickActionButton'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Experimental/SwipeableRow/SwipeableQuickActionButton'
+  >;
 }
 declare module 'react-native/Libraries/Experimental/SwipeableRow/SwipeableQuickActions.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Experimental/SwipeableRow/SwipeableQuickActions'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Experimental/SwipeableRow/SwipeableQuickActions'
+  >;
 }
 declare module 'react-native/Libraries/Experimental/SwipeableRow/SwipeableRow.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Experimental/SwipeableRow/SwipeableRow'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Experimental/SwipeableRow/SwipeableRow'
+  >;
 }
 declare module 'react-native/Libraries/Experimental/WindowedListView.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Experimental/WindowedListView'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Experimental/WindowedListView'
+  >;
 }
 declare module 'react-native/Libraries/Geolocation/Geolocation.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Geolocation/Geolocation'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Geolocation/Geolocation'
+  >;
 }
 declare module 'react-native/Libraries/Image/__tests__/resolveAssetSource-test.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Image/__tests__/resolveAssetSource-test'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Image/__tests__/resolveAssetSource-test'
+  >;
 }
 declare module 'react-native/Libraries/Image/AssetRegistry.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Image/AssetRegistry'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Image/AssetRegistry'
+  >;
 }
 declare module 'react-native/Libraries/Image/AssetSourceResolver.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Image/AssetSourceResolver'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Image/AssetSourceResolver'
+  >;
 }
 declare module 'react-native/Libraries/Image/Image.android.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Image/Image.android'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Image/Image.android'
+  >;
 }
 declare module 'react-native/Libraries/Image/Image.ios.js' {
   declare module.exports: $Exports<'react-native/Libraries/Image/Image.ios'>;
 }
 declare module 'react-native/Libraries/Image/ImageBackground.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Image/ImageBackground'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Image/ImageBackground'
+  >;
 }
 declare module 'react-native/Libraries/Image/ImageEditor.js' {
   declare module.exports: $Exports<'react-native/Libraries/Image/ImageEditor'>;
 }
 declare module 'react-native/Libraries/Image/ImageResizeMode.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Image/ImageResizeMode'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Image/ImageResizeMode'
+  >;
 }
 declare module 'react-native/Libraries/Image/ImageSource.js' {
   declare module.exports: $Exports<'react-native/Libraries/Image/ImageSource'>;
 }
 declare module 'react-native/Libraries/Image/ImageSourcePropType.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Image/ImageSourcePropType'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Image/ImageSourcePropType'
+  >;
 }
 declare module 'react-native/Libraries/Image/ImageStore.js' {
   declare module.exports: $Exports<'react-native/Libraries/Image/ImageStore'>;
 }
 declare module 'react-native/Libraries/Image/ImageStylePropTypes.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Image/ImageStylePropTypes'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Image/ImageStylePropTypes'
+  >;
 }
 declare module 'react-native/Libraries/Image/nativeImageSource.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Image/nativeImageSource'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Image/nativeImageSource'
+  >;
 }
 declare module 'react-native/Libraries/Image/RelativeImageStub.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Image/RelativeImageStub'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Image/RelativeImageStub'
+  >;
 }
 declare module 'react-native/Libraries/Image/resolveAssetSource.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Image/resolveAssetSource'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Image/resolveAssetSource'
+  >;
 }
 declare module 'react-native/Libraries/Inspector/BorderBox.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Inspector/BorderBox'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Inspector/BorderBox'
+  >;
 }
 declare module 'react-native/Libraries/Inspector/BoxInspector.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Inspector/BoxInspector'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Inspector/BoxInspector'
+  >;
 }
 declare module 'react-native/Libraries/Inspector/ElementBox.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Inspector/ElementBox'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Inspector/ElementBox'
+  >;
 }
 declare module 'react-native/Libraries/Inspector/ElementProperties.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Inspector/ElementProperties'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Inspector/ElementProperties'
+  >;
 }
 declare module 'react-native/Libraries/Inspector/Inspector.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Inspector/Inspector'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Inspector/Inspector'
+  >;
 }
 declare module 'react-native/Libraries/Inspector/InspectorOverlay.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Inspector/InspectorOverlay'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Inspector/InspectorOverlay'
+  >;
 }
 declare module 'react-native/Libraries/Inspector/InspectorPanel.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Inspector/InspectorPanel'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Inspector/InspectorPanel'
+  >;
 }
 declare module 'react-native/Libraries/Inspector/NetworkOverlay.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Inspector/NetworkOverlay'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Inspector/NetworkOverlay'
+  >;
 }
 declare module 'react-native/Libraries/Inspector/PerformanceOverlay.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Inspector/PerformanceOverlay'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Inspector/PerformanceOverlay'
+  >;
 }
 declare module 'react-native/Libraries/Inspector/resolveBoxStyle.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Inspector/resolveBoxStyle'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Inspector/resolveBoxStyle'
+  >;
 }
 declare module 'react-native/Libraries/Inspector/StyleInspector.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Inspector/StyleInspector'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Inspector/StyleInspector'
+  >;
 }
 declare module 'react-native/Libraries/Interaction/__tests__/Batchinator-test.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Interaction/__tests__/Batchinator-test'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Interaction/__tests__/Batchinator-test'
+  >;
 }
 declare module 'react-native/Libraries/Interaction/__tests__/InteractionManager-test.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Interaction/__tests__/InteractionManager-test'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Interaction/__tests__/InteractionManager-test'
+  >;
 }
 declare module 'react-native/Libraries/Interaction/__tests__/InteractionMixin-test.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Interaction/__tests__/InteractionMixin-test'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Interaction/__tests__/InteractionMixin-test'
+  >;
 }
 declare module 'react-native/Libraries/Interaction/__tests__/TaskQueue-test.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Interaction/__tests__/TaskQueue-test'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Interaction/__tests__/TaskQueue-test'
+  >;
 }
 declare module 'react-native/Libraries/Interaction/Batchinator.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Interaction/Batchinator'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Interaction/Batchinator'
+  >;
 }
 declare module 'react-native/Libraries/Interaction/BridgeSpyStallHandler.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Interaction/BridgeSpyStallHandler'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Interaction/BridgeSpyStallHandler'
+  >;
 }
 declare module 'react-native/Libraries/Interaction/FrameRateLogger.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Interaction/FrameRateLogger'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Interaction/FrameRateLogger'
+  >;
 }
 declare module 'react-native/Libraries/Interaction/InteractionManager.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Interaction/InteractionManager'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Interaction/InteractionManager'
+  >;
 }
 declare module 'react-native/Libraries/Interaction/InteractionMixin.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Interaction/InteractionMixin'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Interaction/InteractionMixin'
+  >;
 }
 declare module 'react-native/Libraries/Interaction/InteractionStallDebugger.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Interaction/InteractionStallDebugger'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Interaction/InteractionStallDebugger'
+  >;
 }
 declare module 'react-native/Libraries/Interaction/JSEventLoopWatchdog.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Interaction/JSEventLoopWatchdog'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Interaction/JSEventLoopWatchdog'
+  >;
 }
 declare module 'react-native/Libraries/Interaction/PanResponder.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Interaction/PanResponder'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Interaction/PanResponder'
+  >;
 }
 declare module 'react-native/Libraries/Interaction/ReactPerfStallHandler.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Interaction/ReactPerfStallHandler'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Interaction/ReactPerfStallHandler'
+  >;
 }
 declare module 'react-native/Libraries/Interaction/TaskQueue.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Interaction/TaskQueue'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Interaction/TaskQueue'
+  >;
 }
 declare module 'react-native/Libraries/JSInspector/InspectorAgent.js' {
-  declare module.exports: $Exports<'react-native/Libraries/JSInspector/InspectorAgent'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/JSInspector/InspectorAgent'
+  >;
 }
 declare module 'react-native/Libraries/JSInspector/JSInspector.js' {
-  declare module.exports: $Exports<'react-native/Libraries/JSInspector/JSInspector'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/JSInspector/JSInspector'
+  >;
 }
 declare module 'react-native/Libraries/JSInspector/NetworkAgent.js' {
-  declare module.exports: $Exports<'react-native/Libraries/JSInspector/NetworkAgent'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/JSInspector/NetworkAgent'
+  >;
 }
 declare module 'react-native/Libraries/LayoutAnimation/LayoutAnimation.js' {
-  declare module.exports: $Exports<'react-native/Libraries/LayoutAnimation/LayoutAnimation'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/LayoutAnimation/LayoutAnimation'
+  >;
 }
 declare module 'react-native/Libraries/Linking/Linking.js' {
   declare module.exports: $Exports<'react-native/Libraries/Linking/Linking'>;
 }
 declare module 'react-native/Libraries/Lists/__flowtests__/FlatList-flowtest.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Lists/__flowtests__/FlatList-flowtest'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Lists/__flowtests__/FlatList-flowtest'
+  >;
 }
 declare module 'react-native/Libraries/Lists/__flowtests__/SectionList-flowtest.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Lists/__flowtests__/SectionList-flowtest'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Lists/__flowtests__/SectionList-flowtest'
+  >;
 }
 declare module 'react-native/Libraries/Lists/__tests__/FillRateHelper-test.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Lists/__tests__/FillRateHelper-test'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Lists/__tests__/FillRateHelper-test'
+  >;
 }
 declare module 'react-native/Libraries/Lists/__tests__/FlatList-test.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Lists/__tests__/FlatList-test'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Lists/__tests__/FlatList-test'
+  >;
 }
 declare module 'react-native/Libraries/Lists/__tests__/SectionList-test.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Lists/__tests__/SectionList-test'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Lists/__tests__/SectionList-test'
+  >;
 }
 declare module 'react-native/Libraries/Lists/__tests__/ViewabilityHelper-test.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Lists/__tests__/ViewabilityHelper-test'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Lists/__tests__/ViewabilityHelper-test'
+  >;
 }
 declare module 'react-native/Libraries/Lists/__tests__/VirtualizedList-test.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Lists/__tests__/VirtualizedList-test'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Lists/__tests__/VirtualizedList-test'
+  >;
 }
 declare module 'react-native/Libraries/Lists/__tests__/VirtualizeUtils-test.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Lists/__tests__/VirtualizeUtils-test'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Lists/__tests__/VirtualizeUtils-test'
+  >;
 }
 declare module 'react-native/Libraries/Lists/FillRateHelper.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Lists/FillRateHelper'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Lists/FillRateHelper'
+  >;
 }
 declare module 'react-native/Libraries/Lists/FlatList.js' {
   declare module.exports: $Exports<'react-native/Libraries/Lists/FlatList'>;
 }
 declare module 'react-native/Libraries/Lists/ListView/__mocks__/ListViewMock.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Lists/ListView/__mocks__/ListViewMock'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Lists/ListView/__mocks__/ListViewMock'
+  >;
 }
 declare module 'react-native/Libraries/Lists/ListView/ListView.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Lists/ListView/ListView'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Lists/ListView/ListView'
+  >;
 }
 declare module 'react-native/Libraries/Lists/ListView/ListViewDataSource.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Lists/ListView/ListViewDataSource'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Lists/ListView/ListViewDataSource'
+  >;
 }
 declare module 'react-native/Libraries/Lists/MetroListView.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Lists/MetroListView'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Lists/MetroListView'
+  >;
 }
 declare module 'react-native/Libraries/Lists/SectionList.js' {
   declare module.exports: $Exports<'react-native/Libraries/Lists/SectionList'>;
 }
 declare module 'react-native/Libraries/Lists/ViewabilityHelper.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Lists/ViewabilityHelper'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Lists/ViewabilityHelper'
+  >;
 }
 declare module 'react-native/Libraries/Lists/VirtualizedList.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Lists/VirtualizedList'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Lists/VirtualizedList'
+  >;
 }
 declare module 'react-native/Libraries/Lists/VirtualizedSectionList.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Lists/VirtualizedSectionList'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Lists/VirtualizedSectionList'
+  >;
 }
 declare module 'react-native/Libraries/Lists/VirtualizeUtils.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Lists/VirtualizeUtils'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Lists/VirtualizeUtils'
+  >;
 }
 declare module 'react-native/Libraries/Modal/Modal.js' {
   declare module.exports: $Exports<'react-native/Libraries/Modal/Modal'>;
 }
 declare module 'react-native/Libraries/Network/__tests__/FormData-test.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Network/__tests__/FormData-test'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Network/__tests__/FormData-test'
+  >;
 }
 declare module 'react-native/Libraries/Network/__tests__/XMLHttpRequest-test.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Network/__tests__/XMLHttpRequest-test'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Network/__tests__/XMLHttpRequest-test'
+  >;
 }
 declare module 'react-native/Libraries/Network/convertRequestBody.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Network/convertRequestBody'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Network/convertRequestBody'
+  >;
 }
 declare module 'react-native/Libraries/Network/fetch.js' {
   declare module.exports: $Exports<'react-native/Libraries/Network/fetch'>;
@@ -4494,358 +4994,580 @@ declare module 'react-native/Libraries/Network/NetInfo.js' {
   declare module.exports: $Exports<'react-native/Libraries/Network/NetInfo'>;
 }
 declare module 'react-native/Libraries/Network/RCTNetworking.android.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Network/RCTNetworking.android'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Network/RCTNetworking.android'
+  >;
 }
 declare module 'react-native/Libraries/Network/RCTNetworking.ios.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Network/RCTNetworking.ios'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Network/RCTNetworking.ios'
+  >;
 }
 declare module 'react-native/Libraries/Network/XHRInterceptor.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Network/XHRInterceptor'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Network/XHRInterceptor'
+  >;
 }
 declare module 'react-native/Libraries/Network/XMLHttpRequest.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Network/XMLHttpRequest'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Network/XMLHttpRequest'
+  >;
 }
 declare module 'react-native/Libraries/Performance/QuickPerformanceLogger.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Performance/QuickPerformanceLogger'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Performance/QuickPerformanceLogger'
+  >;
 }
 declare module 'react-native/Libraries/Performance/SamplingProfiler.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Performance/SamplingProfiler'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Performance/SamplingProfiler'
+  >;
 }
 declare module 'react-native/Libraries/Performance/Systrace.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Performance/Systrace'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Performance/Systrace'
+  >;
 }
 declare module 'react-native/Libraries/PermissionsAndroid/PermissionsAndroid.js' {
-  declare module.exports: $Exports<'react-native/Libraries/PermissionsAndroid/PermissionsAndroid'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/PermissionsAndroid/PermissionsAndroid'
+  >;
 }
 declare module 'react-native/Libraries/polyfills/__tests__/Object.es7-test.js' {
-  declare module.exports: $Exports<'react-native/Libraries/polyfills/__tests__/Object.es7-test'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/polyfills/__tests__/Object.es7-test'
+  >;
 }
 declare module 'react-native/Libraries/polyfills/Array.es6.js' {
-  declare module.exports: $Exports<'react-native/Libraries/polyfills/Array.es6'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/polyfills/Array.es6'
+  >;
 }
 declare module 'react-native/Libraries/polyfills/Array.prototype.es6.js' {
-  declare module.exports: $Exports<'react-native/Libraries/polyfills/Array.prototype.es6'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/polyfills/Array.prototype.es6'
+  >;
 }
 declare module 'react-native/Libraries/polyfills/babelHelpers.js' {
-  declare module.exports: $Exports<'react-native/Libraries/polyfills/babelHelpers'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/polyfills/babelHelpers'
+  >;
 }
 declare module 'react-native/Libraries/polyfills/console.js' {
   declare module.exports: $Exports<'react-native/Libraries/polyfills/console'>;
 }
 declare module 'react-native/Libraries/polyfills/error-guard.js' {
-  declare module.exports: $Exports<'react-native/Libraries/polyfills/error-guard'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/polyfills/error-guard'
+  >;
 }
 declare module 'react-native/Libraries/polyfills/Number.es6.js' {
-  declare module.exports: $Exports<'react-native/Libraries/polyfills/Number.es6'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/polyfills/Number.es6'
+  >;
 }
 declare module 'react-native/Libraries/polyfills/Object.es6.js' {
-  declare module.exports: $Exports<'react-native/Libraries/polyfills/Object.es6'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/polyfills/Object.es6'
+  >;
 }
 declare module 'react-native/Libraries/polyfills/Object.es7.js' {
-  declare module.exports: $Exports<'react-native/Libraries/polyfills/Object.es7'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/polyfills/Object.es7'
+  >;
 }
 declare module 'react-native/Libraries/polyfills/String.prototype.es6.js' {
-  declare module.exports: $Exports<'react-native/Libraries/polyfills/String.prototype.es6'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/polyfills/String.prototype.es6'
+  >;
 }
 declare module 'react-native/Libraries/Promise.js' {
   declare module.exports: $Exports<'react-native/Libraries/Promise'>;
 }
 declare module 'react-native/Libraries/promiseRejectionIsError.js' {
-  declare module.exports: $Exports<'react-native/Libraries/promiseRejectionIsError'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/promiseRejectionIsError'
+  >;
 }
 declare module 'react-native/Libraries/PushNotificationIOS/PushNotificationIOS.js' {
-  declare module.exports: $Exports<'react-native/Libraries/PushNotificationIOS/PushNotificationIOS'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/PushNotificationIOS/PushNotificationIOS'
+  >;
 }
 declare module 'react-native/Libraries/RCTTest/SnapshotViewIOS.android.js' {
-  declare module.exports: $Exports<'react-native/Libraries/RCTTest/SnapshotViewIOS.android'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/RCTTest/SnapshotViewIOS.android'
+  >;
 }
 declare module 'react-native/Libraries/RCTTest/SnapshotViewIOS.ios.js' {
-  declare module.exports: $Exports<'react-native/Libraries/RCTTest/SnapshotViewIOS.ios'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/RCTTest/SnapshotViewIOS.ios'
+  >;
 }
 declare module 'react-native/Libraries/react-native/react-native-implementation.js' {
-  declare module.exports: $Exports<'react-native/Libraries/react-native/react-native-implementation'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/react-native/react-native-implementation'
+  >;
 }
 declare module 'react-native/Libraries/react-native/react-native-interface.js' {
-  declare module.exports: $Exports<'react-native/Libraries/react-native/react-native-interface'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/react-native/react-native-interface'
+  >;
 }
 declare module 'react-native/Libraries/react-native/React.js' {
   declare module.exports: $Exports<'react-native/Libraries/react-native/React'>;
 }
 declare module 'react-native/Libraries/ReactNative/AppContainer.js' {
-  declare module.exports: $Exports<'react-native/Libraries/ReactNative/AppContainer'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/ReactNative/AppContainer'
+  >;
 }
 declare module 'react-native/Libraries/ReactNative/AppRegistry.js' {
-  declare module.exports: $Exports<'react-native/Libraries/ReactNative/AppRegistry'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/ReactNative/AppRegistry'
+  >;
 }
 declare module 'react-native/Libraries/ReactNative/I18nManager.js' {
-  declare module.exports: $Exports<'react-native/Libraries/ReactNative/I18nManager'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/ReactNative/I18nManager'
+  >;
 }
 declare module 'react-native/Libraries/ReactNative/queryLayoutByID.js' {
-  declare module.exports: $Exports<'react-native/Libraries/ReactNative/queryLayoutByID'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/ReactNative/queryLayoutByID'
+  >;
 }
 declare module 'react-native/Libraries/ReactNative/ReactNativeFeatureFlags.js' {
-  declare module.exports: $Exports<'react-native/Libraries/ReactNative/ReactNativeFeatureFlags'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/ReactNative/ReactNativeFeatureFlags'
+  >;
 }
 declare module 'react-native/Libraries/ReactNative/renderApplication.js' {
-  declare module.exports: $Exports<'react-native/Libraries/ReactNative/renderApplication'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/ReactNative/renderApplication'
+  >;
 }
 declare module 'react-native/Libraries/ReactNative/requireNativeComponent.js' {
-  declare module.exports: $Exports<'react-native/Libraries/ReactNative/requireNativeComponent'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/ReactNative/requireNativeComponent'
+  >;
 }
 declare module 'react-native/Libraries/ReactNative/UIManager.js' {
-  declare module.exports: $Exports<'react-native/Libraries/ReactNative/UIManager'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/ReactNative/UIManager'
+  >;
 }
 declare module 'react-native/Libraries/ReactNative/UIManagerStatTracker.js' {
-  declare module.exports: $Exports<'react-native/Libraries/ReactNative/UIManagerStatTracker'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/ReactNative/UIManagerStatTracker'
+  >;
 }
 declare module 'react-native/Libraries/ReactNative/verifyPropTypes.js' {
-  declare module.exports: $Exports<'react-native/Libraries/ReactNative/verifyPropTypes'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/ReactNative/verifyPropTypes'
+  >;
 }
 declare module 'react-native/Libraries/ReactNative/YellowBox.js' {
-  declare module.exports: $Exports<'react-native/Libraries/ReactNative/YellowBox'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/ReactNative/YellowBox'
+  >;
 }
 declare module 'react-native/Libraries/Renderer/ReactNativeFiber-dev.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Renderer/ReactNativeFiber-dev'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Renderer/ReactNativeFiber-dev'
+  >;
 }
 declare module 'react-native/Libraries/Renderer/ReactNativeFiber-prod.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Renderer/ReactNativeFiber-prod'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Renderer/ReactNativeFiber-prod'
+  >;
 }
 declare module 'react-native/Libraries/Renderer/ReactNativeStack-dev.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Renderer/ReactNativeStack-dev'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Renderer/ReactNativeStack-dev'
+  >;
 }
 declare module 'react-native/Libraries/Renderer/ReactNativeStack-prod.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Renderer/ReactNativeStack-prod'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Renderer/ReactNativeStack-prod'
+  >;
 }
 declare module 'react-native/Libraries/Renderer/shims/createReactNativeComponentClass.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Renderer/shims/createReactNativeComponentClass'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Renderer/shims/createReactNativeComponentClass'
+  >;
 }
 declare module 'react-native/Libraries/Renderer/shims/NativeMethodsMixin.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Renderer/shims/NativeMethodsMixin'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Renderer/shims/NativeMethodsMixin'
+  >;
 }
 declare module 'react-native/Libraries/Renderer/shims/PooledClass.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Renderer/shims/PooledClass'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Renderer/shims/PooledClass'
+  >;
 }
 declare module 'react-native/Libraries/Renderer/shims/ReactDebugTool.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Renderer/shims/ReactDebugTool'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Renderer/shims/ReactDebugTool'
+  >;
 }
 declare module 'react-native/Libraries/Renderer/shims/ReactGlobalSharedState.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Renderer/shims/ReactGlobalSharedState'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Renderer/shims/ReactGlobalSharedState'
+  >;
 }
 declare module 'react-native/Libraries/Renderer/shims/ReactNative.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Renderer/shims/ReactNative'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Renderer/shims/ReactNative'
+  >;
 }
 declare module 'react-native/Libraries/Renderer/shims/ReactNativeComponentTree.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Renderer/shims/ReactNativeComponentTree'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Renderer/shims/ReactNativeComponentTree'
+  >;
 }
 declare module 'react-native/Libraries/Renderer/shims/ReactNativePropRegistry.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Renderer/shims/ReactNativePropRegistry'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Renderer/shims/ReactNativePropRegistry'
+  >;
 }
 declare module 'react-native/Libraries/Renderer/shims/ReactNativeTypes.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Renderer/shims/ReactNativeTypes'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Renderer/shims/ReactNativeTypes'
+  >;
 }
 declare module 'react-native/Libraries/Renderer/shims/ReactPerf.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Renderer/shims/ReactPerf'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Renderer/shims/ReactPerf'
+  >;
 }
 declare module 'react-native/Libraries/Renderer/shims/ReactTypes.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Renderer/shims/ReactTypes'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Renderer/shims/ReactTypes'
+  >;
 }
 declare module 'react-native/Libraries/Renderer/shims/takeSnapshot.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Renderer/shims/takeSnapshot'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Renderer/shims/takeSnapshot'
+  >;
 }
 declare module 'react-native/Libraries/Renderer/shims/TouchHistoryMath.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Renderer/shims/TouchHistoryMath'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Renderer/shims/TouchHistoryMath'
+  >;
 }
 declare module 'react-native/Libraries/Sample/Sample.android.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Sample/Sample.android'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Sample/Sample.android'
+  >;
 }
 declare module 'react-native/Libraries/Sample/Sample.ios.js' {
   declare module.exports: $Exports<'react-native/Libraries/Sample/Sample.ios'>;
 }
 declare module 'react-native/Libraries/Settings/Settings.android.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Settings/Settings.android'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Settings/Settings.android'
+  >;
 }
 declare module 'react-native/Libraries/Settings/Settings.ios.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Settings/Settings.ios'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Settings/Settings.ios'
+  >;
 }
 declare module 'react-native/Libraries/Share/Share.js' {
   declare module.exports: $Exports<'react-native/Libraries/Share/Share'>;
 }
 declare module 'react-native/Libraries/Storage/AsyncStorage.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Storage/AsyncStorage'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Storage/AsyncStorage'
+  >;
 }
 declare module 'react-native/Libraries/StyleSheet/__tests__/flattenStyle-test.js' {
-  declare module.exports: $Exports<'react-native/Libraries/StyleSheet/__tests__/flattenStyle-test'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/StyleSheet/__tests__/flattenStyle-test'
+  >;
 }
 declare module 'react-native/Libraries/StyleSheet/__tests__/normalizeColor-test.js' {
-  declare module.exports: $Exports<'react-native/Libraries/StyleSheet/__tests__/normalizeColor-test'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/StyleSheet/__tests__/normalizeColor-test'
+  >;
 }
 declare module 'react-native/Libraries/StyleSheet/__tests__/processColor-test.js' {
-  declare module.exports: $Exports<'react-native/Libraries/StyleSheet/__tests__/processColor-test'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/StyleSheet/__tests__/processColor-test'
+  >;
 }
 declare module 'react-native/Libraries/StyleSheet/__tests__/processTransform-test.js' {
-  declare module.exports: $Exports<'react-native/Libraries/StyleSheet/__tests__/processTransform-test'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/StyleSheet/__tests__/processTransform-test'
+  >;
 }
 declare module 'react-native/Libraries/StyleSheet/__tests__/setNormalizedColorAlpha-test.js' {
-  declare module.exports: $Exports<'react-native/Libraries/StyleSheet/__tests__/setNormalizedColorAlpha-test'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/StyleSheet/__tests__/setNormalizedColorAlpha-test'
+  >;
 }
 declare module 'react-native/Libraries/StyleSheet/ColorPropType.js' {
-  declare module.exports: $Exports<'react-native/Libraries/StyleSheet/ColorPropType'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/StyleSheet/ColorPropType'
+  >;
 }
 declare module 'react-native/Libraries/StyleSheet/EdgeInsetsPropType.js' {
-  declare module.exports: $Exports<'react-native/Libraries/StyleSheet/EdgeInsetsPropType'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/StyleSheet/EdgeInsetsPropType'
+  >;
 }
 declare module 'react-native/Libraries/StyleSheet/flattenStyle.js' {
-  declare module.exports: $Exports<'react-native/Libraries/StyleSheet/flattenStyle'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/StyleSheet/flattenStyle'
+  >;
 }
 declare module 'react-native/Libraries/StyleSheet/LayoutPropTypes.js' {
-  declare module.exports: $Exports<'react-native/Libraries/StyleSheet/LayoutPropTypes'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/StyleSheet/LayoutPropTypes'
+  >;
 }
 declare module 'react-native/Libraries/StyleSheet/normalizeColor.js' {
-  declare module.exports: $Exports<'react-native/Libraries/StyleSheet/normalizeColor'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/StyleSheet/normalizeColor'
+  >;
 }
 declare module 'react-native/Libraries/StyleSheet/PointPropType.js' {
-  declare module.exports: $Exports<'react-native/Libraries/StyleSheet/PointPropType'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/StyleSheet/PointPropType'
+  >;
 }
 declare module 'react-native/Libraries/StyleSheet/processColor.js' {
-  declare module.exports: $Exports<'react-native/Libraries/StyleSheet/processColor'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/StyleSheet/processColor'
+  >;
 }
 declare module 'react-native/Libraries/StyleSheet/processTransform.js' {
-  declare module.exports: $Exports<'react-native/Libraries/StyleSheet/processTransform'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/StyleSheet/processTransform'
+  >;
 }
 declare module 'react-native/Libraries/StyleSheet/setNormalizedColorAlpha.js' {
-  declare module.exports: $Exports<'react-native/Libraries/StyleSheet/setNormalizedColorAlpha'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/StyleSheet/setNormalizedColorAlpha'
+  >;
 }
 declare module 'react-native/Libraries/StyleSheet/StyleSheet.js' {
-  declare module.exports: $Exports<'react-native/Libraries/StyleSheet/StyleSheet'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/StyleSheet/StyleSheet'
+  >;
 }
 declare module 'react-native/Libraries/StyleSheet/StyleSheetPropType.js' {
-  declare module.exports: $Exports<'react-native/Libraries/StyleSheet/StyleSheetPropType'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/StyleSheet/StyleSheetPropType'
+  >;
 }
 declare module 'react-native/Libraries/StyleSheet/StyleSheetTypes.js' {
-  declare module.exports: $Exports<'react-native/Libraries/StyleSheet/StyleSheetTypes'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/StyleSheet/StyleSheetTypes'
+  >;
 }
 declare module 'react-native/Libraries/StyleSheet/StyleSheetValidation.js' {
-  declare module.exports: $Exports<'react-native/Libraries/StyleSheet/StyleSheetValidation'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/StyleSheet/StyleSheetValidation'
+  >;
 }
 declare module 'react-native/Libraries/StyleSheet/TransformPropTypes.js' {
-  declare module.exports: $Exports<'react-native/Libraries/StyleSheet/TransformPropTypes'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/StyleSheet/TransformPropTypes'
+  >;
 }
 declare module 'react-native/Libraries/Text/Text.js' {
   declare module.exports: $Exports<'react-native/Libraries/Text/Text'>;
 }
 declare module 'react-native/Libraries/Text/TextStylePropTypes.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Text/TextStylePropTypes'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Text/TextStylePropTypes'
+  >;
 }
 declare module 'react-native/Libraries/Text/TextUpdateTest.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Text/TextUpdateTest'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Text/TextUpdateTest'
+  >;
 }
 declare module 'react-native/Libraries/Utilities/__mocks__/BackHandler.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Utilities/__mocks__/BackHandler'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Utilities/__mocks__/BackHandler'
+  >;
 }
 declare module 'react-native/Libraries/Utilities/__mocks__/PixelRatio.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Utilities/__mocks__/PixelRatio'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Utilities/__mocks__/PixelRatio'
+  >;
 }
 declare module 'react-native/Libraries/Utilities/__tests__/buildStyleInterpolator-test.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Utilities/__tests__/buildStyleInterpolator-test'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Utilities/__tests__/buildStyleInterpolator-test'
+  >;
 }
 declare module 'react-native/Libraries/Utilities/__tests__/deepFreezeAndThrowOnMutationInDev-test.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Utilities/__tests__/deepFreezeAndThrowOnMutationInDev-test'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Utilities/__tests__/deepFreezeAndThrowOnMutationInDev-test'
+  >;
 }
 declare module 'react-native/Libraries/Utilities/__tests__/groupByEveryN-test.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Utilities/__tests__/groupByEveryN-test'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Utilities/__tests__/groupByEveryN-test'
+  >;
 }
 declare module 'react-native/Libraries/Utilities/__tests__/mapWithSeparator-test.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Utilities/__tests__/mapWithSeparator-test'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Utilities/__tests__/mapWithSeparator-test'
+  >;
 }
 declare module 'react-native/Libraries/Utilities/__tests__/MatrixMath-test.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Utilities/__tests__/MatrixMath-test'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Utilities/__tests__/MatrixMath-test'
+  >;
 }
 declare module 'react-native/Libraries/Utilities/__tests__/Platform-test.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Utilities/__tests__/Platform-test'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Utilities/__tests__/Platform-test'
+  >;
 }
 declare module 'react-native/Libraries/Utilities/__tests__/SceneTracker-test.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Utilities/__tests__/SceneTracker-test'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Utilities/__tests__/SceneTracker-test'
+  >;
 }
 declare module 'react-native/Libraries/Utilities/__tests__/truncate-test.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Utilities/__tests__/truncate-test'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Utilities/__tests__/truncate-test'
+  >;
 }
 declare module 'react-native/Libraries/Utilities/__tests__/utf8-test.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Utilities/__tests__/utf8-test'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Utilities/__tests__/utf8-test'
+  >;
 }
 declare module 'react-native/Libraries/Utilities/BackAndroid.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Utilities/BackAndroid'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Utilities/BackAndroid'
+  >;
 }
 declare module 'react-native/Libraries/Utilities/BackHandler.android.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Utilities/BackHandler.android'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Utilities/BackHandler.android'
+  >;
 }
 declare module 'react-native/Libraries/Utilities/BackHandler.ios.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Utilities/BackHandler.ios'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Utilities/BackHandler.ios'
+  >;
 }
 declare module 'react-native/Libraries/Utilities/binaryToBase64.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Utilities/binaryToBase64'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Utilities/binaryToBase64'
+  >;
 }
 declare module 'react-native/Libraries/Utilities/buildStyleInterpolator.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Utilities/buildStyleInterpolator'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Utilities/buildStyleInterpolator'
+  >;
 }
 declare module 'react-native/Libraries/Utilities/clamp.js' {
   declare module.exports: $Exports<'react-native/Libraries/Utilities/clamp'>;
 }
 declare module 'react-native/Libraries/Utilities/createStrictShapeTypeChecker.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Utilities/createStrictShapeTypeChecker'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Utilities/createStrictShapeTypeChecker'
+  >;
 }
 declare module 'react-native/Libraries/Utilities/DebugEnvironment.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Utilities/DebugEnvironment'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Utilities/DebugEnvironment'
+  >;
 }
 declare module 'react-native/Libraries/Utilities/deepFreezeAndThrowOnMutationInDev.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Utilities/deepFreezeAndThrowOnMutationInDev'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Utilities/deepFreezeAndThrowOnMutationInDev'
+  >;
 }
 declare module 'react-native/Libraries/Utilities/defineLazyObjectProperty.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Utilities/defineLazyObjectProperty'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Utilities/defineLazyObjectProperty'
+  >;
 }
 declare module 'react-native/Libraries/Utilities/deprecatedPropType.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Utilities/deprecatedPropType'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Utilities/deprecatedPropType'
+  >;
 }
 declare module 'react-native/Libraries/Utilities/DeviceInfo.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Utilities/DeviceInfo'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Utilities/DeviceInfo'
+  >;
 }
 declare module 'react-native/Libraries/Utilities/differ/__tests__/deepDiffer-test.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Utilities/differ/__tests__/deepDiffer-test'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Utilities/differ/__tests__/deepDiffer-test'
+  >;
 }
 declare module 'react-native/Libraries/Utilities/differ/deepDiffer.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Utilities/differ/deepDiffer'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Utilities/differ/deepDiffer'
+  >;
 }
 declare module 'react-native/Libraries/Utilities/differ/insetsDiffer.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Utilities/differ/insetsDiffer'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Utilities/differ/insetsDiffer'
+  >;
 }
 declare module 'react-native/Libraries/Utilities/differ/matricesDiffer.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Utilities/differ/matricesDiffer'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Utilities/differ/matricesDiffer'
+  >;
 }
 declare module 'react-native/Libraries/Utilities/differ/pointsDiffer.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Utilities/differ/pointsDiffer'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Utilities/differ/pointsDiffer'
+  >;
 }
 declare module 'react-native/Libraries/Utilities/differ/sizesDiffer.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Utilities/differ/sizesDiffer'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Utilities/differ/sizesDiffer'
+  >;
 }
 declare module 'react-native/Libraries/Utilities/Dimensions.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Utilities/Dimensions'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Utilities/Dimensions'
+  >;
 }
 declare module 'react-native/Libraries/Utilities/dismissKeyboard.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Utilities/dismissKeyboard'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Utilities/dismissKeyboard'
+  >;
 }
 declare module 'react-native/Libraries/Utilities/groupByEveryN.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Utilities/groupByEveryN'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Utilities/groupByEveryN'
+  >;
 }
 declare module 'react-native/Libraries/Utilities/HeapCapture.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Utilities/HeapCapture'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Utilities/HeapCapture'
+  >;
 }
 declare module 'react-native/Libraries/Utilities/HMRClient.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Utilities/HMRClient'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Utilities/HMRClient'
+  >;
 }
 declare module 'react-native/Libraries/Utilities/HMRLoadingView.android.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Utilities/HMRLoadingView.android'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Utilities/HMRLoadingView.android'
+  >;
 }
 declare module 'react-native/Libraries/Utilities/HMRLoadingView.ios.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Utilities/HMRLoadingView.ios'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Utilities/HMRLoadingView.ios'
+  >;
 }
 declare module 'react-native/Libraries/Utilities/infoLog.js' {
   declare module.exports: $Exports<'react-native/Libraries/Utilities/infoLog'>;
@@ -4854,37 +5576,57 @@ declare module 'react-native/Libraries/Utilities/logError.js' {
   declare module.exports: $Exports<'react-native/Libraries/Utilities/logError'>;
 }
 declare module 'react-native/Libraries/Utilities/mapWithSeparator.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Utilities/mapWithSeparator'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Utilities/mapWithSeparator'
+  >;
 }
 declare module 'react-native/Libraries/Utilities/MatrixMath.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Utilities/MatrixMath'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Utilities/MatrixMath'
+  >;
 }
 declare module 'react-native/Libraries/Utilities/mergeFast.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Utilities/mergeFast'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Utilities/mergeFast'
+  >;
 }
 declare module 'react-native/Libraries/Utilities/mergeIntoFast.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Utilities/mergeIntoFast'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Utilities/mergeIntoFast'
+  >;
 }
 declare module 'react-native/Libraries/Utilities/PerformanceLogger.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Utilities/PerformanceLogger'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Utilities/PerformanceLogger'
+  >;
 }
 declare module 'react-native/Libraries/Utilities/PixelRatio.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Utilities/PixelRatio'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Utilities/PixelRatio'
+  >;
 }
 declare module 'react-native/Libraries/Utilities/Platform.android.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Utilities/Platform.android'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Utilities/Platform.android'
+  >;
 }
 declare module 'react-native/Libraries/Utilities/Platform.ios.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Utilities/Platform.ios'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Utilities/Platform.ios'
+  >;
 }
 declare module 'react-native/Libraries/Utilities/RCTLog.js' {
   declare module.exports: $Exports<'react-native/Libraries/Utilities/RCTLog'>;
 }
 declare module 'react-native/Libraries/Utilities/SceneTracker.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Utilities/SceneTracker'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Utilities/SceneTracker'
+  >;
 }
 declare module 'react-native/Libraries/Utilities/stringifySafe.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Utilities/stringifySafe'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Utilities/stringifySafe'
+  >;
 }
 declare module 'react-native/Libraries/Utilities/truncate.js' {
   declare module.exports: $Exports<'react-native/Libraries/Utilities/truncate'>;
@@ -4893,19 +5635,27 @@ declare module 'react-native/Libraries/Utilities/utf8.js' {
   declare module.exports: $Exports<'react-native/Libraries/Utilities/utf8'>;
 }
 declare module 'react-native/Libraries/vendor/core/_shouldPolyfillES6Collection.js' {
-  declare module.exports: $Exports<'react-native/Libraries/vendor/core/_shouldPolyfillES6Collection'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/vendor/core/_shouldPolyfillES6Collection'
+  >;
 }
 declare module 'react-native/Libraries/vendor/core/ErrorUtils.js' {
-  declare module.exports: $Exports<'react-native/Libraries/vendor/core/ErrorUtils'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/vendor/core/ErrorUtils'
+  >;
 }
 declare module 'react-native/Libraries/vendor/core/getObjectValues.js' {
-  declare module.exports: $Exports<'react-native/Libraries/vendor/core/getObjectValues'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/vendor/core/getObjectValues'
+  >;
 }
 declare module 'react-native/Libraries/vendor/core/guid.js' {
   declare module.exports: $Exports<'react-native/Libraries/vendor/core/guid'>;
 }
 declare module 'react-native/Libraries/vendor/core/isEmpty.js' {
-  declare module.exports: $Exports<'react-native/Libraries/vendor/core/isEmpty'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/vendor/core/isEmpty'
+  >;
 }
 declare module 'react-native/Libraries/vendor/core/Map.js' {
   declare module.exports: $Exports<'react-native/Libraries/vendor/core/Map'>;
@@ -4914,85 +5664,135 @@ declare module 'react-native/Libraries/vendor/core/merge.js' {
   declare module.exports: $Exports<'react-native/Libraries/vendor/core/merge'>;
 }
 declare module 'react-native/Libraries/vendor/core/mergeHelpers.js' {
-  declare module.exports: $Exports<'react-native/Libraries/vendor/core/mergeHelpers'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/vendor/core/mergeHelpers'
+  >;
 }
 declare module 'react-native/Libraries/vendor/core/mergeInto.js' {
-  declare module.exports: $Exports<'react-native/Libraries/vendor/core/mergeInto'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/vendor/core/mergeInto'
+  >;
 }
 declare module 'react-native/Libraries/vendor/core/Set.js' {
   declare module.exports: $Exports<'react-native/Libraries/vendor/core/Set'>;
 }
 declare module 'react-native/Libraries/vendor/core/toIterator.js' {
-  declare module.exports: $Exports<'react-native/Libraries/vendor/core/toIterator'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/vendor/core/toIterator'
+  >;
 }
 declare module 'react-native/Libraries/vendor/document/selection/DocumentSelectionState.js' {
-  declare module.exports: $Exports<'react-native/Libraries/vendor/document/selection/DocumentSelectionState'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/vendor/document/selection/DocumentSelectionState'
+  >;
 }
 declare module 'react-native/Libraries/vendor/emitter/EmitterSubscription.js' {
-  declare module.exports: $Exports<'react-native/Libraries/vendor/emitter/EmitterSubscription'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/vendor/emitter/EmitterSubscription'
+  >;
 }
 declare module 'react-native/Libraries/vendor/emitter/EventEmitter.js' {
-  declare module.exports: $Exports<'react-native/Libraries/vendor/emitter/EventEmitter'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/vendor/emitter/EventEmitter'
+  >;
 }
 declare module 'react-native/Libraries/vendor/emitter/EventEmitterWithHolding.js' {
-  declare module.exports: $Exports<'react-native/Libraries/vendor/emitter/EventEmitterWithHolding'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/vendor/emitter/EventEmitterWithHolding'
+  >;
 }
 declare module 'react-native/Libraries/vendor/emitter/EventHolder.js' {
-  declare module.exports: $Exports<'react-native/Libraries/vendor/emitter/EventHolder'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/vendor/emitter/EventHolder'
+  >;
 }
 declare module 'react-native/Libraries/vendor/emitter/EventSubscription.js' {
-  declare module.exports: $Exports<'react-native/Libraries/vendor/emitter/EventSubscription'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/vendor/emitter/EventSubscription'
+  >;
 }
 declare module 'react-native/Libraries/vendor/emitter/EventSubscriptionVendor.js' {
-  declare module.exports: $Exports<'react-native/Libraries/vendor/emitter/EventSubscriptionVendor'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/vendor/emitter/EventSubscriptionVendor'
+  >;
 }
 declare module 'react-native/Libraries/vendor/emitter/EventValidator.js' {
-  declare module.exports: $Exports<'react-native/Libraries/vendor/emitter/EventValidator'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/vendor/emitter/EventValidator'
+  >;
 }
 declare module 'react-native/Libraries/vendor/emitter/mixInEventEmitter.js' {
-  declare module.exports: $Exports<'react-native/Libraries/vendor/emitter/mixInEventEmitter'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/vendor/emitter/mixInEventEmitter'
+  >;
 }
 declare module 'react-native/Libraries/Vibration/Vibration.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Vibration/Vibration'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Vibration/Vibration'
+  >;
 }
 declare module 'react-native/Libraries/Vibration/VibrationIOS.android.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Vibration/VibrationIOS.android'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Vibration/VibrationIOS.android'
+  >;
 }
 declare module 'react-native/Libraries/Vibration/VibrationIOS.ios.js' {
-  declare module.exports: $Exports<'react-native/Libraries/Vibration/VibrationIOS.ios'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/Vibration/VibrationIOS.ios'
+  >;
 }
 declare module 'react-native/Libraries/WebSocket/__mocks__/event-target-shim.js' {
-  declare module.exports: $Exports<'react-native/Libraries/WebSocket/__mocks__/event-target-shim'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/WebSocket/__mocks__/event-target-shim'
+  >;
 }
 declare module 'react-native/Libraries/WebSocket/__tests__/WebSocket-test.js' {
-  declare module.exports: $Exports<'react-native/Libraries/WebSocket/__tests__/WebSocket-test'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/WebSocket/__tests__/WebSocket-test'
+  >;
 }
 declare module 'react-native/Libraries/WebSocket/WebSocket.js' {
-  declare module.exports: $Exports<'react-native/Libraries/WebSocket/WebSocket'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/WebSocket/WebSocket'
+  >;
 }
 declare module 'react-native/Libraries/WebSocket/WebSocketEvent.js' {
-  declare module.exports: $Exports<'react-native/Libraries/WebSocket/WebSocketEvent'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/WebSocket/WebSocketEvent'
+  >;
 }
 declare module 'react-native/Libraries/WebSocket/WebSocketInterceptor.js' {
-  declare module.exports: $Exports<'react-native/Libraries/WebSocket/WebSocketInterceptor'>;
+  declare module.exports: $Exports<
+    'react-native/Libraries/WebSocket/WebSocketInterceptor'
+  >;
 }
 declare module 'react-native/local-cli/__mocks__/beeper.js' {
   declare module.exports: $Exports<'react-native/local-cli/__mocks__/beeper'>;
 }
 declare module 'react-native/local-cli/bundle/__mocks__/sign.js' {
-  declare module.exports: $Exports<'react-native/local-cli/bundle/__mocks__/sign'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/bundle/__mocks__/sign'
+  >;
 }
 declare module 'react-native/local-cli/bundle/__tests__/filterPlatformAssetScales-test.js' {
-  declare module.exports: $Exports<'react-native/local-cli/bundle/__tests__/filterPlatformAssetScales-test'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/bundle/__tests__/filterPlatformAssetScales-test'
+  >;
 }
 declare module 'react-native/local-cli/bundle/__tests__/getAssetDestPathAndroid-test.js' {
-  declare module.exports: $Exports<'react-native/local-cli/bundle/__tests__/getAssetDestPathAndroid-test'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/bundle/__tests__/getAssetDestPathAndroid-test'
+  >;
 }
 declare module 'react-native/local-cli/bundle/__tests__/getAssetDestPathIOS-test.js' {
-  declare module.exports: $Exports<'react-native/local-cli/bundle/__tests__/getAssetDestPathIOS-test'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/bundle/__tests__/getAssetDestPathIOS-test'
+  >;
 }
 declare module 'react-native/local-cli/bundle/assetPathUtils.js' {
-  declare module.exports: $Exports<'react-native/local-cli/bundle/assetPathUtils'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/bundle/assetPathUtils'
+  >;
 }
 declare module 'react-native/local-cli/bundle/buildBundle.js' {
   declare module.exports: $Exports<'react-native/local-cli/bundle/buildBundle'>;
@@ -5001,16 +5801,24 @@ declare module 'react-native/local-cli/bundle/bundle.js' {
   declare module.exports: $Exports<'react-native/local-cli/bundle/bundle'>;
 }
 declare module 'react-native/local-cli/bundle/bundleCommandLineArgs.js' {
-  declare module.exports: $Exports<'react-native/local-cli/bundle/bundleCommandLineArgs'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/bundle/bundleCommandLineArgs'
+  >;
 }
 declare module 'react-native/local-cli/bundle/filterPlatformAssetScales.js' {
-  declare module.exports: $Exports<'react-native/local-cli/bundle/filterPlatformAssetScales'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/bundle/filterPlatformAssetScales'
+  >;
 }
 declare module 'react-native/local-cli/bundle/getAssetDestPathAndroid.js' {
-  declare module.exports: $Exports<'react-native/local-cli/bundle/getAssetDestPathAndroid'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/bundle/getAssetDestPathAndroid'
+  >;
 }
 declare module 'react-native/local-cli/bundle/getAssetDestPathIOS.js' {
-  declare module.exports: $Exports<'react-native/local-cli/bundle/getAssetDestPathIOS'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/bundle/getAssetDestPathIOS'
+  >;
 }
 declare module 'react-native/local-cli/bundle/saveAssets.js' {
   declare module.exports: $Exports<'react-native/local-cli/bundle/saveAssets'>;
@@ -5031,67 +5839,107 @@ declare module 'react-native/local-cli/commands.js' {
   declare module.exports: $Exports<'react-native/local-cli/commands'>;
 }
 declare module 'react-native/local-cli/core/__fixtures__/android.js' {
-  declare module.exports: $Exports<'react-native/local-cli/core/__fixtures__/android'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/core/__fixtures__/android'
+  >;
 }
 declare module 'react-native/local-cli/core/__fixtures__/commands.js' {
-  declare module.exports: $Exports<'react-native/local-cli/core/__fixtures__/commands'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/core/__fixtures__/commands'
+  >;
 }
 declare module 'react-native/local-cli/core/__fixtures__/dependencies.js' {
-  declare module.exports: $Exports<'react-native/local-cli/core/__fixtures__/dependencies'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/core/__fixtures__/dependencies'
+  >;
 }
 declare module 'react-native/local-cli/core/__fixtures__/ios.js' {
-  declare module.exports: $Exports<'react-native/local-cli/core/__fixtures__/ios'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/core/__fixtures__/ios'
+  >;
 }
 declare module 'react-native/local-cli/core/__fixtures__/projects.js' {
-  declare module.exports: $Exports<'react-native/local-cli/core/__fixtures__/projects'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/core/__fixtures__/projects'
+  >;
 }
 declare module 'react-native/local-cli/core/__tests__/android/findAndroidAppFolder.spec.js' {
-  declare module.exports: $Exports<'react-native/local-cli/core/__tests__/android/findAndroidAppFolder.spec'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/core/__tests__/android/findAndroidAppFolder.spec'
+  >;
 }
 declare module 'react-native/local-cli/core/__tests__/android/findManifest.spec.js' {
-  declare module.exports: $Exports<'react-native/local-cli/core/__tests__/android/findManifest.spec'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/core/__tests__/android/findManifest.spec'
+  >;
 }
 declare module 'react-native/local-cli/core/__tests__/android/findPackageClassName.spec.js' {
-  declare module.exports: $Exports<'react-native/local-cli/core/__tests__/android/findPackageClassName.spec'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/core/__tests__/android/findPackageClassName.spec'
+  >;
 }
 declare module 'react-native/local-cli/core/__tests__/android/getDependencyConfig.spec.js' {
-  declare module.exports: $Exports<'react-native/local-cli/core/__tests__/android/getDependencyConfig.spec'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/core/__tests__/android/getDependencyConfig.spec'
+  >;
 }
 declare module 'react-native/local-cli/core/__tests__/android/getProjectConfig.spec.js' {
-  declare module.exports: $Exports<'react-native/local-cli/core/__tests__/android/getProjectConfig.spec'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/core/__tests__/android/getProjectConfig.spec'
+  >;
 }
 declare module 'react-native/local-cli/core/__tests__/android/readManifest.spec.js' {
-  declare module.exports: $Exports<'react-native/local-cli/core/__tests__/android/readManifest.spec'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/core/__tests__/android/readManifest.spec'
+  >;
 }
 declare module 'react-native/local-cli/core/__tests__/findAssets.spec.js' {
-  declare module.exports: $Exports<'react-native/local-cli/core/__tests__/findAssets.spec'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/core/__tests__/findAssets.spec'
+  >;
 }
 declare module 'react-native/local-cli/core/__tests__/findPlugins.spec.js' {
-  declare module.exports: $Exports<'react-native/local-cli/core/__tests__/findPlugins.spec'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/core/__tests__/findPlugins.spec'
+  >;
 }
 declare module 'react-native/local-cli/core/__tests__/ios/findProject.spec.js' {
-  declare module.exports: $Exports<'react-native/local-cli/core/__tests__/ios/findProject.spec'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/core/__tests__/ios/findProject.spec'
+  >;
 }
 declare module 'react-native/local-cli/core/__tests__/ios/getProjectConfig.spec.js' {
-  declare module.exports: $Exports<'react-native/local-cli/core/__tests__/ios/getProjectConfig.spec'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/core/__tests__/ios/getProjectConfig.spec'
+  >;
 }
 declare module 'react-native/local-cli/core/__tests__/makeCommand.spec.js' {
-  declare module.exports: $Exports<'react-native/local-cli/core/__tests__/makeCommand.spec'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/core/__tests__/makeCommand.spec'
+  >;
 }
 declare module 'react-native/local-cli/core/android/findAndroidAppFolder.js' {
-  declare module.exports: $Exports<'react-native/local-cli/core/android/findAndroidAppFolder'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/core/android/findAndroidAppFolder'
+  >;
 }
 declare module 'react-native/local-cli/core/android/findManifest.js' {
-  declare module.exports: $Exports<'react-native/local-cli/core/android/findManifest'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/core/android/findManifest'
+  >;
 }
 declare module 'react-native/local-cli/core/android/findPackageClassName.js' {
-  declare module.exports: $Exports<'react-native/local-cli/core/android/findPackageClassName'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/core/android/findPackageClassName'
+  >;
 }
 declare module 'react-native/local-cli/core/android/index.js' {
   declare module.exports: $Exports<'react-native/local-cli/core/android/index'>;
 }
 declare module 'react-native/local-cli/core/android/readManifest.js' {
-  declare module.exports: $Exports<'react-native/local-cli/core/android/readManifest'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/core/android/readManifest'
+  >;
 }
 declare module 'react-native/local-cli/core/Constants.js' {
   declare module.exports: $Exports<'react-native/local-cli/core/Constants'>;
@@ -5106,7 +5954,9 @@ declare module 'react-native/local-cli/core/index.js' {
   declare module.exports: $Exports<'react-native/local-cli/core/index'>;
 }
 declare module 'react-native/local-cli/core/ios/findProject.js' {
-  declare module.exports: $Exports<'react-native/local-cli/core/ios/findProject'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/core/ios/findProject'
+  >;
 }
 declare module 'react-native/local-cli/core/ios/index.js' {
   declare module.exports: $Exports<'react-native/local-cli/core/ios/index'>;
@@ -5115,19 +5965,29 @@ declare module 'react-native/local-cli/core/makeCommand.js' {
   declare module.exports: $Exports<'react-native/local-cli/core/makeCommand'>;
 }
 declare module 'react-native/local-cli/core/windows/findNamespace.js' {
-  declare module.exports: $Exports<'react-native/local-cli/core/windows/findNamespace'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/core/windows/findNamespace'
+  >;
 }
 declare module 'react-native/local-cli/core/windows/findPackageClassName.js' {
-  declare module.exports: $Exports<'react-native/local-cli/core/windows/findPackageClassName'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/core/windows/findPackageClassName'
+  >;
 }
 declare module 'react-native/local-cli/core/windows/findProject.js' {
-  declare module.exports: $Exports<'react-native/local-cli/core/windows/findProject'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/core/windows/findProject'
+  >;
 }
 declare module 'react-native/local-cli/core/windows/findWindowsSolution.js' {
-  declare module.exports: $Exports<'react-native/local-cli/core/windows/findWindowsSolution'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/core/windows/findWindowsSolution'
+  >;
 }
 declare module 'react-native/local-cli/core/windows/generateGUID.js' {
-  declare module.exports: $Exports<'react-native/local-cli/core/windows/generateGUID'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/core/windows/generateGUID'
+  >;
 }
 declare module 'react-native/local-cli/core/windows/index.js' {
   declare module.exports: $Exports<'react-native/local-cli/core/windows/index'>;
@@ -5136,22 +5996,32 @@ declare module 'react-native/local-cli/core/wrapCommands.js' {
   declare module.exports: $Exports<'react-native/local-cli/core/wrapCommands'>;
 }
 declare module 'react-native/local-cli/dependencies/dependencies.js' {
-  declare module.exports: $Exports<'react-native/local-cli/dependencies/dependencies'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/dependencies/dependencies'
+  >;
 }
 declare module 'react-native/local-cli/eject/eject.js' {
   declare module.exports: $Exports<'react-native/local-cli/eject/eject'>;
 }
 declare module 'react-native/local-cli/generator/copyProjectTemplateAndReplace.js' {
-  declare module.exports: $Exports<'react-native/local-cli/generator/copyProjectTemplateAndReplace'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/generator/copyProjectTemplateAndReplace'
+  >;
 }
 declare module 'react-native/local-cli/generator/printRunInstructions.js' {
-  declare module.exports: $Exports<'react-native/local-cli/generator/printRunInstructions'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/generator/printRunInstructions'
+  >;
 }
 declare module 'react-native/local-cli/generator/promptSync.js' {
-  declare module.exports: $Exports<'react-native/local-cli/generator/promptSync'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/generator/promptSync'
+  >;
 }
 declare module 'react-native/local-cli/generator/templates.js' {
-  declare module.exports: $Exports<'react-native/local-cli/generator/templates'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/generator/templates'
+  >;
 }
 declare module 'react-native/local-cli/info/info.js' {
   declare module.exports: $Exports<'react-native/local-cli/info/info'>;
@@ -5169,238 +6039,386 @@ declare module 'react-native/local-cli/library/library.js' {
   declare module.exports: $Exports<'react-native/local-cli/library/library'>;
 }
 declare module 'react-native/local-cli/link/__tests__/android/applyPatch.spec.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/__tests__/android/applyPatch.spec'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/__tests__/android/applyPatch.spec'
+  >;
 }
 declare module 'react-native/local-cli/link/__tests__/android/isInstalled.spec.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/__tests__/android/isInstalled.spec'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/__tests__/android/isInstalled.spec'
+  >;
 }
 declare module 'react-native/local-cli/link/__tests__/android/makeBuildPatch.spec.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/__tests__/android/makeBuildPatch.spec'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/__tests__/android/makeBuildPatch.spec'
+  >;
 }
 declare module 'react-native/local-cli/link/__tests__/android/makeImportPatch.spec.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/__tests__/android/makeImportPatch.spec'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/__tests__/android/makeImportPatch.spec'
+  >;
 }
 declare module 'react-native/local-cli/link/__tests__/android/makePackagePatch.spec.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/__tests__/android/makePackagePatch.spec'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/__tests__/android/makePackagePatch.spec'
+  >;
 }
 declare module 'react-native/local-cli/link/__tests__/android/makeSettingsPatch.spec.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/__tests__/android/makeSettingsPatch.spec'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/__tests__/android/makeSettingsPatch.spec'
+  >;
 }
 declare module 'react-native/local-cli/link/__tests__/android/makeStringsPatch.spec.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/__tests__/android/makeStringsPatch.spec'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/__tests__/android/makeStringsPatch.spec'
+  >;
 }
 declare module 'react-native/local-cli/link/__tests__/getDependencyConfig.spec.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/__tests__/getDependencyConfig.spec'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/__tests__/getDependencyConfig.spec'
+  >;
 }
 declare module 'react-native/local-cli/link/__tests__/getProjectDependencies.spec.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/__tests__/getProjectDependencies.spec'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/__tests__/getProjectDependencies.spec'
+  >;
 }
 declare module 'react-native/local-cli/link/__tests__/groupFilesByType.spec.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/__tests__/groupFilesByType.spec'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/__tests__/groupFilesByType.spec'
+  >;
 }
 declare module 'react-native/local-cli/link/__tests__/ios/addFileToProject.spec.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/__tests__/ios/addFileToProject.spec'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/__tests__/ios/addFileToProject.spec'
+  >;
 }
 declare module 'react-native/local-cli/link/__tests__/ios/addProjectToLibraries.spec.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/__tests__/ios/addProjectToLibraries.spec'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/__tests__/ios/addProjectToLibraries.spec'
+  >;
 }
 declare module 'react-native/local-cli/link/__tests__/ios/addSharedLibraries.spec.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/__tests__/ios/addSharedLibraries.spec'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/__tests__/ios/addSharedLibraries.spec'
+  >;
 }
 declare module 'react-native/local-cli/link/__tests__/ios/createGroup.spec.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/__tests__/ios/createGroup.spec'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/__tests__/ios/createGroup.spec'
+  >;
 }
 declare module 'react-native/local-cli/link/__tests__/ios/getBuildProperty.spec.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/__tests__/ios/getBuildProperty.spec'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/__tests__/ios/getBuildProperty.spec'
+  >;
 }
 declare module 'react-native/local-cli/link/__tests__/ios/getGroup.spec.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/__tests__/ios/getGroup.spec'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/__tests__/ios/getGroup.spec'
+  >;
 }
 declare module 'react-native/local-cli/link/__tests__/ios/getHeaderSearchPath.spec.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/__tests__/ios/getHeaderSearchPath.spec'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/__tests__/ios/getHeaderSearchPath.spec'
+  >;
 }
 declare module 'react-native/local-cli/link/__tests__/ios/getHeadersInFolder.spec.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/__tests__/ios/getHeadersInFolder.spec'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/__tests__/ios/getHeadersInFolder.spec'
+  >;
 }
 declare module 'react-native/local-cli/link/__tests__/ios/getPlist.spec.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/__tests__/ios/getPlist.spec'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/__tests__/ios/getPlist.spec'
+  >;
 }
 declare module 'react-native/local-cli/link/__tests__/ios/getPlistPath.spec.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/__tests__/ios/getPlistPath.spec'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/__tests__/ios/getPlistPath.spec'
+  >;
 }
 declare module 'react-native/local-cli/link/__tests__/ios/getProducts.spec.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/__tests__/ios/getProducts.spec'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/__tests__/ios/getProducts.spec'
+  >;
 }
 declare module 'react-native/local-cli/link/__tests__/ios/hasLibraryImported.spec.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/__tests__/ios/hasLibraryImported.spec'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/__tests__/ios/hasLibraryImported.spec'
+  >;
 }
 declare module 'react-native/local-cli/link/__tests__/ios/isInstalled.spec.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/__tests__/ios/isInstalled.spec'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/__tests__/ios/isInstalled.spec'
+  >;
 }
 declare module 'react-native/local-cli/link/__tests__/ios/mapHeaderSearchPaths.spec.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/__tests__/ios/mapHeaderSearchPaths.spec'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/__tests__/ios/mapHeaderSearchPaths.spec'
+  >;
 }
 declare module 'react-native/local-cli/link/__tests__/ios/removeProjectFromLibraries.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/__tests__/ios/removeProjectFromLibraries'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/__tests__/ios/removeProjectFromLibraries'
+  >;
 }
 declare module 'react-native/local-cli/link/__tests__/ios/removeProjectFromProject.spec.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/__tests__/ios/removeProjectFromProject.spec'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/__tests__/ios/removeProjectFromProject.spec'
+  >;
 }
 declare module 'react-native/local-cli/link/__tests__/ios/removeSharedLibrary.spec.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/__tests__/ios/removeSharedLibrary.spec'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/__tests__/ios/removeSharedLibrary.spec'
+  >;
 }
 declare module 'react-native/local-cli/link/__tests__/ios/writePlist.spec.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/__tests__/ios/writePlist.spec'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/__tests__/ios/writePlist.spec'
+  >;
 }
 declare module 'react-native/local-cli/link/__tests__/link.spec.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/__tests__/link.spec'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/__tests__/link.spec'
+  >;
 }
 declare module 'react-native/local-cli/link/__tests__/promiseWaterfall.spec.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/__tests__/promiseWaterfall.spec'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/__tests__/promiseWaterfall.spec'
+  >;
 }
 declare module 'react-native/local-cli/link/android/copyAssets.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/android/copyAssets'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/android/copyAssets'
+  >;
 }
 declare module 'react-native/local-cli/link/android/fs.js' {
   declare module.exports: $Exports<'react-native/local-cli/link/android/fs'>;
 }
 declare module 'react-native/local-cli/link/android/isInstalled.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/android/isInstalled'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/android/isInstalled'
+  >;
 }
 declare module 'react-native/local-cli/link/android/patches/applyParams.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/android/patches/applyParams'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/android/patches/applyParams'
+  >;
 }
 declare module 'react-native/local-cli/link/android/patches/applyPatch.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/android/patches/applyPatch'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/android/patches/applyPatch'
+  >;
 }
 declare module 'react-native/local-cli/link/android/patches/makeBuildPatch.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/android/patches/makeBuildPatch'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/android/patches/makeBuildPatch'
+  >;
 }
 declare module 'react-native/local-cli/link/android/patches/makeImportPatch.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/android/patches/makeImportPatch'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/android/patches/makeImportPatch'
+  >;
 }
 declare module 'react-native/local-cli/link/android/patches/makePackagePatch.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/android/patches/makePackagePatch'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/android/patches/makePackagePatch'
+  >;
 }
 declare module 'react-native/local-cli/link/android/patches/makeSettingsPatch.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/android/patches/makeSettingsPatch'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/android/patches/makeSettingsPatch'
+  >;
 }
 declare module 'react-native/local-cli/link/android/patches/makeStringsPatch.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/android/patches/makeStringsPatch'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/android/patches/makeStringsPatch'
+  >;
 }
 declare module 'react-native/local-cli/link/android/patches/revokePatch.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/android/patches/revokePatch'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/android/patches/revokePatch'
+  >;
 }
 declare module 'react-native/local-cli/link/android/registerNativeModule.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/android/registerNativeModule'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/android/registerNativeModule'
+  >;
 }
 declare module 'react-native/local-cli/link/android/unlinkAssets.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/android/unlinkAssets'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/android/unlinkAssets'
+  >;
 }
 declare module 'react-native/local-cli/link/android/unregisterNativeModule.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/android/unregisterNativeModule'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/android/unregisterNativeModule'
+  >;
 }
 declare module 'react-native/local-cli/link/commandStub.js' {
   declare module.exports: $Exports<'react-native/local-cli/link/commandStub'>;
 }
 declare module 'react-native/local-cli/link/getDependencyConfig.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/getDependencyConfig'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/getDependencyConfig'
+  >;
 }
 declare module 'react-native/local-cli/link/getProjectDependencies.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/getProjectDependencies'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/getProjectDependencies'
+  >;
 }
 declare module 'react-native/local-cli/link/groupFilesByType.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/groupFilesByType'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/groupFilesByType'
+  >;
 }
 declare module 'react-native/local-cli/link/ios/addFileToProject.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/ios/addFileToProject'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/ios/addFileToProject'
+  >;
 }
 declare module 'react-native/local-cli/link/ios/addProjectToLibraries.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/ios/addProjectToLibraries'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/ios/addProjectToLibraries'
+  >;
 }
 declare module 'react-native/local-cli/link/ios/addSharedLibraries.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/ios/addSharedLibraries'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/ios/addSharedLibraries'
+  >;
 }
 declare module 'react-native/local-cli/link/ios/addToHeaderSearchPaths.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/ios/addToHeaderSearchPaths'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/ios/addToHeaderSearchPaths'
+  >;
 }
 declare module 'react-native/local-cli/link/ios/copyAssets.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/ios/copyAssets'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/ios/copyAssets'
+  >;
 }
 declare module 'react-native/local-cli/link/ios/createGroup.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/ios/createGroup'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/ios/createGroup'
+  >;
 }
 declare module 'react-native/local-cli/link/ios/createGroupWithMessage.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/ios/createGroupWithMessage'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/ios/createGroupWithMessage'
+  >;
 }
 declare module 'react-native/local-cli/link/ios/getBuildProperty.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/ios/getBuildProperty'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/ios/getBuildProperty'
+  >;
 }
 declare module 'react-native/local-cli/link/ios/getGroup.js' {
   declare module.exports: $Exports<'react-native/local-cli/link/ios/getGroup'>;
 }
 declare module 'react-native/local-cli/link/ios/getHeaderSearchPath.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/ios/getHeaderSearchPath'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/ios/getHeaderSearchPath'
+  >;
 }
 declare module 'react-native/local-cli/link/ios/getHeadersInFolder.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/ios/getHeadersInFolder'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/ios/getHeadersInFolder'
+  >;
 }
 declare module 'react-native/local-cli/link/ios/getPlist.js' {
   declare module.exports: $Exports<'react-native/local-cli/link/ios/getPlist'>;
 }
 declare module 'react-native/local-cli/link/ios/getPlistPath.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/ios/getPlistPath'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/ios/getPlistPath'
+  >;
 }
 declare module 'react-native/local-cli/link/ios/getProducts.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/ios/getProducts'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/ios/getProducts'
+  >;
 }
 declare module 'react-native/local-cli/link/ios/hasLibraryImported.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/ios/hasLibraryImported'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/ios/hasLibraryImported'
+  >;
 }
 declare module 'react-native/local-cli/link/ios/isInstalled.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/ios/isInstalled'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/ios/isInstalled'
+  >;
 }
 declare module 'react-native/local-cli/link/ios/mapHeaderSearchPaths.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/ios/mapHeaderSearchPaths'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/ios/mapHeaderSearchPaths'
+  >;
 }
 declare module 'react-native/local-cli/link/ios/registerNativeModule.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/ios/registerNativeModule'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/ios/registerNativeModule'
+  >;
 }
 declare module 'react-native/local-cli/link/ios/removeFromHeaderSearchPaths.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/ios/removeFromHeaderSearchPaths'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/ios/removeFromHeaderSearchPaths'
+  >;
 }
 declare module 'react-native/local-cli/link/ios/removeFromPbxItemContainerProxySection.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/ios/removeFromPbxItemContainerProxySection'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/ios/removeFromPbxItemContainerProxySection'
+  >;
 }
 declare module 'react-native/local-cli/link/ios/removeFromPbxReferenceProxySection.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/ios/removeFromPbxReferenceProxySection'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/ios/removeFromPbxReferenceProxySection'
+  >;
 }
 declare module 'react-native/local-cli/link/ios/removeFromProjectReferences.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/ios/removeFromProjectReferences'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/ios/removeFromProjectReferences'
+  >;
 }
 declare module 'react-native/local-cli/link/ios/removeFromStaticLibraries.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/ios/removeFromStaticLibraries'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/ios/removeFromStaticLibraries'
+  >;
 }
 declare module 'react-native/local-cli/link/ios/removeProductGroup.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/ios/removeProductGroup'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/ios/removeProductGroup'
+  >;
 }
 declare module 'react-native/local-cli/link/ios/removeProjectFromLibraries.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/ios/removeProjectFromLibraries'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/ios/removeProjectFromLibraries'
+  >;
 }
 declare module 'react-native/local-cli/link/ios/removeProjectFromProject.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/ios/removeProjectFromProject'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/ios/removeProjectFromProject'
+  >;
 }
 declare module 'react-native/local-cli/link/ios/removeSharedLibraries.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/ios/removeSharedLibraries'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/ios/removeSharedLibraries'
+  >;
 }
 declare module 'react-native/local-cli/link/ios/unlinkAssets.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/ios/unlinkAssets'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/ios/unlinkAssets'
+  >;
 }
 declare module 'react-native/local-cli/link/ios/unregisterNativeModule.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/ios/unregisterNativeModule'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/ios/unregisterNativeModule'
+  >;
 }
 declare module 'react-native/local-cli/link/ios/writePlist.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/ios/writePlist'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/ios/writePlist'
+  >;
 }
 declare module 'react-native/local-cli/link/link.js' {
   declare module.exports: $Exports<'react-native/local-cli/link/link'>;
@@ -5409,7 +6427,9 @@ declare module 'react-native/local-cli/link/pollParams.js' {
   declare module.exports: $Exports<'react-native/local-cli/link/pollParams'>;
 }
 declare module 'react-native/local-cli/link/promiseWaterfall.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/promiseWaterfall'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/promiseWaterfall'
+  >;
 }
 declare module 'react-native/local-cli/link/promisify.js' {
   declare module.exports: $Exports<'react-native/local-cli/link/promisify'>;
@@ -5418,37 +6438,59 @@ declare module 'react-native/local-cli/link/unlink.js' {
   declare module.exports: $Exports<'react-native/local-cli/link/unlink'>;
 }
 declare module 'react-native/local-cli/link/windows/isInstalled.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/windows/isInstalled'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/windows/isInstalled'
+  >;
 }
 declare module 'react-native/local-cli/link/windows/patches/applyParams.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/windows/patches/applyParams'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/windows/patches/applyParams'
+  >;
 }
 declare module 'react-native/local-cli/link/windows/patches/applyPatch.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/windows/patches/applyPatch'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/windows/patches/applyPatch'
+  >;
 }
 declare module 'react-native/local-cli/link/windows/patches/makePackagePatch.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/windows/patches/makePackagePatch'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/windows/patches/makePackagePatch'
+  >;
 }
 declare module 'react-native/local-cli/link/windows/patches/makeProjectPatch.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/windows/patches/makeProjectPatch'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/windows/patches/makeProjectPatch'
+  >;
 }
 declare module 'react-native/local-cli/link/windows/patches/makeSolutionPatch.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/windows/patches/makeSolutionPatch'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/windows/patches/makeSolutionPatch'
+  >;
 }
 declare module 'react-native/local-cli/link/windows/patches/makeUsingPatch.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/windows/patches/makeUsingPatch'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/windows/patches/makeUsingPatch'
+  >;
 }
 declare module 'react-native/local-cli/link/windows/patches/revokePatch.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/windows/patches/revokePatch'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/windows/patches/revokePatch'
+  >;
 }
 declare module 'react-native/local-cli/link/windows/registerNativeModule.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/windows/registerNativeModule'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/windows/registerNativeModule'
+  >;
 }
 declare module 'react-native/local-cli/link/windows/unregisterNativeModule.js' {
-  declare module.exports: $Exports<'react-native/local-cli/link/windows/unregisterNativeModule'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/link/windows/unregisterNativeModule'
+  >;
 }
 declare module 'react-native/local-cli/logAndroid/logAndroid.js' {
-  declare module.exports: $Exports<'react-native/local-cli/logAndroid/logAndroid'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/logAndroid/logAndroid'
+  >;
 }
 declare module 'react-native/local-cli/logIOS/logIOS.js' {
   declare module.exports: $Exports<'react-native/local-cli/logIOS/logIOS'>;
@@ -5457,55 +6499,87 @@ declare module 'react-native/local-cli/runAndroid/adb.js' {
   declare module.exports: $Exports<'react-native/local-cli/runAndroid/adb'>;
 }
 declare module 'react-native/local-cli/runAndroid/runAndroid.js' {
-  declare module.exports: $Exports<'react-native/local-cli/runAndroid/runAndroid'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/runAndroid/runAndroid'
+  >;
 }
 declare module 'react-native/local-cli/runIOS/__tests__/findMatchingSimulator-test.js' {
-  declare module.exports: $Exports<'react-native/local-cli/runIOS/__tests__/findMatchingSimulator-test'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/runIOS/__tests__/findMatchingSimulator-test'
+  >;
 }
 declare module 'react-native/local-cli/runIOS/__tests__/findXcodeProject-test.js' {
-  declare module.exports: $Exports<'react-native/local-cli/runIOS/__tests__/findXcodeProject-test'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/runIOS/__tests__/findXcodeProject-test'
+  >;
 }
 declare module 'react-native/local-cli/runIOS/__tests__/parseIOSDevicesList-test.js' {
-  declare module.exports: $Exports<'react-native/local-cli/runIOS/__tests__/parseIOSDevicesList-test'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/runIOS/__tests__/parseIOSDevicesList-test'
+  >;
 }
 declare module 'react-native/local-cli/runIOS/findMatchingSimulator.js' {
-  declare module.exports: $Exports<'react-native/local-cli/runIOS/findMatchingSimulator'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/runIOS/findMatchingSimulator'
+  >;
 }
 declare module 'react-native/local-cli/runIOS/findXcodeProject.js' {
-  declare module.exports: $Exports<'react-native/local-cli/runIOS/findXcodeProject'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/runIOS/findXcodeProject'
+  >;
 }
 declare module 'react-native/local-cli/runIOS/parseIOSDevicesList.js' {
-  declare module.exports: $Exports<'react-native/local-cli/runIOS/parseIOSDevicesList'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/runIOS/parseIOSDevicesList'
+  >;
 }
 declare module 'react-native/local-cli/runIOS/runIOS.js' {
   declare module.exports: $Exports<'react-native/local-cli/runIOS/runIOS'>;
 }
 declare module 'react-native/local-cli/server/checkNodeVersion.js' {
-  declare module.exports: $Exports<'react-native/local-cli/server/checkNodeVersion'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/server/checkNodeVersion'
+  >;
 }
 declare module 'react-native/local-cli/server/middleware/copyToClipBoardMiddleware.js' {
-  declare module.exports: $Exports<'react-native/local-cli/server/middleware/copyToClipBoardMiddleware'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/server/middleware/copyToClipBoardMiddleware'
+  >;
 }
 declare module 'react-native/local-cli/server/middleware/getDevToolsMiddleware.js' {
-  declare module.exports: $Exports<'react-native/local-cli/server/middleware/getDevToolsMiddleware'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/server/middleware/getDevToolsMiddleware'
+  >;
 }
 declare module 'react-native/local-cli/server/middleware/indexPage.js' {
-  declare module.exports: $Exports<'react-native/local-cli/server/middleware/indexPage'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/server/middleware/indexPage'
+  >;
 }
 declare module 'react-native/local-cli/server/middleware/loadRawBodyMiddleware.js' {
-  declare module.exports: $Exports<'react-native/local-cli/server/middleware/loadRawBodyMiddleware'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/server/middleware/loadRawBodyMiddleware'
+  >;
 }
 declare module 'react-native/local-cli/server/middleware/openStackFrameInEditorMiddleware.js' {
-  declare module.exports: $Exports<'react-native/local-cli/server/middleware/openStackFrameInEditorMiddleware'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/server/middleware/openStackFrameInEditorMiddleware'
+  >;
 }
 declare module 'react-native/local-cli/server/middleware/statusPageMiddleware.js' {
-  declare module.exports: $Exports<'react-native/local-cli/server/middleware/statusPageMiddleware'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/server/middleware/statusPageMiddleware'
+  >;
 }
 declare module 'react-native/local-cli/server/middleware/systraceProfileMiddleware.js' {
-  declare module.exports: $Exports<'react-native/local-cli/server/middleware/systraceProfileMiddleware'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/server/middleware/systraceProfileMiddleware'
+  >;
 }
 declare module 'react-native/local-cli/server/middleware/unless.js' {
-  declare module.exports: $Exports<'react-native/local-cli/server/middleware/unless'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/server/middleware/unless'
+  >;
 }
 declare module 'react-native/local-cli/server/runServer.js' {
   declare module.exports: $Exports<'react-native/local-cli/server/runServer'>;
@@ -5514,73 +6588,119 @@ declare module 'react-native/local-cli/server/server.js' {
   declare module.exports: $Exports<'react-native/local-cli/server/server'>;
 }
 declare module 'react-native/local-cli/server/util/__tests__/getInverseDependencies-test.js' {
-  declare module.exports: $Exports<'react-native/local-cli/server/util/__tests__/getInverseDependencies-test'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/server/util/__tests__/getInverseDependencies-test'
+  >;
 }
 declare module 'react-native/local-cli/server/util/attachHMRServer.js' {
-  declare module.exports: $Exports<'react-native/local-cli/server/util/attachHMRServer'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/server/util/attachHMRServer'
+  >;
 }
 declare module 'react-native/local-cli/server/util/copyToClipBoard.js' {
-  declare module.exports: $Exports<'react-native/local-cli/server/util/copyToClipBoard'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/server/util/copyToClipBoard'
+  >;
 }
 declare module 'react-native/local-cli/server/util/debuggerWorker.js' {
-  declare module.exports: $Exports<'react-native/local-cli/server/util/debuggerWorker'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/server/util/debuggerWorker'
+  >;
 }
 declare module 'react-native/local-cli/server/util/getInverseDependencies.js' {
-  declare module.exports: $Exports<'react-native/local-cli/server/util/getInverseDependencies'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/server/util/getInverseDependencies'
+  >;
 }
 declare module 'react-native/local-cli/server/util/jsPackagerClient.js' {
-  declare module.exports: $Exports<'react-native/local-cli/server/util/jsPackagerClient'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/server/util/jsPackagerClient'
+  >;
 }
 declare module 'react-native/local-cli/server/util/launchChrome.js' {
-  declare module.exports: $Exports<'react-native/local-cli/server/util/launchChrome'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/server/util/launchChrome'
+  >;
 }
 declare module 'react-native/local-cli/server/util/launchEditor.js' {
-  declare module.exports: $Exports<'react-native/local-cli/server/util/launchEditor'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/server/util/launchEditor'
+  >;
 }
 declare module 'react-native/local-cli/server/util/messageSocket.js' {
-  declare module.exports: $Exports<'react-native/local-cli/server/util/messageSocket'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/server/util/messageSocket'
+  >;
 }
 declare module 'react-native/local-cli/server/util/webSocketProxy.js' {
-  declare module.exports: $Exports<'react-native/local-cli/server/util/webSocketProxy'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/server/util/webSocketProxy'
+  >;
 }
 declare module 'react-native/local-cli/templates/HelloNavigation/App.js' {
-  declare module.exports: $Exports<'react-native/local-cli/templates/HelloNavigation/App'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/templates/HelloNavigation/App'
+  >;
 }
 declare module 'react-native/local-cli/templates/HelloNavigation/components/KeyboardSpacer.js' {
-  declare module.exports: $Exports<'react-native/local-cli/templates/HelloNavigation/components/KeyboardSpacer'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/templates/HelloNavigation/components/KeyboardSpacer'
+  >;
 }
 declare module 'react-native/local-cli/templates/HelloNavigation/components/ListItem.js' {
-  declare module.exports: $Exports<'react-native/local-cli/templates/HelloNavigation/components/ListItem'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/templates/HelloNavigation/components/ListItem'
+  >;
 }
 declare module 'react-native/local-cli/templates/HelloNavigation/lib/Backend.js' {
-  declare module.exports: $Exports<'react-native/local-cli/templates/HelloNavigation/lib/Backend'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/templates/HelloNavigation/lib/Backend'
+  >;
 }
 declare module 'react-native/local-cli/templates/HelloNavigation/views/chat/ChatListScreen.js' {
-  declare module.exports: $Exports<'react-native/local-cli/templates/HelloNavigation/views/chat/ChatListScreen'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/templates/HelloNavigation/views/chat/ChatListScreen'
+  >;
 }
 declare module 'react-native/local-cli/templates/HelloNavigation/views/chat/ChatScreen.js' {
-  declare module.exports: $Exports<'react-native/local-cli/templates/HelloNavigation/views/chat/ChatScreen'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/templates/HelloNavigation/views/chat/ChatScreen'
+  >;
 }
-declare module 'react-native/local-cli/templates/HelloNavigation/views/HomeScreenTabNavigator.js' {
-  declare module.exports: $Exports<'react-native/local-cli/templates/HelloNavigation/views/HomeScreenTabNavigator'>;
+declare module 'react-native/local-cli/templates/HelloNavigation/views/HomeScreencreateTabNavigator.js' {
+  declare module.exports: $Exports<
+    'react-native/local-cli/templates/HelloNavigation/views/HomeScreencreateTabNavigator'
+  >;
 }
 declare module 'react-native/local-cli/templates/HelloNavigation/views/welcome/WelcomeScreen.js' {
-  declare module.exports: $Exports<'react-native/local-cli/templates/HelloNavigation/views/welcome/WelcomeScreen'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/templates/HelloNavigation/views/welcome/WelcomeScreen'
+  >;
 }
 declare module 'react-native/local-cli/templates/HelloNavigation/views/welcome/WelcomeText.android.js' {
-  declare module.exports: $Exports<'react-native/local-cli/templates/HelloNavigation/views/welcome/WelcomeText.android'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/templates/HelloNavigation/views/welcome/WelcomeText.android'
+  >;
 }
 declare module 'react-native/local-cli/templates/HelloNavigation/views/welcome/WelcomeText.ios.js' {
-  declare module.exports: $Exports<'react-native/local-cli/templates/HelloNavigation/views/welcome/WelcomeText.ios'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/templates/HelloNavigation/views/welcome/WelcomeText.ios'
+  >;
 }
 declare module 'react-native/local-cli/templates/HelloWorld/__tests__/App.js' {
-  declare module.exports: $Exports<'react-native/local-cli/templates/HelloWorld/__tests__/App'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/templates/HelloWorld/__tests__/App'
+  >;
 }
 declare module 'react-native/local-cli/templates/HelloWorld/App.js' {
-  declare module.exports: $Exports<'react-native/local-cli/templates/HelloWorld/App'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/templates/HelloWorld/App'
+  >;
 }
 declare module 'react-native/local-cli/templates/HelloWorld/index.js' {
-  declare module.exports: $Exports<'react-native/local-cli/templates/HelloWorld/index'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/templates/HelloWorld/index'
+  >;
 }
 declare module 'react-native/local-cli/upgrade/upgrade.js' {
   declare module.exports: $Exports<'react-native/local-cli/upgrade/upgrade'>;
@@ -5592,40 +6712,60 @@ declare module 'react-native/local-cli/util/__mocks__/log.js' {
   declare module.exports: $Exports<'react-native/local-cli/util/__mocks__/log'>;
 }
 declare module 'react-native/local-cli/util/__tests__/findSymlinkedModules-test.js' {
-  declare module.exports: $Exports<'react-native/local-cli/util/__tests__/findSymlinkedModules-test'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/util/__tests__/findSymlinkedModules-test'
+  >;
 }
 declare module 'react-native/local-cli/util/assertRequiredOptions.js' {
-  declare module.exports: $Exports<'react-native/local-cli/util/assertRequiredOptions'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/util/assertRequiredOptions'
+  >;
 }
 declare module 'react-native/local-cli/util/Config.js' {
   declare module.exports: $Exports<'react-native/local-cli/util/Config'>;
 }
 declare module 'react-native/local-cli/util/copyAndReplace.js' {
-  declare module.exports: $Exports<'react-native/local-cli/util/copyAndReplace'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/util/copyAndReplace'
+  >;
 }
 declare module 'react-native/local-cli/util/findReactNativeScripts.js' {
-  declare module.exports: $Exports<'react-native/local-cli/util/findReactNativeScripts'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/util/findReactNativeScripts'
+  >;
 }
 declare module 'react-native/local-cli/util/findSymlinkedModules.js' {
-  declare module.exports: $Exports<'react-native/local-cli/util/findSymlinkedModules'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/util/findSymlinkedModules'
+  >;
 }
 declare module 'react-native/local-cli/util/findSymlinksPaths.js' {
-  declare module.exports: $Exports<'react-native/local-cli/util/findSymlinksPaths'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/util/findSymlinksPaths'
+  >;
 }
 declare module 'react-native/local-cli/util/isPackagerRunning.js' {
-  declare module.exports: $Exports<'react-native/local-cli/util/isPackagerRunning'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/util/isPackagerRunning'
+  >;
 }
 declare module 'react-native/local-cli/util/isValidPackageName.js' {
-  declare module.exports: $Exports<'react-native/local-cli/util/isValidPackageName'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/util/isValidPackageName'
+  >;
 }
 declare module 'react-native/local-cli/util/log.js' {
   declare module.exports: $Exports<'react-native/local-cli/util/log'>;
 }
 declare module 'react-native/local-cli/util/PackageManager.js' {
-  declare module.exports: $Exports<'react-native/local-cli/util/PackageManager'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/util/PackageManager'
+  >;
 }
 declare module 'react-native/local-cli/util/parseCommandLine.js' {
-  declare module.exports: $Exports<'react-native/local-cli/util/parseCommandLine'>;
+  declare module.exports: $Exports<
+    'react-native/local-cli/util/parseCommandLine'
+  >;
 }
 declare module 'react-native/local-cli/util/walk.js' {
   declare module.exports: $Exports<'react-native/local-cli/util/walk'>;
@@ -5640,97 +6780,157 @@ declare module 'react-native/react-native-cli/index.js' {
   declare module.exports: $Exports<'react-native/react-native-cli/index'>;
 }
 declare module 'react-native/react-native-git-upgrade/checks.js' {
-  declare module.exports: $Exports<'react-native/react-native-git-upgrade/checks'>;
+  declare module.exports: $Exports<
+    'react-native/react-native-git-upgrade/checks'
+  >;
 }
 declare module 'react-native/react-native-git-upgrade/cli.js' {
   declare module.exports: $Exports<'react-native/react-native-git-upgrade/cli'>;
 }
 declare module 'react-native/react-native-git-upgrade/cliEntry.js' {
-  declare module.exports: $Exports<'react-native/react-native-git-upgrade/cliEntry'>;
+  declare module.exports: $Exports<
+    'react-native/react-native-git-upgrade/cliEntry'
+  >;
 }
 declare module 'react-native/react-native-git-upgrade/index.js' {
-  declare module.exports: $Exports<'react-native/react-native-git-upgrade/index'>;
+  declare module.exports: $Exports<
+    'react-native/react-native-git-upgrade/index'
+  >;
 }
 declare module 'react-native/react-native-git-upgrade/yarn.js' {
-  declare module.exports: $Exports<'react-native/react-native-git-upgrade/yarn'>;
+  declare module.exports: $Exports<
+    'react-native/react-native-git-upgrade/yarn'
+  >;
 }
 declare module 'react-native/ReactAndroid/src/androidTest/js/Asserts.js' {
-  declare module.exports: $Exports<'react-native/ReactAndroid/src/androidTest/js/Asserts'>;
+  declare module.exports: $Exports<
+    'react-native/ReactAndroid/src/androidTest/js/Asserts'
+  >;
 }
 declare module 'react-native/ReactAndroid/src/androidTest/js/CatalystRootViewTestModule.js' {
-  declare module.exports: $Exports<'react-native/ReactAndroid/src/androidTest/js/CatalystRootViewTestModule'>;
+  declare module.exports: $Exports<
+    'react-native/ReactAndroid/src/androidTest/js/CatalystRootViewTestModule'
+  >;
 }
 declare module 'react-native/ReactAndroid/src/androidTest/js/DatePickerDialogTestModule.js' {
-  declare module.exports: $Exports<'react-native/ReactAndroid/src/androidTest/js/DatePickerDialogTestModule'>;
+  declare module.exports: $Exports<
+    'react-native/ReactAndroid/src/androidTest/js/DatePickerDialogTestModule'
+  >;
 }
 declare module 'react-native/ReactAndroid/src/androidTest/js/InitialPropsTestApp.js' {
-  declare module.exports: $Exports<'react-native/ReactAndroid/src/androidTest/js/InitialPropsTestApp'>;
+  declare module.exports: $Exports<
+    'react-native/ReactAndroid/src/androidTest/js/InitialPropsTestApp'
+  >;
 }
 declare module 'react-native/ReactAndroid/src/androidTest/js/JSResponderTestApp.js' {
-  declare module.exports: $Exports<'react-native/ReactAndroid/src/androidTest/js/JSResponderTestApp'>;
+  declare module.exports: $Exports<
+    'react-native/ReactAndroid/src/androidTest/js/JSResponderTestApp'
+  >;
 }
 declare module 'react-native/ReactAndroid/src/androidTest/js/LayoutEventsTestApp.js' {
-  declare module.exports: $Exports<'react-native/ReactAndroid/src/androidTest/js/LayoutEventsTestApp'>;
+  declare module.exports: $Exports<
+    'react-native/ReactAndroid/src/androidTest/js/LayoutEventsTestApp'
+  >;
 }
 declare module 'react-native/ReactAndroid/src/androidTest/js/MeasureLayoutTestModule.js' {
-  declare module.exports: $Exports<'react-native/ReactAndroid/src/androidTest/js/MeasureLayoutTestModule'>;
+  declare module.exports: $Exports<
+    'react-native/ReactAndroid/src/androidTest/js/MeasureLayoutTestModule'
+  >;
 }
 declare module 'react-native/ReactAndroid/src/androidTest/js/MultitouchHandlingTestAppModule.js' {
-  declare module.exports: $Exports<'react-native/ReactAndroid/src/androidTest/js/MultitouchHandlingTestAppModule'>;
+  declare module.exports: $Exports<
+    'react-native/ReactAndroid/src/androidTest/js/MultitouchHandlingTestAppModule'
+  >;
 }
 declare module 'react-native/ReactAndroid/src/androidTest/js/NativeIdTestModule.js' {
-  declare module.exports: $Exports<'react-native/ReactAndroid/src/androidTest/js/NativeIdTestModule'>;
+  declare module.exports: $Exports<
+    'react-native/ReactAndroid/src/androidTest/js/NativeIdTestModule'
+  >;
 }
 declare module 'react-native/ReactAndroid/src/androidTest/js/PickerAndroidTestModule.js' {
-  declare module.exports: $Exports<'react-native/ReactAndroid/src/androidTest/js/PickerAndroidTestModule'>;
+  declare module.exports: $Exports<
+    'react-native/ReactAndroid/src/androidTest/js/PickerAndroidTestModule'
+  >;
 }
 declare module 'react-native/ReactAndroid/src/androidTest/js/ProgressBarTestModule.js' {
-  declare module.exports: $Exports<'react-native/ReactAndroid/src/androidTest/js/ProgressBarTestModule'>;
+  declare module.exports: $Exports<
+    'react-native/ReactAndroid/src/androidTest/js/ProgressBarTestModule'
+  >;
 }
 declare module 'react-native/ReactAndroid/src/androidTest/js/ScrollViewTestModule.js' {
-  declare module.exports: $Exports<'react-native/ReactAndroid/src/androidTest/js/ScrollViewTestModule'>;
+  declare module.exports: $Exports<
+    'react-native/ReactAndroid/src/androidTest/js/ScrollViewTestModule'
+  >;
 }
 declare module 'react-native/ReactAndroid/src/androidTest/js/ShareTestModule.js' {
-  declare module.exports: $Exports<'react-native/ReactAndroid/src/androidTest/js/ShareTestModule'>;
+  declare module.exports: $Exports<
+    'react-native/ReactAndroid/src/androidTest/js/ShareTestModule'
+  >;
 }
 declare module 'react-native/ReactAndroid/src/androidTest/js/SubviewsClippingTestModule.js' {
-  declare module.exports: $Exports<'react-native/ReactAndroid/src/androidTest/js/SubviewsClippingTestModule'>;
+  declare module.exports: $Exports<
+    'react-native/ReactAndroid/src/androidTest/js/SubviewsClippingTestModule'
+  >;
 }
 declare module 'react-native/ReactAndroid/src/androidTest/js/SwipeRefreshLayoutTestModule.js' {
-  declare module.exports: $Exports<'react-native/ReactAndroid/src/androidTest/js/SwipeRefreshLayoutTestModule'>;
+  declare module.exports: $Exports<
+    'react-native/ReactAndroid/src/androidTest/js/SwipeRefreshLayoutTestModule'
+  >;
 }
 declare module 'react-native/ReactAndroid/src/androidTest/js/TestBundle.js' {
-  declare module.exports: $Exports<'react-native/ReactAndroid/src/androidTest/js/TestBundle'>;
+  declare module.exports: $Exports<
+    'react-native/ReactAndroid/src/androidTest/js/TestBundle'
+  >;
 }
 declare module 'react-native/ReactAndroid/src/androidTest/js/TestIdTestModule.js' {
-  declare module.exports: $Exports<'react-native/ReactAndroid/src/androidTest/js/TestIdTestModule'>;
+  declare module.exports: $Exports<
+    'react-native/ReactAndroid/src/androidTest/js/TestIdTestModule'
+  >;
 }
 declare module 'react-native/ReactAndroid/src/androidTest/js/TestJavaToJSArgumentsModule.js' {
-  declare module.exports: $Exports<'react-native/ReactAndroid/src/androidTest/js/TestJavaToJSArgumentsModule'>;
+  declare module.exports: $Exports<
+    'react-native/ReactAndroid/src/androidTest/js/TestJavaToJSArgumentsModule'
+  >;
 }
 declare module 'react-native/ReactAndroid/src/androidTest/js/TestJavaToJSReturnValuesModule.js' {
-  declare module.exports: $Exports<'react-native/ReactAndroid/src/androidTest/js/TestJavaToJSReturnValuesModule'>;
+  declare module.exports: $Exports<
+    'react-native/ReactAndroid/src/androidTest/js/TestJavaToJSReturnValuesModule'
+  >;
 }
 declare module 'react-native/ReactAndroid/src/androidTest/js/TestJSLocaleModule.js' {
-  declare module.exports: $Exports<'react-native/ReactAndroid/src/androidTest/js/TestJSLocaleModule'>;
+  declare module.exports: $Exports<
+    'react-native/ReactAndroid/src/androidTest/js/TestJSLocaleModule'
+  >;
 }
 declare module 'react-native/ReactAndroid/src/androidTest/js/TestJSToJavaParametersModule.js' {
-  declare module.exports: $Exports<'react-native/ReactAndroid/src/androidTest/js/TestJSToJavaParametersModule'>;
+  declare module.exports: $Exports<
+    'react-native/ReactAndroid/src/androidTest/js/TestJSToJavaParametersModule'
+  >;
 }
 declare module 'react-native/ReactAndroid/src/androidTest/js/TextInputTestModule.js' {
-  declare module.exports: $Exports<'react-native/ReactAndroid/src/androidTest/js/TextInputTestModule'>;
+  declare module.exports: $Exports<
+    'react-native/ReactAndroid/src/androidTest/js/TextInputTestModule'
+  >;
 }
 declare module 'react-native/ReactAndroid/src/androidTest/js/TimePickerDialogTestModule.js' {
-  declare module.exports: $Exports<'react-native/ReactAndroid/src/androidTest/js/TimePickerDialogTestModule'>;
+  declare module.exports: $Exports<
+    'react-native/ReactAndroid/src/androidTest/js/TimePickerDialogTestModule'
+  >;
 }
 declare module 'react-native/ReactAndroid/src/androidTest/js/TouchBubblingTestAppModule.js' {
-  declare module.exports: $Exports<'react-native/ReactAndroid/src/androidTest/js/TouchBubblingTestAppModule'>;
+  declare module.exports: $Exports<
+    'react-native/ReactAndroid/src/androidTest/js/TouchBubblingTestAppModule'
+  >;
 }
 declare module 'react-native/ReactAndroid/src/androidTest/js/UIManagerTestModule.js' {
-  declare module.exports: $Exports<'react-native/ReactAndroid/src/androidTest/js/UIManagerTestModule'>;
+  declare module.exports: $Exports<
+    'react-native/ReactAndroid/src/androidTest/js/UIManagerTestModule'
+  >;
 }
 declare module 'react-native/ReactAndroid/src/androidTest/js/ViewRenderingTestModule.js' {
-  declare module.exports: $Exports<'react-native/ReactAndroid/src/androidTest/js/ViewRenderingTestModule'>;
+  declare module.exports: $Exports<
+    'react-native/ReactAndroid/src/androidTest/js/ViewRenderingTestModule'
+  >;
 }
 declare module 'react-native/rn-cli.config.js' {
   declare module.exports: $Exports<'react-native/rn-cli.config'>;
@@ -5739,16 +6939,24 @@ declare module 'react-native/rn-get-polyfills.js' {
   declare module.exports: $Exports<'react-native/rn-get-polyfills'>;
 }
 declare module 'react-native/RNTester/js/AccessibilityAndroidExample.android.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/AccessibilityAndroidExample.android'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/AccessibilityAndroidExample.android'
+  >;
 }
 declare module 'react-native/RNTester/js/AccessibilityIOSExample.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/AccessibilityIOSExample'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/AccessibilityIOSExample'
+  >;
 }
 declare module 'react-native/RNTester/js/ActionSheetIOSExample.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/ActionSheetIOSExample'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/ActionSheetIOSExample'
+  >;
 }
 declare module 'react-native/RNTester/js/ActivityIndicatorExample.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/ActivityIndicatorExample'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/ActivityIndicatorExample'
+  >;
 }
 declare module 'react-native/RNTester/js/AlertExample.js' {
   declare module.exports: $Exports<'react-native/RNTester/js/AlertExample'>;
@@ -5760,22 +6968,34 @@ declare module 'react-native/RNTester/js/AnimatedExample.js' {
   declare module.exports: $Exports<'react-native/RNTester/js/AnimatedExample'>;
 }
 declare module 'react-native/RNTester/js/AnimatedGratuitousApp/AnExApp.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/AnimatedGratuitousApp/AnExApp'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/AnimatedGratuitousApp/AnExApp'
+  >;
 }
 declare module 'react-native/RNTester/js/AnimatedGratuitousApp/AnExBobble.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/AnimatedGratuitousApp/AnExBobble'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/AnimatedGratuitousApp/AnExBobble'
+  >;
 }
 declare module 'react-native/RNTester/js/AnimatedGratuitousApp/AnExChained.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/AnimatedGratuitousApp/AnExChained'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/AnimatedGratuitousApp/AnExChained'
+  >;
 }
 declare module 'react-native/RNTester/js/AnimatedGratuitousApp/AnExScroll.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/AnimatedGratuitousApp/AnExScroll'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/AnimatedGratuitousApp/AnExScroll'
+  >;
 }
 declare module 'react-native/RNTester/js/AnimatedGratuitousApp/AnExSet.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/AnimatedGratuitousApp/AnExSet'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/AnimatedGratuitousApp/AnExSet'
+  >;
 }
 declare module 'react-native/RNTester/js/AnimatedGratuitousApp/AnExTilt.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/AnimatedGratuitousApp/AnExTilt'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/AnimatedGratuitousApp/AnExTilt'
+  >;
 }
 declare module 'react-native/RNTester/js/AppStateExample.js' {
   declare module.exports: $Exports<'react-native/RNTester/js/AppStateExample'>;
@@ -5784,10 +7004,14 @@ declare module 'react-native/RNTester/js/ARTExample.js' {
   declare module.exports: $Exports<'react-native/RNTester/js/ARTExample'>;
 }
 declare module 'react-native/RNTester/js/AssetScaledImageExample.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/AssetScaledImageExample'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/AssetScaledImageExample'
+  >;
 }
 declare module 'react-native/RNTester/js/AsyncStorageExample.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/AsyncStorageExample'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/AsyncStorageExample'
+  >;
 }
 declare module 'react-native/RNTester/js/BorderExample.js' {
   declare module.exports: $Exports<'react-native/RNTester/js/BorderExample'>;
@@ -5799,7 +7023,9 @@ declare module 'react-native/RNTester/js/ButtonExample.js' {
   declare module.exports: $Exports<'react-native/RNTester/js/ButtonExample'>;
 }
 declare module 'react-native/RNTester/js/CameraRollExample.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/CameraRollExample'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/CameraRollExample'
+  >;
 }
 declare module 'react-native/RNTester/js/CameraRollView.js' {
   declare module.exports: $Exports<'react-native/RNTester/js/CameraRollView'>;
@@ -5811,13 +7037,19 @@ declare module 'react-native/RNTester/js/ClipboardExample.js' {
   declare module.exports: $Exports<'react-native/RNTester/js/ClipboardExample'>;
 }
 declare module 'react-native/RNTester/js/createExamplePage.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/createExamplePage'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/createExamplePage'
+  >;
 }
 declare module 'react-native/RNTester/js/DatePickerAndroidExample.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/DatePickerAndroidExample'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/DatePickerAndroidExample'
+  >;
 }
 declare module 'react-native/RNTester/js/DatePickerIOSExample.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/DatePickerIOSExample'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/DatePickerIOSExample'
+  >;
 }
 declare module 'react-native/RNTester/js/ExampleTypes.js' {
   declare module.exports: $Exports<'react-native/RNTester/js/ExampleTypes'>;
@@ -5826,28 +7058,40 @@ declare module 'react-native/RNTester/js/FlatListExample.js' {
   declare module.exports: $Exports<'react-native/RNTester/js/FlatListExample'>;
 }
 declare module 'react-native/RNTester/js/GeolocationExample.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/GeolocationExample'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/GeolocationExample'
+  >;
 }
 declare module 'react-native/RNTester/js/http_test_server.js' {
   declare module.exports: $Exports<'react-native/RNTester/js/http_test_server'>;
 }
 declare module 'react-native/RNTester/js/ImageCapInsetsExample.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/ImageCapInsetsExample'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/ImageCapInsetsExample'
+  >;
 }
 declare module 'react-native/RNTester/js/ImageEditingExample.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/ImageEditingExample'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/ImageEditingExample'
+  >;
 }
 declare module 'react-native/RNTester/js/ImageExample.js' {
   declare module.exports: $Exports<'react-native/RNTester/js/ImageExample'>;
 }
 declare module 'react-native/RNTester/js/KeyboardAvoidingViewExample.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/KeyboardAvoidingViewExample'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/KeyboardAvoidingViewExample'
+  >;
 }
 declare module 'react-native/RNTester/js/LayoutAnimationExample.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/LayoutAnimationExample'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/LayoutAnimationExample'
+  >;
 }
 declare module 'react-native/RNTester/js/LayoutEventsExample.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/LayoutEventsExample'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/LayoutEventsExample'
+  >;
 }
 declare module 'react-native/RNTester/js/LayoutExample.js' {
   declare module.exports: $Exports<'react-native/RNTester/js/LayoutExample'>;
@@ -5856,49 +7100,73 @@ declare module 'react-native/RNTester/js/LinkingExample.js' {
   declare module.exports: $Exports<'react-native/RNTester/js/LinkingExample'>;
 }
 declare module 'react-native/RNTester/js/ListExampleShared.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/ListExampleShared'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/ListExampleShared'
+  >;
 }
 declare module 'react-native/RNTester/js/ListViewExample.js' {
   declare module.exports: $Exports<'react-native/RNTester/js/ListViewExample'>;
 }
 declare module 'react-native/RNTester/js/ListViewGridLayoutExample.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/ListViewGridLayoutExample'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/ListViewGridLayoutExample'
+  >;
 }
 declare module 'react-native/RNTester/js/ListViewPagingExample.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/ListViewPagingExample'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/ListViewPagingExample'
+  >;
 }
 declare module 'react-native/RNTester/js/MaskedViewExample.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/MaskedViewExample'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/MaskedViewExample'
+  >;
 }
 declare module 'react-native/RNTester/js/ModalExample.js' {
   declare module.exports: $Exports<'react-native/RNTester/js/ModalExample'>;
 }
 declare module 'react-native/RNTester/js/MultiColumnExample.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/MultiColumnExample'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/MultiColumnExample'
+  >;
 }
 declare module 'react-native/RNTester/js/NativeAnimationsExample.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/NativeAnimationsExample'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/NativeAnimationsExample'
+  >;
 }
 declare module 'react-native/RNTester/js/NavigatorIOSBarStyleExample.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/NavigatorIOSBarStyleExample'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/NavigatorIOSBarStyleExample'
+  >;
 }
 declare module 'react-native/RNTester/js/NavigatorIOSColorsExample.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/NavigatorIOSColorsExample'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/NavigatorIOSColorsExample'
+  >;
 }
 declare module 'react-native/RNTester/js/NavigatorIOSExample.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/NavigatorIOSExample'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/NavigatorIOSExample'
+  >;
 }
 declare module 'react-native/RNTester/js/NetInfoExample.js' {
   declare module.exports: $Exports<'react-native/RNTester/js/NetInfoExample'>;
 }
 declare module 'react-native/RNTester/js/OrientationChangeExample.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/OrientationChangeExample'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/OrientationChangeExample'
+  >;
 }
 declare module 'react-native/RNTester/js/PanResponderExample.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/PanResponderExample'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/PanResponderExample'
+  >;
 }
 declare module 'react-native/RNTester/js/PermissionsExampleAndroid.android.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/PermissionsExampleAndroid.android'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/PermissionsExampleAndroid.android'
+  >;
 }
 declare module 'react-native/RNTester/js/PickerExample.js' {
   declare module.exports: $Exports<'react-native/RNTester/js/PickerExample'>;
@@ -5907,28 +7175,42 @@ declare module 'react-native/RNTester/js/PickerIOSExample.js' {
   declare module.exports: $Exports<'react-native/RNTester/js/PickerIOSExample'>;
 }
 declare module 'react-native/RNTester/js/PointerEventsExample.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/PointerEventsExample'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/PointerEventsExample'
+  >;
 }
 declare module 'react-native/RNTester/js/ProgressBarAndroidExample.android.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/ProgressBarAndroidExample.android'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/ProgressBarAndroidExample.android'
+  >;
 }
 declare module 'react-native/RNTester/js/ProgressViewIOSExample.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/ProgressViewIOSExample'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/ProgressViewIOSExample'
+  >;
 }
 declare module 'react-native/RNTester/js/PushNotificationIOSExample.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/PushNotificationIOSExample'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/PushNotificationIOSExample'
+  >;
 }
 declare module 'react-native/RNTester/js/RCTRootViewIOSExample.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/RCTRootViewIOSExample'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/RCTRootViewIOSExample'
+  >;
 }
 declare module 'react-native/RNTester/js/RefreshControlExample.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/RefreshControlExample'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/RefreshControlExample'
+  >;
 }
 declare module 'react-native/RNTester/js/RNTesterActions.js' {
   declare module.exports: $Exports<'react-native/RNTester/js/RNTesterActions'>;
 }
 declare module 'react-native/RNTester/js/RNTesterApp.android.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/RNTesterApp.android'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/RNTesterApp.android'
+  >;
 }
 declare module 'react-native/RNTester/js/RNTesterApp.ios.js' {
   declare module.exports: $Exports<'react-native/RNTester/js/RNTesterApp.ios'>;
@@ -5940,52 +7222,76 @@ declare module 'react-native/RNTester/js/RNTesterButton.js' {
   declare module.exports: $Exports<'react-native/RNTester/js/RNTesterButton'>;
 }
 declare module 'react-native/RNTester/js/RNTesterExampleContainer.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/RNTesterExampleContainer'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/RNTesterExampleContainer'
+  >;
 }
 declare module 'react-native/RNTester/js/RNTesterExampleList.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/RNTesterExampleList'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/RNTesterExampleList'
+  >;
 }
 declare module 'react-native/RNTester/js/RNTesterList.android.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/RNTesterList.android'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/RNTesterList.android'
+  >;
 }
 declare module 'react-native/RNTester/js/RNTesterList.ios.js' {
   declare module.exports: $Exports<'react-native/RNTester/js/RNTesterList.ios'>;
 }
 declare module 'react-native/RNTester/js/RNTesterNavigationReducer.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/RNTesterNavigationReducer'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/RNTesterNavigationReducer'
+  >;
 }
 declare module 'react-native/RNTester/js/RNTesterPage.js' {
   declare module.exports: $Exports<'react-native/RNTester/js/RNTesterPage'>;
 }
 declare module 'react-native/RNTester/js/RNTesterSettingSwitchRow.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/RNTesterSettingSwitchRow'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/RNTesterSettingSwitchRow'
+  >;
 }
 declare module 'react-native/RNTester/js/RNTesterStatePersister.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/RNTesterStatePersister'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/RNTesterStatePersister'
+  >;
 }
 declare module 'react-native/RNTester/js/RNTesterTitle.js' {
   declare module.exports: $Exports<'react-native/RNTester/js/RNTesterTitle'>;
 }
 declare module 'react-native/RNTester/js/RootViewSizeFlexibilityExampleApp.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/RootViewSizeFlexibilityExampleApp'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/RootViewSizeFlexibilityExampleApp'
+  >;
 }
 declare module 'react-native/RNTester/js/RTLExample.js' {
   declare module.exports: $Exports<'react-native/RNTester/js/RTLExample'>;
 }
 declare module 'react-native/RNTester/js/ScrollViewExample.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/ScrollViewExample'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/ScrollViewExample'
+  >;
 }
 declare module 'react-native/RNTester/js/ScrollViewSimpleExample.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/ScrollViewSimpleExample'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/ScrollViewSimpleExample'
+  >;
 }
 declare module 'react-native/RNTester/js/SectionListExample.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/SectionListExample'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/SectionListExample'
+  >;
 }
 declare module 'react-native/RNTester/js/SegmentedControlIOSExample.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/SegmentedControlIOSExample'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/SegmentedControlIOSExample'
+  >;
 }
 declare module 'react-native/RNTester/js/SetPropertiesExampleApp.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/SetPropertiesExampleApp'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/SetPropertiesExampleApp'
+  >;
 }
 declare module 'react-native/RNTester/js/ShareExample.js' {
   declare module.exports: $Exports<'react-native/RNTester/js/ShareExample'>;
@@ -6000,40 +7306,56 @@ declare module 'react-native/RNTester/js/StatusBarExample.js' {
   declare module.exports: $Exports<'react-native/RNTester/js/StatusBarExample'>;
 }
 declare module 'react-native/RNTester/js/SwipeableListViewExample.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/SwipeableListViewExample'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/SwipeableListViewExample'
+  >;
 }
 declare module 'react-native/RNTester/js/SwitchExample.js' {
   declare module.exports: $Exports<'react-native/RNTester/js/SwitchExample'>;
 }
 declare module 'react-native/RNTester/js/TabBarIOSBarStyleExample.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/TabBarIOSBarStyleExample'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/TabBarIOSBarStyleExample'
+  >;
 }
 declare module 'react-native/RNTester/js/TabBarIOSExample.js' {
   declare module.exports: $Exports<'react-native/RNTester/js/TabBarIOSExample'>;
 }
 declare module 'react-native/RNTester/js/TextExample.android.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/TextExample.android'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/TextExample.android'
+  >;
 }
 declare module 'react-native/RNTester/js/TextExample.ios.js' {
   declare module.exports: $Exports<'react-native/RNTester/js/TextExample.ios'>;
 }
 declare module 'react-native/RNTester/js/TextInputExample.android.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/TextInputExample.android'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/TextInputExample.android'
+  >;
 }
 declare module 'react-native/RNTester/js/TextInputExample.ios.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/TextInputExample.ios'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/TextInputExample.ios'
+  >;
 }
 declare module 'react-native/RNTester/js/TimePickerAndroidExample.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/TimePickerAndroidExample'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/TimePickerAndroidExample'
+  >;
 }
 declare module 'react-native/RNTester/js/TimerExample.js' {
   declare module.exports: $Exports<'react-native/RNTester/js/TimerExample'>;
 }
 declare module 'react-native/RNTester/js/ToastAndroidExample.android.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/ToastAndroidExample.android'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/ToastAndroidExample.android'
+  >;
 }
 declare module 'react-native/RNTester/js/ToolbarAndroidExample.android.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/ToolbarAndroidExample.android'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/ToolbarAndroidExample.android'
+  >;
 }
 declare module 'react-native/RNTester/js/TouchableExample.js' {
   declare module.exports: $Exports<'react-native/RNTester/js/TouchableExample'>;
@@ -6042,10 +7364,14 @@ declare module 'react-native/RNTester/js/TransformExample.js' {
   declare module.exports: $Exports<'react-native/RNTester/js/TransformExample'>;
 }
 declare module 'react-native/RNTester/js/TransparentHitTestExample.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/TransparentHitTestExample'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/TransparentHitTestExample'
+  >;
 }
 declare module 'react-native/RNTester/js/TVEventHandlerExample.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/TVEventHandlerExample'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/TVEventHandlerExample'
+  >;
 }
 declare module 'react-native/RNTester/js/URIActionMap.js' {
   declare module.exports: $Exports<'react-native/RNTester/js/URIActionMap'>;
@@ -6054,16 +7380,22 @@ declare module 'react-native/RNTester/js/VibrationExample.js' {
   declare module.exports: $Exports<'react-native/RNTester/js/VibrationExample'>;
 }
 declare module 'react-native/RNTester/js/VibrationIOSExample.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/VibrationIOSExample'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/VibrationIOSExample'
+  >;
 }
 declare module 'react-native/RNTester/js/ViewExample.js' {
   declare module.exports: $Exports<'react-native/RNTester/js/ViewExample'>;
 }
 declare module 'react-native/RNTester/js/ViewPagerAndroidExample.android.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/ViewPagerAndroidExample.android'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/ViewPagerAndroidExample.android'
+  >;
 }
 declare module 'react-native/RNTester/js/websocket_test_server.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/websocket_test_server'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/websocket_test_server'
+  >;
 }
 declare module 'react-native/RNTester/js/WebSocketExample.js' {
   declare module.exports: $Exports<'react-native/RNTester/js/WebSocketExample'>;
@@ -6075,28 +7407,42 @@ declare module 'react-native/RNTester/js/XHRExample.js' {
   declare module.exports: $Exports<'react-native/RNTester/js/XHRExample'>;
 }
 declare module 'react-native/RNTester/js/XHRExampleBinaryUpload.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/XHRExampleBinaryUpload'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/XHRExampleBinaryUpload'
+  >;
 }
 declare module 'react-native/RNTester/js/XHRExampleCookies.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/XHRExampleCookies'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/XHRExampleCookies'
+  >;
 }
 declare module 'react-native/RNTester/js/XHRExampleDownload.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/XHRExampleDownload'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/XHRExampleDownload'
+  >;
 }
 declare module 'react-native/RNTester/js/XHRExampleFetch.js' {
   declare module.exports: $Exports<'react-native/RNTester/js/XHRExampleFetch'>;
 }
 declare module 'react-native/RNTester/js/XHRExampleFormData.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/XHRExampleFormData'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/XHRExampleFormData'
+  >;
 }
 declare module 'react-native/RNTester/js/XHRExampleHeaders.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/XHRExampleHeaders'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/XHRExampleHeaders'
+  >;
 }
 declare module 'react-native/RNTester/js/XHRExampleOnTimeOut.js' {
-  declare module.exports: $Exports<'react-native/RNTester/js/XHRExampleOnTimeOut'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/js/XHRExampleOnTimeOut'
+  >;
 }
 declare module 'react-native/RNTester/RNTesterUnitTests/RNTesterUnitTestsBundle.js' {
-  declare module.exports: $Exports<'react-native/RNTester/RNTesterUnitTests/RNTesterUnitTestsBundle'>;
+  declare module.exports: $Exports<
+    'react-native/RNTester/RNTesterUnitTests/RNTesterUnitTestsBundle'
+  >;
 }
 declare module 'react-native/scripts/android-e2e-test.js' {
   declare module.exports: $Exports<'react-native/scripts/android-e2e-test'>;
@@ -6108,7 +7454,9 @@ declare module 'react-native/scripts/publish-npm.js' {
   declare module.exports: $Exports<'react-native/scripts/publish-npm'>;
 }
 declare module 'react-native/scripts/run-android-ci-instrumentation-tests.js' {
-  declare module.exports: $Exports<'react-native/scripts/run-android-ci-instrumentation-tests'>;
+  declare module.exports: $Exports<
+    'react-native/scripts/run-android-ci-instrumentation-tests'
+  >;
 }
 declare module 'react-native/scripts/run-ci-e2e-tests.js' {
   declare module.exports: $Exports<'react-native/scripts/run-ci-e2e-tests'>;
@@ -6123,7 +7471,9 @@ declare module 'react-native/setupBabel.js' {
   declare module.exports: $Exports<'react-native/setupBabel'>;
 }
 declare module 'react-native/website/core/AlgoliaDocSearch.js' {
-  declare module.exports: $Exports<'react-native/website/core/AlgoliaDocSearch'>;
+  declare module.exports: $Exports<
+    'react-native/website/core/AlgoliaDocSearch'
+  >;
 }
 declare module 'react-native/website/core/BlogPost.js' {
   declare module.exports: $Exports<'react-native/website/core/BlogPost'>;
@@ -6165,7 +7515,9 @@ declare module 'react-native/website/core/HeaderLinks.js' {
   declare module.exports: $Exports<'react-native/website/core/HeaderLinks'>;
 }
 declare module 'react-native/website/core/HeaderWithGithub.js' {
-  declare module.exports: $Exports<'react-native/website/core/HeaderWithGithub'>;
+  declare module.exports: $Exports<
+    'react-native/website/core/HeaderWithGithub'
+  >;
 }
 declare module 'react-native/website/core/Hero.js' {
   declare module.exports: $Exports<'react-native/website/core/Hero'>;
@@ -6195,16 +7547,24 @@ declare module 'react-native/website/core/WebPlayer.js' {
   declare module.exports: $Exports<'react-native/website/core/WebPlayer'>;
 }
 declare module 'react-native/website/jsdocs/__tests__/jsdocs-test.js' {
-  declare module.exports: $Exports<'react-native/website/jsdocs/__tests__/jsdocs-test'>;
+  declare module.exports: $Exports<
+    'react-native/website/jsdocs/__tests__/jsdocs-test'
+  >;
 }
 declare module 'react-native/website/jsdocs/findExportDefinition.js' {
-  declare module.exports: $Exports<'react-native/website/jsdocs/findExportDefinition'>;
+  declare module.exports: $Exports<
+    'react-native/website/jsdocs/findExportDefinition'
+  >;
 }
 declare module 'react-native/website/jsdocs/generic-function-visitor.js' {
-  declare module.exports: $Exports<'react-native/website/jsdocs/generic-function-visitor'>;
+  declare module.exports: $Exports<
+    'react-native/website/jsdocs/generic-function-visitor'
+  >;
 }
 declare module 'react-native/website/jsdocs/jsdoc-plugin-values.js' {
-  declare module.exports: $Exports<'react-native/website/jsdocs/jsdoc-plugin-values'>;
+  declare module.exports: $Exports<
+    'react-native/website/jsdocs/jsdoc-plugin-values'
+  >;
 }
 declare module 'react-native/website/jsdocs/jsdocs.js' {
   declare module.exports: $Exports<'react-native/website/jsdocs/jsdocs'>;
@@ -6222,16 +7582,24 @@ declare module 'react-native/website/jsdocs/type.js' {
   declare module.exports: $Exports<'react-native/website/jsdocs/type'>;
 }
 declare module 'react-native/website/jsdocs/TypeExpressionParser.js' {
-  declare module.exports: $Exports<'react-native/website/jsdocs/TypeExpressionParser'>;
+  declare module.exports: $Exports<
+    'react-native/website/jsdocs/TypeExpressionParser'
+  >;
 }
 declare module 'react-native/website/layout/AutodocsLayout.js' {
-  declare module.exports: $Exports<'react-native/website/layout/AutodocsLayout'>;
+  declare module.exports: $Exports<
+    'react-native/website/layout/AutodocsLayout'
+  >;
 }
 declare module 'react-native/website/layout/BlogPageLayout.js' {
-  declare module.exports: $Exports<'react-native/website/layout/BlogPageLayout'>;
+  declare module.exports: $Exports<
+    'react-native/website/layout/BlogPageLayout'
+  >;
 }
 declare module 'react-native/website/layout/BlogPostLayout.js' {
-  declare module.exports: $Exports<'react-native/website/layout/BlogPostLayout'>;
+  declare module.exports: $Exports<
+    'react-native/website/layout/BlogPostLayout'
+  >;
 }
 declare module 'react-native/website/layout/DocsLayout.js' {
   declare module.exports: $Exports<'react-native/website/layout/DocsLayout'>;
@@ -6240,7 +7608,9 @@ declare module 'react-native/website/layout/PageLayout.js' {
   declare module.exports: $Exports<'react-native/website/layout/PageLayout'>;
 }
 declare module 'react-native/website/layout/RedirectLayout.js' {
-  declare module.exports: $Exports<'react-native/website/layout/RedirectLayout'>;
+  declare module.exports: $Exports<
+    'react-native/website/layout/RedirectLayout'
+  >;
 }
 declare module 'react-native/website/publish-gh-pages.js' {
   declare module.exports: $Exports<'react-native/website/publish-gh-pages'>;
@@ -6267,17 +7637,27 @@ declare module 'react-native/website/src/react-native/404.js' {
   declare module.exports: $Exports<'react-native/website/src/react-native/404'>;
 }
 declare module 'react-native/website/src/react-native/index.js' {
-  declare module.exports: $Exports<'react-native/website/src/react-native/index'>;
+  declare module.exports: $Exports<
+    'react-native/website/src/react-native/index'
+  >;
 }
 declare module 'react-native/website/src/react-native/js/scripts.js' {
-  declare module.exports: $Exports<'react-native/website/src/react-native/js/scripts'>;
+  declare module.exports: $Exports<
+    'react-native/website/src/react-native/js/scripts'
+  >;
 }
 declare module 'react-native/website/src/react-native/showcase.js' {
-  declare module.exports: $Exports<'react-native/website/src/react-native/showcase'>;
+  declare module.exports: $Exports<
+    'react-native/website/src/react-native/showcase'
+  >;
 }
 declare module 'react-native/website/src/react-native/support.js' {
-  declare module.exports: $Exports<'react-native/website/src/react-native/support'>;
+  declare module.exports: $Exports<
+    'react-native/website/src/react-native/support'
+  >;
 }
 declare module 'react-native/website/src/react-native/versions.js' {
-  declare module.exports: $Exports<'react-native/website/src/react-native/versions'>;
+  declare module.exports: $Exports<
+    'react-native/website/src/react-native/versions'
+  >;
 }

--- a/examples/NavigationPlayground/js/App.js
+++ b/examples/NavigationPlayground/js/App.js
@@ -16,7 +16,7 @@ import {
   StatusBar,
   View,
 } from 'react-native';
-import { SafeAreaView, StackNavigator } from 'react-navigation';
+import { SafeAreaView, createStackNavigator } from 'react-navigation';
 
 import CustomTabs from './CustomTabs';
 import CustomTransitioner from './CustomTransitioner';
@@ -288,7 +288,7 @@ class MainScreen extends React.Component<any, State> {
   }
 }
 
-const AppNavigator = StackNavigator(
+const AppNavigator = createStackNavigator(
   {
     ...ExampleRoutes,
     Index: {

--- a/examples/NavigationPlayground/js/Drawer.js
+++ b/examples/NavigationPlayground/js/Drawer.js
@@ -5,8 +5,8 @@
 import React from 'react';
 import { Platform, ScrollView, StatusBar } from 'react-native';
 import {
-  StackNavigator,
-  DrawerNavigator,
+  createStackNavigator,
+  createDrawerNavigator,
   SafeAreaView,
 } from 'react-navigation';
 import MaterialIcons from 'react-native-vector-icons/MaterialIcons';
@@ -56,17 +56,17 @@ DraftsScreen.navigationOptions = {
   ),
 };
 
-const InboxStack = StackNavigator({
+const InboxStack = createStackNavigator({
   Inbox: { screen: InboxScreen },
   Email: { screen: EmailScreen },
 });
 
-const DraftsStack = StackNavigator({
+const DraftsStack = createStackNavigator({
   Drafts: { screen: DraftsScreen },
   Email: { screen: EmailScreen },
 });
 
-const DrawerExample = DrawerNavigator(
+const DrawerExample = createDrawerNavigator(
   {
     Inbox: {
       path: '/',

--- a/examples/NavigationPlayground/js/ModalStack.js
+++ b/examples/NavigationPlayground/js/ModalStack.js
@@ -4,7 +4,7 @@
 
 import React from 'react';
 import { ScrollView, StatusBar, Text } from 'react-native';
-import { SafeAreaView, StackNavigator } from 'react-navigation';
+import { SafeAreaView, createStackNavigator } from 'react-navigation';
 import SampleText from './SampleText';
 import { Button } from './commonComponents/ButtonWithMargin';
 
@@ -59,7 +59,7 @@ MyProfileScreen.navigationOptions = ({ navigation }) => ({
   title: `${navigation.state.params.name}'s Profile!`,
 });
 
-const ProfileNavigator = StackNavigator(
+const ProfileNavigator = createStackNavigator(
   {
     Home: {
       screen: MyHomeScreen,
@@ -89,7 +89,7 @@ MyHeaderTestScreen.navigationOptions = ({ navigation }) => {
   };
 };
 
-const ModalStack = StackNavigator(
+const ModalStack = createStackNavigator(
   {
     ProfileNavigator: {
       screen: ProfileNavigator,

--- a/examples/NavigationPlayground/js/MultipleDrawer.js
+++ b/examples/NavigationPlayground/js/MultipleDrawer.js
@@ -4,7 +4,7 @@
 
 import React from 'react';
 import { Platform, ScrollView, StyleSheet } from 'react-native';
-import { DrawerNavigator } from 'react-navigation';
+import { createDrawerNavigator } from 'react-navigation';
 import MaterialIcons from 'react-native-vector-icons/MaterialIcons';
 import SampleText from './SampleText';
 import { Button } from './commonComponents/ButtonWithMargin';
@@ -41,7 +41,7 @@ DraftsScreen.navigationOptions = {
   ),
 };
 
-const DrawerExample = DrawerNavigator(
+const DrawerExample = createDrawerNavigator(
   {
     Inbox: {
       path: '/',
@@ -60,7 +60,7 @@ const DrawerExample = DrawerNavigator(
   }
 );
 
-const MainDrawerExample = DrawerNavigator({
+const MainDrawerExample = createDrawerNavigator({
   Drafts: {
     screen: DrawerExample,
   },

--- a/examples/NavigationPlayground/js/SimpleStack.js
+++ b/examples/NavigationPlayground/js/SimpleStack.js
@@ -9,7 +9,11 @@ import type {
 
 import * as React from 'react';
 import { ScrollView, StatusBar } from 'react-native';
-import { StackNavigator, SafeAreaView, withNavigation } from 'react-navigation';
+import {
+  createStackNavigator,
+  SafeAreaView,
+  withNavigation,
+} from 'react-navigation';
 import SampleText from './SampleText';
 import { Button } from './commonComponents/ButtonWithMargin';
 import { HeaderButtons } from './commonComponents/HeaderButtons';
@@ -187,7 +191,7 @@ MyProfileScreen.navigationOptions = props => {
   };
 };
 
-const SimpleStack = StackNavigator({
+const SimpleStack = createStackNavigator({
   Home: {
     screen: MyHomeScreen,
   },

--- a/examples/NavigationPlayground/js/SimpleTabs.js
+++ b/examples/NavigationPlayground/js/SimpleTabs.js
@@ -9,7 +9,7 @@ import type {
 
 import React from 'react';
 import { Platform, ScrollView, StatusBar, View } from 'react-native';
-import { SafeAreaView, TabNavigator } from 'react-navigation';
+import { SafeAreaView, createTabNavigator } from 'react-navigation';
 import Ionicons from 'react-native-vector-icons/Ionicons';
 import SampleText from './SampleText';
 import { Button } from './commonComponents/ButtonWithMargin';
@@ -144,7 +144,7 @@ MySettingsScreen.navigationOptions = {
   ),
 };
 
-const SimpleTabs = TabNavigator(
+const SimpleTabs = createTabNavigator(
   {
     Home: {
       screen: MyHomeScreen,

--- a/examples/NavigationPlayground/js/StackWithCustomHeaderBackImage.js
+++ b/examples/NavigationPlayground/js/StackWithCustomHeaderBackImage.js
@@ -6,7 +6,7 @@ import type { NavigationScreenProp } from 'react-navigation';
 
 import * as React from 'react';
 import { Image, Button, StatusBar, StyleSheet } from 'react-native';
-import { StackNavigator, SafeAreaView } from 'react-navigation';
+import { createStackNavigator, SafeAreaView } from 'react-navigation';
 import SampleText from './SampleText';
 
 type MyNavScreenProps = {
@@ -107,7 +107,7 @@ class MyProfileScreen extends React.Component<MyProfileScreenProps> {
   }
 }
 
-const StackWithCustomHeaderBackImage = StackNavigator(
+const StackWithCustomHeaderBackImage = createStackNavigator(
   {
     Home: {
       screen: MyHomeScreen,

--- a/examples/NavigationPlayground/js/StackWithHeaderPreset.js
+++ b/examples/NavigationPlayground/js/StackWithHeaderPreset.js
@@ -5,7 +5,7 @@ import type { NavigationScreenProp } from 'react-navigation';
 
 import * as React from 'react';
 import { ScrollView, StatusBar } from 'react-native';
-import { StackNavigator, SafeAreaView } from 'react-navigation';
+import { createStackNavigator, SafeAreaView } from 'react-navigation';
 import { Button } from './commonComponents/ButtonWithMargin';
 
 type NavScreenProps = {
@@ -56,7 +56,7 @@ class OtherScreen extends React.Component<NavScreenProps> {
   }
 }
 
-const StackWithHeaderPreset = StackNavigator(
+const StackWithHeaderPreset = createStackNavigator(
   {
     Home: HomeScreen,
     Other: OtherScreen,

--- a/examples/NavigationPlayground/js/StackWithTranslucentHeader.js
+++ b/examples/NavigationPlayground/js/StackWithTranslucentHeader.js
@@ -18,7 +18,7 @@ import {
   StatusBar,
   View,
 } from 'react-native';
-import { Header, StackNavigator } from 'react-navigation';
+import { Header, createStackNavigator } from 'react-navigation';
 import SampleText from './SampleText';
 import { Button } from './commonComponents/ButtonWithMargin';
 import { HeaderButtons } from './commonComponents/HeaderButtons';
@@ -206,7 +206,7 @@ MyProfileScreen.navigationOptions = props => {
   };
 };
 
-const StackWithTranslucentHeader = StackNavigator(
+const StackWithTranslucentHeader = createStackNavigator(
   {
     Home: {
       screen: MyHomeScreen,

--- a/examples/NavigationPlayground/js/StacksInTabs.js
+++ b/examples/NavigationPlayground/js/StacksInTabs.js
@@ -4,7 +4,11 @@
 
 import React from 'react';
 import { ScrollView, StatusBar } from 'react-native';
-import { SafeAreaView, StackNavigator, TabNavigator } from 'react-navigation';
+import {
+  SafeAreaView,
+  createStackNavigator,
+  createTabNavigator,
+} from 'react-navigation';
 
 import Ionicons from 'react-native-vector-icons/Ionicons';
 import SampleText from './SampleText';
@@ -52,7 +56,7 @@ const MySettingsScreen = ({ navigation }) => (
   <MyNavScreen banner="Settings Screen" navigation={navigation} />
 );
 
-const MainTab = StackNavigator({
+const MainTab = createStackNavigator({
   Home: {
     screen: MyHomeScreen,
     path: '/',
@@ -69,7 +73,7 @@ const MainTab = StackNavigator({
   },
 });
 
-const SettingsTab = StackNavigator({
+const SettingsTab = createStackNavigator({
   Settings: {
     screen: MySettingsScreen,
     path: '/',
@@ -85,7 +89,7 @@ const SettingsTab = StackNavigator({
   },
 });
 
-const StacksInTabs = TabNavigator(
+const StacksInTabs = createTabNavigator(
   {
     MainTab: {
       screen: MainTab,

--- a/examples/NavigationPlayground/js/StacksOverTabs.js
+++ b/examples/NavigationPlayground/js/StacksOverTabs.js
@@ -4,7 +4,11 @@
 
 import React from 'react';
 import { ScrollView, StatusBar } from 'react-native';
-import { SafeAreaView, StackNavigator, TabNavigator } from 'react-navigation';
+import {
+  SafeAreaView,
+  createStackNavigator,
+  createTabNavigator,
+} from 'react-navigation';
 
 import Ionicons from 'react-native-vector-icons/Ionicons';
 import SampleText from './SampleText';
@@ -51,7 +55,7 @@ const MySettingsScreen = ({ navigation }) => (
   <MyNavScreen banner="Settings Screen" navigation={navigation} />
 );
 
-const TabNav = TabNavigator(
+const TabNav = createTabNavigator(
   {
     MainTab: {
       screen: MyHomeScreen,
@@ -90,7 +94,7 @@ const TabNav = TabNavigator(
   }
 );
 
-const StacksOverTabs = StackNavigator({
+const StacksOverTabs = createStackNavigator({
   Root: {
     screen: TabNav,
   },

--- a/examples/NavigationPlayground/js/StacksWithKeys.js
+++ b/examples/NavigationPlayground/js/StacksWithKeys.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { StatusBar, Text, View } from 'react-native';
-import { StackNavigator } from 'react-navigation';
+import { createStackNavigator } from 'react-navigation';
 import { Button } from './commonComponents/ButtonWithMargin';
 
 class HomeScreen extends React.Component<any, any> {
@@ -82,7 +82,7 @@ class SettingsScreen extends React.Component<any, any> {
   }
 }
 
-const Stack = StackNavigator(
+const Stack = createStackNavigator(
   {
     Home: {
       screen: HomeScreen,

--- a/examples/NavigationPlayground/js/SwitchWithStacks.js
+++ b/examples/NavigationPlayground/js/SwitchWithStacks.js
@@ -10,7 +10,7 @@ import {
   StyleSheet,
   View,
 } from 'react-native';
-import { StackNavigator, SwitchNavigator } from 'react-navigation';
+import { createStackNavigator, createSwitchNavigator } from 'react-navigation';
 import { Button } from './commonComponents/ButtonWithMargin';
 
 class SignInScreen extends React.Component<any, any> {
@@ -111,10 +111,10 @@ const styles = StyleSheet.create({
   },
 });
 
-const AppStack = StackNavigator({ Home: HomeScreen, Other: OtherScreen });
-const AuthStack = StackNavigator({ SignIn: SignInScreen });
+const AppStack = createStackNavigator({ Home: HomeScreen, Other: OtherScreen });
+const AuthStack = createStackNavigator({ SignIn: SignInScreen });
 
-export default SwitchNavigator({
+export default createSwitchNavigator({
   Loading: LoadingScreen,
   App: AppStack,
   Auth: AuthStack,

--- a/examples/NavigationPlayground/js/TabAnimations.js
+++ b/examples/NavigationPlayground/js/TabAnimations.js
@@ -4,7 +4,7 @@
 
 import React from 'react';
 import { Animated, ScrollView, StatusBar } from 'react-native';
-import { StackNavigator, TabNavigator } from 'react-navigation';
+import { createStackNavigator, createTabNavigator } from 'react-navigation';
 import { Button } from './commonComponents/ButtonWithMargin';
 
 import Ionicons from 'react-native-vector-icons/Ionicons';
@@ -49,7 +49,7 @@ const MySettingsScreen = ({ navigation }) => (
   <MyNavScreen banner="Settings Screen" navigation={navigation} />
 );
 
-const MainTab = StackNavigator({
+const MainTab = createStackNavigator({
   Home: {
     screen: MyHomeScreen,
     path: '/',
@@ -66,7 +66,7 @@ const MainTab = StackNavigator({
   },
 });
 
-const SettingsTab = StackNavigator({
+const SettingsTab = createStackNavigator({
   Settings: {
     screen: MySettingsScreen,
     path: '/',
@@ -82,7 +82,7 @@ const SettingsTab = StackNavigator({
   },
 });
 
-const TabAnimations = TabNavigator(
+const TabAnimations = createTabNavigator(
   {
     MainTab: {
       screen: MainTab,

--- a/examples/NavigationPlayground/js/TabsInDrawer.js
+++ b/examples/NavigationPlayground/js/TabsInDrawer.js
@@ -4,12 +4,12 @@
 
 import React from 'react';
 import { Platform, ScrollView } from 'react-native';
-import { TabNavigator, DrawerNavigator } from 'react-navigation';
+import { createTabNavigator, createDrawerNavigator } from 'react-navigation';
 import MaterialIcons from 'react-native-vector-icons/MaterialIcons';
 import SimpleTabs from './SimpleTabs';
 import StacksOverTabs from './StacksOverTabs';
 
-const TabsInDrawer = DrawerNavigator({
+const TabsInDrawer = createDrawerNavigator({
   SimpleTabs: {
     screen: SimpleTabs,
     navigationOptions: {

--- a/examples/NavigationPlayground/js/TabsWithNavigationFocus.js
+++ b/examples/NavigationPlayground/js/TabsWithNavigationFocus.js
@@ -4,7 +4,7 @@
 
 import React from 'react';
 import { SafeAreaView, Text } from 'react-native';
-import { TabNavigator, withNavigationFocus } from 'react-navigation';
+import { createTabNavigator, withNavigationFocus } from 'react-navigation';
 import MaterialCommunityIcons from 'react-native-vector-icons/MaterialCommunityIcons';
 import { Button } from './commonComponents/ButtonWithMargin';
 
@@ -76,7 +76,7 @@ const createTabScreen = (name, icon, focusedIcon, tintColor = '#673ab7') => {
   return withNavigationFocus(TabScreen);
 };
 
-const TabsWithNavigationFocus = TabNavigator(
+const TabsWithNavigationFocus = createTabNavigator(
   {
     One: {
       screen: createTabScreen('One', 'numeric-1-box-outline', 'numeric-1-box'),

--- a/flow/react-navigation.js
+++ b/flow/react-navigation.js
@@ -761,6 +761,10 @@ declare module 'react-navigation' {
     routeConfigMap: NavigationRouteConfigMap,
     stackConfig?: StackNavigatorConfig
   ): NavigationContainer<*, *, *>;
+  declare export function createStackNavigator(
+    routeConfigMap: NavigationRouteConfigMap,
+    stackConfig?: StackNavigatorConfig
+  ): NavigationContainer<*, *, *>;
 
   declare type _TabViewConfig = {|
     tabBarComponent?: React$ElementType,
@@ -785,10 +789,18 @@ declare module 'react-navigation' {
     routeConfigs: NavigationRouteConfigMap,
     config?: _TabNavigatorConfig
   ): NavigationContainer<*, *, *>;
+  declare export function createTabNavigator(
+    routeConfigs: NavigationRouteConfigMap,
+    config?: _TabNavigatorConfig
+  ): NavigationContainer<*, *, *>;
   declare type _SwitchNavigatorConfig = {|
     ...NavigationSwitchRouterConfig,
   |};
   declare export function SwitchNavigator(
+    routeConfigs: NavigationRouteConfigMap,
+    config?: _SwitchNavigatorConfig
+  ): NavigationContainer<*, *, *>;
+  declare export function createSwitchNavigator(
     routeConfigs: NavigationRouteConfigMap,
     config?: _SwitchNavigatorConfig
   ): NavigationContainer<*, *, *>;
@@ -810,6 +822,10 @@ declare module 'react-navigation' {
     containerConfig?: void,
   }>;
   declare export function DrawerNavigator(
+    routeConfigs: NavigationRouteConfigMap,
+    config?: _DrawerNavigatorConfig
+  ): NavigationContainer<*, *, *>;
+  declare export function createDrawerNavigator(
     routeConfigs: NavigationRouteConfigMap,
     config?: _DrawerNavigatorConfig
   ): NavigationContainer<*, *, *>;

--- a/src/react-navigation.js
+++ b/src/react-navigation.js
@@ -19,16 +19,40 @@ module.exports = {
   get createNavigator() {
     return require('./navigators/createNavigator').default;
   },
-  get StackNavigator() {
+  get createStackNavigator() {
     return require('./navigators/createStackNavigator').default;
   },
-  get SwitchNavigator() {
+  get StackNavigator() {
+    console.warn(
+      'The StackNavigator function name is deprecated, please use createStackNavigator instead'
+    );
+    return require('./navigators/createStackNavigator').default;
+  },
+  get createSwitchNavigator() {
     return require('./navigators/createSwitchNavigator').default;
   },
-  get TabNavigator() {
+  get SwitchNavigator() {
+    console.warn(
+      'The SwitchNavigator function name is deprecated, please use createSwitchNavigator instead'
+    );
+    return require('./navigators/createSwitchNavigator').default;
+  },
+  get createTabNavigator() {
     return require('./navigators/createTabNavigator').default;
   },
+  get TabNavigator() {
+    console.warn(
+      'The TabNavigator function name is deprecated, please use createTabNavigator instead'
+    );
+    return require('./navigators/createTabNavigator').default;
+  },
+  get createDrawerNavigator() {
+    return require('./navigators/createDrawerNavigator').default;
+  },
   get DrawerNavigator() {
+    console.warn(
+      'The DrawerNavigator function name is deprecated, please use createDrawerNavigator instead'
+    );
     return require('./navigators/createDrawerNavigator').default;
   },
 


### PR DESCRIPTION
# Motivation

It is a bit strange that the HOCs for navigators have been named, eg: `StackNavigator`, rather than `createStackNavigator`. The former doesn't imply that this is an HOC but rather that it is just a component. The latter implies that you are creating a component, which is correct.

I think that renaming these functions will help to make the library more intuitive.

# Test plan

It's just a rename