### PR TITLE
Export default transition config in stack navigator

### DIFF
--- a/src/react-navigation.js
+++ b/src/react-navigation.js
@@ -145,4 +145,10 @@ module.exports = {
   get withOrientation() {
     return require('./views/withOrientation').default;
   },
+
+  // Default Settings
+  get defaultStackViewTransitionConfig() {
+    return require('./views/StackView/StackViewTransitionConfigs')
+      .defaultTransitionConfig;
+  },
 };

--- a/src/views/StackView/StackViewTransitionConfigs.js
+++ b/src/views/StackView/StackViewTransitionConfigs.js
@@ -60,7 +60,7 @@ const FadeOutToBottomAndroid = {
   screenInterpolator: StyleInterpolator.forFadeFromBottomAndroid,
 };
 
-function defaultTransitionConfig(
+export function defaultTransitionConfig(
   transitionProps,
   prevTransitionProps,
   isModal


### PR DESCRIPTION
Addresses https://github.com/react-navigation/react-navigation/issues/3674 by exporting the default transition config for stack navigation. I'm not sure where the best place to export is — I tried in the navigation, but that seemed lower level than a screen transition. Also looking for suggestion as to the best place to test.