### PR TITLE
Lazy loading placeholder element for TabNavigator

### DIFF
--- a/src/navigators/TabNavigator.js
+++ b/src/navigators/TabNavigator.js
@@ -20,6 +20,7 @@ const TabNavigator = (routeConfigs, config = {}) => {
     tabBarPosition,
     tabBarOptions,
     lazy,
+    lazyPlaceholder,
     removeClippedSubviews,
     swipeEnabled,
     animationEnabled,
@@ -34,6 +35,7 @@ const TabNavigator = (routeConfigs, config = {}) => {
     <TabView
       {...props}
       lazy={lazy}
+      lazyPlaceholder={lazyPlaceholder}
       removeClippedSubviews={removeClippedSubviews}
       tabBarComponent={tabBarComponent}
       tabBarPosition={tabBarPosition}

--- a/src/views/ResourceSavingSceneView.js
+++ b/src/views/ResourceSavingSceneView.js
@@ -32,6 +32,7 @@ class ResourceSavingSceneView extends React.PureComponent {
       navigation,
       removeClippedSubviews,
       lazy,
+      lazyPlaceholder,
       ...rest
     } = this.props;
 
@@ -52,7 +53,11 @@ class ResourceSavingSceneView extends React.PureComponent {
               : styles.innerDetached
           }
         >
-          {awake ? <SceneView {...rest} navigation={childNavigation} /> : null}
+          {awake ? (
+            <SceneView {...rest} navigation={childNavigation} />
+          ) : (
+            lazyPlaceholder
+          )}
         </View>
       </View>
     );

--- a/src/views/TabView/TabView.js
+++ b/src/views/TabView/TabView.js
@@ -9,6 +9,7 @@ import withCachedChildNavigation from '../../withCachedChildNavigation';
 class TabView extends React.PureComponent {
   static defaultProps = {
     lazy: true,
+    lazyPlaceholder: null,
     removedClippedSubviews: true,
     // fix for https://github.com/react-native-community/react-native-tab-view/issues/312
     initialLayout: Platform.select({
@@ -34,6 +35,7 @@ class TabView extends React.PureComponent {
     return (
       <ResourceSavingSceneView
         lazy={this.props.lazy}
+        lazyPlaceholder={this.props.lazyPlaceholder}
         isFocused={focusedKey === key}
         removeClippedSubViews={this.props.removeClippedSubviews}
         animationEnabled={this.props.animationEnabled}

--- a/src/views/__tests__/TabView-test.js
+++ b/src/views/__tests__/TabView-test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View } from 'react-native';
+import { View, Text } from 'react-native';
 import renderer from 'react-test-renderer';
 import TabRouter from '../../routers/TabRouter';
 
@@ -24,6 +24,33 @@ describe('TabBarBottom', () => {
     const rendered = renderer
       .create(
         <TabView
+          tabBarComponent={TabBarBottom}
+          navigation={navigation}
+          router={router}
+        />
+      )
+      .toJSON();
+
+    expect(rendered).toMatchSnapshot();
+  });
+});
+
+describe('TabBarBottom w/ lazyPlaceholder', () => {
+  it('renders successfully', () => {
+    const navigation = {
+      state: {
+        index: 0,
+        routes: [{ key: 's1', routeName: 's1' }],
+      },
+      addListener: dummyEventSubscriber,
+    };
+    const router = TabRouter({ s1: { screen: View } });
+
+    const rendered = renderer
+      .create(
+        <TabView
+          lazy={true}
+          lazyPlaceholder={<Text>Loading...</Text>}
           tabBarComponent={TabBarBottom}
           navigation={navigation}
           router={router}

--- a/src/views/__tests__/__snapshots__/TabView-test.js.snap
+++ b/src/views/__tests__/__snapshots__/TabView-test.js.snap
@@ -274,3 +274,278 @@ exports[`TabBarBottom renders successfully 1`] = `
   </RCTScrollView>
 </View>
 `;
+
+exports[`TabBarBottom w/ lazyPlaceholder renders successfully 1`] = `
+<View
+  loaded={
+    Array [
+      0,
+    ]
+  }
+  onLayout={[Function]}
+  style={
+    Array [
+      Object {
+        "flex": 1,
+        "overflow": "hidden",
+      },
+      Object {
+        "flex": 1,
+      },
+    ]
+  }
+>
+  <View
+    collapsable={undefined}
+    style={undefined}
+  >
+    <View
+      collapsable={undefined}
+      onLayout={[Function]}
+      pointerEvents="box-none"
+      style={
+        Object {
+          "backgroundColor": "#F7F7F7",
+          "borderTopColor": "rgba(0, 0, 0, .3)",
+          "borderTopWidth": 0.5,
+          "flexDirection": "row",
+          "height": 49,
+          "paddingBottom": 0,
+          "paddingLeft": 0,
+          "paddingRight": 0,
+          "paddingTop": 0,
+        }
+      }
+    >
+      <View
+        accessibilityComponentType={undefined}
+        accessibilityLabel={undefined}
+        accessibilityTraits={undefined}
+        accessible={true}
+        collapsable={undefined}
+        hitSlop={undefined}
+        nativeID={undefined}
+        onLayout={undefined}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "alignItems": "center",
+            "backgroundColor": "rgba(0, 0, 0, 0)",
+            "flex": 1,
+          }
+        }
+        testID={undefined}
+      >
+        <View
+          style={
+            Array [
+              Object {
+                "alignItems": "center",
+                "flex": 1,
+              },
+              Object {
+                "flexDirection": "column",
+                "justifyContent": "flex-end",
+              },
+              undefined,
+            ]
+          }
+        >
+          <View
+            style={
+              Array [
+                Object {
+                  "height": 29,
+                },
+                false,
+                Object {
+                  "flexGrow": 1,
+                },
+              ]
+            }
+          >
+            <View
+              collapsable={undefined}
+              style={
+                Object {
+                  "alignItems": "center",
+                  "alignSelf": "center",
+                  "height": "100%",
+                  "justifyContent": "center",
+                  "opacity": 1,
+                  "position": "absolute",
+                  "width": "100%",
+                }
+              }
+            />
+            <View
+              collapsable={undefined}
+              style={
+                Object {
+                  "alignItems": "center",
+                  "alignSelf": "center",
+                  "height": "100%",
+                  "justifyContent": "center",
+                  "opacity": 0,
+                  "position": "absolute",
+                  "width": "100%",
+                }
+              }
+            />
+          </View>
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            collapsable={undefined}
+            ellipsizeMode="tail"
+            numberOfLines={1}
+            style={
+              Object {
+                "backgroundColor": "transparent",
+                "color": "rgba(52, 120, 246, 1)",
+                "fontSize": 10,
+                "marginBottom": 1.5,
+                "textAlign": "center",
+              }
+            }
+          >
+            s1
+          </Text>
+        </View>
+      </View>
+    </View>
+  </View>
+  <RCTScrollView
+    DEPRECATED_sendUpdatedChildFrames={false}
+    alwaysBounceHorizontal={false}
+    alwaysBounceVertical={false}
+    automaticallyAdjustContentInsets={false}
+    bounces={false}
+    contentContainerStyle={
+      Object {
+        "flex": 1,
+      }
+    }
+    contentOffset={
+      Object {
+        "x": 0,
+        "y": 0,
+      }
+    }
+    directionalLockEnabled={true}
+    horizontal={true}
+    keyboardDismissMode="on-drag"
+    keyboardShouldPersistTaps="always"
+    onContentSizeChange={null}
+    onMomentumScrollBegin={[Function]}
+    onMomentumScrollEnd={[Function]}
+    onResponderGrant={[Function]}
+    onResponderReject={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={undefined}
+    onResponderTerminationRequest={[Function]}
+    onScroll={[Function]}
+    onScrollBeginDrag={[Function]}
+    onScrollEndDrag={[Function]}
+    onScrollShouldSetResponder={[Function]}
+    onStartShouldSetResponder={[Function]}
+    onStartShouldSetResponderCapture={[Function]}
+    onTouchCancel={[Function]}
+    onTouchEnd={[Function]}
+    onTouchMove={[Function]}
+    onTouchStart={[Function]}
+    overScrollMode="never"
+    pagingEnabled={true}
+    scrollEnabled={undefined}
+    scrollEventThrottle={1}
+    scrollsToTop={false}
+    sendMomentumEvents={true}
+    showsHorizontalScrollIndicator={false}
+    style={
+      Array [
+        Object {
+          "flexDirection": "row",
+          "flexGrow": 1,
+          "flexShrink": 1,
+          "overflow": "scroll",
+        },
+        Object {
+          "flex": 1,
+        },
+      ]
+    }
+  >
+    <RCTScrollContentView
+      collapsable={false}
+      removeClippedSubviews={undefined}
+      style={
+        Array [
+          Object {
+            "flexDirection": "row",
+          },
+          Object {
+            "flex": 1,
+          },
+        ]
+      }
+    >
+      <View
+        style={
+          Object {
+            "flex": 1,
+            "overflow": "hidden",
+          }
+        }
+        testID={undefined}
+      >
+        <View
+          collapsable={false}
+          removeClippedSubviews={false}
+          style={
+            Object {
+              "flex": 1,
+              "overflow": "hidden",
+            }
+          }
+        >
+          <View
+            style={
+              Object {
+                "flex": 1,
+              }
+            }
+          >
+            <View
+              navigation={
+                Object {
+                  "addListener": [Function],
+                  "dispatch": undefined,
+                  "getParam": [Function],
+                  "goBack": [Function],
+                  "isFocused": [Function],
+                  "navigate": [Function],
+                  "pop": [Function],
+                  "popToTop": [Function],
+                  "push": [Function],
+                  "replace": [Function],
+                  "setParams": [Function],
+                  "state": Object {
+                    "key": "s1",
+                    "routeName": "s1",
+                  },
+                }
+              }
+              screenProps={undefined}
+            />
+          </View>
+        </View>
+      </View>
+    </RCTScrollContentView>
+  </RCTScrollView>
+</View>
+`;


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

Explain the **motivation** for making this change. What existing problem does the pull request solve? 

It adds a `lazyPlaceholder` prop that can take a react element to render in place of null to give the user a better experience on tab change.

**Test plan (required)**
As there aren't any tests currently detailing the lazy loading feature, I wasn't sure how to thoroughly test this, but am willing to make this more robust with a little direction.

I re-used my reproduction repo from an open issue, and created a lazyPlaceholder branch to show this in action. https://github.com/kevinsperrine/react-navigation-dynamic-redux-tab-test/tree/lazyPlaceholder I've ran this in expo on both platforms. 
![lazyplaceholder](https://user-images.githubusercontent.com/609466/37559063-01ae0fa4-29ed-11e8-9d5a-5d2461f24b42.gif)

