### PR TITLE
Fix path matching for SwitchRouter and empty paths

### DIFF
--- a/src/routers/StackRouter.js
+++ b/src/routers/StackRouter.js
@@ -471,6 +471,7 @@ export default (routeConfigs, stackConfig = {}) => {
       if (!pathToResolve) {
         return NavigationActions.navigate({
           routeName: initialRouteName,
+          params: inputParams,
         });
       }
 
@@ -541,7 +542,7 @@ export default (routeConfigs, stackConfig = {}) => {
         if (key.asterisk || !key) {
           return result;
         }
-        const nextResult = result || {};
+        const nextResult = result || inputParams || {};
         const paramName = key.name;
 
         let decodedMatchResult;

--- a/src/routers/SwitchRouter.js
+++ b/src/routers/SwitchRouter.js
@@ -319,22 +319,31 @@ export default (routeConfigs, config = {}) => {
      * This will return null if there is no action matched
      */
     getActionForPathAndParams(path, params) {
+      if (!path) {
+        return NavigationActions.navigate({
+          routeName: initialRouteName,
+          params,
+        });
+      }
       return (
         order
           .map(childId => {
             const parts = path.split('/');
             const pathToTest = paths[childId];
-            if (parts[0] === pathToTest) {
+            const partsInTestPath = pathToTest.split('/').length;
+            const pathPartsToTest = parts.slice(0, partsInTestPath).join('/');
+            if (pathPartsToTest === pathToTest) {
               const childRouter = childRouters[childId];
               const action = NavigationActions.navigate({
                 routeName: childId,
               });
               if (childRouter && childRouter.getActionForPathAndParams) {
                 action.action = childRouter.getActionForPathAndParams(
-                  parts.slice(1).join('/'),
+                  parts.slice(partsInTestPath).join('/'),
                   params
                 );
-              } else if (params) {
+              }
+              if (params) {
                 action.params = params;
               }
               return action;

--- a/src/routers/__tests__/SwitchRouter-test.js
+++ b/src/routers/__tests__/SwitchRouter-test.js
@@ -77,6 +77,49 @@ describe('SwitchRouter', () => {
 
     expect(state3.index).toEqual(0);
   });
+
+  test('provides correct action for getActionForPathAndParams', () => {
+    const router = getExampleRouter({ backBehavior: 'initialRoute' });
+    const action = router.getActionForPathAndParams('A1', { foo: 'bar' });
+    expect(action.type).toEqual(NavigationActions.NAVIGATE);
+    expect(action.routeName).toEqual('A1');
+
+    const action1 = router.getActionForPathAndParams('', {});
+    expect(action1.type).toEqual(NavigationActions.NAVIGATE);
+    expect(action1.routeName).toEqual('A');
+
+    const action2 = router.getActionForPathAndParams(null, {});
+    expect(action2.type).toEqual(NavigationActions.NAVIGATE);
+    expect(action2.routeName).toEqual('A');
+
+    const action3 = router.getActionForPathAndParams('great/path', {
+      foo: 'baz',
+    });
+    expect(action3).toEqual({
+      type: NavigationActions.NAVIGATE,
+      routeName: 'B',
+      params: { foo: 'baz' },
+      action: {
+        type: NavigationActions.NAVIGATE,
+        routeName: 'B1',
+        params: { foo: 'baz' },
+      },
+    });
+
+    const action4 = router.getActionForPathAndParams('great/path/B2', {
+      foo: 'baz',
+    });
+    expect(action4).toEqual({
+      type: NavigationActions.NAVIGATE,
+      routeName: 'B',
+      params: { foo: 'baz' },
+      action: {
+        type: NavigationActions.NAVIGATE,
+        routeName: 'B2',
+        params: { foo: 'baz' },
+      },
+    });
+  });
 });
 
 const getExampleRouter = (config = {}) => {
@@ -96,8 +139,14 @@ const getExampleRouter = (config = {}) => {
 
   const router = SwitchRouter(
     {
-      A: StackA,
-      B: StackB,
+      A: {
+        screen: StackA,
+        path: '',
+      },
+      B: {
+        screen: StackB,
+        path: 'great/path',
+      },
     },
     {
       initialRouteName: 'A',

--- a/src/routers/__tests__/TabRouter-test.js
+++ b/src/routers/__tests__/TabRouter-test.js
@@ -181,6 +181,7 @@ describe('TabRouter', () => {
     const navAction = {
       type: NavigationActions.NAVIGATE,
       routeName: 'Baz',
+      params: { foo: '42' },
       action: {
         type: NavigationActions.NAVIGATE,
         routeName: 'Bar',


### PR DESCRIPTION
Adds a test for path matching on switch router. This use case is blocking some experimentation on web..