### PR TITLE
Allow setting explicit gestureDirection for more control

### DIFF
--- a/src/views/StackView/StackViewLayout.js
+++ b/src/views/StackView/StackViewLayout.js
@@ -207,10 +207,14 @@ class StackViewLayout extends React.Component {
       mode,
     } = this.props;
     const { index } = navigation.state;
-    const isVertical = mode === 'modal';
     const { options } = scene.descriptor;
+    const isVertical = mode === 'modal'
+      || options.gestureDirection === 'up'
+      || options.gestureDirection === 'down';
 
-    const gestureDirectionInverted = options.gestureDirection === 'inverted';
+    const gestureDirectionInverted = options.gestureDirection === 'inverted'
+      || options.gestureDirection === 'left'
+      || options.gestureDirection === 'up';
 
     const gesturesEnabled =
       typeof options.gesturesEnabled === 'boolean'

--- a/src/views/StackView/StackViewLayout.js
+++ b/src/views/StackView/StackViewLayout.js
@@ -208,13 +208,15 @@ class StackViewLayout extends React.Component {
     } = this.props;
     const { index } = navigation.state;
     const { options } = scene.descriptor;
-    const isVertical = mode === 'modal'
-      || options.gestureDirection === 'up'
-      || options.gestureDirection === 'down';
+    const isVertical =
+      mode === 'modal' ||
+      options.gestureDirection === 'up' ||
+      options.gestureDirection === 'down';
 
-    const gestureDirectionInverted = options.gestureDirection === 'inverted'
-      || options.gestureDirection === 'left'
-      || options.gestureDirection === 'up';
+    const gestureDirectionInverted =
+      options.gestureDirection === 'inverted' ||
+      options.gestureDirection === 'left' ||
+      options.gestureDirection === 'up';
 
     const gesturesEnabled =
       typeof options.gesturesEnabled === 'boolean'


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

**Motivation**

I need more control over how the gestures work. Right now when overwriting the `transitionConfig.screenInterpolator`, the gestures mismatch the animation. By changing the `navigationOptions.gestureDirection` (in a backwards compatible way) to support the values `up`, `down`, `left` and `right` this allows to configure the direction, where `default` and `inverted` would (in combination with `mode`) fail to _fix_ the user experience.

**Test plan (required)**

I will try to setup an expo snack

**Code formatting**

Will do when finished
