### PR TITLE
Smoothly transition header visibility in Stack

### DIFF
--- a/examples/NavigationPlayground/js/StackWithHeaderPreset.js
+++ b/examples/NavigationPlayground/js/StackWithHeaderPreset.js
@@ -26,8 +26,11 @@ class HomeScreen extends React.Component<NavScreenProps> {
           onPress={() => navigation.push('Other')}
           title="Push another screen"
         />
-        <Button onPress={() => navigation.pop()} title="Pop" />
-        <Button onPress={() => navigation.goBack(null)} title="Go back" />
+        <Button
+          onPress={() => navigation.push('ScreenWithNoHeader')}
+          title="Push screen with no header"
+        />
+        <Button onPress={() => navigation.goBack(null)} title="Go Home" />
         <StatusBar barStyle="default" />
       </SafeAreaView>
     );
@@ -37,6 +40,51 @@ class HomeScreen extends React.Component<NavScreenProps> {
 class OtherScreen extends React.Component<NavScreenProps> {
   static navigationOptions = {
     title: 'Your title here',
+  };
+
+  render() {
+    const { navigation } = this.props;
+
+    return (
+      <SafeAreaView style={{ paddingTop: 30 }}>
+        <Button
+          onPress={() => navigation.push('ScreenWithLongTitle')}
+          title="Push another screen"
+        />
+        <Button
+          onPress={() => navigation.push('ScreenWithNoHeader')}
+          title="Push screen with no header"
+        />
+        <Button onPress={() => navigation.pop()} title="Pop" />
+        <Button onPress={() => navigation.goBack(null)} title="Go back" />
+        <StatusBar barStyle="default" />
+      </SafeAreaView>
+    );
+  }
+}
+
+class ScreenWithLongTitle extends React.Component<NavScreenProps> {
+  static navigationOptions = {
+    title: "Another title that's kind of long",
+  };
+
+  render() {
+    const { navigation } = this.props;
+
+    return (
+      <SafeAreaView style={{ paddingTop: 30 }}>
+        <Button onPress={() => navigation.pop()} title="Pop" />
+        <Button onPress={() => navigation.goBack(null)} title="Go back" />
+        <StatusBar barStyle="default" />
+      </SafeAreaView>
+    );
+  }
+}
+
+class ScreenWithNoHeader extends React.Component<NavScreenProps> {
+  static navigationOptions = {
+    header: null,
+    title: 'No Header',
   };
 
   render() {
@@ -60,6 +108,8 @@ const StackWithHeaderPreset = createStackNavigator(
   {
     Home: HomeScreen,
     Other: OtherScreen,
+    ScreenWithNoHeader: ScreenWithNoHeader,
+    ScreenWithLongTitle: ScreenWithLongTitle,
   },
   {
     headerTransitionPreset: 'uikit',

--- a/src/navigators/__tests__/__snapshots__/StackNavigator-test.js.snap
+++ b/src/navigators/__tests__/__snapshots__/StackNavigator-test.js.snap
@@ -51,6 +51,7 @@ exports[`StackNavigator applies correct values when headerRight is present 1`] =
             "backgroundColor": "#E9E9EF",
             "bottom": 0,
             "left": 0,
+            "marginTop": 0,
             "opacity": 1,
             "position": "absolute",
             "right": 0,
@@ -77,36 +78,31 @@ exports[`StackNavigator applies correct values when headerRight is present 1`] =
     <View
       collapsable={undefined}
       onLayout={[Function]}
-      pointerEvents="box-none"
       style={
         Object {
-          "backgroundColor": "red",
-          "borderBottomColor": "#A7A7AA",
-          "borderBottomWidth": 0.5,
-          "height": 64,
-          "opacity": 0.5,
-          "paddingBottom": 0,
-          "paddingLeft": 0,
-          "paddingRight": 0,
-          "paddingTop": 20,
+          "transform": Array [
+            Object {
+              "translateX": 0,
+            },
+          ],
         }
       }
     >
       <View
+        collapsable={undefined}
+        onLayout={[Function]}
+        pointerEvents="box-none"
         style={
           Object {
-            "bottom": 0,
-            "left": 0,
-            "position": "absolute",
-            "right": 0,
-            "top": 0,
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "flex": 1,
+            "backgroundColor": "red",
+            "borderBottomColor": "#A7A7AA",
+            "borderBottomWidth": 0.5,
+            "height": 64,
+            "opacity": 0.5,
+            "paddingBottom": 0,
+            "paddingLeft": 0,
+            "paddingRight": 0,
+            "paddingTop": 20,
           }
         }
       >
@@ -114,70 +110,89 @@ exports[`StackNavigator applies correct values when headerRight is present 1`] =
           style={
             Object {
               "bottom": 0,
-              "flexDirection": "row",
               "left": 0,
               "position": "absolute",
               "right": 0,
               "top": 0,
             }
           }
+        />
+        <View
+          style={
+            Object {
+              "flex": 1,
+            }
+          }
         >
           <View
-            collapsable={undefined}
-            pointerEvents="box-none"
             style={
               Object {
-                "alignItems": "center",
-                "backgroundColor": "transparent",
                 "bottom": 0,
                 "flexDirection": "row",
-                "justifyContent": "center",
-                "left": 70,
-                "opacity": 1,
-                "position": "absolute",
-                "right": 70,
-                "top": 0,
-              }
-            }
-          >
-            <Text
-              accessibilityTraits="header"
-              accessible={true}
-              allowFontScaling={true}
-              collapsable={undefined}
-              ellipsizeMode="tail"
-              numberOfLines={1}
-              onLayout={[Function]}
-              style={
-                Object {
-                  "color": "rgba(0, 0, 0, .9)",
-                  "fontSize": 17,
-                  "fontWeight": "700",
-                  "marginHorizontal": 16,
-                  "textAlign": "center",
-                }
-              }
-            >
-              Welcome anonymous
-            </Text>
-          </View>
-          <View
-            collapsable={undefined}
-            pointerEvents="box-none"
-            style={
-              Object {
-                "alignItems": "center",
-                "backgroundColor": "transparent",
-                "bottom": 0,
-                "flexDirection": "row",
-                "opacity": 1,
+                "left": 0,
                 "position": "absolute",
                 "right": 0,
                 "top": 0,
               }
             }
           >
-            <View />
+            <View
+              collapsable={undefined}
+              pointerEvents="box-none"
+              style={
+                Object {
+                  "alignItems": "center",
+                  "backgroundColor": "transparent",
+                  "bottom": 0,
+                  "flexDirection": "row",
+                  "justifyContent": "center",
+                  "left": 70,
+                  "opacity": 1,
+                  "position": "absolute",
+                  "right": 70,
+                  "top": 0,
+                }
+              }
+            >
+              <Text
+                accessibilityTraits="header"
+                accessible={true}
+                allowFontScaling={true}
+                collapsable={undefined}
+                ellipsizeMode="tail"
+                numberOfLines={1}
+                onLayout={[Function]}
+                style={
+                  Object {
+                    "color": "rgba(0, 0, 0, .9)",
+                    "fontSize": 17,
+                    "fontWeight": "700",
+                    "marginHorizontal": 16,
+                    "textAlign": "center",
+                  }
+                }
+              >
+                Welcome anonymous
+              </Text>
+            </View>
+            <View
+              collapsable={undefined}
+              pointerEvents="box-none"
+              style={
+                Object {
+                  "alignItems": "center",
+                  "backgroundColor": "transparent",
+                  "bottom": 0,
+                  "flexDirection": "row",
+                  "opacity": 1,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                }
+              }
+            >
+              <View />
+            </View>
           </View>
         </View>
       </View>
@@ -237,6 +252,7 @@ exports[`StackNavigator renders successfully 1`] = `
             "backgroundColor": "#E9E9EF",
             "bottom": 0,
             "left": 0,
+            "marginTop": 0,
             "opacity": 1,
             "position": "absolute",
             "right": 0,
@@ -263,36 +279,31 @@ exports[`StackNavigator renders successfully 1`] = `
     <View
       collapsable={undefined}
       onLayout={[Function]}
-      pointerEvents="box-none"
       style={
         Object {
-          "backgroundColor": "red",
-          "borderBottomColor": "#A7A7AA",
-          "borderBottomWidth": 0.5,
-          "height": 64,
-          "opacity": 0.5,
-          "paddingBottom": 0,
-          "paddingLeft": 0,
-          "paddingRight": 0,
-          "paddingTop": 20,
+          "transform": Array [
+            Object {
+              "translateX": 0,
+            },
+          ],
         }
       }
     >
       <View
+        collapsable={undefined}
+        onLayout={[Function]}
+        pointerEvents="box-none"
         style={
           Object {
-            "bottom": 0,
-            "left": 0,
-            "position": "absolute",
-            "right": 0,
-            "top": 0,
-          }
-        }
-      />
-      <View
-        style={
-          Object {
-            "flex": 1,
+            "backgroundColor": "red",
+            "borderBottomColor": "#A7A7AA",
+            "borderBottomWidth": 0.5,
+            "height": 64,
+            "opacity": 0.5,
+            "paddingBottom": 0,
+            "paddingLeft": 0,
+            "paddingRight": 0,
+            "paddingTop": 20,
           }
         }
       >
@@ -300,52 +311,71 @@ exports[`StackNavigator renders successfully 1`] = `
           style={
             Object {
               "bottom": 0,
-              "flexDirection": "row",
               "left": 0,
               "position": "absolute",
               "right": 0,
               "top": 0,
             }
           }
+        />
+        <View
+          style={
+            Object {
+              "flex": 1,
+            }
+          }
         >
           <View
-            collapsable={undefined}
-            pointerEvents="box-none"
             style={
               Object {
-                "alignItems": "center",
-                "backgroundColor": "transparent",
                 "bottom": 0,
                 "flexDirection": "row",
-                "justifyContent": "center",
                 "left": 0,
-                "opacity": 1,
                 "position": "absolute",
                 "right": 0,
                 "top": 0,
               }
             }
           >
-            <Text
-              accessibilityTraits="header"
-              accessible={true}
-              allowFontScaling={true}
+            <View
               collapsable={undefined}
-              ellipsizeMode="tail"
-              numberOfLines={1}
-              onLayout={[Function]}
+              pointerEvents="box-none"
               style={
                 Object {
-                  "color": "rgba(0, 0, 0, .9)",
-                  "fontSize": 17,
-                  "fontWeight": "700",
-                  "marginHorizontal": 16,
-                  "textAlign": "center",
+                  "alignItems": "center",
+                  "backgroundColor": "transparent",
+                  "bottom": 0,
+                  "flexDirection": "row",
+                  "justifyContent": "center",
+                  "left": 0,
+                  "opacity": 1,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
                 }
               }
             >
-              Welcome anonymous
-            </Text>
+              <Text
+                accessibilityTraits="header"
+                accessible={true}
+                allowFontScaling={true}
+                collapsable={undefined}
+                ellipsizeMode="tail"
+                numberOfLines={1}
+                onLayout={[Function]}
+                style={
+                  Object {
+                    "color": "rgba(0, 0, 0, .9)",
+                    "fontSize": 17,
+                    "fontWeight": "700",
+                    "marginHorizontal": 16,
+                    "textAlign": "center",
+                  }
+                }
+              >
+                Welcome anonymous
+              </Text>
+            </View>
           </View>
         </View>
       </View>

--- a/src/views/Header/Header.js
+++ b/src/views/Header/Header.js
@@ -495,7 +495,7 @@ class Header extends React.PureComponent {
 
     return (
       <Animated.View
-        style={[{ ...this.props.layoutInterpolator(this.props) }]}
+        style={this.props.layoutInterpolator(this.props)}
         onLayout={this._handleOnLayout}
       >
         <SafeAreaView forceInset={forceInset} style={containerStyles}>

--- a/src/views/Header/Header.js
+++ b/src/views/Header/Header.js
@@ -30,6 +30,7 @@ const getAppBarHeight = isLandscape => {
 
 class Header extends React.PureComponent {
   static defaultProps = {
+    layoutInterpolator: HeaderStyleInterpolator.forLayout,
     leftInterpolator: HeaderStyleInterpolator.forLeft,
     leftButtonInterpolator: HeaderStyleInterpolator.forLeftButton,
     leftLabelInterpolator: HeaderStyleInterpolator.forLeftLabel,
@@ -44,6 +45,12 @@ class Header extends React.PureComponent {
 
   state = {
     widths: {},
+  };
+
+  _handleOnLayout = e => {
+    if (typeof this.props.onLayout === 'function') {
+      this.props.onLayout(e.nativeEvent.layout);
+    }
   };
 
   _getHeaderTitleString(scene) {
@@ -370,6 +377,10 @@ class Header extends React.PureComponent {
   }
 
   _renderHeader(props) {
+    const { options } = props.scene.descriptor;
+    if (options.header === null) {
+      return null;
+    }
     const left = this._renderLeft(props);
     const right = this._renderRight(props);
     const title = this._renderTitle(props, {
@@ -378,7 +389,6 @@ class Header extends React.PureComponent {
     });
 
     const { isLandscape, transitionPreset } = this.props;
-    const { options } = props.scene.descriptor;
 
     const wrapperProps = {
       style: styles.header,
@@ -484,10 +494,17 @@ class Header extends React.PureComponent {
     const forceInset = headerForceInset || { top: 'always', bottom: 'never' };
 
     return (
-      <SafeAreaView forceInset={forceInset} style={containerStyles}>
-        <View style={StyleSheet.absoluteFill}>{options.headerBackground}</View>
-        <View style={styles.flexOne}>{appBar}</View>
-      </SafeAreaView>
+      <Animated.View
+        style={[{ ...this.props.layoutInterpolator(this.props) }]}
+        onLayout={this._handleOnLayout}
+      >
+        <SafeAreaView forceInset={forceInset} style={containerStyles}>
+          <View style={StyleSheet.absoluteFill}>
+            {options.headerBackground}
+          </View>
+          <View style={styles.flexOne}>{appBar}</View>
+        </SafeAreaView>
+      </Animated.View>
     );
   }
 }


### PR DESCRIPTION
### Summary

This addresses #2732 (which also happens to be the top issue on canny.io).

Transitioning between screens with and without headers when `headerMode` is set to "screen" works just fine, but the current experience when `headerMode` is set to "float" is very broken. The goal of this PR is to replicate the behavior of UIKit on iOS: when a screen without a header is pushed, the header on the previous screen is pushed off the screen to the left, and the individual components of the header do not animate. When a screen with a header is pushed _after_ a screen without one, we slide the new header on the screen from right to left, in sync with the push animation, again while avoiding animating the individual header components.

I also updated the UIKit transition example in Navigation Playground to demonstrate this.

Here's a gif of the animation from a native iOS app:

![gif of native ios transition](https://d3vv6lp55qjaqc.cloudfront.net/items/2M0q2k3E2l113v2w2r1i/Screen%20Recording%202018-03-22%20at%2009.18%20PM.gif?X-CloudApp-Visitor-Id=8611&v=fd63baba)

### Test Plan:

Try the UIKit transition example in Navigation Playground.