### PR TITLE
Update Flowtype to support navigation.navigate({})

### DIFF
--- a/flow/react-navigation.js
+++ b/flow/react-navigation.js
@@ -488,7 +488,12 @@ declare module 'react-navigation' {
     goBack: (routeKey?: ?string) => boolean,
     dismiss: () => boolean,
     navigate: (
-      routeName: string,
+      routeName: string | {
+        routeName: string,
+        params?: NavigationParams,
+        action?: NavigationNavigateAction,
+        key?: string
+      },
       params?: NavigationParams,
       action?: NavigationNavigateAction
     ) => boolean,


### PR DESCRIPTION
according to implementation, this is legit:

```
navigation.navigate({
  routeName: "EditAccount",
  params: { account },
  key: "editaccount"
})
```

however, the flowtype don't allow that.