### PR TITLE
Fix back button in redux example

### DIFF
--- a/examples/ReduxExample/src/navigators/AppNavigator.js
+++ b/examples/ReduxExample/src/navigators/AppNavigator.js
@@ -1,7 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { StackNavigator } from 'react-navigation';
+import {
+  StackNavigator,
+  addNavigationHelpers,
+} from 'react-navigation';
 
 import LoginScreen from '../components/LoginScreen';
 import MainScreen from '../components/MainScreen';
@@ -24,11 +27,11 @@ class AppWithNavigationState extends React.Component {
     const { dispatch, nav } = this.props;
     return (
       <AppNavigator
-        navigation={{
+        navigation={addNavigationHelpers({
           dispatch,
           state: nav,
           addListener,
-        }}
+        })}
       />
     );
   }


### PR DESCRIPTION
# Motivation

Pressing the header back button on the provided redux example doesn't work. Adding `addNavigationHelpers` solves the problem.

# Test plan
Run the ReduxExample and press back button.