### PR TITLE
Add check for undefined prevState in SwitchRouter

### DIFF
--- a/src/routers/SwitchRouter.js
+++ b/src/routers/SwitchRouter.js
@@ -77,6 +77,10 @@ export default (routeConfigs, config = {}) => {
     },
 
     getNextState(prevState, possibleNextState) {
+      if (!prevState) {
+        return possibleNextState;
+      }
+
       let nextState;
       if (prevState.index !== possibleNextState.index && resetOnBlur) {
         const prevRouteName = prevState.routes[prevState.index].routeName;

--- a/src/routers/__tests__/SwitchRouter-test.js
+++ b/src/routers/__tests__/SwitchRouter-test.js
@@ -25,6 +25,20 @@ describe('SwitchRouter', () => {
     expect(state3.routes[0].routes.length).toEqual(1);
   });
 
+  test('sets the next state even if no previous state is provided', () => {
+    const router = getExampleRouter();
+    const initialState = router.getStateForAction({
+      type: NavigationActions.INIT,
+    });
+    const nextState = router.getStateForAction({
+      type: NavigationActions.NAVIGATE,
+      routeName: 'A2',
+    });
+
+    expect(nextState.routes[0].index).toEqual(1);
+    expect(nextState.routes[0].routes.length).toEqual(2);
+  });
+
   test('does not reset the route on unfocus if resetOnBlur is false', () => {
     const router = getExampleRouter({ resetOnBlur: false });
     const state = router.getStateForAction({ type: NavigationActions.INIT });


### PR DESCRIPTION
## Motivation
Fixes #3788. This is a patch from [2.x](https://github.com/react-navigation/react-navigation/commit/bdda6fa5be2cbdef2a1f4f5b3a65fa4518003c27#diff-ae1aa3891dfecf6877acb9deb37db793) (not sure if we should just cherry-pick that commit instead?)
## Test Plan
- [x] Add coverage 