### PR TITLE
Moved params resolution and passed them into child routes

### DIFF
--- a/src/routers/StackRouter.js
+++ b/src/routers/StackRouter.js
@@ -547,21 +547,6 @@ export default (routeConfigs, stackConfig = {}) => {
         return null;
       }
 
-      // Determine nested actions:
-      // If our matched route for this router is a child router,
-      // get the action for the path AFTER the matched path for this
-      // router
-      let nestedAction;
-      let nestedQueryString = queryString ? '?' + queryString : '';
-      if (childRouters[matchedRouteName]) {
-        nestedAction = childRouters[matchedRouteName].getActionForPathAndParams(
-          pathMatch.slice(pathMatchKeys.length).join('/') + nestedQueryString
-        );
-        if (!nestedAction) {
-          return null;
-        }
-      }
-
       // reduce the items of the query string. any query params may
       // be overridden by path params
       const queryParams = !isEmpty(inputParams)
@@ -596,6 +581,22 @@ export default (routeConfigs, stackConfig = {}) => {
         nextResult[paramName] = decodedMatchResult || matchResult;
         return nextResult;
       }, queryParams);
+
+      // Determine nested actions:
+      // If our matched route for this router is a child router,
+      // get the action for the path AFTER the matched path for this
+      // router
+      let nestedAction;
+      let nestedQueryString = queryString ? '?' + queryString : '';
+      if (childRouters[matchedRouteName]) {
+        nestedAction = childRouters[matchedRouteName].getActionForPathAndParams(
+          pathMatch.slice(pathMatchKeys.length).join('/') + nestedQueryString,
+          params
+        );
+        if (!nestedAction) {
+          return null;
+        }
+      }
 
       return NavigationActions.navigate({
         routeName: matchedRouteName,

--- a/src/routers/StackRouter.js
+++ b/src/routers/StackRouter.js
@@ -591,8 +591,10 @@ export default (routeConfigs, stackConfig = {}) => {
       let nestedAction;
       let nestedQueryString = queryString ? '?' + queryString : '';
       if (childRouters[matchedRouteName]) {
-        let passedParams = (matchedRouteConfig.passParams || [])
-          .reduce((o, param) => o[param] = params[param], {})
+        let passedParams = (matchedRouteConfig.passParams || []).reduce(
+          (o, param) => (o[param] = params[param]),
+          {}
+        )
         nestedAction = childRouters[matchedRouteName].getActionForPathAndParams(
           pathMatch.slice(pathMatchKeys.length).join('/') + nestedQueryString,
           passedParams

--- a/src/routers/StackRouter.js
+++ b/src/routers/StackRouter.js
@@ -547,6 +547,8 @@ export default (routeConfigs, stackConfig = {}) => {
         return null;
       }
 
+      let matchedRouteConfig = routeConfigs[matchedRouteName];
+
       // reduce the items of the query string. any query params may
       // be overridden by path params
       const queryParams = !isEmpty(inputParams)
@@ -589,9 +591,11 @@ export default (routeConfigs, stackConfig = {}) => {
       let nestedAction;
       let nestedQueryString = queryString ? '?' + queryString : '';
       if (childRouters[matchedRouteName]) {
+        let passedParams = (matchedRouteConfig.passParams || [])
+          .reduce((o, param) => o[param] = params[param], {})
         nestedAction = childRouters[matchedRouteName].getActionForPathAndParams(
           pathMatch.slice(pathMatchKeys.length).join('/') + nestedQueryString,
-          params
+          passedParams
         );
         if (!nestedAction) {
           return null;

--- a/src/routers/SwitchRouter.js
+++ b/src/routers/SwitchRouter.js
@@ -347,7 +347,7 @@ export default (routeConfigs, config = {}) => {
                 routeName: childId,
               });
               if (childRouter && childRouter.getActionForPathAndParams) {
-                let childRouteConfig = childRouteConfig[childId];
+                let childRouteConfig = routeConfigs[childId];
                 let passedParams = (childRouteConfig.passParams || []).reduce(
                   (o, param) => (o[param] = params[param]),
                   {}

--- a/src/routers/SwitchRouter.js
+++ b/src/routers/SwitchRouter.js
@@ -347,9 +347,12 @@ export default (routeConfigs, config = {}) => {
                 routeName: childId,
               });
               if (childRouter && childRouter.getActionForPathAndParams) {
+                let childRouteConfig = childRouteConfig[childId];
+                let passedParams = (childRouteConfig.passParams || [])
+                  .reduce((o, param) => o[param] = params[param], {})
                 action.action = childRouter.getActionForPathAndParams(
                   parts.slice(partsInTestPath).join('/'),
-                  params
+                  passedParams
                 );
               }
               if (params) {

--- a/src/routers/SwitchRouter.js
+++ b/src/routers/SwitchRouter.js
@@ -348,8 +348,10 @@ export default (routeConfigs, config = {}) => {
               });
               if (childRouter && childRouter.getActionForPathAndParams) {
                 let childRouteConfig = childRouteConfig[childId];
-                let passedParams = (childRouteConfig.passParams || [])
-                  .reduce((o, param) => o[param] = params[param], {})
+                let passedParams = (childRouteConfig.passParams || []).reduce(
+                  (o, param) => (o[param] = params[param]),
+                  {}
+                )
                 action.action = childRouter.getActionForPathAndParams(
                   parts.slice(partsInTestPath).join('/'),
                   passedParams

--- a/src/routers/validateRouteConfigMap.js
+++ b/src/routers/validateRouteConfigMap.js
@@ -42,6 +42,11 @@ function validateRouteConfigMap(routeConfigs) {
           'a getScreen, not both.'
       );
     }
+
+    if (routeConfig.passParams && !Array.isArray(routeConfig.passParams)) {
+      throw new Error(`Route config for route '${routeName}' declares ` +
+        'passParams but it is not an array.')
+    }
   });
 }
 

--- a/src/routers/validateRouteConfigMap.js
+++ b/src/routers/validateRouteConfigMap.js
@@ -44,8 +44,10 @@ function validateRouteConfigMap(routeConfigs) {
     }
 
     if (routeConfig.passParams && !Array.isArray(routeConfig.passParams)) {
-      throw new Error(`Route config for route '${routeName}' declares ` +
-        'passParams but it is not an array.')
+      throw new Error(
+        `Route config for route '${routeName}' declares ` +
+        'passParams but it is not an array.'
+      );
     }
   });
 }


### PR DESCRIPTION
This is a breaking change which will pass all parent route parameters from a router into its child routers.

**Motivation**
While deep linking into a route stack comprised of multiple nested routers, it appears to be impossible for the target screen to pick up all of the parameters from the route resolution (particularly the ones which have been parsed by parent routers.) This seems to be counter-intuitive to the purpose of a router, which is to let the target action manage the full route and parameters parsed by the router.

In particular, I have the following scenario:

As a user I am deep linked into the app with the following URI: `trn://123/foo/456/bar`. The app should then land on the Bar screen. No intermediate rendering in the navigation stack has been done as the exact screen was determined statically -- that means until the Bar screen is mounted, there has been no opportunity to use the path parameters `123` or `456`. Once the app lands on the Bar screen, it then performs a lookup using these path parameters: `loadData(params.firstId, params.secondId)`

The navigator stack looks like this:

```
StackNavigator
    DrawerNavigator
        TabNavigator
```

**Caveats of the solution provided**

If two different routers use the same parameter name in any of their routes, and the app is deep linked into those two routes one after the other, the parameter will be overwritten by the child router. This means developers should be cautious when creating routes with simple parameter names like `:id`. This is consistent with server-based routing: you can't have two route parameters with the same name.

**Tests have not been provided as this is just a proposal. I would be happy to create tests if you are willing to proceed.**