### PR TITLE
Allow Explicitly Setting Gesture Direction and Show Proper Transition Direction

### DIFF
--- a/src/views/StackView/StackView.js
+++ b/src/views/StackView/StackView.js
@@ -40,13 +40,18 @@ class StackView extends React.Component {
 
   _configureTransition = (transitionProps, prevTransitionProps) => {
     this.gestureDirection = this.gestureDirection || null;
-    this.gestureDirection = transitionProps.index === prevTransitionProps.index ? this.gestureDirection : transitionProps.scene.descriptor.options.gestureDirection;
+    this.gestureDirection =
+      transitionProps.index === prevTransitionProps.index
+        ? this.gestureDirection
+        : transitionProps.scene.descriptor.options.gestureDirection;
     return {
       ...TransitionConfigs.getTransitionConfig(
         this.props.navigationConfig.transitionConfig,
         transitionProps,
         prevTransitionProps,
-        this.props.navigationConfig.mode === 'modal' || this.gestureDirection === 'down' || this.gestureDirection === 'up'
+        this.props.navigationConfig.mode === 'modal' ||
+          this.gestureDirection === 'down' ||
+          this.gestureDirection === 'up'
       ).transitionSpec,
       useNativeDriver: !!NativeAnimatedModule,
     };

--- a/src/views/StackView/StackView.js
+++ b/src/views/StackView/StackView.js
@@ -39,12 +39,14 @@ class StackView extends React.Component {
   }
 
   _configureTransition = (transitionProps, prevTransitionProps) => {
+    this.gestureDirection = this.gestureDirection || null;
+    this.gestureDirection = transitionProps.index === prevTransitionProps.index ? this.gestureDirection : transitionProps.scene.descriptor.options.gestureDirection;
     return {
       ...TransitionConfigs.getTransitionConfig(
         this.props.navigationConfig.transitionConfig,
         transitionProps,
         prevTransitionProps,
-        this.props.navigationConfig.mode === 'modal'
+        this.props.navigationConfig.mode === 'modal' || this.gestureDirection === 'down' || this.gestureDirection === 'up'
       ).transitionSpec,
       useNativeDriver: !!NativeAnimatedModule,
     };

--- a/src/views/StackView/StackViewLayout.js
+++ b/src/views/StackView/StackViewLayout.js
@@ -436,9 +436,18 @@ class StackViewLayout extends React.Component {
   }
 
   _getTransitionConfig = () => {
-    const {transitionConfig, transitionProps, prevTransitionProps, mode} = this.props;
-    this.gestureDirection = transitionProps.scene.descriptor.options.gestureDirection;
-    const isVertical  = mode === 'modal' || this.gestureDirection === 'down' || this.gestureDirection === 'up';
+    const {
+      transitionConfig,
+      transitionProps,
+      prevTransitionProps,
+      mode,
+    } = this.props;
+    this.gestureDirection =
+      transitionProps.scene.descriptor.options.gestureDirection;
+    const isVertical =
+      mode === 'modal' ||
+      this.gestureDirection === 'down' ||
+      this.gestureDirection === 'up';
 
     return TransitionConfigs.getTransitionConfig(
       transitionConfig,

--- a/src/views/StackView/StackViewLayout.js
+++ b/src/views/StackView/StackViewLayout.js
@@ -226,19 +226,22 @@ class StackViewLayout extends React.Component {
     } = this.props;
     const { index } = navigation.state;
     const { options } = scene.descriptor;
+    const opts = options || 
+          {};
+
     const isVertical =
       mode === 'modal' ||
-      options.gestureDirection === 'up' ||
-      options.gestureDirection === 'down';
+      opts.gestureDirection === 'up' ||
+      opts.gestureDirection === 'down';
 
     const gestureDirectionInverted =
-      options.gestureDirection === 'inverted' ||
-      options.gestureDirection === 'left' ||
-      options.gestureDirection === 'up';
+      opts.gestureDirection === 'inverted' ||
+      opts.gestureDirection === 'left' ||
+      opts.gestureDirection === 'up';
 
     const gesturesEnabled =
-      typeof options.gesturesEnabled === 'boolean'
-        ? options.gesturesEnabled
+      typeof opts.gesturesEnabled === 'boolean'
+        ? opts.gesturesEnabled
         : Platform.OS === 'ios';
 
     const responder = !gesturesEnabled

--- a/src/views/StackView/StackViewLayout.js
+++ b/src/views/StackView/StackViewLayout.js
@@ -225,10 +225,11 @@ class StackViewLayout extends React.Component {
       mode,
     } = this.props;
     const { index } = navigation.state;
-    const options = scene.descriptor &&
-                    scene.descriptor.options
-                      ? scene.descriptor.options
-                      : {};
+
+    const options =
+      scene.descriptor && scene.descriptor.options
+        ? scene.descriptor.options
+        : {};
 
     const isVertical =
       mode === 'modal' ||

--- a/src/views/StackView/StackViewLayout.js
+++ b/src/views/StackView/StackViewLayout.js
@@ -225,23 +225,24 @@ class StackViewLayout extends React.Component {
       mode,
     } = this.props;
     const { index } = navigation.state;
-    const { options } = scene.descriptor;
-    const opts = options || 
-          {};
+    const options = scene.descriptor &&
+                    scene.descriptor.options
+                      ? scene.descriptor.options
+                      : {};
 
     const isVertical =
       mode === 'modal' ||
-      opts.gestureDirection === 'up' ||
-      opts.gestureDirection === 'down';
+      options.gestureDirection === 'up' ||
+      options.gestureDirection === 'down';
 
     const gestureDirectionInverted =
-      opts.gestureDirection === 'inverted' ||
-      opts.gestureDirection === 'left' ||
-      opts.gestureDirection === 'up';
+      options.gestureDirection === 'inverted' ||
+      options.gestureDirection === 'left' ||
+      options.gestureDirection === 'up';
 
     const gesturesEnabled =
-      typeof opts.gesturesEnabled === 'boolean'
-        ? opts.gesturesEnabled
+      typeof options.gesturesEnabled === 'boolean'
+        ? options.gesturesEnabled
         : Platform.OS === 'ios';
 
     const responder = !gesturesEnabled

--- a/src/views/StackView/StackViewLayout.js
+++ b/src/views/StackView/StackViewLayout.js
@@ -220,10 +220,16 @@ class StackViewLayout extends React.Component {
       mode,
     } = this.props;
     const { index } = navigation.state;
-    const isVertical = mode === 'modal';
     const { options } = scene.descriptor;
+    const isVertical =
+      mode === 'modal' ||
+      options.gestureDirection === 'up' ||
+      options.gestureDirection === 'down';
 
-    const gestureDirectionInverted = options.gestureDirection === 'inverted';
+    const gestureDirectionInverted =
+      options.gestureDirection === 'inverted' ||
+      options.gestureDirection === 'left' ||
+      options.gestureDirection === 'up';
 
     const gesturesEnabled =
       typeof options.gesturesEnabled === 'boolean'
@@ -430,13 +436,15 @@ class StackViewLayout extends React.Component {
   }
 
   _getTransitionConfig = () => {
-    const isModal = this.props.mode === 'modal';
+    const {transitionConfig, transitionProps, prevTransitionProps, mode} = this.props;
+    this.gestureDirection = transitionProps.scene.descriptor.options.gestureDirection;
+    const isVertical  = mode === 'modal' || this.gestureDirection === 'down' || this.gestureDirection === 'up';
 
     return TransitionConfigs.getTransitionConfig(
-      this.props.transitionConfig,
-      this.props.transitionProps,
-      this.props.prevTransitionProps,
-      isModal
+      transitionConfig,
+      transitionProps,
+      prevTransitionProps,
+      isVertical
     );
   };
 

--- a/src/views/StackView/StackViewTransitionConfigs.js
+++ b/src/views/StackView/StackViewTransitionConfigs.js
@@ -63,7 +63,7 @@ const FadeOutToBottomAndroid = {
 function defaultTransitionConfig(
   transitionProps,
   prevTransitionProps,
-  isModal
+  isVertical
 ) {
   if (Platform.OS === 'android') {
     // Use the default Android animation no matter if the screen is a modal.
@@ -78,7 +78,7 @@ function defaultTransitionConfig(
     return FadeInFromBottomAndroid;
   }
   // iOS and other platforms
-  if (isModal) {
+  if (isVertical) {
     return ModalSlideFromBottomIOS;
   }
   return SlideFromRightIOS;
@@ -88,17 +88,17 @@ function getTransitionConfig(
   transitionConfigurer,
   transitionProps,
   prevTransitionProps,
-  isModal
+  isVertical
 ) {
   const defaultConfig = defaultTransitionConfig(
     transitionProps,
     prevTransitionProps,
-    isModal
+    isVertical
   );
   if (transitionConfigurer) {
     return {
       ...defaultConfig,
-      ...transitionConfigurer(transitionProps, prevTransitionProps, isModal),
+      ...transitionConfigurer(transitionProps, prevTransitionProps, isVertical),
     };
   }
   return defaultConfig;


### PR DESCRIPTION
**Motivation:** 
I have a project with a custom transitionConfig that has some app screens entering from the bottom of the device screen, and others entering from the right of the device screen. I wanted to allow users to use swipe gestures with these screens in a logical direction based on the way the screens entered.
