### PR TITLE
Fix glaring header back button bug

### DIFF
--- a/src/views/Header/Header.js
+++ b/src/views/Header/Header.js
@@ -150,7 +150,7 @@ class Header extends React.PureComponent {
     const goBack = () => {
       // Go back on next tick because button ripple effect needs to happen on Android
       requestAnimationFrame(() => {
-        this.props.navigation.goBack(props.scene.descriptor.key);
+        props.scene.descriptor.navigation.goBack(props.scene.descriptor.key);
       });
     };
     return (


### PR DESCRIPTION
This fix is super simple thanks to the new createNavigator scene descriptors concept. We want this button to call "go back from this scene", not "go back from this navigator". This should continue to ensure the back action is idempotent when pressing this button twice quickly.