### PR TITLE
Avoid unnecessary navigation completion dispatches

### DIFF
--- a/src/views/StackView/StackView.js
+++ b/src/views/StackView/StackView.js
@@ -25,14 +25,19 @@ class StackView extends React.Component {
         navigation={this.props.navigation}
         descriptors={this.props.descriptors}
         onTransitionStart={this.props.onTransitionStart}
-        onTransitionEnd={(lastTransition, transition) => {
+        onTransitionEnd={(transition, lastTransition) => {
           const { onTransitionEnd, navigation } = this.props;
-          navigation.dispatch(
-            StackActions.completeTransition({
-              key: navigation.state.key,
-            })
-          );
-          onTransitionEnd && onTransitionEnd(lastTransition, transition);
+          if (
+            transition.navigation.state.isTransitioning &&
+            !lastTransition.navigation.state.isTransitioning
+          ) {
+            navigation.dispatch(
+              StackActions.completeTransition({
+                key: navigation.state.key,
+              })
+            );
+          }
+          onTransitionEnd && onTransitionEnd(transition, lastTransition);
         }}
       />
     );


### PR DESCRIPTION
There is an excess of dispatched events coming from this, because "onTransitionEnd" will happen even after immediate transitions.

This ensures that the completion action is only dispatched when it is explicitly needed