### PR TITLE
no more component will mount

### DIFF
--- a/examples/NavigationPlayground/js/App.js
+++ b/examples/NavigationPlayground/js/App.js
@@ -153,7 +153,7 @@ class MainScreen extends React.Component<any, State> {
     scrollY: new Animated.Value(0),
   };
 
-  componentWillMount() {
+  componentDidMount() {
     Asset.fromModule(
       require('react-navigation/src/views/assets/back-icon-mask.png')
     ).downloadAsync();


### PR DESCRIPTION
Aside from Transitioner, this is the only reference to cWM in the repo.

The transitioner willMount is removed here: https://github.com/react-navigation/react-navigation/pull/3901/files