### PR TITLE
fix for when a StackNavigator has an empty router state

### DIFF
--- a/src/getChildEventSubscriber.js
+++ b/src/getChildEventSubscriber.js
@@ -70,8 +70,8 @@ export default function getChildEventSubscriber(addListener, key) {
       const routes = state && state.routes;
 
       const lastFocusKey =
-        lastState && lastState.routes && lastState.routes[lastState.index].key;
-      const focusKey = routes && routes[state.index].key;
+        lastState && lastState.routes && lastState.routes.length && lastState.routes[lastState.index].key;
+      const focusKey = routes && routes.length && routes[state.index].key;
 
       const isChildFocused = focusKey === key;
       const lastRoute =


### PR DESCRIPTION
In my app I have two StackNavigators. One nested inside the other.

If navigating to the nested StackNavigator, then using the Android back button until the app exits, re-opening the app will cause a crash. The nested stack navigator is initialized with an empty stack, so it attempts to get the "key" of undefined.

I can fix this locally by initializing the nested navigator with a dummy route, but it seems like react-navigation should be able to handle nested navigators that are initialized with empty router state.

**Test plan (required)**

In my app I have two StackNavigators. One nested inside the other.

If navigating to the nested StackNavigator, then using the Android back button until the app exits, re-opening the app will cause a crash. The nested stack navigator is initialized with an empty stack, so it attempts to get the "key" of undefined.
