### PR TITLE
keep render headerLeft component on first screen

### DIFF
--- a/src/views/Header/Header.js
+++ b/src/views/Header/Header.js
@@ -136,7 +136,7 @@ class Header extends React.PureComponent {
       return options.headerLeft;
     }
 
-    if (props.scene.index === 0) {
+    if (props.scene.index === 0 && options.headerLeft === undefined) {
       return;
     }
 


### PR DESCRIPTION
rendering headerLeft with component when route index === 0 isn't working