### PR TITLE
Fix transition between 2 screens with no header

### DIFF
--- a/src/views/Header/HeaderStyleInterpolator.js
+++ b/src/views/Header/HeaderStyleInterpolator.js
@@ -55,8 +55,19 @@ function forLayout(props) {
 
   const { first, last } = interpolate;
   const index = scene.index;
-
   const width = layout.initWidth;
+
+  // Make sure the header stays hidden when transitioning between 2 screens
+  // with no header.
+  if (
+    (isBack && !hasHeader(scenes[index]) && !hasHeader(scenes[last])) ||
+    (!isBack && !hasHeader(scenes[first]) && !hasHeader(scenes[index]))
+  ) {
+    return {
+      transform: [{ translateX: width }],
+    };
+  }
+
   const rtlMult = I18nManager.isRTL ? -1 : 1;
   const translateX = position.interpolate({
     inputRange: [first, index, last],
@@ -163,11 +174,11 @@ function forLeftButton(props) {
   };
 }
 
-/* 
+/*
  * NOTE: this offset calculation is an approximation that gives us
  * decent results in many cases, but it is ultimately a poor substitute
  * for text measurement. See the comment on title for more information.
- * 
+ *
  * - 70 is the width of the left button area.
  * - 25 is the width of the left button icon (to account for label offset)
  */
@@ -234,14 +245,14 @@ function forLeftLabel(props) {
   };
 }
 
-/* 
+/*
  * NOTE: this offset calculation is a an approximation that gives us
  * decent results in many cases, but it is ultimately a poor substitute
  * for text measurement. We want the back button label to transition
  * smoothly into the title text and to do this we need to understand
  * where the title is positioned within the title container (since it is
  * centered).
- * 
+ *
  * - 70 is the width of the left button area.
  * - 25 is the width of the left button icon (to account for label offset)
  */


### PR DESCRIPTION
This fixes a broken transition between 2 screens with no header.

https://user-images.githubusercontent.com/2677334/38449859-e9efc2d0-39e2-11e8-81cf-e5832e9effe9.gif

If we detect that we are transitioning between 2 screens with no header just make sure it is hidden, this avoids adding complexity to the already complex interpolation we use.

**Test plan (required)**

Tested that the fix works in the app where I noticed the bug.
