### PR TITLE
Use Header.HEIGHT instead of measuring to avoid flicker

### DIFF
--- a/src/navigators/__tests__/__snapshots__/StackNavigator-test.js.snap
+++ b/src/navigators/__tests__/__snapshots__/StackNavigator-test.js.snap
@@ -77,7 +77,6 @@ exports[`StackNavigator applies correct values when headerRight is present 1`] =
     </View>
     <View
       collapsable={undefined}
-      onLayout={[Function]}
       style={
         Object {
           "transform": Array [
@@ -278,7 +277,6 @@ exports[`StackNavigator renders successfully 1`] = `
     </View>
     <View
       collapsable={undefined}
-      onLayout={[Function]}
       style={
         Object {
           "transform": Array [

--- a/src/views/Header/Header.js
+++ b/src/views/Header/Header.js
@@ -47,12 +47,6 @@ class Header extends React.PureComponent {
     widths: {},
   };
 
-  _handleOnLayout = e => {
-    if (typeof this.props.onLayout === 'function') {
-      this.props.onLayout(e.nativeEvent.layout);
-    }
-  };
-
   _getHeaderTitleString(scene) {
     const options = scene.descriptor.options;
     if (typeof options.headerTitle === 'string') {
@@ -494,10 +488,7 @@ class Header extends React.PureComponent {
     const forceInset = headerForceInset || { top: 'always', bottom: 'never' };
 
     return (
-      <Animated.View
-        style={this.props.layoutInterpolator(this.props)}
-        onLayout={this._handleOnLayout}
-      >
+      <Animated.View style={this.props.layoutInterpolator(this.props)}>
         <SafeAreaView forceInset={forceInset} style={containerStyles}>
           <View style={StyleSheet.absoluteFill}>
             {options.headerBackground}

--- a/src/views/StackView/StackViewLayout.js
+++ b/src/views/StackView/StackViewLayout.js
@@ -94,11 +94,7 @@ class StackViewLayout extends React.Component {
     }
 
     // Handle the case where the header option is a function, and provide the default
-    const renderHeader =
-      header ||
-      (props => (
-        <Header onLayout={layout => (this._headerLayout = layout)} {...props} />
-      ));
+    const renderHeader = header || (props => <Header {...props} />);
 
     const {
       headerLeftInterpolator,
@@ -453,8 +449,8 @@ class StackViewLayout extends React.Component {
     const hasHeader = options.header !== null;
     const headerMode = this._getHeaderMode();
     let marginTop = 0;
-    if (!hasHeader && headerMode === 'float' && this._headerLayout) {
-      marginTop = -this._headerLayout.height;
+    if (!hasHeader && headerMode === 'float') {
+      marginTop = -Header.HEIGHT;
     }
 
     return (


### PR DESCRIPTION
The current technique we use to measure the header doesn't work properly because it is async and will cause the screen to jump. The main problem is that there's no way to know the height of the header synchronously for custom headers. For the default one we know the height already so it is pretty easy (although someone could use headerStyles to change the height and would break this).

This is mostly just to discuss the best way to fix this, I don't think using Header.HEIGHT is fine since it breaks custom header height but can be a good temporary patch for now.

I can see 2 possible solutions:

1. Try to read style props to figure out the height (might not be 100% reliable).
2. Add a navigationOption to customize the header height.

**Test plan (required)**

Tested that this fixes the flicker in the app where I noticed it.