### PR TITLE
Add component support for header / drawerIcon / drawerLabel options

### DIFF
--- a/flow/react-navigation.js
+++ b/flow/react-navigation.js
@@ -335,7 +335,7 @@ declare module 'react-navigation' {
    */
 
   declare export type NavigationStackScreenOptions = NavigationScreenOptions & {
-    header?: ?(React$Node | (HeaderProps => React$Node)),
+    header?: ?(React$Node | React$ComponentType<HeaderProps>),
     headerTransparent?: boolean,
     headerTitle?: string | React$Node | React$ElementType,
     headerTitleStyle?: AnimatedTextStyleProp,
@@ -440,10 +440,10 @@ declare module 'react-navigation' {
     ...$Exact<NavigationScreenOptions>,
     drawerIcon?:
       | React$Node
-      | ((options: { tintColor: ?string, focused: boolean }) => ?React$Node),
+      | React$ComponentType<{ tintColor: ?string, focused: boolean }>,
     drawerLabel?:
       | React$Node
-      | ((options: { tintColor: ?string, focused: boolean }) => ?React$Node),
+      | React$ComponentType<{ tintColor: ?string, focused: boolean }>,
     drawerLockMode?: 'unlocked' | 'locked-closed' | 'locked-open',
   |};
 

--- a/src/views/Drawer/DrawerSidebar.js
+++ b/src/views/Drawer/DrawerSidebar.js
@@ -24,7 +24,7 @@ class DrawerSidebar extends React.PureComponent {
       if (React.isValidElement(drawerLabel)) {
         return drawerLabel;
       }
-      return React.createElement(drawerLabel, { tintColor, focused })
+      return React.createElement(drawerLabel, { tintColor, focused });
     }
 
     if (typeof title === 'string') {
@@ -40,7 +40,7 @@ class DrawerSidebar extends React.PureComponent {
       if (React.isValidElement(drawerIcon)) {
         return drawerIcon;
       }
-      return React.createElement(drawerIcon, { tintColor, focused })
+      return React.createElement(drawerIcon, { tintColor, focused });
     }
     return null;
   };

--- a/src/views/Drawer/DrawerSidebar.js
+++ b/src/views/Drawer/DrawerSidebar.js
@@ -21,9 +21,10 @@ class DrawerSidebar extends React.PureComponent {
   _getLabel = ({ focused, tintColor, route }) => {
     const { drawerLabel, title } = this._getScreenOptions(route.key);
     if (drawerLabel) {
-      return typeof drawerLabel === 'function'
-        ? drawerLabel({ tintColor, focused })
-        : drawerLabel;
+      if (React.isValidElement(drawerLabel)) {
+        return drawerLabel;
+      }
+      return React.createElement(drawerLabel, { tintColor, focused })
     }
 
     if (typeof title === 'string') {
@@ -36,9 +37,10 @@ class DrawerSidebar extends React.PureComponent {
   _renderIcon = ({ focused, tintColor, route }) => {
     const { drawerIcon } = this._getScreenOptions(route.key);
     if (drawerIcon) {
-      return typeof drawerIcon === 'function'
-        ? drawerIcon({ tintColor, focused })
-        : drawerIcon;
+      if (React.isValidElement(drawerIcon)) {
+        return drawerIcon;
+      }
+      return React.createElement(drawerIcon, { tintColor, focused })
     }
     return null;
   };

--- a/src/views/StackView/StackViewLayout.js
+++ b/src/views/StackView/StackViewLayout.js
@@ -96,9 +96,9 @@ class StackViewLayout extends React.Component {
     // Handle the case where the header option is a function or class, and provide the default
     const renderHeader = CustomHeader
       ? CustomHeader.prototype.render
-        ? (props => <CustomHeader {...props} />)
+        ? props => <CustomHeader {...props} />
         : CustomHeader
-      : (props => <Header {...props} />);
+      : props => <Header {...props} />;
 
     const {
       headerLeftInterpolator,

--- a/src/views/StackView/StackViewLayout.js
+++ b/src/views/StackView/StackViewLayout.js
@@ -93,8 +93,12 @@ class StackViewLayout extends React.Component {
       return header;
     }
 
-    // Handle the case where the header option is a function, and provide the default
-    const renderHeader = header || (props => <Header {...props} />);
+    // Handle the case where the header option is a function or class, and provide the default
+    const renderHeader = header
+      ? header.prototype.render
+        ? (props => <header {...props} />)
+        : header
+      : (props => <Header {...props} />);
 
     const {
       headerLeftInterpolator,

--- a/src/views/StackView/StackViewLayout.js
+++ b/src/views/StackView/StackViewLayout.js
@@ -82,22 +82,22 @@ class StackViewLayout extends React.Component {
 
   _renderHeader(scene, headerMode) {
     const { options } = scene.descriptor;
-    const { header } = options;
+    const { header: CustomHeader } = options;
 
-    if (header === null && headerMode === 'screen') {
+    if (CustomHeader === null && headerMode === 'screen') {
       return null;
     }
 
     // check if it's a react element
-    if (React.isValidElement(header)) {
-      return header;
+    if (React.isValidElement(CustomHeader)) {
+      return CustomHeader;
     }
 
     // Handle the case where the header option is a function or class, and provide the default
-    const renderHeader = header
-      ? header.prototype.render
-        ? (props => <header {...props} />)
-        : header
+    const renderHeader = CustomHeader
+      ? CustomHeader.prototype.render
+        ? (props => <CustomHeader {...props} />)
+        : CustomHeader
       : (props => <Header {...props} />);
 
     const {


### PR DESCRIPTION
if `header` passed to navigation option is a class-based component. The program will fail with error message `TypeError: Cannot call a class as a function`.

Changed variable name due to react-native require component name to be capitalized.

_Screenshot_

![1181523346353_ pic_hd](https://user-images.githubusercontent.com/8013313/38543143-54d38fe6-3cd6-11e8-8e89-e7169235ac20.jpg)

**Test plan (required)**

After add fix

_Screenshot_

![1191523346843_ pic](https://user-images.githubusercontent.com/8013313/38543560-6ec0a88e-3cd7-11e8-902d-fc0d17c8d1b3.jpg)


**Code formatting**

