### PR TITLE
Fix Easing usage in StackViewTransitionConfigs

### DIFF
--- a/src/views/StackView/StackViewTransitionConfigs.js
+++ b/src/views/StackView/StackViewTransitionConfigs.js
@@ -43,7 +43,7 @@ const FadeInFromBottomAndroid = {
   // See http://androidxref.com/7.1.1_r6/xref/frameworks/base/core/res/res/anim/activity_open_enter.xml
   transitionSpec: {
     duration: 350,
-    easing: Easing.out(Easing.poly(5)), // decelerate
+    easing: Easing.out(Easing.poly)(5), // decelerate
     timing: Animated.timing,
   },
   screenInterpolator: StyleInterpolator.forFadeFromBottomAndroid,
@@ -54,7 +54,7 @@ const FadeOutToBottomAndroid = {
   // See http://androidxref.com/7.1.1_r6/xref/frameworks/base/core/res/res/anim/activity_close_exit.xml
   transitionSpec: {
     duration: 230,
-    easing: Easing.in(Easing.poly(4)), // accelerate
+    easing: Easing.in(Easing.poly)(4), // accelerate
     timing: Animated.timing,
   },
   screenInterpolator: StyleInterpolator.forFadeFromBottomAndroid,


### PR DESCRIPTION
According to `react-native` source https://github.com/facebook/react-native/blob/master/Libraries/Animated/src/Easing.js#L225-L241 `Easing.in` and `Easing.out` takes an `EasingFunction` and return an `EasingFunction`.

The original code has no effect.

**Test plan (required)**

Test via example app on android device.

Make sure you test on both platforms if your change affects both platforms.

The code must pass tests.

**Code formatting**