### PR TITLE
Fix the routing error if the remained path after matched path is empty.

### DIFF
--- a/src/routers/StackRouter.js
+++ b/src/routers/StackRouter.js
@@ -523,11 +523,14 @@ export default (routeConfigs, stackConfig = {}) => {
       let nestedAction;
       let nestedQueryString = queryString ? '?' + queryString : '';
       if (childRouters[matchedRouteName]) {
-        nestedAction = childRouters[matchedRouteName].getActionForPathAndParams(
-          pathMatch.slice(pathMatchKeys.length).join('/') + nestedQueryString
-        );
-        if (!nestedAction) {
-          return null;
+        const remainedPath = pathMatch.slice(pathMatchKeys.length).join('/');
+        if (remainedPath.length > 0) {
+          nestedAction = childRouters[matchedRouteName].getActionForPathAndParams(
+            remainedPath + nestedQueryString
+          );
+          if (!nestedAction) {
+            return null;
+          }
         }
       }
 


### PR DESCRIPTION
If I click a link `schema://aaa/bbb/ccc?q=123` and setup a path `aaa/bbb/ccc` in `StackNavigator`. The first run of recursive function `getActionForPathAndParams` resolve the correct matched path `aaa/bbb/ccc` from `aaa/bbb/ccc?q=123`. But next run will resolve an incorrect path `q=123` from `q=123` because the path is empty.

The easiest way to fix it is check the length of remained path after the matched path is not zero. A small change can fix this issue.
