### PR TITLE
AppNavigator.js fixed due to docs

### DIFF
--- a/examples/ReduxExample/src/navigators/AppNavigator.js
+++ b/examples/ReduxExample/src/navigators/AppNavigator.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { StackNavigator } from 'react-navigation';
+import { StackNavigator, addNavigationHelpers } from 'react-navigation';
 
 import LoginScreen from '../components/LoginScreen';
 import MainScreen from '../components/MainScreen';
@@ -24,11 +24,11 @@ class AppWithNavigationState extends React.Component {
     const { dispatch, nav } = this.props;
     return (
       <AppNavigator
-        navigation={{
+        navigation={addNavigationHelpers({
           dispatch,
           state: nav,
           addListener,
-        }}
+        })}
       />
     );
   }


### PR DESCRIPTION
On docs, you wrote we need to use `addNavigationHelpers` but it is absent on the example code.