### PR TITLE
Fix/1.5.11 issue 3266 custom drawer route names

### DIFF
--- a/src/views/Drawer/DrawerSidebar.js
+++ b/src/views/Drawer/DrawerSidebar.js
@@ -11,8 +11,9 @@ import invariant from '../../utils/invariant';
  */
 class DrawerSidebar extends React.PureComponent {
   _getScreenOptions = routeKey => {
+    const { drawerCloseRoute } = this.props;
     const DrawerScreen = this.props.router.getComponentForRouteName(
-      'DrawerClose'
+      drawerCloseRoute
     );
     invariant(
       DrawerScreen.router,
@@ -56,7 +57,8 @@ class DrawerSidebar extends React.PureComponent {
   };
 
   _onItemPress = ({ route, focused }) => {
-    this.props.navigation.navigate('DrawerClose');
+    const { drawerCloseRoute } = this.props;
+    this.props.navigation.navigate(drawerCloseRoute);
     if (!focused) {
       let subAction;
       // if the child screen is a StackRouter then always navigate to its first screen (see #1914)

--- a/src/views/Drawer/DrawerView.js
+++ b/src/views/Drawer/DrawerView.js
@@ -133,11 +133,7 @@ export default class DrawerView extends React.PureComponent {
   };
 
   _renderNavigationView = () => {
-    const {
-      drawerOpenRoute,
-      drawerCloseRoute,
-      drawerToggleRoute,
-    } = this.props;
+    const { drawerOpenRoute, drawerCloseRoute, drawerToggleRoute } = this.props;
 
     return (
       <DrawerSidebar
@@ -153,7 +149,7 @@ export default class DrawerView extends React.PureComponent {
         drawerToggleRoute={drawerToggleRoute}
       />
     );
-  }
+  };
 
   render() {
     const DrawerScreen = this.props.router.getComponentForRouteName(

--- a/src/views/Drawer/DrawerView.js
+++ b/src/views/Drawer/DrawerView.js
@@ -132,17 +132,28 @@ export default class DrawerView extends React.PureComponent {
     return navigationState;
   };
 
-  _renderNavigationView = () => (
-    <DrawerSidebar
-      screenProps={this.props.screenProps}
-      navigation={this._screenNavigationProp}
-      router={this.props.router}
-      contentComponent={this.props.contentComponent}
-      contentOptions={this.props.contentOptions}
-      drawerPosition={this.props.drawerPosition}
-      style={this.props.style}
-    />
-  );
+  _renderNavigationView = () => {
+    const {
+      drawerOpenRoute,
+      drawerCloseRoute,
+      drawerToggleRoute,
+    } = this.props;
+
+    return (
+      <DrawerSidebar
+        screenProps={this.props.screenProps}
+        navigation={this._screenNavigationProp}
+        router={this.props.router}
+        contentComponent={this.props.contentComponent}
+        contentOptions={this.props.contentOptions}
+        drawerPosition={this.props.drawerPosition}
+        style={this.props.style}
+        drawerOpenRoute={drawerOpenRoute}
+        drawerCloseRoute={drawerCloseRoute}
+        drawerToggleRoute={drawerToggleRoute}
+      />
+    );
+  }
 
   render() {
     const DrawerScreen = this.props.router.getComponentForRouteName(


### PR DESCRIPTION
Solves [3266](https://github.com/react-navigation/react-navigation/issues/3266) by allowing custom drawer open/close/toggle routes.

Previously, if you declared a `DrawerNavigator` with `drawerCloseRoute` other than `'DrawerClose'`, you would get an error in `react-navigation` that the `'DrawerClose'` route was not defined.


**Test plan (required)**

`npm run lint`
`npm run jest`