### PR TITLE
Fix TabNavigator export ( Issue #3962 )

### DIFF
--- a/src/react-navigation.js
+++ b/src/react-navigation.js
@@ -51,7 +51,7 @@ module.exports = {
     console.warn(
       'TabNavigator is deprecated. Please use the createBottomTabNavigator or createMaterialTopNavigator instead.'
     );
-    return require('react-navigation-deprecated-tab-navigator').default;
+    return require('react-navigation-deprecated-tab-navigator').createTabNavigator;
   },
   get createBottomTabNavigator() {
     return require('react-navigation-tabs').createBottomTabNavigator;


### PR DESCRIPTION
https://github.com/react-navigation/react-navigation/issues/3962

 In v1.5.2 TabNavigator is a function

```
const TabNavigator = (routeConfigs, config = {}) => {
    ...
}
```

and default export from main file of `react-navigation-deprecated-tab-navigator` is not a function
https://github.com/react-navigation/react-navigation-deprecated-tab-navigator/blob/master/src/index.js#L6-L11

Current code leads to error `undefined is not a function`
```
  get TabNavigator() {
    ...
    return require('react-navigation-deprecated-tab-navigator').default;
  },
```

This pull request fixes it.