### PR TITLE
Fix header hardcoded height to accound for iPhone X and orientation changes

### DIFF
--- a/src/views/StackView/StackViewLayout.js
+++ b/src/views/StackView/StackViewLayout.js
@@ -9,6 +9,7 @@ import {
   View,
   I18nManager,
   Easing,
+  Dimensions,
 } from 'react-native';
 
 import Card from './StackViewCard';
@@ -16,12 +17,20 @@ import Header from '../Header/Header';
 import NavigationActions from '../../NavigationActions';
 import StackActions from '../../routers/StackActions';
 import SceneView from '../SceneView';
+import withOrientation from '../withOrientation';
 import { NavigationProvider } from '../NavigationContext';
 
 import TransitionConfigs from './StackViewTransitionConfigs';
 import * as ReactNativeFeatures from '../../utils/ReactNativeFeatures';
 
 const emptyFunction = () => {};
+
+const { width: WINDOW_WIDTH, height: WINDOW_HEIGHT } = Dimensions.get('window');
+const IS_IPHONE_X =
+  Platform.OS === 'ios' &&
+  !Platform.isPad &&
+  !Platform.isTVOS &&
+  (WINDOW_HEIGHT === 812 || WINDOW_WIDTH === 812);
 
 const EaseInOut = Easing.inOut(Easing.ease);
 
@@ -450,7 +459,19 @@ class StackViewLayout extends React.Component {
     const headerMode = this._getHeaderMode();
     let marginTop = 0;
     if (!hasHeader && headerMode === 'float') {
-      marginTop = -Header.HEIGHT;
+      const { isLandscape } = this.props;
+      let headerHeight;
+      if (Platform.OS === 'android') {
+        // TODO: Need to handle translucent status bar.
+        headerHeight = 56;
+      } else if (isLandscape && !Platform.isPad) {
+        headerHeight = 52;
+      } else if (IS_IPHONE_X) {
+        headerHeight = 88;
+      } else {
+        headerHeight = 64;
+      }
+      marginTop = -headerHeight;
     }
 
     return (
@@ -480,4 +501,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default StackViewLayout;
+export default withOrientation(StackViewLayout);


### PR DESCRIPTION
My previous PR did not account for iPhone X and orientation changes, this fixes it.

One main issue that remains is translucent status bar on android, the library as a whole doesn't support it well anyway at the moment so I just left a TODO. 

**Test plan (required)**

Been using this patch for a while and tested it on iPhone X, normal iPhone and Android with orientation changes.