### PR TITLE
Fix header ModularLeftComponent to goBack from child navigation

### DIFF
--- a/src/views/Header/Header.js
+++ b/src/views/Header/Header.js
@@ -172,7 +172,7 @@ class Header extends React.PureComponent {
     ButtonContainerComponent,
     LabelContainerComponent
   ) => {
-    const { options } = props.scene.descriptor;
+    const { options, navigation } = props.scene.descriptor;
     const backButtonTitle = this._getBackButtonTitleString(props.scene);
     const truncatedBackButtonTitle = this._getTruncatedBackButtonTitle(
       props.scene
@@ -184,7 +184,7 @@ class Header extends React.PureComponent {
     const goBack = () => {
       // Go back on next tick because button ripple effect needs to happen on Android
       requestAnimationFrame(() => {
-        this.props.navigation.goBack(props.scene.descriptor.key);
+        navigation.goBack(props.scene.descriptor.key);
       });
     };
 


### PR DESCRIPTION
Fixes issue where goBack is not a function in the modular uikit header back button. Use child navigation prop which has the goBack helper correctly scoped to this scene. Pressing the back button will dispatch an action to dismiss this scene/route