### PR TITLE
Typo in deprecation notice

### DIFF
--- a/src/react-navigation.js
+++ b/src/react-navigation.js
@@ -42,14 +42,14 @@ module.exports = {
   },
   get createTabNavigator() {
     console.warn(
-      'TabNavigator is deprecated. Please use the createBottomTabNavigator or createMaterialTopNavigator instead.'
+      'createTabNavigator is deprecated. Please use the createBottomTabNavigator or createMaterialTopTabNavigator instead.'
     );
     return require('react-navigation-deprecated-tab-navigator')
       .createTabNavigator;
   },
   get TabNavigator() {
     console.warn(
-      'TabNavigator is deprecated. Please use the createBottomTabNavigator or createMaterialTopNavigator instead.'
+      'TabNavigator is deprecated. Please use the createBottomTabNavigator or createMaterialTopTabNavigator instead.'
     );
     return require('react-navigation-deprecated-tab-navigator')
       .createTabNavigator;


### PR DESCRIPTION
Looks like there's a typo in the deprecation notice for `TabNavigator` and `createTabNavigator`:

```diff
- createMaterialTopNavigator
+ createMaterialTopTabNavigator
```
For reference, `createMaterialTopTabNavigator is defined [here](https://github.com/react-navigation/react-navigation/blob/0890896824c507528e553f43ce421a2b6e934d46/src/react-navigation.js#L63).