### PR TITLE
Give inactive routes in stack opportunity to handle action

### DIFF
--- a/examples/NavigationPlayground/js/App.js
+++ b/examples/NavigationPlayground/js/App.js
@@ -48,7 +48,8 @@ const ExampleInfo = {
   },
   InactiveStack: {
     name: 'Navigate idempotently to stacks in inactive routes',
-    description: 'Weird description I know',
+    description:
+      'An inactive route in a stack should be given the opportunity to handle actions',
   },
   StackWithCustomHeaderBackImage: {
     name: 'Custom header back image',
@@ -155,7 +156,8 @@ const ExampleRoutes = {
   },
   TabsWithNavigationFocus,
   KeyboardHandlingExample,
-  InactiveStack,
+  // This is commented out because it's rarely useful
+  // InactiveStack,
 };
 
 type State = {

--- a/examples/NavigationPlayground/js/App.js
+++ b/examples/NavigationPlayground/js/App.js
@@ -130,7 +130,6 @@ const ExampleInfo = {
 const ExampleRoutes = {
   SimpleStack,
   SwitchWithStacks,
-  InactiveStack,
   SimpleTabs: SimpleTabs,
   Drawer: Drawer,
   // MultipleDrawer: {
@@ -156,6 +155,7 @@ const ExampleRoutes = {
   },
   TabsWithNavigationFocus,
   KeyboardHandlingExample,
+  InactiveStack,
 };
 
 type State = {
@@ -320,7 +320,7 @@ const AppNavigator = createStackNavigator(
   }
 );
 
-export default () => <AppNavigator />;
+export default () => <AppNavigator persistenceKey="NavState" />;
 
 const styles = StyleSheet.create({
   item: {

--- a/examples/NavigationPlayground/js/App.js
+++ b/examples/NavigationPlayground/js/App.js
@@ -27,6 +27,7 @@ import ModalStack from './ModalStack';
 import StacksInTabs from './StacksInTabs';
 import StacksOverTabs from './StacksOverTabs';
 import StacksWithKeys from './StacksWithKeys';
+import InactiveStack from './InactiveStack';
 import StackWithCustomHeaderBackImage from './StackWithCustomHeaderBackImage';
 import SimpleStack from './SimpleStack';
 import StackWithHeaderPreset from './StackWithHeaderPreset';
@@ -44,6 +45,10 @@ const ExampleInfo = {
   SwitchWithStacks: {
     name: 'Switch between routes',
     description: 'Jump between routes',
+  },
+  InactiveStack: {
+    name: 'Navigate idempotently to stacks in inactive routes',
+    description: 'Weird description I know',
   },
   StackWithCustomHeaderBackImage: {
     name: 'Custom header back image',
@@ -125,6 +130,7 @@ const ExampleInfo = {
 const ExampleRoutes = {
   SimpleStack,
   SwitchWithStacks,
+  InactiveStack,
   SimpleTabs: SimpleTabs,
   Drawer: Drawer,
   // MultipleDrawer: {
@@ -314,7 +320,7 @@ const AppNavigator = createStackNavigator(
   }
 );
 
-export default () => <AppNavigator persistenceKey="NavState" />;
+export default () => <AppNavigator />;
 
 const styles = StyleSheet.create({
   item: {

--- a/examples/NavigationPlayground/js/InactiveStack.js
+++ b/examples/NavigationPlayground/js/InactiveStack.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button, Text, View, StyleSheet } from 'react-native';
+import { Button, Text, StatusBar, View, StyleSheet } from 'react-native';
 import {
   SafeAreaView,
   createStackNavigator,
@@ -8,15 +8,12 @@ import {
 } from 'react-navigation';
 
 const runSubRoutes = navigation => {
-  // expected: `navigation.dispatch(toFirst2)` navigates back to existing `First.First2`
-  // actual: duplicate `First.First2` is pushed
   navigation.dispatch(NavigationActions.navigate({ routeName: 'First2' }));
   navigation.dispatch(NavigationActions.navigate({ routeName: 'Second2' }));
   navigation.dispatch(NavigationActions.navigate({ routeName: 'First2' }));
 };
 
 const runSubRoutesWithIntermediate = navigation => {
-  // works with explicit intermediate step to `First` navigator
   navigation.dispatch(toFirst1);
   navigation.dispatch(toSecond2);
   navigation.dispatch(toFirst);
@@ -24,8 +21,6 @@ const runSubRoutesWithIntermediate = navigation => {
 };
 
 const runSubAction = navigation => {
-  // expected: `navigation.dispatch(toFirstChild1)` navigates to 'First1'.
-  // actual: navigates to 'First2'. Seems to find 'First' but not run `action`
   navigation.dispatch(toFirst2);
   navigation.dispatch(toSecond2);
   navigation.dispatch(toFirstChild1);
@@ -64,6 +59,7 @@ const DummyScreen = ({ routeName, navigation, style }) => {
           onPress={() => runSubAction(navigation)}
         />
       </View>
+      <StatusBar barStyle="default" />
     </SafeAreaView>
   );
 };

--- a/examples/NavigationPlayground/js/InactiveStack.js
+++ b/examples/NavigationPlayground/js/InactiveStack.js
@@ -1,0 +1,100 @@
+import React from 'react';
+import { Button, Text, View, StyleSheet } from 'react-native';
+import {
+  SafeAreaView,
+  createStackNavigator,
+  createSwitchNavigator,
+  NavigationActions,
+} from 'react-navigation';
+
+const runSubRoutes = navigation => {
+  // expected: `navigation.dispatch(toFirst2)` navigates back to existing `First.First2`
+  // actual: duplicate `First.First2` is pushed
+  navigation.dispatch(NavigationActions.navigate({ routeName: 'First2' }));
+  navigation.dispatch(NavigationActions.navigate({ routeName: 'Second2' }));
+  navigation.dispatch(NavigationActions.navigate({ routeName: 'First2' }));
+};
+
+const runSubRoutesWithIntermediate = navigation => {
+  // works with explicit intermediate step to `First` navigator
+  navigation.dispatch(toFirst1);
+  navigation.dispatch(toSecond2);
+  navigation.dispatch(toFirst);
+  navigation.dispatch(toFirst2);
+};
+
+const runSubAction = navigation => {
+  // expected: `navigation.dispatch(toFirstChild1)` navigates to 'First1'.
+  // actual: navigates to 'First2'. Seems to find 'First' but not run `action`
+  navigation.dispatch(toFirst2);
+  navigation.dispatch(toSecond2);
+  navigation.dispatch(toFirstChild1);
+};
+
+const DummyScreen = ({ routeName, navigation, style }) => {
+  return (
+    <SafeAreaView
+      style={[
+        StyleSheet.absoluteFill,
+        {
+          alignItems: 'center',
+          justifyContent: 'center',
+          backgroundColor: 'white',
+        },
+        style,
+      ]}
+    >
+      <Text style={{ fontWeight: '800' }}>
+        {routeName}({navigation.state.key})
+      </Text>
+      <View>
+        <Button title="back" onPress={() => navigation.goBack()} />
+        <Button title="dismiss" onPress={() => navigation.dismiss()} />
+        <Button
+          title="between sub-routes"
+          onPress={() => runSubRoutes(navigation)}
+        />
+        <Button
+          title="between sub-routes (with intermediate)"
+          onPress={() => runSubRoutesWithIntermediate(navigation)}
+        />
+
+        <Button
+          title="with sub-action"
+          onPress={() => runSubAction(navigation)}
+        />
+      </View>
+    </SafeAreaView>
+  );
+};
+
+const createDummyScreen = routeName => {
+  const BoundDummyScreen = props => DummyScreen({ ...props, routeName });
+  return BoundDummyScreen;
+};
+
+const toFirst = NavigationActions.navigate({ routeName: 'First' });
+const toFirst1 = NavigationActions.navigate({ routeName: 'First1' });
+const toFirst2 = NavigationActions.navigate({ routeName: 'First2' });
+const toSecond2 = NavigationActions.navigate({ routeName: 'Second2' });
+const toFirstChild1 = NavigationActions.navigate({
+  routeName: 'First',
+  action: NavigationActions.navigate({ routeName: 'First1' }),
+});
+
+export default createStackNavigator(
+  {
+    Other: createDummyScreen('Leaf'),
+    First: createStackNavigator({
+      First1: createDummyScreen('First1'),
+      First2: createDummyScreen('First2'),
+    }),
+    Second: createStackNavigator({
+      Second1: createDummyScreen('Second1'),
+      Second2: createDummyScreen('Second2'),
+    }),
+  },
+  {
+    headerMode: 'none',
+  }
+);

--- a/src/StateUtils.js
+++ b/src/StateUtils.js
@@ -120,11 +120,12 @@ const StateUtils = {
    * stack is at and updates the routes array accordingly.
    */
   replaceAndPrune(state, key, route) {
-    let replaced = StateUtils.replaceAt(state, key, route);
+    const index = StateUtils.indexOf(state, key);
+    const replaced = StateUtils.replaceAtIndex(state, index, route);
 
     return {
       ...replaced,
-      routes: replaced.routes.slice(0, replaced.index + 1),
+      routes: replaced.routes.slice(0, index + 1),
     };
   },
 

--- a/src/StateUtils.js
+++ b/src/StateUtils.js
@@ -126,7 +126,6 @@ const StateUtils = {
     return {
       ...replaced,
       routes: replaced.routes.slice(0, index + 1),
-      index,
     };
   },
 
@@ -153,7 +152,7 @@ const StateUtils = {
       route.key
     );
 
-    if (state.routes[index] === route) {
+    if (state.routes[index] === route && index === state.index) {
       return state;
     }
 

--- a/src/StateUtils.js
+++ b/src/StateUtils.js
@@ -126,6 +126,7 @@ const StateUtils = {
     return {
       ...replaced,
       routes: replaced.routes.slice(0, index + 1),
+      index,
     };
   },
 

--- a/src/StateUtils.js
+++ b/src/StateUtils.js
@@ -116,8 +116,22 @@ const StateUtils = {
 
   /**
    * Replace a route by a key.
-   * Note that this moves the index to the positon to where the new route in the
-   * stack is at.
+   * Note that this moves the index to the position to where the new route in the
+   * stack is at and updates the routes array accordingly.
+   */
+  replaceAndPrune(state, key, route) {
+    let replaced = StateUtils.replaceAt(state, key, route);
+
+    return {
+      ...replaced,
+      routes: replaced.routes.slice(0, replaced.index + 1),
+    };
+  },
+
+  /**
+   * Replace a route by a key.
+   * Note that this moves the index to the position to where the new route in the
+   * stack is at. Does not prune the routes.
    */
   replaceAt(state, key, route) {
     const index = StateUtils.indexOf(state, key);
@@ -153,7 +167,7 @@ const StateUtils = {
 
   /**
    * Resets all routes.
-   * Note that this moves the index to the positon to where the last route in the
+   * Note that this moves the index to the position to where the last route in the
    * stack is at if the param `index` isn't provided.
    */
   reset(state, routes, index) {

--- a/src/__tests__/NavigationStateUtils-test.js
+++ b/src/__tests__/NavigationStateUtils-test.js
@@ -202,7 +202,7 @@ describe('StateUtils', () => {
     ).toEqual(newState);
   });
 
-  it('Returns the state if index matches the route', () => {
+  it('Returns the state with updated index if route is unchanged but index changes', () => {
     const state = {
       index: 0,
       routes: [{ key: 'a', routeName }, { key: 'b', routeName }],
@@ -210,7 +210,7 @@ describe('StateUtils', () => {
     };
     expect(
       NavigationStateUtils.replaceAtIndex(state, 1, state.routes[1])
-    ).toEqual(state);
+    ).toEqual({ ...state, index: 1 });
   });
 
   // Reset

--- a/src/navigators/__tests__/__snapshots__/TabNavigator-test.js.snap
+++ b/src/navigators/__tests__/__snapshots__/TabNavigator-test.js.snap
@@ -143,7 +143,7 @@ exports[`TabNavigator renders successfully 1`] = `
                 },
                 false,
                 Object {
-                  "flexGrow": 1,
+                  "flex": 1,
                 },
               ]
             }
@@ -156,6 +156,7 @@ exports[`TabNavigator renders successfully 1`] = `
                   "alignSelf": "center",
                   "height": "100%",
                   "justifyContent": "center",
+                  "minWidth": 30,
                   "opacity": 1,
                   "position": "absolute",
                   "width": "100%",
@@ -170,6 +171,7 @@ exports[`TabNavigator renders successfully 1`] = `
                   "alignSelf": "center",
                   "height": "100%",
                   "justifyContent": "center",
+                  "minWidth": 30,
                   "opacity": 0,
                   "position": "absolute",
                   "width": "100%",

--- a/src/routers/StackRouter.js
+++ b/src/routers/StackRouter.js
@@ -251,7 +251,9 @@ export default (routeConfigs, stackConfig = {}) => {
           }
         }
       } else if (action.type === NavigationActions.NAVIGATE) {
-        for (let childRoute of [...state.routes].reverse()) {
+        // Traverse routes from the top of the stack to the bottom, so the
+        // active route has the first opportunity, then the one before it, etc.
+        for (let childRoute of state.routes.slice().reverse()) {
           let childRouter = childRouters[childRoute.routeName];
           let debug = action.params && action.params.debug;
 

--- a/src/routers/StackRouter.js
+++ b/src/routers/StackRouter.js
@@ -27,6 +27,10 @@ function behavesLikePushAction(action) {
 
 const defaultActionCreators = (route, navStateKey) => ({});
 
+function isResetToRootStack(action) {
+  return action.type === StackActions.RESET && action.key === null;
+}
+
 export default (routeConfigs, stackConfig = {}) => {
   // Fail fast on invalid route definitions
   validateRouteConfigMap(routeConfigs);
@@ -223,7 +227,10 @@ export default (routeConfigs, stackConfig = {}) => {
 
       // Check if the focused child scene wants to handle the action, as long as
       // it is not a reset to the root stack
-      if (action.type !== StackActions.RESET || action.key !== null) {
+      if (
+        !isResetToRootStack(action) &&
+        action.type !== NavigationActions.NAVIGATE
+      ) {
         const keyIndex = action.key
           ? StateUtils.indexOf(state, action.key)
           : -1;
@@ -241,6 +248,26 @@ export default (routeConfigs, stackConfig = {}) => {
           }
           if (route && route !== childRoute) {
             return StateUtils.replaceAt(state, childRoute.key, route);
+          }
+        }
+      } else if (action.type === NavigationActions.NAVIGATE) {
+        for (let childRoute of [...state.routes].reverse()) {
+          let childRouter = childRouters[childRoute.routeName];
+          let debug = action.params && action.params.debug;
+
+          if (childRouter) {
+            const nextRouteState = childRouter.getStateForAction(
+              action,
+              childRoute
+            );
+
+            if (nextRouteState === null || nextRouteState !== childRoute) {
+              return StateUtils.replaceAndPrune(
+                state,
+                nextRouteState ? nextRouteState.key : childRoute.key,
+                nextRouteState ? nextRouteState : childRoute
+              );
+            }
           }
         }
       }

--- a/src/routers/__tests__/StackRouter-test.js
+++ b/src/routers/__tests__/StackRouter-test.js
@@ -721,10 +721,12 @@ describe('StackRouter', () => {
     });
 
     const state = router.getStateForAction({ type: NavigationActions.INIT });
+
     const first = router.getStateForAction(
       NavigationActions.navigate({ routeName: 'First2' }),
       state
     );
+
     const second = router.getStateForAction(
       NavigationActions.navigate({ routeName: 'Second2' }),
       first


### PR DESCRIPTION
# Motivation

Fixes https://github.com/react-navigation/react-navigation/issues/4063 and makes "less pushy" behavior consistent in this case with stack routers. It's unclear to me how useful this is in practice, but I was happy to implement it because it produces a consistent mental model, so we should have some good reasons to deviate if we do.

# Test plan

Run test, try example in playground