### PR TITLE
Introduce TypeScript to co-exist with JavaScript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ yarn-error.log
 
 # Jest
 coverage
+
+# TypeScript-generated files
+*.d.ts

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ coverage
 
 # TypeScript-generated files
 *.d.ts
+!src/react-navigation.d.ts

--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,5 @@
 examples
 __tests__
+
+*.ts
+!*.d.ts

--- a/package.json
+++ b/package.json
@@ -13,13 +13,21 @@
     "start": "npm run ios",
     "ios": "cd examples/NavigationPlayground && yarn && yarn ios",
     "android": "cd examples/NavigationPlayground && yarn && yarn android",
-    "test": "npm run lint && npm run jest",
+    "pretest": "npm run lint && npm run build",
+    "test": "npm run jest",
     "codecov": "codecov",
     "jest": "jest",
     "test-update-snapshot": "jest --updateSnapshot",
-    "lint": "eslint .",
+    "lint": "npm run lint:es && npm run lint:ts",
+    "lint:es": "eslint .",
+    "lint:ts": "tslint --project tsconfig.test.json",
     "format": "eslint --fix .",
-    "precommit": "lint-staged"
+    "precommit": "lint-staged",
+    "prettier:js": "prettier --write flow/react-navigation.js",
+    "prettier:ts": "prettier --parser typescript --write src/**/*.ts",
+    "build": "tsc",
+    "build:watch": "tsc -p tsconfig.test.json --watch",
+    "watch": "npm test -- --watch"
   },
   "files": [
     "src"
@@ -41,6 +49,7 @@
     "react-navigation-tabs": "0.1.0-alpha.8"
   },
   "devDependencies": {
+    "@types/jest": "^22.2.3",
     "babel-cli": "^6.24.1",
     "babel-core": "^6.25.0",
     "babel-eslint": "^7.2.3",
@@ -62,12 +71,15 @@
     "react": "16.2.0",
     "react-native": "^0.52.0",
     "react-native-vector-icons": "^4.2.0",
-    "react-test-renderer": "^16.0.0"
+    "react-test-renderer": "^16.0.0",
+    "ts-jest": "^22.4.4",
+    "tslint": "^5.9.1",
+    "typescript": "^2.8.3"
   },
   "jest": {
     "notify": true,
     "preset": "react-native",
-    "testRegex": "/__tests__/[^/]+-test\\.js$",
+    "testRegex": "/__tests__/[^/]+-test\\.[jt]sx?$",
     "setupFiles": [
       "<rootDir>/jest-setup.js"
     ],
@@ -88,14 +100,21 @@
     "modulePathIgnorePatterns": [
       "<rootDir>/examples/"
     ],
+    "transform": {
+      "^.+\\.tsx?$": "<rootDir>/node_modules/ts-jest/preprocessor.js"
+    },
     "transformIgnorePatterns": [
       "node_modules/(?!(jest-)?react-native|react-clone-referenced-element|react-navigation-deprecated-tab-navigator)"
     ]
   },
   "lint-staged": {
+    "*.ts": [
+      "npm run prettier:ts",
+      "git add"
+    ],
     "*.js": [
-      "eslint --fix",
-      "prettier --write flow/react-navigation.js",
+      "npm run format",
+      "npm run prettier:js",
       "git add"
     ]
   }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.0-rc.7",
   "description": "Routing and navigation for your React Native apps",
   "main": "src/react-navigation.js",
+  "types": "src/react-navigation.d.ts",
   "repository": {
     "url": "git@github.com:react-navigation/react-navigation.git",
     "type": "git"

--- a/src/react-navigation.d.ts
+++ b/src/react-navigation.d.ts
@@ -1,0 +1,994 @@
+// Type definitions for react-navigation 1.5
+// Project: https://github.com/react-navigation/react-navigation
+// Definitions by: Huhuanming <https://github.com/huhuanming>
+//                 mhcgrq <https://github.com/mhcgrq>
+//                 fangpenlin <https://github.com/fangpenlin>
+//                 petejkim <https://github.com/petejkim>
+//                 Kyle Roach <https://github.com/iRoachie>
+//                 phanalpha <https://github.com/phanalpha>
+//                 charlesfamu <https://github.com/charlesfamu>
+//                 Tim Wang <https://github.com/timwangdev>
+//                 Qibang Sun <https://github.com/bang88>
+//                 Sergei Butko: <https://github.com/svbutko>
+//                 Veit Lehmann: <https://github.com/levito>
+//                 Roberto Huertas: <https://github.com/robertohuertasm>
+//                 Steven Miller <https://github.com/YourGamesBeOver>
+//                 Armando Assuncao <https://github.com/ArmandoAssuncao>
+//                 Ciaran Liedeman <https://github.com/cliedeman>
+//                 Edward Sammut Alessi <https://github.com/Slessi>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.6
+
+/**
+ * Reference: https://github.com/react-navigation/react-navigation/tree/a37473c5e4833f48796ee6c7c9cb4a8ac49d9c06
+ *
+ * NOTE: Please update the commit/link above when updating to a new Flow
+ * react-navigation/flow/react-navigation.js reference, so we can conveniently just look at diffs on
+ * react-navigation/flow/react-navigation.js between this latest reference point and the one you are
+ * using when making new updates.
+ */
+
+import * as React from 'react';
+import {
+  Animated,
+  TextStyle,
+  ViewProps,
+  ViewStyle,
+  StyleProp,
+} from 'react-native';
+
+// @todo when we split types into common, native and web,
+// we can properly change Animated.Value to its real value
+export type AnimatedValue = any;
+
+export type HeaderMode = 'float' | 'screen' | 'none';
+
+export interface HeaderProps extends NavigationSceneRendererProps {
+  mode: HeaderMode;
+  router: NavigationRouter<NavigationState, NavigationStackScreenOptions>;
+  getScreenDetails: (
+    navigationScene: NavigationScene
+  ) => NavigationScreenDetails<NavigationStackScreenOptions>;
+  style: StyleProp<ViewStyle>;
+}
+
+/**
+ * NavigationState is a tree of routes for a single navigator, where each child
+ * route may either be a NavigationScreenRoute or a NavigationRouterRoute.
+ * NavigationScreenRoute represents a leaf screen, while the
+ * NavigationRouterRoute represents the state of a child navigator.
+ *
+ * NOTE: NavigationState is a state tree local to a single navigator and
+ * its child navigators (via the routes field).
+ * If we're in navigator nested deep inside the app, the state will only be the
+ * state for that navigator.
+ * The state for the root navigator of our app represents the whole navigation
+ * state for the whole app.
+ */
+export interface NavigationState {
+  /**
+   * Index refers to the active child route in the routes array.
+   */
+  index: number;
+  routes: any[];
+}
+
+export type NavigationRoute<Params = NavigationParams> =
+  | NavigationLeafRoute<Params>
+  | NavigationStateRoute<Params>;
+
+export interface NavigationLeafRoute<Params> {
+  /**
+   * React's key used by some navigators. No need to specify these manually,
+   * they will be defined by the router.
+   */
+  key: string;
+  /**
+   * For example 'Home'.
+   * This is used as a key in a route config when creating a navigator.
+   */
+  routeName: string;
+  /**
+   * Path is an advanced feature used for deep linking and on the web.
+   */
+  path?: string;
+  /**
+   * Params passed to this route when navigating to it,
+   * e.g. `{ car_id: 123 }` in a route that displays a car.
+   */
+  params?: Params;
+}
+
+export type NavigationStateRoute<
+  NavigationLeafRouteParams
+> = NavigationLeafRoute<NavigationLeafRouteParams> & NavigationState;
+
+export type NavigationScreenOptionsGetter<Options> = (
+  navigation: NavigationScreenProp<NavigationRoute<any>>,
+  screenProps?: { [key: string]: any }
+) => Options;
+
+export interface NavigationRouter<State = NavigationState, Options = {}> {
+  /**
+   * The reducer that outputs the new navigation state for a given action, with
+   * an optional previous state. When the action is considered handled but the
+   * state is unchanged, the output state is null.
+   */
+  getStateForAction: (
+    action: NavigationAction,
+    lastState?: State
+  ) => State | null;
+
+  /**
+   * Maps a URI-like string to an action. This can be mapped to a state
+   * using `getStateForAction`.
+   */
+  getActionForPathAndParams: (
+    path: string,
+    params?: NavigationParams
+  ) => NavigationAction | null;
+
+  getPathAndParamsForState: (
+    state: State
+  ) => {
+    path: string;
+    params?: NavigationParams;
+  };
+
+  getComponentForRouteName: (routeName: string) => NavigationComponent;
+
+  getComponentForState: (state: State) => NavigationComponent;
+
+  /**
+   * Gets the screen navigation options for a given screen.
+   *
+   * For example, we could get the config for the 'Foo' screen when the
+   * `navigation.state` is:
+   *
+   *  {routeName: 'Foo', key: '123'}
+   */
+  getScreenOptions: NavigationScreenOptionsGetter<Options>;
+}
+
+export type NavigationScreenOption<T> =
+  | T
+  | ((navigation: NavigationScreenProp<NavigationRoute>, config: T) => T);
+
+export interface NavigationScreenDetails<T> {
+  options: T;
+  state: NavigationRoute;
+  navigation: NavigationScreenProp<NavigationRoute>;
+}
+
+export type NavigationScreenOptions = NavigationStackScreenOptions &
+  NavigationTabScreenOptions &
+  NavigationDrawerScreenOptions;
+
+export interface NavigationScreenConfigProps {
+  navigation: NavigationScreenProp<NavigationRoute>;
+  screenProps: { [key: string]: any };
+}
+
+export type NavigationScreenConfig<Options> =
+  | Options
+  | ((
+      navigationOptionsContainer: NavigationScreenConfigProps & {
+        navigationOptions: NavigationScreenProp<NavigationRoute>;
+      }
+    ) => Options);
+
+export type NavigationComponent =
+  | NavigationScreenComponent<any, any, any>
+  | NavigationNavigator<any, any, any>;
+
+export type NavigationScreenComponent<
+  Params = NavigationParams,
+  Options = {},
+  Props = {}
+> = React.ComponentType<NavigationScreenProps<Params, Options> & Props> & {
+  navigationOptions?: NavigationScreenConfig<Options>;
+};
+
+export type NavigationNavigator<
+  State = NavigationState,
+  Options = {},
+  Props = {}
+> = React.ComponentType<NavigationNavigatorProps<Options, State> & Props> & {
+  router: NavigationRouter<State, Options>;
+  navigationOptions?: NavigationScreenConfig<Options>;
+};
+
+export interface NavigationParams {
+  [key: string]: any;
+}
+
+export interface NavigationNavigateActionPayload {
+  routeName: string;
+  params?: NavigationParams;
+
+  // The action to run inside the sub-router
+  action?: NavigationNavigateAction;
+
+  key?: string;
+}
+
+export interface NavigationNavigateAction
+  extends NavigationNavigateActionPayload {
+  type: 'Navigation/NAVIGATE';
+}
+
+export interface NavigationBackActionPayload {
+  key?: string | null;
+}
+
+export interface NavigationBackAction extends NavigationBackActionPayload {
+  type: 'Navigation/BACK';
+}
+
+export interface NavigationSetParamsActionPayload {
+  // The key of the route where the params should be set
+  key: string;
+
+  // The new params to merge into the existing route params
+  params?: NavigationParams;
+}
+
+export interface NavigationSetParamsAction
+  extends NavigationSetParamsActionPayload {
+  type: 'Navigation/SET_PARAMS';
+}
+
+export interface NavigationInitActionPayload {
+  params?: NavigationParams;
+}
+
+export interface NavigationInitAction extends NavigationInitActionPayload {
+  type: 'Navigation/INIT';
+}
+
+export interface NavigationResetActionPayload {
+  index: number;
+  key?: string | null;
+  actions: NavigationNavigateAction[];
+}
+
+export interface NavigationResetAction extends NavigationResetActionPayload {
+  type: 'Navigation/RESET';
+}
+
+export interface NavigationUriActionPayload {
+  uri: string;
+}
+
+export interface NavigationUriAction extends NavigationUriActionPayload {
+  type: 'Navigation/URI';
+}
+
+export interface NavigationPopActionPayload {
+  // n: the number of routes to pop of the stack
+  n?: number;
+  immediate?: boolean;
+}
+
+export interface NavigationPopAction extends NavigationPopActionPayload {
+  type: 'Navigation/POP';
+}
+
+export interface NavigationPopToTopActionPayload {
+  key?: string;
+  immediate?: boolean;
+}
+
+export interface NavigationPopToTopAction
+  extends NavigationPopToTopActionPayload {
+  type: 'Navigation/POP_TO_TOP';
+}
+
+export interface NavigationStackViewConfig {
+  mode?: 'card' | 'modal';
+  headerMode?: HeaderMode;
+  cardStyle?: StyleProp<ViewStyle>;
+  transitionConfig?: (
+    transitionProps: NavigationTransitionProps,
+    prevTransitionProps: NavigationTransitionProps,
+    isModal: boolean
+  ) => TransitionConfig;
+  onTransitionStart?: (
+    transitionProps: NavigationTransitionProps,
+    prevTransitionProps?: NavigationTransitionProps
+  ) => Promise<void> | void;
+  onTransitionEnd?: (
+    transitionProps: NavigationTransitionProps,
+    prevTransitionProps?: NavigationTransitionProps
+  ) => void;
+}
+
+export interface NavigationStackScreenOptions {
+  title?: string;
+  header?:
+    | (
+        | React.ReactElement<any>
+        | ((headerProps: HeaderProps) => React.ReactElement<any>))
+    | null;
+  headerTransparent?: boolean;
+  headerTitle?: string | React.ReactElement<any>;
+  headerTitleStyle?: StyleProp<TextStyle>;
+  headerTintColor?: string;
+  headerLeft?: React.ReactElement<any>;
+  headerBackTitle?: string | null;
+  headerTruncatedBackTitle?: string;
+  headerBackTitleStyle?: StyleProp<TextStyle>;
+  headerPressColorAndroid?: string;
+  headerRight?: React.ReactElement<any>;
+  headerStyle?: StyleProp<ViewStyle>;
+  headerBackground?: React.ReactNode | React.ReactType;
+  gesturesEnabled?: boolean;
+  gestureResponseDistance?: { vertical?: number; horizontal?: number };
+}
+
+export interface NavigationStackRouterConfig {
+  headerTransitionPreset?: 'fade-in-place' | 'uikit';
+  initialRouteName?: string;
+  initialRouteParams?: NavigationParams;
+  paths?: NavigationPathsConfig;
+  navigationOptions?: NavigationScreenConfig<NavigationScreenOptions>;
+}
+
+export type NavigationStackAction =
+  | NavigationInitAction
+  | NavigationNavigateAction
+  | NavigationBackAction
+  | NavigationSetParamsAction
+  | NavigationResetAction
+  | NavigationPopAction
+  | NavigationPopToTopAction;
+
+export type NavigationTabAction =
+  | NavigationInitAction
+  | NavigationNavigateAction
+  | NavigationBackAction;
+
+export type NavigationAction =
+  | NavigationInitAction
+  | NavigationStackAction
+  | NavigationTabAction;
+
+export type NavigationRouteConfig =
+  | NavigationComponent
+  | ({
+      navigationOptions?: NavigationScreenConfig<any>;
+      path?: string;
+    } & NavigationScreenRouteConfig);
+
+export type NavigationScreenRouteConfig =
+  | NavigationComponent
+  | {
+      screen: NavigationComponent;
+    }
+  | {
+      getScreen: () => NavigationComponent;
+    };
+
+export interface NavigationPathsConfig {
+  [routeName: string]: string;
+}
+
+export interface NavigationTabRouterConfig {
+  initialRouteName?: string;
+  paths?: NavigationPathsConfig;
+  navigationOptions?: NavigationScreenConfig<NavigationScreenOptions>;
+  order?: string[]; // todo: type these as the real route names rather than 'string'
+
+  // Does the back button cause the router to switch to the initial tab
+  backBehavior?: 'none' | 'initialRoute'; // defaults `initialRoute`
+}
+export interface TabScene {
+  route: NavigationRoute;
+  focused: boolean;
+  index: number;
+  tintColor?: string;
+}
+export interface NavigationTabScreenOptions {
+  title?: string;
+  tabBarIcon?:
+    | React.ReactElement<any>
+    | ((
+        options: { tintColor: string | null; focused: boolean }
+      ) => React.ReactElement<any> | null);
+  tabBarLabel?:
+    | string
+    | React.ReactElement<any>
+    | ((
+        options: { tintColor: string | null; focused: boolean }
+      ) => React.ReactElement<any> | string | null);
+  tabBarVisible?: boolean;
+  tabBarTestIDProps?: { testID?: string; accessibilityLabel?: string };
+  tabBarOnPress?: (
+    options: {
+      scene: TabScene;
+      jumpToIndex: (index: number) => void;
+    }
+  ) => void;
+}
+
+export interface NavigationDrawerScreenOptions {
+  title?: string;
+  drawerIcon?:
+    | React.ReactElement<any>
+    | ((
+        options: { tintColor: string | null; focused: boolean }
+      ) => React.ReactElement<any> | null);
+  drawerLabel?:
+    | string
+    | React.ReactElement<any>
+    | ((
+        options: { tintColor: string | null; focused: boolean }
+      ) => React.ReactElement<any> | null);
+}
+
+export interface NavigationRouteConfigMap {
+  [routeName: string]: NavigationRouteConfig;
+}
+
+export type NavigationDispatch = (action: NavigationAction) => boolean;
+
+export interface NavigationProp<S> {
+  state: S;
+  dispatch: NavigationDispatch;
+}
+
+export type EventType =
+  | 'willFocus'
+  | 'didFocus'
+  | 'willBlur'
+  | 'didBlur'
+  | 'action';
+
+export interface NavigationEventPayload {
+  type: EventType;
+  action: NavigationAction;
+  state: NavigationState;
+  lastState: NavigationState;
+}
+
+export type NavigationEventCallback = (payload: NavigationEventPayload) => void;
+
+export interface NavigationEventSubscription {
+  remove: () => void;
+}
+
+export interface NavigationScreenProp<S, P = NavigationParams> {
+  state: S;
+  dispatch: NavigationDispatch;
+  goBack: (routeKey?: string | null) => boolean;
+  navigate(options: {
+    routeName: string;
+    params?: NavigationParams;
+    action?: NavigationAction;
+    key?: string;
+  }): boolean;
+  navigate(
+    routeNameOrOptions: string,
+    params?: NavigationParams,
+    action?: NavigationAction
+  ): boolean;
+  getParam: <T extends keyof P>(param: T, fallback?: P[T]) => P[T];
+  setParams: (newParams: P) => boolean;
+  addListener: (
+    eventName: string,
+    callback: NavigationEventCallback
+  ) => NavigationEventSubscription;
+  push: (
+    routeName: string,
+    params?: NavigationParams,
+    action?: NavigationNavigateAction
+  ) => boolean;
+  replace: (
+    routeName: string,
+    params?: NavigationParams,
+    action?: NavigationNavigateAction
+  ) => boolean;
+  pop: (n?: number, params?: { immediate?: boolean }) => boolean;
+  popToTop: (params?: { immediate?: boolean }) => boolean;
+}
+
+export interface NavigationNavigatorProps<O = {}, S = {}> {
+  navigation?: NavigationProp<S>;
+  screenProps?: { [key: string]: any };
+  navigationOptions?: O;
+}
+
+/**
+ * Gestures, Animations, and Interpolators
+ */
+
+export type NavigationGestureDirection = 'horizontal' | 'vertical';
+
+export interface NavigationLayout {
+  height: AnimatedValue;
+  initHeight: number;
+  initWidth: number;
+  isMeasured: boolean;
+  width: AnimatedValue;
+}
+
+export interface NavigationScene {
+  index: number;
+  isActive: boolean;
+  isStale: boolean;
+  key: string;
+  route: NavigationRoute;
+}
+
+export interface NavigationTransitionProps {
+  // The layout of the screen container
+  layout: NavigationLayout;
+
+  // The destination navigation state of the transition
+  navigation: NavigationScreenProp<NavigationState>;
+
+  // The progressive index of the transitioner's navigation state.
+  position: AnimatedValue;
+
+  // The value that represents the progress of the transition when navigation
+  // state changes from one to another. Its numberic value will range from 0
+  // to 1.
+  //  progress.__getAnimatedValue() < 1 : transtion is happening.
+  //  progress.__getAnimatedValue() == 1 : transtion completes.
+  progress: AnimatedValue;
+
+  // All the scenes of the transitioner.
+  scenes: NavigationScene[];
+
+  // The active scene, corresponding to the route at
+  // `navigation.state.routes[navigation.state.index]`. When rendering
+  // NavigationSceneRendererPropsIndex, the scene does not refer to the active
+  // scene, but instead the scene that is being rendered. The index always
+  // is the index of the scene
+  scene: NavigationScene;
+  index: number;
+
+  screenProps?: { [key: string]: any };
+}
+
+// The scene renderer props are nearly identical to the props used for rendering
+// a transition. The exception is that the passed scene is not the active scene
+// but is instead the scene that the renderer should render content for.
+export type NavigationSceneRendererProps = NavigationTransitionProps;
+
+export interface NavigationTransitionSpec {
+  duration?: number;
+  // An easing function from `Easing`.
+  easing?: (t: number) => number;
+  // A timing function such as `Animated.timing`.
+  timing?: (value: AnimatedValue, config: any) => any;
+}
+
+/**
+ * Describes a visual transition from one screen to another.
+ */
+export interface TransitionConfig {
+  // The basics properties of the animation, such as duration and easing
+  transitionSpec?: NavigationTransitionSpec;
+  // How to animate position and opacity of the screen
+  // based on the value generated by the transitionSpec
+  screenInterpolator?: (props: NavigationSceneRendererProps) => any;
+}
+
+export type NavigationAnimationSetter = (
+  position: AnimatedValue,
+  newState: NavigationState,
+  lastState: NavigationState
+) => void;
+
+export type NavigationSceneRenderer = () => React.ReactElement<any> | null;
+
+export type NavigationStyleInterpolator = (
+  props: NavigationSceneRendererProps
+) => ViewStyle;
+
+export interface LayoutEvent {
+  nativeEvent: {
+    layout: {
+      x: number;
+      y: number;
+      width: number;
+      height: number;
+    };
+  };
+}
+
+export type NavigatorType =
+  | 'react-navigation/STACK'
+  | 'react-navigation/TABS'
+  | 'react-navigation/DRAWER';
+
+export function addNavigationHelpers<S = {}>(navigation: {
+  state: S;
+  dispatch: (action: NavigationAction) => any;
+  addListener?: (
+    eventName: string,
+    callback: NavigationEventCallback
+  ) => NavigationEventSubscription;
+}): NavigationScreenProp<S>;
+
+export interface NavigationContainerProps {
+  uriPrefix?: string | RegExp;
+  onNavigationStateChange?: (
+    prevNavigationState: NavigationState,
+    nextNavigationState: NavigationState,
+    action: NavigationAction
+  ) => void;
+  style?: StyleProp<ViewStyle>;
+}
+
+export interface NavigationContainerComponent
+  extends React.Component<
+      NavigationContainerProps & NavigationNavigatorProps<any>
+    > {
+  dispatch: NavigationDispatch;
+}
+
+export interface NavigationContainer
+  extends React.ComponentClass<
+      NavigationContainerProps & NavigationNavigatorProps<any>
+    > {
+  new (
+    props: NavigationContainerProps & NavigationNavigatorProps<any>,
+    context?: any
+  ): NavigationContainerComponent;
+
+  router: NavigationRouter<any, any>;
+  screenProps: { [key: string]: any };
+  navigationOptions: any;
+  state: { nav: NavigationState | null };
+}
+
+export interface StackNavigatorConfig
+  extends NavigationStackViewConfig,
+    NavigationStackRouterConfig {
+  containerOptions?: any;
+}
+
+// Return createNavigationContainer
+export function StackNavigator(
+  routeConfigMap: NavigationRouteConfigMap,
+  stackConfig?: StackNavigatorConfig
+): NavigationContainer;
+
+export interface SwitchNavigatorConfig {
+  initialRouteName: string;
+  resetOnBlur?: boolean;
+  paths?: NavigationPathsConfig;
+  backBehavior?: 'none' | 'intialRoute';
+}
+
+// Return createNavigationContainer
+export function SwitchNavigator(
+  routeConfigMap: NavigationRouteConfigMap,
+  switchConfig?: SwitchNavigatorConfig
+): NavigationContainer;
+
+// DrawerItems
+export const DrawerItems: React.ReactType;
+
+/**
+ * Drawer Navigator
+ */
+export interface DrawerViewConfig {
+  drawerBackgroundColor?: string;
+  drawerWidth?: number;
+  drawerPosition?: 'left' | 'right';
+  contentComponent?: React.ReactType;
+  contentOptions?: any;
+  style?: StyleProp<ViewStyle>;
+}
+export interface DrawerNavigatorConfig
+  extends NavigationTabRouterConfig,
+    DrawerViewConfig {
+  containerConfig?: any;
+  contentOptions?: {
+    activeTintColor?: string;
+    activeBackgroundColor?: string;
+    inactiveTintColor?: string;
+    inactiveBackgroundColor?: string;
+    style?: StyleProp<ViewStyle>;
+    labelStyle?: StyleProp<TextStyle>;
+  };
+}
+
+export function DrawerNavigator(
+  routeConfigMap: NavigationRouteConfigMap,
+  drawerConfig?: DrawerNavigatorConfig
+): NavigationContainer;
+
+/**
+ * Tab Navigator
+ */
+
+// From views/TabView/TabView.js
+export interface TabViewConfig {
+  tabBarComponent?: React.ReactType;
+  tabBarPosition?: 'top' | 'bottom';
+  tabBarOptions?: {
+    activeTintColor?: string;
+    allowFontScaling?: boolean;
+    activeBackgroundColor?: string;
+    inactiveTintColor?: string;
+    inactiveBackgroundColor?: string;
+    showLabel?: boolean;
+    style?: StyleProp<ViewStyle>;
+    labelStyle?: StyleProp<TextStyle>;
+    iconStyle?: StyleProp<ViewStyle>;
+    // Top
+    showIcon?: boolean;
+    upperCaseLabel?: boolean;
+    pressColor?: string;
+    pressOpacity?: number;
+    scrollEnabled?: boolean;
+    tabStyle?: StyleProp<ViewStyle>;
+    indicatorStyle?: StyleProp<ViewStyle>;
+  };
+  swipeEnabled?: boolean;
+  animationEnabled?: boolean;
+  lazy?: boolean;
+}
+
+// From navigators/TabNavigator.js
+export interface TabNavigatorConfig
+  extends NavigationTabRouterConfig,
+    TabViewConfig {
+  lazy?: boolean;
+  removeClippedSubviews?: boolean;
+  initialLayout?: { height: number; width: number };
+}
+
+// From navigators/TabNavigator.js
+export function TabNavigator(
+  routeConfigMap: NavigationRouteConfigMap,
+  drawConfig?: TabNavigatorConfig
+): NavigationContainer;
+
+export interface TabBarTopProps {
+  activeTintColor: string;
+  inactiveTintColor: string;
+  indicatorStyle: StyleProp<ViewStyle>;
+  showIcon: boolean;
+  showLabel: boolean;
+  upperCaseLabel: boolean;
+  allowFontScaling: boolean;
+  position: AnimatedValue;
+  tabBarPosition: string;
+  navigation: NavigationScreenProp<NavigationState>;
+  jumpToIndex: (index: number) => void;
+  getLabel: (scene: TabScene) => React.ReactNode | string;
+  getOnPress: (
+    previousScene: NavigationRoute,
+    scene: TabScene
+  ) => (
+    args: {
+      previousScene: NavigationRoute;
+      scene: TabScene;
+      jumpToIndex: (index: number) => void;
+    }
+  ) => void;
+  renderIcon: (scene: TabScene) => React.ReactElement<any>;
+  labelStyle?: TextStyle;
+  iconStyle?: ViewStyle;
+}
+
+export interface TabBarBottomProps {
+  activeTintColor: string;
+  activeBackgroundColor: string;
+  adaptive?: boolean;
+  inactiveTintColor: string;
+  inactiveBackgroundColor: string;
+  showLabel?: boolean;
+  allowFontScaling: boolean;
+  position: AnimatedValue;
+  navigation: NavigationScreenProp<NavigationState>;
+  jumpToIndex: (index: number) => void;
+  getLabel: (scene: TabScene) => React.ReactNode | string;
+  getOnPress: (
+    previousScene: NavigationRoute,
+    scene: TabScene
+  ) => (
+    args: {
+      previousScene: NavigationRoute;
+      scene: TabScene;
+      jumpToIndex: (index: number) => void;
+    }
+  ) => void;
+  getTestIDProps: (scene: TabScene) => (scene: TabScene) => any;
+  renderIcon: (scene: TabScene) => React.ReactNode;
+  style?: ViewStyle;
+  animateStyle?: ViewStyle;
+  labelStyle?: TextStyle;
+  tabStyle?: ViewStyle;
+  showIcon?: boolean;
+}
+
+export const TabBarTop: React.ComponentType<TabBarTopProps>;
+export const TabBarBottom: React.ComponentType<TabBarBottomProps>;
+
+/**
+ * NavigationActions
+ */
+export namespace NavigationActions {
+  const BACK: 'Navigation/BACK';
+  const INIT: 'Navigation/INIT';
+  const NAVIGATE: 'Navigation/NAVIGATE';
+  const RESET: 'Navigation/RESET';
+  const SET_PARAMS: 'Navigation/SET_PARAMS';
+  const URI: 'Navigation/URI';
+  const POP: 'Navigation/POP';
+  const POP_TO_TOP: 'Navigation/POP_TO_TOP';
+
+  function init(options?: NavigationInitActionPayload): NavigationInitAction;
+  function navigate(
+    options: NavigationNavigateActionPayload
+  ): NavigationNavigateAction;
+  function reset(options: NavigationResetActionPayload): NavigationResetAction;
+  function back(options?: NavigationBackActionPayload): NavigationBackAction;
+  function setParams(
+    options: NavigationSetParamsActionPayload
+  ): NavigationSetParamsAction;
+  function pop(options: NavigationPopActionPayload): NavigationPopAction;
+  function popToTop(
+    options: NavigationPopToTopActionPayload
+  ): NavigationPopToTopAction;
+}
+
+/**
+ * Transitioner
+ * @desc From react-navigation/src/views/Transitioner.js
+ */
+export interface TransitionerProps {
+  configureTransition: (
+    transitionProps: NavigationTransitionProps,
+    prevTransitionProps?: NavigationTransitionProps
+  ) => NavigationTransitionSpec;
+  navigation: NavigationScreenProp<NavigationState>;
+  onTransitionStart?: (
+    transitionProps: NavigationTransitionProps,
+    prevTransitionProps?: NavigationTransitionProps
+  ) => Promise<void> | void;
+  onTransitionEnd?: (
+    transitionProps: NavigationTransitionProps,
+    prevTransitionProps?: NavigationTransitionProps
+  ) => void;
+  render: (
+    transitionProps: NavigationTransitionProps,
+    prevTransitionProps?: NavigationTransitionProps
+  ) => any;
+  style?: StyleProp<ViewStyle>;
+}
+
+export interface TransitionerState {
+  layout: NavigationLayout;
+  position: Animated.Value;
+  progress: Animated.Value;
+  scenes: NavigationScene[];
+}
+
+export class Transitioner extends React.Component<
+  TransitionerProps,
+  TransitionerState
+> {}
+
+/**
+ * Tab Router
+ *
+ * @desc from react-navigation/src/routers/TabRouter.js
+ */
+export function TabRouter(
+  routeConfigs: NavigationRouteConfigMap,
+  config: NavigationTabRouterConfig
+): NavigationRouter<any, any>;
+
+/**
+ * Stack Router
+ *
+ * @desc from react-navigation/src/routers/StackRouter.js
+ */
+export function StackRouter(
+  routeConfigs: NavigationRouteConfigMap,
+  config: NavigationTabRouterConfig
+): NavigationRouter<any, any>;
+
+/**
+ * Create Navigator
+ *
+ * @see https://github.com/react-navigation/react-navigation/blob/master/src/navigators/createNavigator.js
+ */
+export function createNavigator<C, S, Options>(
+  router: NavigationRouter<S, Options>,
+  routeConfigs?: NavigationRouteConfigMap,
+  navigatorConfig?: {} | null,
+  navigatorType?: NavigatorType
+): (
+  NavigationView: React.ComponentClass<C>
+) => NavigationNavigator<C, S, Options>;
+
+/**
+ * Create an HOC that injects the navigation and manages the navigation state
+ * in case it's not passed from above.
+ * This allows to use e.g. the StackNavigator and TabNavigator as root-level
+ * components.
+ *
+ * @see https://github.com/react-navigation/react-navigation/blob/master/src/createNavigationContainer.js
+ */
+export function createNavigationContainer(
+  Component: NavigationNavigator<any, any, any>
+): NavigationContainer;
+/**
+ * END MANUAL DEFINITIONS OUTSIDE OF TYPEDEFINITION.JS
+ */
+
+/**
+ * BEGIN CUSTOM CONVENIENCE INTERFACES
+ */
+
+export interface NavigationScreenProps<
+  Params = NavigationParams,
+  Options = any
+> {
+  navigation: NavigationScreenProp<NavigationRoute<Params>, Params>;
+  screenProps?: { [key: string]: any };
+  navigationOptions?: NavigationScreenConfig<Options>;
+}
+
+/**
+ * END CUSTOM CONVENIENCE INTERFACES
+ */
+
+/*
+ * Header
+ */
+
+// src/views/HeaderBackButton.js
+
+export interface HeaderBackButtonProps {
+  onPress?: () => void;
+  pressColorAndroid?: string;
+  title?: string;
+  titleStyle?: StyleProp<TextStyle>;
+  tintColor?: string;
+  truncatedTitle?: string;
+  width?: number;
+}
+
+export const HeaderBackButton: React.ComponentClass<HeaderBackButtonProps>;
+/**
+ * Header Component
+ */
+export const Header: React.ComponentClass<HeaderProps>;
+
+export interface NavigationInjectedProps {
+  navigation: NavigationScreenProp<NavigationState>;
+}
+
+export function withNavigation<T = {}>(
+  Component: React.ComponentType<T & NavigationInjectedProps>
+): React.ComponentType<T>;
+
+export function withNavigationFocus<T = {}>(
+  Component: React.ComponentType<T & NavigationInjectedProps>
+): React.ComponentType<T>;
+
+/**
+ * SafeAreaView Component
+ */
+export type SafeAreaViewForceInsetValue = 'always' | 'never';
+export interface SafeAreaViewProps extends ViewProps {
+  forceInset?: {
+    top?: SafeAreaViewForceInsetValue;
+    bottom?: SafeAreaViewForceInsetValue;
+    left?: SafeAreaViewForceInsetValue;
+    right?: SafeAreaViewForceInsetValue;
+    horizontal?: SafeAreaViewForceInsetValue;
+    vertical?: SafeAreaViewForceInsetValue;
+  };
+}
+
+export const SafeAreaView: React.ComponentClass<SafeAreaViewProps>;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,40 @@
+{
+  "compilerOptions": {
+    "module": "es2015",
+    "target": "es2015",
+    "lib": ["dom", "es2015", "es2016"],
+    "sourceMap": false,
+    "moduleResolution": "node",
+    "rootDir": "src",
+    "forceConsistentCasingInFileNames": true,
+    "noImplicitReturns": true,
+    "noImplicitThis": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "suppressImplicitAnyIndexErrors": true,
+    "noUnusedLocals": true,
+    "declaration": true,
+    "pretty": true,
+    "jsx": "react-native",
+    "noEmitHelpers": true,
+    "importHelpers": true,
+    "strict": true
+  },
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx"
+  ],
+  "exclude": [
+    "src/**/*.d.ts",
+    "src/**/*.d.tsx",
+    "node_modules"
+  ],
+  "typeAcquisition": {
+    "enable": true,
+    "include": [
+      "prop-types",
+      "react",
+      "react-native"
+    ]
+  }
+}

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "sourceMap": true
+  }
+}

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,15 @@
+{
+  "extends": "tslint:recommended",
+  "rules": {
+    "arrow-parens": [true, "ban-single-arg-parens"],
+    "arrow-return-shorthand": [true, "multiline"],
+    "trailing-comma": false,
+    "quotemark": {
+      "options": [
+        "single",
+        "avoid-escape"
+      ]
+    },
+    "object-literal-sort-keys": false
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,6 +16,10 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
+"@types/jest@^22.2.3":
+  version "22.2.3"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-22.2.3.tgz#0157c0316dc3722c43a7b71de3fdf3acbccef10d"
+
 abab@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"
@@ -108,7 +112,7 @@ ansi-gray@^0.1.1:
   dependencies:
     ansi-wrap "0.1.0"
 
-ansi-regex@^2.0.0, ansi-regex@^2.1.1:
+ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
 
@@ -120,7 +124,7 @@ ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
-ansi-styles@^3.0.0, ansi-styles@^3.2.0, ansi-styles@^3.2.1:
+ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
   dependencies:
@@ -535,6 +539,15 @@ babel-plugin-external-helpers@^6.18.0:
   dependencies:
     babel-runtime "^6.22.0"
 
+babel-plugin-istanbul@^4.1.4:
+  version "4.1.6"
+  resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz#36c59b2192efce81c5b378321b74175add1c9a45"
+  dependencies:
+    babel-plugin-syntax-object-rest-spread "^6.13.0"
+    find-up "^2.1.0"
+    istanbul-lib-instrument "^1.10.1"
+    test-exclude "^4.2.1"
+
 babel-plugin-istanbul@^4.1.5:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.5.tgz#6760cdd977f411d3e175bb064f2bc327d99b2b6e"
@@ -546,6 +559,10 @@ babel-plugin-istanbul@^4.1.5:
 babel-plugin-jest-hoist@^22.4.1:
   version "22.4.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.4.1.tgz#d712fe5da8b6965f3191dacddbefdbdf4fb66d63"
+
+babel-plugin-jest-hoist@^22.4.3:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.4.3.tgz#7d8bcccadc2667f96a0dcc6afe1891875ee6c14a"
 
 babel-plugin-react-transform@2.0.2:
   version "2.0.2"
@@ -680,6 +697,15 @@ babel-plugin-transform-es2015-literals@^6.5.0, babel-plugin-transform-es2015-lit
 babel-plugin-transform-es2015-modules-commonjs@6.x, babel-plugin-transform-es2015-modules-commonjs@^6.5.0, babel-plugin-transform-es2015-modules-commonjs@^6.8.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz#0d8394029b7dc6abe1a97ef181e00758dd2e5d8a"
+  dependencies:
+    babel-plugin-transform-strict-mode "^6.24.1"
+    babel-runtime "^6.26.0"
+    babel-template "^6.26.0"
+    babel-types "^6.26.0"
+
+babel-plugin-transform-es2015-modules-commonjs@^6.26.0:
+  version "6.26.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz#58a793863a9e7ca870bdc5a881117ffac27db6f3"
   dependencies:
     babel-plugin-transform-strict-mode "^6.24.1"
     babel-runtime "^6.26.0"
@@ -868,6 +894,13 @@ babel-preset-fbjs@^2.1.2, babel-preset-fbjs@^2.1.4:
     babel-plugin-transform-react-display-name "^6.8.0"
     babel-plugin-transform-react-jsx "^6.8.0"
 
+babel-preset-jest@^22.4.0:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-22.4.3.tgz#e92eef9813b7026ab4ca675799f37419b5a44156"
+  dependencies:
+    babel-plugin-jest-hoist "^22.4.3"
+    babel-plugin-syntax-object-rest-spread "^6.13.0"
+
 babel-preset-jest@^22.4.1:
   version "22.4.1"
   resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-22.4.1.tgz#efa2e5f5334242a9457a068452d7d09735db172a"
@@ -957,7 +990,7 @@ babel-register@^6.24.1, babel-register@^6.26.0:
     mkdirp "^0.5.1"
     source-map-support "^0.4.15"
 
-babel-runtime@^6.0.0, babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.23.0, babel-runtime@^6.26.0:
+babel-runtime@^6.0.0, babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.23.0, babel-runtime@^6.26.0, babel-runtime@^6.9.2:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   dependencies:
@@ -1243,11 +1276,19 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
+chalk@^2.3.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
+  dependencies:
+    ansi-styles "^3.2.1"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.3.0"
+
 chardet@^0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
 
-chokidar@^1.6.1:
+chokidar@^1.6.0, chokidar@^1.6.1:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-1.7.0.tgz#798e689778151c8076b4b360e5edd28cda2bb468"
   dependencies:
@@ -1409,6 +1450,10 @@ combined-stream@1.0.6, combined-stream@^1.0.5, combined-stream@~1.0.5:
 commander@^2.11.0, commander@^2.9.0:
   version "2.15.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.0.tgz#ad2a23a1c3b036e392469b8012cec6b33b4c1322"
+
+commander@^2.12.1:
+  version "2.15.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
 
 commander@~2.13.0:
   version "2.13.0"
@@ -1574,6 +1619,22 @@ cosmiconfig@^1.1.0:
     parse-json "^2.2.0"
     pinkie-promise "^2.0.0"
     require-from-string "^1.1.0"
+
+cpx@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/cpx/-/cpx-1.5.0.tgz#185be018511d87270dedccc293171e37655ab88f"
+  dependencies:
+    babel-runtime "^6.9.2"
+    chokidar "^1.6.0"
+    duplexer "^0.1.1"
+    glob "^7.0.5"
+    glob2base "^0.0.12"
+    minimatch "^3.0.2"
+    mkdirp "^0.5.1"
+    resolve "^1.1.7"
+    safe-buffer "^5.0.1"
+    shell-quote "^1.6.1"
+    subarg "^1.0.0"
 
 crc@3.3.0:
   version "3.3.0"
@@ -1823,6 +1884,10 @@ duplexer2@0.0.2:
   dependencies:
     readable-stream "~1.1.9"
 
+duplexer@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
+
 ecc-jsbn@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"
@@ -1915,7 +1980,7 @@ escodegen@^1.9.0:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-config-prettier@^2.3.0:
+eslint-config-prettier@^2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-2.9.0.tgz#5ecd65174d486c22dff389fe036febf502d468a3"
   dependencies:
@@ -1962,7 +2027,7 @@ eslint-plugin-jsx-a11y@^6.0.2:
     emoji-regex "^6.1.0"
     jsx-ast-utils "^2.0.0"
 
-eslint-plugin-prettier@^2.1.2:
+eslint-plugin-prettier@^2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-2.6.0.tgz#33e4e228bdb06142d03c560ce04ec23f6c767dd7"
   dependencies:
@@ -1989,7 +2054,50 @@ eslint-visitor-keys@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
 
-eslint@^4.2.0, eslint@^4.5.0:
+eslint@^4.0.0:
+  version "4.19.1"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.19.1.tgz#32d1d653e1d90408854bfb296f076ec7e186a300"
+  dependencies:
+    ajv "^5.3.0"
+    babel-code-frame "^6.22.0"
+    chalk "^2.1.0"
+    concat-stream "^1.6.0"
+    cross-spawn "^5.1.0"
+    debug "^3.1.0"
+    doctrine "^2.1.0"
+    eslint-scope "^3.7.1"
+    eslint-visitor-keys "^1.0.0"
+    espree "^3.5.4"
+    esquery "^1.0.0"
+    esutils "^2.0.2"
+    file-entry-cache "^2.0.0"
+    functional-red-black-tree "^1.0.1"
+    glob "^7.1.2"
+    globals "^11.0.1"
+    ignore "^3.3.3"
+    imurmurhash "^0.1.4"
+    inquirer "^3.0.6"
+    is-resolvable "^1.0.0"
+    js-yaml "^3.9.1"
+    json-stable-stringify-without-jsonify "^1.0.1"
+    levn "^0.3.0"
+    lodash "^4.17.4"
+    minimatch "^3.0.2"
+    mkdirp "^0.5.1"
+    natural-compare "^1.4.0"
+    optionator "^0.8.2"
+    path-is-inside "^1.0.2"
+    pluralize "^7.0.0"
+    progress "^2.0.0"
+    regexpp "^1.0.1"
+    require-uncached "^1.0.3"
+    semver "^5.3.0"
+    strip-ansi "^4.0.0"
+    strip-json-comments "~2.0.1"
+    table "4.0.2"
+    text-table "~0.2.0"
+
+eslint@^4.2.0:
   version "4.18.2"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.18.2.tgz#0f81267ad1012e7d2051e186a9004cc2267b8d45"
   dependencies:
@@ -2031,7 +2139,7 @@ eslint@^4.2.0, eslint@^4.5.0:
     table "4.0.2"
     text-table "~0.2.0"
 
-espree@^3.5.2:
+espree@^3.5.2, espree@^3.5.4:
   version "3.5.4"
   resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.4.tgz#b0f447187c8a8bed944b815a660bddf5deb5d1a7"
   dependencies:
@@ -2343,6 +2451,10 @@ finalhandler@1.1.0:
     statuses "~1.3.1"
     unpipe "~1.0.0"
 
+find-index@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/find-index/-/find-index-0.1.1.tgz#675d358b2ca3892d795a1ab47232f8b6e2e0dde4"
+
 find-up@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-1.1.2.tgz#6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f"
@@ -2408,6 +2520,14 @@ fragment-cache@^0.2.1:
 fresh@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.3.0.tgz#651f838e22424e7566de161d8358caa199f83d4f"
+
+fs-extra@4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.3.tgz#0d852122e5bc5beb453fb028e9c0c9bf36340c94"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
 
 fs-extra@^1.0.0:
   version "1.0.0"
@@ -2528,6 +2648,12 @@ glob-parent@^2.0.0:
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-2.0.0.tgz#81383d72db054fcccf5336daa902f182f6edbb28"
   dependencies:
     is-glob "^2.0.0"
+
+glob2base@^0.0.12:
+  version "0.0.12"
+  resolved "https://registry.yarnpkg.com/glob2base/-/glob2base-0.0.12.tgz#9d419b3e28f12e83a362164a277055922c9c0d56"
+  dependencies:
+    find-index "^0.1.1"
 
 glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
   version "7.1.2"
@@ -3629,6 +3755,12 @@ jsonfile@^2.1.0:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
+jsonfile@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
 jsonify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
@@ -3902,6 +4034,10 @@ lodash.templatesettings@^3.0.0:
 lodash.throttle@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
+
+lodash.unescape@4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.unescape/-/lodash.unescape-4.0.1.tgz#bf2249886ce514cda112fae9218cdc065211fc9c"
 
 lodash@^3.5.0:
   version "3.10.1"
@@ -4688,34 +4824,37 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier-eslint@^6.4.2:
-  version "6.4.3"
-  resolved "https://registry.yarnpkg.com/prettier-eslint/-/prettier-eslint-6.4.3.tgz#8335b7a8bd50d01879a9d505bc0b9208caa9ecfc"
+prettier-eslint@^8.8.1:
+  version "8.8.1"
+  resolved "https://registry.yarnpkg.com/prettier-eslint/-/prettier-eslint-8.8.1.tgz#38505163274742f2a0b31653c39e40f37ebd07da"
   dependencies:
+    babel-runtime "^6.26.0"
     common-tags "^1.4.0"
     dlv "^1.1.0"
-    eslint "^4.5.0"
+    eslint "^4.0.0"
     indent-string "^3.2.0"
     lodash.merge "^4.6.0"
     loglevel-colored-level-prefix "^1.0.0"
-    prettier "^1.6.0"
-    pretty-format "^20.0.3"
+    prettier "^1.7.0"
+    pretty-format "^22.0.3"
     require-relative "^0.8.7"
+    typescript "^2.5.1"
+    typescript-eslint-parser "^11.0.0"
 
-prettier@^1.5.3, prettier@^1.6.0:
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.11.1.tgz#61e43fc4cd44e68f2b0dfc2c38cd4bb0fccdcc75"
-
-pretty-format@^20.0.3:
-  version "20.0.3"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-20.0.3.tgz#020e350a560a1fe1a98dc3beb6ccffb386de8b14"
-  dependencies:
-    ansi-regex "^2.1.1"
-    ansi-styles "^3.0.0"
+prettier@^1.12.1, prettier@^1.7.0:
+  version "1.12.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.12.1.tgz#c1ad20e803e7749faf905a409d2367e06bbe7325"
 
 pretty-format@^21.2.1:
   version "21.2.1"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-21.2.1.tgz#ae5407f3cf21066cd011aa1ba5fce7b6a2eddb36"
+  dependencies:
+    ansi-regex "^3.0.0"
+    ansi-styles "^3.2.0"
+
+pretty-format@^22.0.3:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-22.4.3.tgz#f873d780839a9c02e9664c8a082e9ee79eaac16f"
   dependencies:
     ansi-regex "^3.0.0"
     ansi-styles "^3.2.0"
@@ -5106,6 +5245,10 @@ regex-not@^1.0.0, regex-not@^1.0.2:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
 
+regexpp@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-1.1.0.tgz#0e3516dd0b7904f413d2d4193dce4618c3a689ab"
+
 regexpu-core@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-2.0.0.tgz#49d038837b8dcf8bfa5b9a42139938e6ea2ae240"
@@ -5284,6 +5427,12 @@ resolve@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
+resolve@^1.1.7, resolve@^1.3.2:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.7.1.tgz#aadd656374fd298aee895bc026b8297418677fd3"
+  dependencies:
+    path-parse "^1.0.5"
+
 resolve@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.5.0.tgz#1f09acce796c9a762579f31b2c1cc4c3cddf9f36"
@@ -5396,6 +5545,10 @@ sax@~1.1.1:
 "semver@2 || 3 || 4 || 5", semver@5.x, semver@^5.0.1, semver@^5.0.3, semver@^5.1.0, semver@^5.3.0, semver@^5.4.1:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
+
+semver@5.4.1:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
 
 send@0.13.2:
   version "0.13.2"
@@ -5792,6 +5945,12 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
+subarg@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/subarg/-/subarg-1.0.0.tgz#f62cf17581e996b48fc965699f54c06ae268b8d2"
+  dependencies:
+    minimist "^1.1.0"
+
 supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
@@ -5855,7 +6014,7 @@ temp@0.8.3:
     os-tmpdir "^1.0.0"
     rimraf "~2.2.6"
 
-test-exclude@^4.1.1:
+test-exclude@^4.1.1, test-exclude@^4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-4.2.1.tgz#dfa222f03480bca69207ca728b37d74b45f724fa"
   dependencies:
@@ -5940,9 +6099,50 @@ trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
 
+ts-jest@^22.4.4:
+  version "22.4.4"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-22.4.4.tgz#7b5c0abb2188fe7170840df9f80e78659aaf8a24"
+  dependencies:
+    babel-core "^6.26.0"
+    babel-plugin-istanbul "^4.1.4"
+    babel-plugin-transform-es2015-modules-commonjs "^6.26.0"
+    babel-preset-jest "^22.4.0"
+    cpx "^1.5.0"
+    fs-extra "4.0.3"
+    jest-config "^22.4.2"
+    pkg-dir "^2.0.0"
+    yargs "^11.0.0"
+
+tslib@^1.8.0, tslib@^1.8.1:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.0.tgz#e37a86fda8cbbaf23a057f473c9f4dc64e5fc2e8"
+
+tslint@^5.9.1:
+  version "5.9.1"
+  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.9.1.tgz#1255f87a3ff57eb0b0e1f0e610a8b4748046c9ae"
+  dependencies:
+    babel-code-frame "^6.22.0"
+    builtin-modules "^1.1.1"
+    chalk "^2.3.0"
+    commander "^2.12.1"
+    diff "^3.2.0"
+    glob "^7.1.1"
+    js-yaml "^3.7.0"
+    minimatch "^3.0.4"
+    resolve "^1.3.2"
+    semver "^5.3.0"
+    tslib "^1.8.0"
+    tsutils "^2.12.1"
+
 tsscmp@1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/tsscmp/-/tsscmp-1.0.5.tgz#7dc4a33af71581ab4337da91d85ca5427ebd9a97"
+
+tsutils@^2.12.1:
+  version "2.26.2"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.26.2.tgz#a9f9f63434a456a5e0c95a45d9a59181cb32d3bf"
+  dependencies:
+    tslib "^1.8.1"
 
 tunnel-agent@^0.6.0:
   version "0.6.0"
@@ -5974,6 +6174,17 @@ type-is@~1.6.6:
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
+
+typescript-eslint-parser@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/typescript-eslint-parser/-/typescript-eslint-parser-11.0.0.tgz#37dba6a0130dd307504aa4b4b21b0d3dc7d4e9f2"
+  dependencies:
+    lodash.unescape "4.0.1"
+    semver "5.4.1"
+
+typescript@^2.5.1, typescript@^2.8.3:
+  version "2.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.3.tgz#5d817f9b6f31bb871835f4edf0089f21abe6c170"
 
 ua-parser-js@^0.7.9:
   version "0.7.17"
@@ -6031,6 +6242,10 @@ union-value@^1.0.0:
     get-value "^2.0.6"
     is-extendable "^0.1.1"
     set-value "^0.4.3"
+
+universalify@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.1.tgz#fa71badd4437af4c148841e3b3b165f9e9e590b7"
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
@@ -6326,6 +6541,12 @@ yargs-parser@^8.1.0:
   dependencies:
     camelcase "^4.1.0"
 
+yargs-parser@^9.0.2:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-9.0.2.tgz#9ccf6a43460fe4ed40a9bb68f48d43b8a68cc077"
+  dependencies:
+    camelcase "^4.1.0"
+
 yargs@^10.0.3:
   version "10.1.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-10.1.2.tgz#454d074c2b16a51a43e2fb7807e4f9de69ccb5c5"
@@ -6342,6 +6563,23 @@ yargs@^10.0.3:
     which-module "^2.0.0"
     y18n "^3.2.1"
     yargs-parser "^8.1.0"
+
+yargs@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-11.0.0.tgz#c052931006c5eee74610e5fc0354bedfd08a201b"
+  dependencies:
+    cliui "^4.0.0"
+    decamelize "^1.1.1"
+    find-up "^2.1.0"
+    get-caller-file "^1.0.1"
+    os-locale "^2.0.0"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^2.0.0"
+    which-module "^2.0.0"
+    y18n "^3.2.1"
+    yargs-parser "^9.0.2"
 
 yargs@^8.0.2:
   version "8.0.2"


### PR DESCRIPTION
- In response to https://github.com/react-navigation/rfcs/issues/34

### Motivation: First-Class ✈️ TypeScript ❤️ Support 💪 

The [existing TypeScript definitions](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/react-navigation) have problems:
1. They are manually typed ⌨️ (very difficult to maintain).
1. Kudos to the author(s), but the missing type information is 🤦‍♂️ and not ideal. The definitions don't provide enough information about the most important features of react-navigation.
1. Even if they did, they don't come 📦 with react-navigation, so it's very likely to get definitions that are a bit out of sync.

### Strategy 🤔 

1. Introduce TypeScript into the build system to co-exist with JavaScript files.
1. Incrementally convert existing JavaScript files into TypeScript 👷, starting with the files that have no dependencies and working up. 🚧 
1. New TypeScript files are transpiled in-place with generated type definitions beside them (`.d.ts` files).
1. For now, port [`react-navigation.d.ts` from DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react-navigation/index.d.ts) and publicize the typings in `package.json#types` (See f31f7b0fcf7a1c460a833f5107c79913d59195d4 and below this list).
1. At the very end 🏁 convert `src/react-navigation.js` into TypeScript, after which it will generate a 100% accurate `.d.ts` file with all the 🔔 & whistles (e.g., generics).
```json
  "types": "src/react-navigation.d.ts",
```

_Note: If this PR is merged, I'll be happy to continue the effort diligently until all source files are typed with advanced features... or my wife is 😠 at me for staying up too late 🌃._

### Tests ✅ 

The test configuration has also been updated to support TypeScript.
```
npm test
```
1. Lints (pre-task).
1. If successful, runs tests (both JS & TS).
1. If successful, transpiles Typescript into JavaScript in-place (post-task).

### Code formatting 💅 

I ensured that prettier was formatting TypeScript files on the same `precommit#lint-staged` script as well as the introduction of a simple `tslint.json` file, which we can modify as needed.
