### PR TITLE
add a test so that #2856 can be closed

### DIFF
--- a/src/views/__tests__/Transitioner-test.js
+++ b/src/views/__tests__/Transitioner-test.js
@@ -5,8 +5,8 @@ import Transitioner from '../Transitioner';
 
 describe('Transitioner', () => {
   it('should not trigger onTransitionStart and onTransitionEnd when route params are changed', () => {
-    const onTransitionStartCallBack = jest.fn();
-    const onTransitionEndCallBack = jest.fn();
+    const onTransitionStartCallback = jest.fn();
+    const onTransitionEndCallback = jest.fn();
 
     const transitionerProps = {
       configureTransition: (transitionProps, prevTransitionProps) => ({}),
@@ -24,8 +24,8 @@ describe('Transitioner', () => {
         navigate: () => false,
       },
       render: () => <div />,
-      onTransitionStart: onTransitionStartCallBack,
-      onTransitionEnd: onTransitionEndCallBack,
+      onTransitionStart: onTransitionStartCallback,
+      onTransitionEnd: onTransitionEndCallback,
     };
 
     const nextTransitionerProps = {
@@ -43,7 +43,7 @@ describe('Transitioner', () => {
     };
     const component = renderer.create(<Transitioner {...transitionerProps} />);
     component.update(<Transitioner {...nextTransitionerProps} />);
-    expect(onTransitionStartCallBack).not.toBeCalled();
-    expect(onTransitionEndCallBack).not.toBeCalled();
+    expect(onTransitionStartCallback).not.toBeCalled();
+    expect(onTransitionEndCallback).not.toBeCalled();
   });
 });

--- a/src/views/__tests__/Transitioner-test.js
+++ b/src/views/__tests__/Transitioner-test.js
@@ -1,0 +1,49 @@
+/* eslint react/display-name:0 */
+import * as React from 'react';
+import renderer from 'react-test-renderer';
+import Transitioner from '../Transitioner';
+
+describe('Transitioner', () => {
+  it('should not trigger onTransitionStart and onTransitionEnd when route params are changed', () => {
+    const onTransitionStartCallBack = jest.fn();
+    const onTransitionEndCallBack = jest.fn();
+
+    const transitionerProps = {
+      configureTransition: (transitionProps, prevTransitionProps) => ({}),
+      navigation: {
+        state: {
+          index: 0,
+          routes: [
+            { key: '1', routeName: 'Foo' },
+            { key: '2', routeName: 'Bar' },
+          ],
+        },
+        goBack: () => false,
+        dispatch: () => false,
+        setParams: () => false,
+        navigate: () => false,
+      },
+      render: () => <div />,
+      onTransitionStart: onTransitionStartCallBack,
+      onTransitionEnd: onTransitionEndCallBack,
+    };
+
+    const nextTransitionerProps = {
+      ...transitionerProps,
+      navigation: {
+        ...transitionerProps.navigation,
+        state: {
+          index: 0,
+          routes: [
+            { key: '1', routeName: 'Foo', params: { name: 'Zoom' } },
+            { key: '2', routeName: 'Bar' },
+          ],
+        },
+      },
+    };
+    const component = renderer.create(<Transitioner {...transitionerProps} />);
+    component.update(<Transitioner {...nextTransitionerProps} />);
+    expect(onTransitionStartCallBack).not.toBeCalled();
+    expect(onTransitionEndCallBack).not.toBeCalled();
+  });
+});


### PR DESCRIPTION
This is a test which should ensure that #2856 is no longer an issue. It is taken from the original PR, with small modifications. I have verified that the test fails with 1.0.0-beta15 which was the release the PR was probably made for (it was made at the time of beta 15 release). It passes on the current master so the issue should not longer be present.

cc @brentvatne 