### PR TITLE
Fix issue with nested navigation actions in stack

### DIFF
--- a/src/routers/StackRouter.js
+++ b/src/routers/StackRouter.js
@@ -257,9 +257,13 @@ export default (routeConfigs, stackConfig = {}) => {
           let childRouter = childRouters[childRoute.routeName];
           let debug = action.params && action.params.debug;
 
+          let childAction =
+            action.routeName === childRoute.routeName && action.action
+              ? action.action
+              : action;
           if (childRouter) {
             const nextRouteState = childRouter.getStateForAction(
-              action,
+              childAction,
               childRoute
             );
 


### PR DESCRIPTION
Fixes https://github.com/react-navigation/react-navigation/issues/4111

When you navigate with a specific route name and a custom action, we want to run the *child* action, rather than the top level action