### PR TITLE
Fix CompletionAction trigger

### DIFF
--- a/src/views/StackView/StackView.js
+++ b/src/views/StackView/StackView.js
@@ -27,10 +27,7 @@ class StackView extends React.Component {
         onTransitionStart={this.props.onTransitionStart}
         onTransitionEnd={(transition, lastTransition) => {
           const { onTransitionEnd, navigation } = this.props;
-          if (
-            transition.navigation.state.isTransitioning &&
-            !lastTransition.navigation.state.isTransitioning
-          ) {
+          if (transition.navigation.state.isTransitioning) {
             navigation.dispatch(
               StackActions.completeTransition({
                 key: navigation.state.key,


### PR DESCRIPTION
The completion action should always fire when the current navigation state isTransitioning.

There were some problems surrounding this with persisted states and isTransitioning.