### PR TITLE
Fix event unsubscription logic

### DIFF
--- a/src/getChildEventSubscriber.js
+++ b/src/getChildEventSubscriber.js
@@ -138,11 +138,14 @@ export default function getChildEventSubscriber(addListener, key) {
           emit((lastEmittedEvent = 'didBlur'), childPayload);
         }
       }
+
+      if (lastEmittedEvent === 'didBlur' && !newRoute) {
+        removeAll();
+      }
     })
   );
 
   return {
-    removeAll,
     addListener(eventName, eventHandler) {
       const subscribers = getChildSubscribers(eventName);
       if (!subscribers) {

--- a/src/navigators/createNavigator.js
+++ b/src/navigators/createNavigator.js
@@ -14,15 +14,14 @@ function createNavigator(NavigatorView, router, navigationConfig) {
       const activeKeys = this.props.navigation.state.routes.map(r => r.key);
       Object.keys(this.childEventSubscribers).forEach(key => {
         if (!activeKeys.includes(key)) {
-          this.childEventSubscribers[key].removeAll();
           delete this.childEventSubscribers[key];
         }
       });
     }
 
-    // Remove all subscriptions
+    // Remove all subscription references
     componentWillUnmount() {
-      Object.values(this.childEventSubscribers).map(s => s.removeAll());
+      this.childEventSubscribers = {};
     }
 
     _isRouteFocused = route => {


### PR DESCRIPTION
Events were getting unsubscribed too early, so that the inner willBlur event was getting skipped when trying to “dismiss” a deep navigation stack.

This changes the un-subscription logic to happen within the event emitter itself, which should be a bit more maintainable. It will wait for a didBlur event on a route that is not in the stack, and then it will unsubscribe from the upstream events.