### PR TITLE
Fix for broken swipe back gesture in RTL mode

### DIFF
--- a/src/views/Header/Header.js
+++ b/src/views/Header/Header.js
@@ -7,6 +7,7 @@ import {
   Platform,
   StyleSheet,
   View,
+  I18nManager,
   ViewPropTypes,
 } from 'react-native';
 import { MaskedViewIOS } from '../../PlatformHelpers';
@@ -565,6 +566,7 @@ const styles = StyleSheet.create({
     marginTop: -0.5, // resizes down to 20.5
     alignSelf: 'center',
     resizeMode: 'contain',
+    transform: [{ scaleX: I18nManager.isRTL ? -1 : 1 }],
   },
   title: {
     bottom: 0,

--- a/src/views/StackView/StackViewLayout.js
+++ b/src/views/StackView/StackViewLayout.js
@@ -306,7 +306,7 @@ class StackViewLayout extends React.Component {
               ? layout.height.__getValue()
               : layout.width.__getValue();
             const currentValue =
-              gestureDirectionInverted && axis === 'dx'
+              axis === 'dx' && gestureDirectionInverted
                 ? startValue + gesture[axis] / axisDistance
                 : startValue - gesture[axis] / axisDistance;
             const value = clamp(index - 1, currentValue, index);

--- a/src/views/StackView/StackViewLayout.js
+++ b/src/views/StackView/StackViewLayout.js
@@ -227,8 +227,12 @@ class StackViewLayout extends React.Component {
     const { index } = navigation.state;
     const isVertical = mode === 'modal';
     const { options } = scene.descriptor;
+    const gestureDirection = options.gestureDirection;
 
-    const gestureDirectionInverted = options.gestureDirection === 'inverted';
+    const gestureDirectionInverted =
+      typeof gestureDirection === 'string'
+        ? gestureDirection === 'inverted'
+        : I18nManager.isRTL;
 
     const gesturesEnabled =
       typeof options.gesturesEnabled === 'boolean'
@@ -302,7 +306,7 @@ class StackViewLayout extends React.Component {
               ? layout.height.__getValue()
               : layout.width.__getValue();
             const currentValue =
-              (I18nManager.isRTL && axis === 'dx') !== gestureDirectionInverted
+              gestureDirectionInverted && axis === 'dx'
                 ? startValue + gesture[axis] / axisDistance
                 : startValue - gesture[axis] / axisDistance;
             const value = clamp(index - 1, currentValue, index);


### PR DESCRIPTION
**Motivation**

Swipe back doesn't work in RTL mode by default and even when you set navigationOptions.gestureDirection to 'inverted' value to facilitate it functionality remains broken: one is able to swipe back but stack card responds to user's gesture in a jerky near-edge movement.

**Test plan (required)**

I've tested the new code in the app we develop (however I'm not at liberty to share screenshots / video due to NDA).

Steps to reproduce original issue are given at https://github.com/react-navigation/react-navigation/issues/4118.

P.S. I also fixed the default back button's mask in RTL mode.

Thanks guys!