### PR TITLE
Fix drawer navigation dispatch

### DIFF
--- a/src/views/Drawer/DrawerSidebar.js
+++ b/src/views/Drawer/DrawerSidebar.js
@@ -57,7 +57,12 @@ class DrawerSidebar extends React.PureComponent {
           ],
         });
       }
-      this.props.navigation.navigate(route.routeName, undefined, subAction);
+      this.props.navigation.dispatch(
+        NavigationActions.navigate({
+          routeName: route.routeName,
+          action: subAction,
+        })
+      );
     }
   };
 


### PR DESCRIPTION
Broken in v2 for top-level drawer navigators, because there is no helper here