### PR TITLE
Fix regression causing setting undefined value to isTransitioning

### DIFF
--- a/src/routers/StackRouter.js
+++ b/src/routers/StackRouter.js
@@ -327,7 +327,7 @@ export default (routeConfigs, stackConfig = {}) => {
             isTransitioning:
               state.index !== lastRouteIndex
                 ? action.immediate !== true
-                : undefined,
+                : state.isTransitioning,
             index: lastRouteIndex,
             routes,
           };


### PR DESCRIPTION
PR #3393 introduced a regression: in some cases a value of `isTransitioning` property of navigation state is lost.

In that PR there's a comment:

> // Return state with new index. Change isTransitioning only if index has changed

However, if index hasn't changed, `isTransitioning` becomes `undefined`. This PR makes `isTransitioning` to be indeed unchanged if index hasn't changed.

**Test plan**

You can check [this snack](https://snack.expo.io/@angly/istransitioning-issue) for demonstration. `stateAfterSecondNavigation` should have saved `isTransitioning` value from the previous state, which was `true`, but it became `undefined` (and because of that Expo's logging just don't print it at all). With this PR, it will preserve a value of `isTransitioning`.