### PR TITLE
Added ability to set titleOffset via options

### DIFF
--- a/src/views/Header/Header.js
+++ b/src/views/Header/Header.js
@@ -232,6 +232,19 @@ class Header extends React.PureComponent {
     const style = {};
     const { transitionPreset } = this.props;
 
+    const details = this.props.getScreenDetails(props.scene);
+    const { titleOffset } = details.options;
+
+    if (titleOffset) {
+      if (typeof titleOffset === 'number') {
+        style.left = titleOffset;
+        style.right = titleOffset;
+      } else if (typeof titleOffset === 'object') {
+        style.left = titleOffset.left;
+        style.right = titleOffset.right;
+      }
+    }
+
     if (Platform.OS === 'android') {
       if (!options.hasLeftComponent) {
         style.left = 0;

--- a/src/views/Header/Header.js
+++ b/src/views/Header/Header.js
@@ -240,8 +240,13 @@ class Header extends React.PureComponent {
         style.left = titleOffset;
         style.right = titleOffset;
       } else if (typeof titleOffset === 'object') {
-        style.left = titleOffset.left;
-        style.right = titleOffset.right;
+        if (typeof titleOffset.left === 'number') {
+          style.left = titleOffset.left;
+        }
+
+        if (typeof titleOffset.right === 'number') {
+          style.left = titleOffset.right;
+        }
       }
     }
 


### PR DESCRIPTION
Header component has hardcoded value of `titleOffset`, this PR add an ability to change the value via `navigationOptions`

supported number(set both left and right) or object ({ left: number, right: number })

Before:
```
| < Back               My awesome ti...                   |
```
After:  
```js
static navigationOptions = ({ navigation }) => ({
    title: 'My awesome header',
    titleOffset: 50,
})
```
```
| < Back               My awesome title                   |
```