### PR TITLE
Navigation Action Helpers at root

### DIFF
--- a/src/createNavigationContainer.js
+++ b/src/createNavigationContainer.js
@@ -5,6 +5,7 @@ import { polyfill } from 'react-lifecycles-compat';
 import { BackHandler } from './PlatformHelpers';
 import NavigationActions from './NavigationActions';
 import invariant from './utils/invariant';
+import getNavigationActionCreators from './routers/getNavigationActionCreators';
 import docsUrl from './utils/docsUrl';
 
 function isStateful(props) {
@@ -359,6 +360,11 @@ export default function createNavigationContainer(Component) {
               };
             },
           };
+          const actionCreators = getNavigationActionCreators(nav);
+          Object.keys(actionCreators).forEach(actionName => {
+            this._navigation[actionName] = (...args) =>
+              this.dispatch(actionCreators[actionName](...args));
+          });
         }
         navigation = this._navigation;
       }

--- a/src/routers/StackRouter.js
+++ b/src/routers/StackRouter.js
@@ -164,7 +164,7 @@ export default (routeConfigs, stackConfig = {}) => {
 
     getActionCreators(route, navStateKey) {
       return {
-        ...getNavigationActionCreators(route, navStateKey),
+        ...getNavigationActionCreators(route),
         ...getCustomActionCreators(route, navStateKey),
         pop: (n, params) =>
           StackActions.pop({

--- a/src/routers/SwitchRouter.js
+++ b/src/routers/SwitchRouter.js
@@ -108,7 +108,7 @@ export default (routeConfigs, config = {}) => {
 
     getActionCreators(route, stateKey) {
       return {
-        ...getNavigationActionCreators(route, stateKey),
+        ...getNavigationActionCreators(route),
         ...getCustomActionCreators(route, stateKey),
       };
     },


### PR DESCRIPTION
Top level navigation prop can have these helpers at least, to make sure navigation.navigate and .goBack are always available. Won't break anything and it will ease the transition from addNavigationHelpers