### PR TITLE
Fix exposing undefined actions in addNavigationHelpers

### DIFF
--- a/src/addNavigationHelpers.js
+++ b/src/addNavigationHelpers.js
@@ -51,14 +51,6 @@ export default function(navigation) {
       );
       return navigation.dispatch(NavigationActions.navigate(navigateTo));
     },
-    pop: (n, params) =>
-      navigation.dispatch(
-        NavigationActions.pop({ n, immediate: params && params.immediate })
-      ),
-    popToTop: params =>
-      navigation.dispatch(
-        NavigationActions.popToTop({ immediate: params && params.immediate })
-      ),
     /**
      * For updating current route params. For example the nav bar title and
      * buttons are based on the route params.
@@ -82,24 +74,5 @@ export default function(navigation) {
 
       return defaultValue;
     },
-
-    push: (routeName, params, action) =>
-      navigation.dispatch(
-        NavigationActions.push({ routeName, params, action })
-      ),
-
-    replace: (routeName, params, action) =>
-      navigation.dispatch(
-        NavigationActions.replace({
-          routeName,
-          params,
-          action,
-          key: navigation.state.key,
-        })
-      ),
-
-    openDrawer: () => navigation.dispatch(NavigationActions.openDrawer()),
-    closeDrawer: () => navigation.dispatch(NavigationActions.closeDrawer()),
-    toggleDrawer: () => navigation.dispatch(NavigationActions.toggleDrawer()),
   };
 }


### PR DESCRIPTION
While upgrading our codebase to react-nav 2.0, I noticed that there were some uses of NavigationActions internally within react-navigation that _appeared_ accidental.  Further reviewing the code, this does not appear to part of the public API (however, we were using it for react-native-web support).  So potentially this should be removed entirely, in favor of `router.createActionCreators`.

I'll leave it up to the maintainers to determine what the correct fix is.  This just popped up in my search when I was migrating `NavigationActions` -> `StackActions` in our internal code, and I thought I'd raise it here.