### PR TITLE
Added ability to set titleOffset via options

### DIFF
--- a/src/views/Header/Header.js
+++ b/src/views/Header/Header.js
@@ -239,7 +239,6 @@ class Header extends React.PureComponent {
   _renderTitle(props, options) {
     const style = {};
     const { transitionPreset } = this.props;
-
     const { options: { titleOffset } } = props.scene.descriptor;
 
     if (titleOffset) {
@@ -252,7 +251,7 @@ class Header extends React.PureComponent {
         }
 
         if (typeof titleOffset.right === 'number') {
-          style.left = titleOffset.right;
+          style.right = titleOffset.right;
         }
       }
     }

--- a/src/views/Header/Header.js
+++ b/src/views/Header/Header.js
@@ -254,22 +254,22 @@ class Header extends React.PureComponent {
           style.right = titleOffset.right;
         }
       }
-    }
-
-    if (Platform.OS === 'android') {
-      if (!options.hasLeftComponent) {
+    } else {
+      if (Platform.OS === 'android') {
+        if (!options.hasLeftComponent) {
+          style.left = 0;
+        }
+        if (!options.hasRightComponent) {
+          style.right = 0;
+        }
+      } else if (
+        Platform.OS === 'ios' &&
+        !options.hasLeftComponent &&
+        !options.hasRightComponent
+      ) {
         style.left = 0;
-      }
-      if (!options.hasRightComponent) {
         style.right = 0;
       }
-    } else if (
-      Platform.OS === 'ios' &&
-      !options.hasLeftComponent &&
-      !options.hasRightComponent
-    ) {
-      style.left = 0;
-      style.right = 0;
     }
 
     return this._renderSubView(

--- a/src/views/Header/Header.js
+++ b/src/views/Header/Header.js
@@ -240,6 +240,24 @@ class Header extends React.PureComponent {
     const style = {};
     const { transitionPreset } = this.props;
 
+    const details = this.props.getScreenDetails(props.scene);
+    const { titleOffset } = details.options;
+
+    if (titleOffset) {
+      if (typeof titleOffset === 'number') {
+        style.left = titleOffset;
+        style.right = titleOffset;
+      } else if (typeof titleOffset === 'object') {
+        if (typeof titleOffset.left === 'number') {
+          style.left = titleOffset.left;
+        }
+
+        if (typeof titleOffset.right === 'number') {
+          style.left = titleOffset.right;
+        }
+      }
+    }
+
     if (Platform.OS === 'android') {
       if (!options.hasLeftComponent) {
         style.left = 0;

--- a/src/views/Header/Header.js
+++ b/src/views/Header/Header.js
@@ -240,8 +240,7 @@ class Header extends React.PureComponent {
     const style = {};
     const { transitionPreset } = this.props;
 
-    const details = this.props.getScreenDetails(props.scene);
-    const { titleOffset } = details.options;
+    const { options: { titleOffset } } = props.scene.descriptor;
 
     if (titleOffset) {
       if (typeof titleOffset === 'number') {


### PR DESCRIPTION
Header component has hardcoded value of `titleOffset`, this PR add an ability to change the value via `navigationOptions`

supported number(set both left and right) or object ({ left: number, right: number })

Before:
```
| < Back               My awesome ti...              Done |
```
After:  
```js
static navigationOptions = ({ navigation }) => ({
    title: 'My awesome title',
    titleOffset: 50,
})
```
```
| < Back               My awesome title              Done |
```

The main goal of this is to give a title more space, especially on small iOS devices such as 5s, SE... when you have 320px screen width, back icon and right button "Done" long title will be truncated... in this case the title has width about 180px but it should be longer...

also this can help with https://github.com/react-navigation/react-navigation/issues/842 https://github.com/react-navigation/react-navigation/issues/253

Prev PR to 1.x branch https://github.com/react-navigation/react-navigation/pull/4145