### PR TITLE
Fix missing NavigationActions.replace flow type

### DIFF
--- a/flow/react-navigation.js
+++ b/flow/react-navigation.js
@@ -722,6 +722,7 @@ declare module 'react-navigation' {
     INIT: 'Navigation/INIT',
     NAVIGATE: 'Navigation/NAVIGATE',
     RESET: 'Navigation/RESET',
+    REPLACE = 'Navigation/REPLACE',
     SET_PARAMS: 'Navigation/SET_PARAMS',
     URI: 'Navigation/URI',
     back: {
@@ -746,6 +747,17 @@ declare module 'react-navigation' {
         key?: ?string,
         actions: Array<NavigationNavigateAction>,
       }): NavigationResetAction,
+      toString: () => string,
+    },
+    replace: {
+      (payload: {
+        routeName: string,
+        key: string,
+        newKey?: ?string,
+        params?: ?NavigationParams,
+        action?: ?NavigationNavigateAction,
+        immediate?: ?boolean,
+      }): NavigationReplaceAction,
       toString: () => string,
     },
     setParams: {


### PR DESCRIPTION
This PR adds flow type definition for `NavigationActions.replace()` method