### PR TITLE
Use Animated.Image for back button

### DIFF
--- a/src/views/Header/HeaderBackButton.js
+++ b/src/views/Header/HeaderBackButton.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import {
+  Animated,
   I18nManager,
   Image,
   Text,
@@ -47,7 +48,7 @@ class HeaderBackButton extends React.PureComponent {
         title,
       };
     } else {
-      BackImage = Image;
+      BackImage = Animated.Image;
       props = {
         style: [
           styles.icon,

--- a/src/views/Header/ModularHeaderBackButton.js
+++ b/src/views/Header/ModularHeaderBackButton.js
@@ -1,5 +1,12 @@
 import React from 'react';
-import { I18nManager, Image, Text, View, StyleSheet } from 'react-native';
+import {
+  Animated,
+  I18nManager,
+  Image,
+  Text,
+  View,
+  StyleSheet,
+} from 'react-native';
 
 import TouchableItem from '../TouchableItem';
 
@@ -37,7 +44,7 @@ class ModularHeaderBackButton extends React.PureComponent {
         title,
       };
     } else {
-      BackImage = Image;
+      BackImage = Animated.Image;
       props = {
         style: [
           styles.icon,


### PR DESCRIPTION
**Motivation**:
Current behavior: when tintColor is an animated value (e.g. interpolated scroll position) only title color is changed, back button doesn't respect this changes

**Fix**:
Use `Animated.Image` instead of `Image` for default back button
