### PR TITLE
Apply DrawerLockMode from DrawerScreen options to DrawerLayout component

### DIFF
--- a/src/views/Drawer/DrawerView.js
+++ b/src/views/Drawer/DrawerView.js
@@ -93,6 +93,7 @@ export default class DrawerView extends React.PureComponent {
           this._drawer = c;
         }}
         drawerLockMode={
+          drawerLockMode ||
           (this.props.screenProps && this.props.screenProps.drawerLockMode) ||
           this.props.navigationConfig.drawerLockMode
         }


### PR DESCRIPTION
While migrating from v1 to v2, I lost the `navigationOptions through tree` feature and had to implement an alternative way to enable/disable the `DrawerLockMode` on `DrawerNavigator` .

> In previous version of React Navigation, the library used to dig through your component tree to find navigationOptions. This is no longer the case, and only navigationOptions on screen components of a particular navigator will apply to that navigator. You can read more about this in the Navigation options resolution guide.
[react-navigation v2 documentation](https://reactnavigation.org/docs/en/common-mistakes.html)

Looking at the code, seams like `DrawerLockMode` from `DrawerScreen options` is **read, initialised, but never used**. Might be a simple mistake, but this allow to be more flexible and I think would make sense to have 👍

Fix #4201
