### PR TITLE
[Web] Fix header height margin

### DIFF
--- a/src/views/StackView/StackViewLayout.js
+++ b/src/views/StackView/StackViewLayout.js
@@ -518,15 +518,17 @@ class StackViewLayout extends React.Component {
     if (!hasHeader && headerMode === 'float') {
       const { isLandscape } = this.props;
       let headerHeight;
-      if (Platform.OS === 'android') {
-        // TODO: Need to handle translucent status bar.
-        headerHeight = 56;
-      } else if (isLandscape && !Platform.isPad) {
-        headerHeight = 52;
-      } else if (IS_IPHONE_X) {
-        headerHeight = 88;
+      if (Platform.OS === 'ios') {
+        if (isLandscape && !Platform.isPad) {
+          headerHeight = 52;
+        } else if (IS_IPHONE_X) {
+          headerHeight = 88;
+        } else {
+          headerHeight = 64;
+        }
       } else {
-        headerHeight = 64;
+        headerHeight = 56;
+        // TODO (Android only): Need to handle translucent status bar.
       }
       marginTop = -headerHeight;
     }


### PR DESCRIPTION
Hello, this is a follow-up of this [commit comment](https://github.com/react-navigation/react-navigation/pull/4017#pullrequestreview-119239864): I noticed that on the web the header margin for the StackNavigator was off of several pixels. This is because the [condition](https://github.com/react-navigation/react-navigation/blob/master/src/views/StackView/StackViewLayout.js#L521) to target the platform is inversed compared to the condition for the app bar height [here](https://github.com/react-navigation/react-navigation/blob/master/src/views/Header/Header.js#L27). This may be worth refactoring in a separate PR (although there's no mention of the iPhone X on the latter file), let me know :)

**Test plan (required)**

* [Before](https://user-images.githubusercontent.com/82368/39893204-5387d78e-54a3-11e8-93d1-d82583935ba1.png)
* [After](https://user-images.githubusercontent.com/82368/39921360-e2a6117a-551a-11e8-9a02-a63d28f29470.png)

Also checked on Android and iOS devices.