### PR TITLE
passActiveRouteOption to support nested configs

### DIFF
--- a/examples/NavigationPlayground/js/StacksOverTabs.js
+++ b/examples/NavigationPlayground/js/StacksOverTabs.js
@@ -8,6 +8,7 @@ import {
   SafeAreaView,
   createStackNavigator,
   createBottomTabNavigator,
+  passActiveRouteOption,
 } from 'react-navigation';
 
 import Ionicons from 'react-native-vector-icons/Ionicons';
@@ -61,7 +62,7 @@ const TabNav = createBottomTabNavigator(
       screen: MyHomeScreen,
       path: '/',
       navigationOptions: {
-        title: 'Welcome',
+        headerTitle: 'Welcome',
         tabBarLabel: 'Home',
         tabBarIcon: ({ tintColor, focused }) => (
           <Ionicons
@@ -75,8 +76,14 @@ const TabNav = createBottomTabNavigator(
     SettingsTab: {
       screen: MySettingsScreen,
       path: '/settings',
-      navigationOptions: {
-        title: 'Settings',
+      navigationOptions: ({ navigation }) => ({
+        headerTitle: 'Settings',
+        headerRight: (
+          <Button
+            title="Help"
+            onPress={() => navigation.navigate('NotifSettings')}
+          />
+        ),
         tabBarIcon: ({ tintColor, focused }) => (
           <Ionicons
             name={focused ? 'ios-settings' : 'ios-settings-outline'}
@@ -84,7 +91,7 @@ const TabNav = createBottomTabNavigator(
             style={{ color: tintColor }}
           />
         ),
-      },
+      }),
     },
   },
   {
@@ -93,6 +100,13 @@ const TabNav = createBottomTabNavigator(
     swipeEnabled: false,
   }
 );
+
+TabNav.navigationOptions = ({ navigation }) => {
+  return {
+    headerTitle: passActiveRouteOption(navigation, 'headerTitle'),
+    headerRight: passActiveRouteOption(navigation, 'headerRight'),
+  };
+};
 
 const StacksOverTabs = createStackNavigator({
   Root: {
@@ -107,9 +121,9 @@ const StacksOverTabs = createStackNavigator({
   Profile: {
     screen: MyProfileScreen,
     path: '/people/:name',
-    navigationOptions: ({ navigation }) => {
-      title: `${navigation.state.params.name}'s Profile!`;
-    },
+    navigationOptions: ({ navigation }) => ({
+      title: `${navigation.state.params.name}'s Profile!`,
+    }),
   },
 });
 

--- a/flow/react-navigation.js
+++ b/flow/react-navigation.js
@@ -762,6 +762,12 @@ declare module 'react-navigation' {
     navigation: NavigationScreenProp<S>,
   }>;
 
+  declare export function passActiveRouteOption<OptionType: *>(
+    navigation: NavigationScreenProp<*>,
+    optionName: string,
+    defaultValue: OptionType
+  ): OptionType;
+
   declare export function createNavigator<O: *, S: *, NavigatorConfig: *>(
     view: NavigationView<O, S>,
     router: NavigationRouter<S, O>,

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "create-react-context": "^0.2.1",
     "hoist-non-react-statics": "^2.2.0",
     "path-to-regexp": "^1.7.0",
-    "prop-types": "^15.5.10",
     "react-lifecycles-compat": "^3",
     "react-native-drawer-layout-polyfill": "^1.3.2",
     "react-native-safe-area-view": "^0.7.0",

--- a/src/createChildNavigationGetter.js
+++ b/src/createChildNavigationGetter.js
@@ -1,0 +1,79 @@
+import getChildEventSubscriber from './getChildEventSubscriber';
+
+const createParamGetter = route => (paramName, defaultValue) => {
+  const params = route.params;
+
+  if (params && paramName in params) {
+    return params[paramName];
+  }
+
+  return defaultValue;
+};
+
+function createChildNavigationGetter(navigation, childKey) {
+  const children =
+    navigation.childrenNavigation || (navigation.childrenNavigation = {});
+
+  const route = navigation.state.routes.find(r => r.key === childKey);
+
+  if (children[childKey] && children[childKey].state === route) {
+    return children[childKey];
+  }
+
+  const childRouters = navigation.router.childRouters || {};
+
+  const actionCreators = {
+    ...navigation.actions,
+    ...navigation.router.getActionCreators(route, navigation.state.key),
+  };
+  const actionHelpers = {};
+  Object.keys(actionCreators).forEach(actionName => {
+    actionHelpers[actionName] = (...args) => {
+      const actionCreator = actionCreators[actionName];
+      const action = actionCreator(...args);
+      navigation.dispatch(action);
+    };
+  });
+
+  if (children[childKey]) {
+    children[childKey] = {
+      ...children[childKey],
+      ...actionHelpers,
+      state: route,
+      router: childRouters[route.routeName],
+      actions: actionCreators,
+      getParam: createParamGetter(route),
+    };
+    return children[childKey];
+  }
+
+  const childSubscriber = getChildEventSubscriber(
+    navigation.addListener,
+    childKey
+  );
+
+  children[childKey] = {
+    ...actionHelpers,
+
+    state: route,
+    router: childRouters[route.routeName],
+    actions: actionCreators,
+    getParam: createParamGetter(route),
+
+    getChildNavigation: grandChildKey =>
+      createChildNavigationGetter(children[childKey], grandChildKey),
+
+    isFocused: () => {
+      const { state } = navigation;
+      const focusedRoute = state.routes[state.index];
+      return children[childKey].state === focusedRoute;
+    },
+    dispatch: navigation.dispatch,
+    getScreenProps: navigation.getScreenProps,
+    dangerouslyGetParent: () => navigation,
+    addListener: childSubscriber.addListener,
+  };
+  return children[childKey];
+}
+
+export default createChildNavigationGetter;

--- a/src/createNavigationContainer.js
+++ b/src/createNavigationContainer.js
@@ -6,6 +6,7 @@ import { BackHandler } from './PlatformHelpers';
 import NavigationActions from './NavigationActions';
 import invariant from './utils/invariant';
 import getNavigationActionCreators from './routers/getNavigationActionCreators';
+import createChildNavigationGetter from './createChildNavigationGetter';
 import docsUrl from './utils/docsUrl';
 
 function isStateful(props) {
@@ -352,36 +353,54 @@ export default function createNavigationContainer(Component) {
       return false;
     };
 
+    _addNavigationListener = (eventName, handler) => {
+      if (eventName !== 'action') {
+        return { remove: () => {} };
+      }
+      this._actionEventSubscribers.add(handler);
+      return {
+        remove: () => {
+          this._actionEventSubscribers.delete(handler);
+        },
+      };
+    };
+
+    _getNavigation() {
+      if (this._navigation && this._navigation.state === this.state.nav) {
+        return this._navigation;
+      }
+
+      this._navigation = {
+        state: this.state.nav,
+        dispatch: this.dispatch,
+        getScreenProps: () => this.props.screenProps,
+        getChildNavigation: childKey =>
+          createChildNavigationGetter(this._navigation, childKey),
+        router: Component.router,
+        addListener: this._addNavigationListener,
+        dangerouslyGetParent: () => null,
+      };
+
+      const actionCreators = getNavigationActionCreators(
+        this._navigation.state
+      );
+
+      Object.keys(actionCreators).forEach(actionName => {
+        this._navigation[actionName] = (...args) =>
+          this._navigation.dispatch(actionCreators[actionName](...args));
+      });
+
+      return this._navigation;
+    }
+
     render() {
       let navigation = this.props.navigation;
+      const { screenProps } = this.props;
       if (this._isStateful()) {
-        const nav = this.state.nav;
-        if (!nav) {
+        if (!this.state.nav) {
           return this._renderLoading();
         }
-        if (!this._navigation || this._navigation.state !== nav) {
-          this._navigation = {
-            dispatch: this.dispatch,
-            state: nav,
-            addListener: (eventName, handler) => {
-              if (eventName !== 'action') {
-                return { remove: () => {} };
-              }
-              this._actionEventSubscribers.add(handler);
-              return {
-                remove: () => {
-                  this._actionEventSubscribers.delete(handler);
-                },
-              };
-            },
-          };
-          const actionCreators = getNavigationActionCreators(nav);
-          Object.keys(actionCreators).forEach(actionName => {
-            this._navigation[actionName] = (...args) =>
-              this.dispatch(actionCreators[actionName](...args));
-          });
-        }
-        navigation = this._navigation;
+        navigation = this._getNavigation();
       }
       invariant(navigation, 'failed to get navigation');
       return <Component {...this.props} navigation={navigation} />;

--- a/src/navigators/createContainedDrawerNavigator.js
+++ b/src/navigators/createContainedDrawerNavigator.js
@@ -1,0 +1,9 @@
+import createNavigationContainer from '../createNavigationContainer';
+import createDrawerNavigator from './createDrawerNavigator';
+
+const DrawerNavigator = (routeConfigs, config = {}) => {
+  const navigator = createDrawerNavigator(routeConfigs, config);
+  return createNavigationContainer(navigator);
+};
+
+export default DrawerNavigator;

--- a/src/navigators/createContainedStackNavigator.js
+++ b/src/navigators/createContainedStackNavigator.js
@@ -1,0 +1,9 @@
+import createNavigationContainer from '../createNavigationContainer';
+import createStackNavigator from './createStackNavigator';
+
+const StackNavigator = (routeConfigs, config = {}) => {
+  const navigator = createStackNavigator(routeConfigs, config);
+  return createNavigationContainer(navigator);
+};
+
+export default StackNavigator;

--- a/src/navigators/createContainedSwitchNavigator.js
+++ b/src/navigators/createContainedSwitchNavigator.js
@@ -1,0 +1,9 @@
+import createNavigationContainer from '../createNavigationContainer';
+import createSwitchNavigator from './createSwitchNavigator';
+
+const SwitchNavigator = (routeConfigs, config = {}) => {
+  const navigator = createSwitchNavigator(routeConfigs, config);
+  return createNavigationContainer(navigator);
+};
+
+export default SwitchNavigator;

--- a/src/navigators/createDrawerNavigator.js
+++ b/src/navigators/createDrawerNavigator.js
@@ -3,7 +3,6 @@ import { Dimensions, Platform, ScrollView } from 'react-native';
 import SafeAreaView from 'react-native-safe-area-view';
 
 import createNavigator from './createNavigator';
-import createNavigationContainer from '../createNavigationContainer';
 import DrawerRouter from '../routers/DrawerRouter';
 import DrawerScreen from '../views/Drawer/DrawerScreen';
 import DrawerView from '../views/Drawer/DrawerView';
@@ -63,9 +62,9 @@ const DrawerNavigator = (routeConfigs, config = {}) => {
 
   const drawerRouter = DrawerRouter(routeConfigs, routerConfig);
 
-  const navigator = createNavigator(DrawerView, drawerRouter, drawerConfig);
+  const Navigator = createNavigator(DrawerView, drawerRouter, drawerConfig);
 
-  return createNavigationContainer(navigator);
+  return Navigator;
 };
 
 export default DrawerNavigator;

--- a/src/navigators/createNavigator.js
+++ b/src/navigators/createNavigator.js
@@ -1,41 +1,12 @@
 import React from 'react';
 
-import getChildEventSubscriber from '../getChildEventSubscriber';
-
 function createNavigator(NavigatorView, router, navigationConfig) {
   class Navigator extends React.Component {
     static router = router;
     static navigationOptions = null;
 
-    childEventSubscribers = {};
-
-    // Cleanup subscriptions for routes that no longer exist
-    componentDidUpdate() {
-      const activeKeys = this.props.navigation.state.routes.map(r => r.key);
-      Object.keys(this.childEventSubscribers).forEach(key => {
-        if (!activeKeys.includes(key)) {
-          delete this.childEventSubscribers[key];
-        }
-      });
-    }
-
-    // Remove all subscription references
-    componentWillUnmount() {
-      this.childEventSubscribers = {};
-    }
-
-    _isRouteFocused = route => {
-      const { state } = this.props.navigation;
-      const focusedRoute = state.routes[state.index];
-      return route === focusedRoute;
-    };
-
-    _dangerouslyGetParent = () => {
-      return this.props.navigation;
-    };
-
     render() {
-      const { navigation, screenProps } = this.props;
+      const { navigation } = this.props;
       const { dispatch, state, addListener } = navigation;
       const { routes } = state;
 
@@ -44,45 +15,10 @@ function createNavigator(NavigatorView, router, navigationConfig) {
         const getComponent = () =>
           router.getComponentForRouteName(route.routeName);
 
-        if (!this.childEventSubscribers[route.key]) {
-          this.childEventSubscribers[route.key] = getChildEventSubscriber(
-            addListener,
-            route.key
-          );
-        }
+        const childNavigation = navigation.getChildNavigation(route.key);
 
-        const actionCreators = {
-          ...navigation.actions,
-          ...router.getActionCreators(route, state.key),
-        };
-        const actionHelpers = {};
-        Object.keys(actionCreators).forEach(actionName => {
-          actionHelpers[actionName] = (...args) => {
-            const actionCreator = actionCreators[actionName];
-            const action = actionCreator(...args);
-            dispatch(action);
-          };
-        });
-        const childNavigation = {
-          ...actionHelpers,
-          actions: actionCreators,
-          dispatch,
-          state: route,
-          isFocused: () => this._isRouteFocused(route),
-          dangerouslyGetParent: this._dangerouslyGetParent,
-          addListener: this.childEventSubscribers[route.key].addListener,
-          getParam: (paramName, defaultValue) => {
-            const params = route.params;
+        const options = router.getScreenOptions(childNavigation);
 
-            if (params && paramName in params) {
-              return params[paramName];
-            }
-
-            return defaultValue;
-          },
-        };
-
-        const options = router.getScreenOptions(childNavigation, screenProps);
         descriptors[route.key] = {
           key: route.key,
           getComponent,
@@ -95,7 +31,7 @@ function createNavigator(NavigatorView, router, navigationConfig) {
       return (
         <NavigatorView
           {...this.props}
-          screenProps={screenProps}
+          screenProps={navigation.getScreenProps()}
           navigation={navigation}
           navigationConfig={navigationConfig}
           descriptors={descriptors}

--- a/src/navigators/createStackNavigator.js
+++ b/src/navigators/createStackNavigator.js
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import createKeyboardAwareNavigator from './createKeyboardAwareNavigator';
 import createNavigator from './createNavigator';
 import StackView from '../views/StackView/StackView';

--- a/src/navigators/createStackNavigator.js
+++ b/src/navigators/createStackNavigator.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import createNavigationContainer from '../createNavigationContainer';
 import createKeyboardAwareNavigator from './createKeyboardAwareNavigator';
 import createNavigator from './createNavigator';
 import StackView from '../views/StackView/StackView';
@@ -31,8 +30,7 @@ function createStackNavigator(routeConfigMap, stackConfig = {}) {
     Navigator = createKeyboardAwareNavigator(Navigator);
   }
 
-  // HOC to provide the navigation prop for the top-level navigator (when the prop is missing)
-  return createNavigationContainer(Navigator);
+  return Navigator;
 }
 
 export default createStackNavigator;

--- a/src/navigators/createSwitchNavigator.js
+++ b/src/navigators/createSwitchNavigator.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import createNavigationContainer from '../createNavigationContainer';
 import createNavigator from '../navigators/createNavigator';
 import SwitchRouter from '../routers/SwitchRouter';
 import SwitchView from '../views/SwitchView/SwitchView';
@@ -7,7 +6,7 @@ import SwitchView from '../views/SwitchView/SwitchView';
 function createSwitchNavigator(routeConfigMap, switchConfig = {}) {
   const router = SwitchRouter(routeConfigMap, switchConfig);
   const Navigator = createNavigator(SwitchView, router, switchConfig);
-  return createNavigationContainer(Navigator);
+  return Navigator;
 }
 
 export default createSwitchNavigator;

--- a/src/react-navigation.js
+++ b/src/react-navigation.js
@@ -17,31 +17,31 @@ module.exports = {
     return require('./navigators/createNavigator').default;
   },
   get createStackNavigator() {
-    return require('./navigators/createStackNavigator').default;
+    return require('./navigators/createContainedStackNavigator').default;
   },
   get StackNavigator() {
     console.warn(
       'The StackNavigator function name is deprecated, please use createStackNavigator instead'
     );
-    return require('./navigators/createStackNavigator').default;
+    return require('./navigators/createContainedStackNavigator').default;
   },
   get createSwitchNavigator() {
-    return require('./navigators/createSwitchNavigator').default;
+    return require('./navigators/createContainedSwitchNavigator').default;
   },
   get SwitchNavigator() {
     console.warn(
       'The SwitchNavigator function name is deprecated, please use createSwitchNavigator instead'
     );
-    return require('./navigators/createSwitchNavigator').default;
+    return require('./navigators/createContainedSwitchNavigator').default;
   },
   get createDrawerNavigator() {
-    return require('./navigators/createDrawerNavigator').default;
+    return require('./navigators/createContainedDrawerNavigator').default;
   },
   get DrawerNavigator() {
     console.warn(
       'The DrawerNavigator function name is deprecated, please use createDrawerNavigator instead'
     );
-    return require('./navigators/createDrawerNavigator').default;
+    return require('./navigators/createContainedDrawerNavigator').default;
   },
   get createTabNavigator() {
     console.warn(

--- a/src/react-navigation.js
+++ b/src/react-navigation.js
@@ -8,6 +8,9 @@ module.exports = {
   get StateUtils() {
     return require('./StateUtils').default;
   },
+  get passActiveRouteOption() {
+    return require('./routers/passActiveRouteOption').default;
+  },
 
   // Navigators
   get createNavigator() {

--- a/src/routers/StackRouter.js
+++ b/src/routers/StackRouter.js
@@ -662,5 +662,7 @@ export default (routeConfigs, stackConfig = {}) => {
       routeConfigs,
       stackConfig.navigationOptions
     ),
+
+    childRouters,
   };
 };

--- a/src/routers/SwitchRouter.js
+++ b/src/routers/SwitchRouter.js
@@ -384,5 +384,7 @@ export default (routeConfigs, config = {}) => {
       routeConfigs,
       config.navigationOptions
     ),
+
+    childRouters,
   };
 };

--- a/src/routers/__tests__/Routers-test.js
+++ b/src/routers/__tests__/Routers-test.js
@@ -60,6 +60,7 @@ Object.keys(ROUTERS).forEach(routerName => {
         router.getScreenOptions(
           {
             state: routes[0],
+            getScreenProps: () => ({}),
             dispatch: () => false,
             addListener: dummyEventSubscriber,
           },
@@ -70,6 +71,7 @@ Object.keys(ROUTERS).forEach(routerName => {
         router.getScreenOptions(
           {
             state: routes[1],
+            getScreenProps: () => ({}),
             dispatch: () => false,
             addListener: dummyEventSubscriber,
           },
@@ -80,6 +82,7 @@ Object.keys(ROUTERS).forEach(routerName => {
         router.getScreenOptions(
           {
             state: routes[2],
+            getScreenProps: () => ({}),
             dispatch: () => false,
             addListener: dummyEventSubscriber,
           },

--- a/src/routers/__tests__/createConfigGetter-test.js
+++ b/src/routers/__tests__/createConfigGetter-test.js
@@ -68,6 +68,7 @@ test('should get config for screen', () => {
     getScreenOptions(
       {
         state: routes[0],
+        getScreenProps: () => ({}),
         dispatch: () => false,
         addListener: dummyEventSubscriber,
       },
@@ -78,6 +79,7 @@ test('should get config for screen', () => {
     getScreenOptions(
       {
         state: routes[1],
+        getScreenProps: () => ({}),
         dispatch: () => false,
         addListener: dummyEventSubscriber,
       },
@@ -88,6 +90,7 @@ test('should get config for screen', () => {
     getScreenOptions(
       {
         state: routes[0],
+        getScreenProps: () => ({}),
         dispatch: () => false,
         addListener: dummyEventSubscriber,
       },
@@ -98,6 +101,7 @@ test('should get config for screen', () => {
     getScreenOptions(
       {
         state: routes[2],
+        getScreenProps: () => ({}),
         dispatch: () => false,
         addListener: dummyEventSubscriber,
       },
@@ -108,6 +112,7 @@ test('should get config for screen', () => {
     getScreenOptions(
       {
         state: routes[2],
+        getScreenProps: () => ({}),
         dispatch: () => false,
         addListener: dummyEventSubscriber,
       },
@@ -118,6 +123,7 @@ test('should get config for screen', () => {
     getScreenOptions(
       {
         state: routes[3],
+        getScreenProps: () => ({}),
         dispatch: () => false,
         addListener: dummyEventSubscriber,
       },
@@ -128,6 +134,7 @@ test('should get config for screen', () => {
     getScreenOptions(
       {
         state: routes[3],
+        getScreenProps: () => ({}),
         dispatch: () => false,
         addListener: dummyEventSubscriber,
       },
@@ -138,6 +145,7 @@ test('should get config for screen', () => {
     getScreenOptions(
       {
         state: routes[4],
+        getScreenProps: () => ({}),
         dispatch: () => false,
         addListener: dummyEventSubscriber,
       },
@@ -165,6 +173,7 @@ test('should throw if the route does not exist', () => {
     getScreenOptions(
       {
         state: routes[0],
+        getScreenProps: () => ({}),
         dispatch: () => false,
         addListener: dummyEventSubscriber,
       },

--- a/src/routers/createConfigGetter.js
+++ b/src/routers/createConfigGetter.js
@@ -22,10 +22,7 @@ function applyConfig(configurer, navigationOptions, configProps) {
   return navigationOptions;
 }
 
-export default (routeConfigs, navigatorScreenConfig) => (
-  navigation,
-  screenProps
-) => {
+export default (routeConfigs, navigatorScreenConfig) => navigation => {
   const { state, dispatch } = navigation;
   const route = state;
 
@@ -42,7 +39,10 @@ export default (routeConfigs, navigatorScreenConfig) => (
     routeConfig === Component ? null : routeConfig.navigationOptions;
   const componentScreenConfig = Component.navigationOptions;
 
-  const configOptions = { navigation, screenProps: screenProps || {} };
+  const configOptions = {
+    navigation,
+    screenProps: navigation.getScreenProps() || {},
+  };
 
   let outputConfig = applyConfig(navigatorScreenConfig, {}, configOptions);
   outputConfig = applyConfig(

--- a/src/routers/passActiveRouteOption.js
+++ b/src/routers/passActiveRouteOption.js
@@ -1,0 +1,15 @@
+const passActiveRouteOption = (nav, optionName, defaultValue = undefined) => {
+  const parentNav = nav.dangerouslyGetParent();
+  if (!parentNav) {
+    return undefined;
+  }
+  const router = parentNav.router.childRouters[nav.state.routeName];
+  const activeRoute = nav.state.routes[nav.state.index];
+
+  const childNav = nav.getChildNavigation(activeRoute.key);
+  const opts = router.getScreenOptions(childNav);
+
+  return opts[optionName];
+};
+
+export default passActiveRouteOption;

--- a/src/routers/validateRouteConfigMap.js
+++ b/src/routers/validateRouteConfigMap.js
@@ -21,25 +21,25 @@ function validateRouteConfigMap(routeConfigs) {
         typeof screenComponent !== 'string' &&
         !routeConfig.getScreen)
     ) {
-      throw new Error(
-        `The component for route '${routeName}' must be a ` +
-          'React component. For example:\n\n' +
-          "import MyScreen from './MyScreen';\n" +
-          '...\n' +
-          `${routeName}: MyScreen,\n` +
-          '}\n\n' +
-          'You can also use a navigator:\n\n' +
-          "import MyNavigator from './MyNavigator';\n" +
-          '...\n' +
-          `${routeName}: MyNavigator,\n` +
-          '}'
-      );
+      throw new Error(`The component for route '${routeName}' must be a
+React component. For example:
+
+import MyScreen from './MyScreen';
+...
+${routeName}: MyScreen,
+
+You can also use a navigator:
+
+import MyNavigator from './MyNavigator';
+...
+${routeName}: MyNavigator,
+
+`);
     }
 
     if (routeConfig.screen && routeConfig.getScreen) {
       throw new Error(
-        `Route '${routeName}' should declare a screen or ` +
-          'a getScreen, not both.'
+        `Route '${routeName}' should declare a screen or a getScreen, not both.`
       );
     }
   });

--- a/src/utils/invariant.js
+++ b/src/utils/invariant.js
@@ -1,15 +1,4 @@
 /**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
- *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
- */
-
-'use strict';
-
-/**
  * Use invariant() to assert state which your program assumes to be true.
  *
  * Provide sprintf-style format (only %s is supported) and arguments

--- a/src/utils/shallowEqual.js
+++ b/src/utils/shallowEqual.js
@@ -1,19 +1,3 @@
-/**
- * Copyright (c) 2013-present, Facebook, Inc.
- * All rights reserved.
- *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
- *
- * @typechecks
- *
- */
-
-/*eslint-disable no-self-compare */
-
-'use strict';
-
 const hasOwnProperty = Object.prototype.hasOwnProperty;
 
 /**
@@ -71,4 +55,4 @@ function shallowEqual(objA, objB) {
   return true;
 }
 
-module.exports = shallowEqual;
+export default shallowEqual;

--- a/src/utils/shallowEqual.js
+++ b/src/utils/shallowEqual.js
@@ -1,3 +1,5 @@
+/*eslint-disable no-self-compare */
+
 const hasOwnProperty = Object.prototype.hasOwnProperty;
 
 /**

--- a/src/views/NavigationConsumer.js
+++ b/src/views/NavigationConsumer.js
@@ -1,0 +1,3 @@
+import { NavigationConsumer } from './NavigationContext';
+
+export default NavigationConsumer;

--- a/src/views/NavigationContext.js
+++ b/src/views/NavigationContext.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import propTypes from 'prop-types';
 import createReactContext from 'create-react-context';
 
 const NavigationContext = createReactContext();

--- a/src/views/NavigationProvider.js
+++ b/src/views/NavigationProvider.js
@@ -1,0 +1,3 @@
+import { NavigationProvider } from './NavigationContext';
+
+export default NavigationProvider;

--- a/src/views/SceneView.js
+++ b/src/views/SceneView.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import propTypes from 'prop-types';
 import { NavigationProvider } from './NavigationContext';
 
 export default class SceneView extends React.PureComponent {

--- a/src/views/StackView/StackView.js
+++ b/src/views/StackView/StackView.js
@@ -3,7 +3,6 @@ import { NativeModules } from 'react-native';
 
 import StackViewLayout from './StackViewLayout';
 import Transitioner from '../Transitioner';
-import NavigationActions from '../../NavigationActions';
 import StackActions from '../../routers/StackActions';
 import TransitionConfigs from './StackViewTransitionConfigs';
 

--- a/src/views/StackView/StackViewLayout.js
+++ b/src/views/StackView/StackViewLayout.js
@@ -228,7 +228,7 @@ class StackViewLayout extends React.Component {
     },
     onMoveShouldSetPanResponder: (event, gesture) => {
       const {
-        transitionProps: { navigation, position, layout, scene, scenes },
+        transitionProps: { navigation, layout, scene },
         mode,
       } = this.props;
       const { index } = navigation.state;
@@ -396,18 +396,10 @@ class StackViewLayout extends React.Component {
       );
     }
     const {
-      transitionProps: { navigation, position, layout, scene, scenes },
+      transitionProps: { scene, scenes },
       mode,
     } = this.props;
-    const { index } = navigation.state;
-    const isVertical = mode === 'modal';
     const { options } = scene.descriptor;
-    const gestureDirection = options.gestureDirection;
-
-    const gestureDirectionInverted =
-      typeof gestureDirection === 'string'
-        ? gestureDirection === 'inverted'
-        : I18nManager.isRTL;
 
     const gesturesEnabled =
       typeof options.gesturesEnabled === 'boolean'

--- a/src/views/StackView/StackViewLayout.js
+++ b/src/views/StackView/StackViewLayout.js
@@ -219,7 +219,7 @@ class StackViewLayout extends React.Component {
         return false;
       }
 
-      position.stopAnimation((value: number) => {
+      position.stopAnimation(value => {
         this._isResponding = true;
         this._gestureStartValue = value;
       });

--- a/src/views/StackView/StackViewLayout.js
+++ b/src/views/StackView/StackViewLayout.js
@@ -21,7 +21,7 @@ import withOrientation from '../withOrientation';
 import { NavigationProvider } from '../NavigationContext';
 
 import TransitionConfigs from './StackViewTransitionConfigs';
-import * as ReactNativeFeatures from '../../utils/ReactNativeFeatures';
+import { supportsImprovedSpringAnimation } from '../../utils/ReactNativeFeatures';
 
 const emptyFunction = () => {};
 
@@ -145,10 +145,7 @@ class StackViewLayout extends React.Component {
   }
 
   _reset(resetToIndex, duration) {
-    if (
-      Platform.OS === 'ios' &&
-      ReactNativeFeatures.supportsImprovedSpringAnimation()
-    ) {
+    if (Platform.OS === 'ios' && supportsImprovedSpringAnimation()) {
       Animated.spring(this.props.transitionProps.position, {
         toValue: resetToIndex,
         stiffness: 5000,
@@ -188,10 +185,7 @@ class StackViewLayout extends React.Component {
       }
     };
 
-    if (
-      Platform.OS === 'ios' &&
-      ReactNativeFeatures.supportsImprovedSpringAnimation()
-    ) {
+    if (Platform.OS === 'ios' && supportsImprovedSpringAnimation()) {
       Animated.spring(position, {
         toValue,
         stiffness: 5000,

--- a/src/views/StackView/StackViewLayout.js
+++ b/src/views/StackView/StackViewLayout.js
@@ -206,6 +206,7 @@ class StackViewLayout extends React.Component {
   _panResponder = PanResponder.create({
     onPanResponderTerminate: () => {
       this._isResponding = false;
+      const { index } = this.props.navigation.state;
       this._reset(index, 0);
       this.props.onGestureCanceled && this.props.onGestureCanceled();
     },

--- a/src/views/StackView/StackViewTransitionConfigs.js
+++ b/src/views/StackView/StackViewTransitionConfigs.js
@@ -1,9 +1,9 @@
 import { Animated, Easing, Platform } from 'react-native';
 import StyleInterpolator from './StackViewStyleInterpolator';
-import * as ReactNativeFeatures from '../../utils/ReactNativeFeatures';
+import { supportsImprovedSpringAnimation } from '../../utils/ReactNativeFeatures';
 
 let IOSTransitionSpec;
-if (ReactNativeFeatures.supportsImprovedSpringAnimation()) {
+if (supportsImprovedSpringAnimation()) {
   // These are the exact values from UINavigationController's animation configuration
   IOSTransitionSpec = {
     timing: Animated.spring,


### PR DESCRIPTION
New API to support nested configuration, such as the header title within the “StacksOverTabs” example. In v2, this nested configuration behavior is explicit.

While I’m happy with the new API and don’t see any bugs, this is a pretty invasive change to the core code, and we should review the changes to the navigation prop. The following new pieces of API have been added:

- passActiveRouteOption. See how its used in `StacksOverTabs.js`
- router.childRouters, a map of routeName to child router. Needed for static access to child router
- navigation.router refers to the router that maintains the navigation state. This should be safe
- navigation.childrenNavigation is a map of route key to child navigation objects. This might be ok, but might be a footgun
- navigation.getScreenProps, added as a convenience and I think it is safe. Maybe should rename to discourage screenProps usage altogether.
- navigation.getChildNavigation. This is how all children navigation props are accessed, and is important for the new nested configurer to get access to the child navigation prop

Lots of changed code:

- big changes to navigation prop and createNavigationContainer will break redux support
- dangerously get parent seems less dangerous now, so I use it within passActiveRouteOption
- subscriptions (addListener) are now cached inside the child navigation creator

So this does seem to address the problem fine, but I think we should be careful moving forward here. Careful code review would be appreciated!
