### PR TITLE
Fix broken tabs-in-drawer behavior

### DIFF
--- a/src/views/Drawer/DrawerSidebar.js
+++ b/src/views/Drawer/DrawerSidebar.js
@@ -46,23 +46,9 @@ class DrawerSidebar extends React.PureComponent {
 
   _onItemPress = ({ route, focused }) => {
     if (!focused) {
-      let subAction;
-      // TODO (v3): Revisit and repeal this behavior:
-      // if the child screen is a StackRouter then always navigate to its first screen (see #1914)
-      if (route.index != null && route.index !== 0) {
-        subAction = StackActions.reset({
-          index: 0,
-          actions: [
-            NavigationActions.navigate({
-              routeName: route.routes[0].routeName,
-            }),
-          ],
-        });
-      }
       this.props.navigation.dispatch(
         NavigationActions.navigate({
           routeName: route.routeName,
-          action: subAction,
         })
       );
     }


### PR DESCRIPTION
This code assumes that the child of a drawer will be a stack.

Its a very confusing behavior anyways, and the "less pushy navigate" will address the concern of the original issue

closes https://github.com/react-navigation/react-navigation/issues/3954