### PR TITLE
Fixed the Header Title Center bug on Android

### DIFF
--- a/src/views/Header/Header.js
+++ b/src/views/Header/Header.js
@@ -576,7 +576,7 @@ const styles = StyleSheet.create({
     position: 'absolute',
     alignItems: 'center',
     flexDirection: 'row',
-    justifyContent: Platform.OS === 'ios' ? 'center' : 'flex-start',
+    justifyContent: Platform.OS === 'ios' ? 'center' : 'center',
   },
   left: {
     left: 0,


### PR DESCRIPTION
The Title in the header of the Stack Navigator wasn't centred by default for Android Devices and was set to 'flex-start' for any devices without iOS. 

The main motivation was when I was trying to build an Instagram UI Clone in React Native on Android. I used the title in navigation options and saw that the title wasn't centred by default for Android devices whereas it was for the iOS devices. I had a look at the Header source code and figured out that for devices other than iOS, the value should be 'centre' instead of 'flex-start' which indeed solved the issue.

Please refer to the screenshots below and after the changes:

**Before**

![Before](https://image.ibb.co/cc0cFd/Screenshot_20180516_042805.png)

**After**

![After](https://image.ibb.co/gd88MJ/Screenshot_20180516_044008.png)


Everything works fine on iOS by default but I guess this fixes the problem on Android devices.