### PR TITLE
Fix for broken transition callbacks in StackView

### DIFF
--- a/src/views/StackView/StackView.js
+++ b/src/views/StackView/StackView.js
@@ -24,9 +24,12 @@ class StackView extends React.Component {
         configureTransition={this._configureTransition}
         navigation={this.props.navigation}
         descriptors={this.props.descriptors}
-        onTransitionStart={this.props.onTransitionStart}
+        onTransitionStart={this.props.navigationConfig.onTransitionStart}
         onTransitionEnd={(transition, lastTransition) => {
-          const { onTransitionEnd, navigation } = this.props;
+          const {
+            navigationConfig: { onTransitionEnd },
+            navigation,
+          } = this.props;
           if (transition.navigation.state.isTransitioning) {
             navigation.dispatch(
               StackActions.completeTransition({


### PR DESCRIPTION
Looks like in `createNavigation` the `stackConfig` from
`createStackNavigation` is passed inside `navigationConfig` prop. This
commit pulls the values from the correct place inside `StackView`.

TestPlan:
Applied the change locally and saw the `onTransitionEnd` callback pass.
Removed the `onTransitionEnd` callback from my test code and didn't get
a red box :P

Fixes #4252

