### PR TITLE
[flow] Fix tabBarOnPress type for react-navigation@2.0

### DIFF
--- a/flow/react-navigation.js
+++ b/flow/react-navigation.js
@@ -426,10 +426,9 @@ declare module 'react-navigation' {
       | ((options: { tintColor: ?string, focused: boolean }) => ?React$Node),
     tabBarVisible?: boolean,
     tabBarTestIDProps?: { testID?: string, accessibilityLabel?: string },
-    tabBarOnPress?: (
-      scene: TabScene,
-      jumpToIndex: (index: number) => void
-    ) => void,
+    tabBarOnPress?: ({
+      navigation: NavigationScreenProp<NavigationRoute>,
+    }) => void,
   |};
 
   /**


### PR DESCRIPTION
This fixes the Flow type to conform with the new API for `react-navigation@2.0`.