### PR TITLE
fix(create-nav-container): pass up error on catch

### DIFF
--- a/src/createNavigationContainer.js
+++ b/src/createNavigationContainer.js
@@ -285,6 +285,8 @@ export default function createNavigationContainer(Component) {
           'Uncaught exception while starting app from persisted navigation state! Trying to render again with a fresh navigation state..'
         );
         this.dispatch(NavigationActions.init());
+      } else {
+        throw new Error(e);
       }
     }
 


### PR DESCRIPTION
Errors are getting stuck inside the `createNavigationContainer`, so implementing `componentDidCatch` above any Navigator isn't working. This fixes according to this issue #4250 
