### PR TITLE
Fix bug: params not be passed to navigator inside SwitchNavigator

### DIFF
--- a/src/routers/SwitchRouter.js
+++ b/src/routers/SwitchRouter.js
@@ -189,7 +189,7 @@ export default (routeConfigs, config = {}) => {
             newChildState = childRouter
               ? childRouter.getStateForAction(action.action, childState)
               : null;
-          } else if (!action.action && !childRouter && action.params) {
+          } else if (!action.action && action.params) {
             newChildState = {
               ...childState,
               params: {


### PR DESCRIPTION
As @sahil290791 described in [ issue #3787](https://github.com/react-navigation/react-navigation/issues/3787), I have implemented my navigator and use some logic depend on params passed from last screen, like choosing some page to show, providing context for all the screen. So I think it is necessary for child navigator to receive params like a ordinary screen component.