### PR TITLE
[flow] Fix NavigationScreenComponent's navigationOptions

### DIFF
--- a/flow/react-navigation.js
+++ b/flow/react-navigation.js
@@ -271,6 +271,10 @@ declare module 'react-navigation' {
     | NavigationScreenComponent<NavigationRoute, *, *>
     | NavigationContainer<*, *, *>;
 
+  declare interface withOptionalNavigationOptions<Options> {
+    navigationOptions?: NavigationScreenConfig<Options>,
+  }
+
   declare export type NavigationScreenComponent<
     Route: NavigationRoute,
     Options: {},
@@ -278,8 +282,11 @@ declare module 'react-navigation' {
   > = React$ComponentType<{
     ...Props,
     ...NavigationNavigatorProps<Options, Route>,
-  }> &
-    ({} | { navigationOptions: NavigationScreenConfig<Options> });
+  }> & withOptionalNavigationOptions<Options>;
+
+  declare interface withRouter<State, Options> {
+    router: NavigationRouter<State, Options>,
+  }
 
   declare export type NavigationNavigator<
     State: NavigationState,
@@ -288,10 +295,7 @@ declare module 'react-navigation' {
   > = React$ComponentType<{
     ...Props,
     ...NavigationNavigatorProps<Options, State>,
-  }> & {
-    router: NavigationRouter<State, Options>,
-    navigationOptions?: ?NavigationScreenConfig<Options>,
-  };
+  }> & withRouter<State, Options> & withOptionalNavigationOptions<Options>;
 
   declare export type NavigationRouteConfig =
     | NavigationComponent
@@ -537,10 +541,7 @@ declare module 'react-navigation' {
   > = React$ComponentType<{
     ...Props,
     ...NavigationContainerProps<State, Options>,
-  }> & {
-    router: NavigationRouter<State, Options>,
-    navigationOptions?: ?NavigationScreenConfig<Options>,
-  };
+  }> & withRouter<State, Options> & withOptionalNavigationOptions<Options>;
 
   declare export type NavigationContainerProps<S: {}, O: {}> = $Shape<{
     uriPrefix?: string | RegExp,


### PR DESCRIPTION
Current types give an error. Check this [Flow-annotated code snippet](https://flow.org/try/#0PQKgBAAgZgNg9gdzCYAoVBLAtgBzgJwBcwAlAUwEMBjQgGjAG8wAFAV3zIGE5c4A7Mn2IBfMFHw8wAcg7VCUgNzpCATxxkwAOQoA3DAHMKhDPwDKVDoO58oBgDwB5HMf4BnAHxgAvKjBgAPmBOLnyuvgFgABSRDOF+fny6BkYmfABcWkmGIeaWfMwSOHbaetmpJHCshGTutHHxrhZkggVwOK4ZDMJ18fGJpSn8wakdQc4jPfHCAJTensNu00qoqupgAKI6goQAKmoaPn6BUggYMDAAYnBUrK5S4ccAJhiPVzd3D9Kn5wBCMOz3I7SZ6PP4Az5SOSpRTKfaZAYhTbbZgUFTwCiPbyMcKrMgZJFCPbqSZQ-gZErJEIAQRoqUmrkIRjx8MpqVMjOqkxgFAZ7KZGQA-BSymYOWQ6sJlriWSK+ATCJwKOcAEbUADWWMi4RwqPRj3JWUGcq2QhRaLgGNQsy8nh0cBeUrhwqN8tMrGVjXwGHG-CxsT8HCwcC2GUi1tt9seEsda2dIRR+AoWFcfvCAG01WQVBkGV6+PoALoZLAYAAeZCjqElsNjhpCcbINJCfv8OP2GSkcdSwE0VIAagBJADiVJ26ykkwkVTI2iwzNzGHzkx1ieTAoNCNSCaTrjq4WAwDAOwAFhpSXwwIQ4GB8KwL4vXC8NIRT2BXO6ALRT6r4cLn9cykaDZNnS6B+JmKgAQuS6oP41YrE6dapD86ogb6XiMK2fi4h2Xb8MAPxUpwADSE7hBBAECtB+h1HBMYaHhfCmGQhDbsmaEXhhDBYZe7bSIxwCmOsOwAPrMFSJBUgAsqYZH7oeJ4aBBYBwFAl6vt+GgIKeHDqRoK47m+x6VDAmLKhorgseRWY5oQeY0WBYAHker4CEgBnJpe15zvg+gaIuV56WAZClhgDKLvoN6VNUYAeWEfhxRurL8Gxu6wfB0qMQOfAYIQHEtm26i4Uh+EDpoA47GRCUUKurgAYxqW0RliGbvw5CWXltLoZhhXMp2JV8MAJDrEJlWTIujwhRkfCsFg5n4JMFGCtRJJdaEGRUvgiYqMUA3AWttTpfRgEhAAql6+VcTxOH8QNwCnSQA5VWA7AYLZ9lNcdjHkDg3JUI2a0FX4ADUN39a1g3DcwAAyRHjpMwMQe9EUI5ps7znZKPhMDcX1QNjXY-+SWyvtISfTWDH420l09SDYMCcwDjMM9wN8ABM1zWQC3Y9gc7PEyAHKnAcAwJQfDkwhtYQ8wbQ7HAcs4DT3HY-Td2M8wIk7A4mtMyzvMVhgAsZELItixLmX47cx5KzxoN8eDyWDcwp2mAAEizaNJhjH3Y7jxNGgTINEydqSk6BINLW+mMwXRFMh-wl2fFlOWdSESd7XWANp0C31kL91BZ6k6fS9Ta3F47Ms4HLCsceXspsK41tlznA0oVQaq1y3EPMaxNU7p3ES5x1HFfQNAAiYU6oQVDHpqf5rf71Jl+GYAm6LFB8KP3dNC0hR2MDpieFx2MMvyYCmJMzyuFPM+L6kE-X0YM+TPocBt2qoaacRWaUdRK9r2bcIV8SyuFGGGOYq9hbr3FuEfolJmRal6J7OcaR6hAmomgiI-peg4OQd7LGOCcF+3jvkPuyZJiEL8MHRiYd+AUMoZHFamC-DdHqMQhqZC0q9GoRnBEhd+DhH-lAwBfgOqpVDG5cRJDUpCNNhvF+LE2Khg8ujZGS4xBKhgKqduAEN4qBXnokkjxHjQzCtUAQ+BQz1DICaQgqio4+16FQTR2iP4kPlIqFU6pBEQMYq6d0npvRk21FbKxSDoozi9mohyvR2H404fQnhENaF8B8TaSBciYEBjzn9BB9Q8HRPoXE6WCT6hJMdiktJngAHyO1G0CR7NZrzXoMQpg+t+bVEFsIjeYAZgQJqVk2Kst5b1KiK0sA7TDadONt0i8fT0kDPGq4N4twKyhlkdA6MccaF1gIK0dojhOjdHPkco+YAAAkphjwUHUHYbBcDZR3zMDvfIe9D70hefsuqRzJgPKNAsUIAEHASncFvR2fIYrHz8KAEAcRwDZUmqWG8ZAoBcxTIFF8Z5aRbDADPM4mJNITIvJiqK04Uw1W2gAOjhWgPwE0ppgA5s08ImlRibW2rtCGFRpyHWalLR23LIV1yNNDSgUBBVkGFTkMUEqwWylFRQcVETUzQpALC+I4ByByCkCmZSqyzIqDfDwDQfyrz4FcJSrQ14BAVi8m+dQVAMBQENZiyyYAsAb1YJolQFDwCYsNd8GAq8NCTVsAIA1QVNL4GpRq2lYAkYOIIU5NVcKwBXHwMFUsSZfoaCkK7Y1UgY1+HACeMKEyUz6rADyKt8asxEprYSqg-BbCRW0oIXFshjD5hraaggRbkBxoKYmmCqr1XFpYEYWeZaekYh0Bvf6mJUVGHYBoStUACBgEmnnMAMBFxqgilWvgmJfQkoQGQZU-aUDaknVBaOMTk1juQBO2qsUeSWUxBi48ZbCVtovKag9gVcq+uCpS-QlqAAGTBnH4BEi8DIABGAATAAZl6eB+tFBSUxRfEYTdk9uQqHJbimql643FIrqUvllNu4yuVRhRiCqlXTjAAAMnCIxCFZA5VGlyM0Pg3BeACCEHYcIEqnl8AlZMAFowuiTC+Uc1AZytU0HOQJvAQndj7DueESlumvmTF05SnZCI9mFFcI4H0oR6ASt5Z4NjfgYiiECEwf9QxLOjA4y86wLaLMhA8L0pY6AqDclAWAKkmbzGPBTMpwglK2AcDU-wbYdzhCeGwafYwVBGUDWk5qFejnAt+BZYISa+BwHYPiBwQg7A-2sHOEoFhVYgtuGID8cTvGrA8HU8lkA9BevIDOVSZYTqog-Epa5vg0nZjYOcqYY1L4IrUuEEAA).

It gives ```all branches are incompatible: Either property `navigationOptions` is missing in `React.StatelessFunctionalComponent` [1]. Or property `navigationOptions` is missing in object type [2].``` error.

Basically, I've just copied all related types without changes from `flow/react-navigation.js` there and added a bit of code at the very bottom.

Proposed changes for `NavigationScreenComponent` type fix that error. Check this [modified Flow-annotated code snippet](https://flow.org/try/#0PQKgBAAgZgNg9gdzCYAoVBLAtgBzgJwBcwAlAUwEMBjQgGjAG8wAFAV3zIGE5c4A7Mn2IBfMFHw8wAcg7VCUgNzpCATxxkwAOQoA3DAHMKhDPwDKVDoO58oBgDwB5HMf4BnAHxgAvKjBgAPmBOLnyuvgFgABSRDOF+fny6BkYmfABcWkmGIeaWfMwSOHbaetmpJHCshGTutHHxrhZkggVwOK4ZDMJ18fGJpSn8wakdQc4jPfHCAJTensNu00qoqupgAKI6goQAKmoaPn6BUggYMDAAYnBUrK5S4ccAJhiPVzd3D9Kn5wBCMOz3I7SZ6PP4Az5SOSpRTKfaZAYhTbbZgUFTwCiPbyMcKrMgZJFCPbqSZQ-gZErJEIAQRoqUmrkIRjx8MpqVMjOqkxgFAZ7KZGQA-BSymYOWQ6sJlriWSK+ATCJwKOcAEbUADWWMi4RwqPRj3JWUGcq2QhRaLgGNQsy8nh0cBeUrhwqN8tMrGVjXwGHG-CxsT8HCwcC2GUi1tt9seEsda2dIRR+AoWFcfvCAG01WQVBkGV6+PoALoZLAYAAeZCjqElsNjhpCcbINJCfv8OP2GSkcdSwE0VIAagBJADiVJ26ykkwkVTI2iwzNzGHzkx1ieTAoNCNSCaTrjq4WAwDAOwAFhpSXwwIQ4GB8KwL4vXC8NIRT2BXO6ALRT6r4cLn9cykaDZNnS6B+JmKgAQuS6oP41YrE6dapD86ogb6XiMK2fi4h2Xb8MAPxUpwADSE7hBBAECtB+h1HBMYaHhfCmGQhDbsmaEXhhDBYZe7bSIxwCmOsOwAPrMFSJBUgAsqYZH7oeJ4aBBYBwFAl6vt+GgIKeHDqRoK47m+x6VDAmLKhorgseRWY5oQeY0WBYAHker4CEgBnJpe15zvg+gaIuV56WAZClhgDKLvoN6VNUYAeWEfhxRurL8Gxu6wfB0qMQOfAYIQHEtm26i4Uh+EDpoA47GRCUUKurgAYxqW0RliGbvw5CWXltLoZhhXMp2JV8MAJDrEJlWTIujwhRkfCsFg5n4JMFGCtRJJdaEGRUvgiYqMUA3AWttTpfRgEhAAql6+VcTxOH8QNwCnSQA5VWA7AYLZ9lNcdjHkDg3JUI2a0FX4ADUN39a1g3DcwAAyRHjpMwMQe9EUI5ps7znZKPhMDcX1QNjXY-+SWyvtISfTWDH420l09SDYMCcwDjMM9wN8ABM1zWQC3Y9gc7PEyAHKnAcAwJQfDkwhtYQ8wbQ7HAcs4DT3HY-Td2M8wIk7A4mtMyzvMVhgAsZELItixLmX47cx5KzxoN8eDyWDcwp2mAAEizaNJhjH3Y7jxNGgTINEydqSk6BINLW+mMwXRFMh-wl2fFlOWdSESd7XWANp0C31kL91BZ6k6fS9Ta3F47Ms4HLCsceXspsK41tlznA0oVQaq1y3EPMaxNU7p3ES5x1HFfQNAAiYU6oQVDHpqf5rf71Jl+GYAm6LFB8KP3dNC0hR2MDpieFx2MMvyYCmJMzyuFPM+L6kE-X0YM+TPocBt2qoaacRWaUdRK9r2bcIV8SyuFGGGOYq9hbr3FuEfolJmRal6J7OcaR6hAmomgiI-peg4OQd7LGOCcF+3jvkPuyZJiEL8MHRiYd+AUMoZHFamC-DdHqMQhqZC0q9GoRnBEhd+DhH-lAwBfgOqpVDG5cRJDUpCNNhvF+LE2Khg8ujZGS4xBKhgKqduAEN4qBXnokkjxHjQzCtUAQ+BQz1DICaQgqio4+16FQTR2iP4kPlIqFU6pBEQMYq6d0npvRk21FbKxSDoozi9mohyvR2H404fQnhENaF8B8TaSBciYEBjzn9BB9Q8HRPoXE6WCT6hJMdiktJngAHyO1G0CR7NZrzXoMQpg+t+bVEFsIjeYAZgQJqVk2Kst5b1KiK0sA7TDadONt0i8fT0kDPGq4N4twKyhlkdA6MccaF1gIK0dojhOjdHPkco+YAAAkphjwUHUHYbBcDZR3zMDvfIe9D70hefsuqRzJgPKNAsUIAEHASncFvR2fIYrHz8KAEAcRwDZUmqWG8ZAoBcxTIFF8Z5aRbDADPM4mJNITIvJiqK04Uw1W2gAOjhWgPwE0ppgA5s08ImlRibW2rtCGFRpyHWalLR23LIV1yNNDSgUBBVkGFTkMUEqwWylFRQcVETUzQpALC+I4ByByCkCmZSqyzIqDfDwDQfyrz4FcJSrQ14BAVi8m+dQVAMBQENZiyyYAsAb1YJolQFDwCYsNd8GAq8NCTVsAIA1QVNL4GpRq2lYAkYOIIU5NVcKwBXHwMFUsSZfoaCkK7Y1UgY1+HACeMKEyUz6rADyKt8asxEprYSqg-BbCRW0oIXFshjD5hraaggRbkBxoKYmmCqr1XFpYEYWeZaekYh0Bvf6mJUVGHYBoStUACBgEmnnMAMBFxqgilWvgmJfQkoQGQZU-aUDaknVBaOMTk1juQBO2qsUeSWUxBi48ZbCVtovKag9gVcq+uCpS-QlqAAGTBnH4BEi8DIABGAATAAZl6eB+tFBSUxRfEYTdk9uQqHJbimql643FIrqUvllNu4yuVRhRiCqlXTjAAAMnCIxCFZA5VGlyM0Pg3BeACCEHYcIEqnl8AlZMAFowuiTC+Uc1AZytU0HOQJvAQndj7DueESlumvmTF05SnZCI9mFFcI4H0oR6ASt5Z4Fj2IEgDWk3jbeeRrAtosyEDwVZlhUG5KAsAVJM3mMeCmZThBKVsA4Gp-g2w7nCE8Ng0+xgqCMqc5ZlMGFwHpJiDMJQfgWWCEmvgcB2D4gcEIOwP9rBzj5d6VWdATbQjEB+OJ3jVgeDqbiyAegPXkBnKpMsJ1UQfiUv-UMDLsxsHOVMMal8EVqXCCAA). No errors.

**Test plan (required)**

Check both of code snippets at the links above.