### PR TITLE
Pass getCustomActionCreators to StackRouter

### DIFF
--- a/src/navigators/createStackNavigator.js
+++ b/src/navigators/createStackNavigator.js
@@ -13,6 +13,7 @@ function createStackNavigator(routeConfigMap, stackConfig = {}) {
     paths,
     navigationOptions,
     disableKeyboardHandling,
+    getCustomActionCreators,
   } = stackConfig;
 
   const stackRouterConfig = {
@@ -21,6 +22,7 @@ function createStackNavigator(routeConfigMap, stackConfig = {}) {
     initialRouteParams,
     paths,
     navigationOptions,
+    getCustomActionCreators,
   };
 
   const router = StackRouter(routeConfigMap, stackRouterConfig);


### PR DESCRIPTION
**Motivation**
This PR fixes #4360. When creating stack navigator, `getCustomActionCreators` method is not passed to `StackRouter`, so custom action creators are not included in navigation props.

**Test plan (required)**

I've tested on iOS and Android. You can run following code snippet. 

```
import React from 'react';
import { StyleSheet, Text, View } from 'react-native';
import { createStackNavigator, NavigationActions } from 'react-navigation';

class HomeScreen extends React.Component {
  static navigationOptions = { tabBarLabel: 'Home!' };
  render() {
    console.log('Home', this.props.navigation);
    return (
      <View style={styles.container}>
        <Text>HomeScreen</Text>
        <Text onPress={() => this.props.navigation.goDetail()}>Go to Detail</Text>
      </View>
    );
  }
}

class DetailScreen extends React.Component {
  static navigationOptions = { tabBarLabel: 'Detail!' };
  render() {
    console.log('Detail', this.props.navigation);
    return (
      <View style={styles.container}>
        <Text>DetailScreen</Text>
      </View>
    );
  }
}

const AppNavigator = createStackNavigator(
  { Home: HomeScreen, Detail: DetailScreen },
  {
    getCustomActionCreators: (route, navStateKey) => {
      console.log(route, navStateKey);
      return {
        goDetail: () => {
          return NavigationActions.navigate({ routeName: 'Detail' });
        },
      };
    },
  },
);

export default class App extends React.Component {
  debugger;
  render() {
    return <AppNavigator />;
  }
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    justifyContent: 'center',
    alignItems: 'center',
  },
});
```

