### PR TITLE
Update deprecated StackNavigator usage in Redux example

### DIFF
--- a/examples/ReduxExample/src/navigators/AppNavigator.js
+++ b/examples/ReduxExample/src/navigators/AppNavigator.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { StackNavigator } from 'react-navigation';
+import { createStackNavigator } from 'react-navigation';
 import { initializeListeners } from 'react-navigation-redux-helpers';
 
 import LoginScreen from '../components/LoginScreen';
@@ -9,7 +9,7 @@ import MainScreen from '../components/MainScreen';
 import ProfileScreen from '../components/ProfileScreen';
 import { navigationPropConstructor } from '../utils/redux';
 
-export const AppNavigator = StackNavigator({
+export const AppNavigator = createStackNavigator({
   Login: { screen: LoginScreen },
   Main: { screen: MainScreen },
   Profile: { screen: ProfileScreen },


### PR DESCRIPTION
Use createStackNavigator instead of [deprecated StackNavigator](https://github.com/react-navigation/react-navigation/blob/5467f0e22d0cdcd3c7c64d7280ddc13eec6f3b28/src/react-navigation.js#L21) to create navigator component.
Solves issue https://github.com/react-navigation/react-navigation/issues/4134 for [v2](https://github.com/react-navigation/react-navigation/blob/5467f0e22d0cdcd3c7c64d7280ddc13eec6f3b28/package.json#L3).
