### PR TITLE
Fix swipe to go back by providing the index

### DIFF
--- a/src/views/StackView/StackViewLayout.js
+++ b/src/views/StackView/StackViewLayout.js
@@ -211,6 +211,8 @@ class StackViewLayout extends React.Component {
 
   _panResponder = PanResponder.create({
     onPanResponderTerminate: () => {
+      const { navigation } = this.props.transitionProps;
+      const { index } = navigation.state;
       this._isResponding = false;
       this._reset(index, 0);
       this.props.onGestureCanceled && this.props.onGestureCanceled();


### PR DESCRIPTION
**Motivation**
Fix a bug that would occur when trying to swipe to go back. The `index` variable was not defined in the `onPanResponderTerminate` function.

See screenshot below:

![img_6846](https://user-images.githubusercontent.com/2947763/40882270-30f9a396-66aa-11e8-9f30-483b3f1d31d8.PNG)


