### PR TITLE
Refactor, move child navigation to navigation prop

### DIFF
--- a/src/__tests__/getNavigation-test.js
+++ b/src/__tests__/getNavigation-test.js
@@ -1,0 +1,97 @@
+import getNavigation from '../getNavigation';
+
+test('getNavigation provides default action helpers', () => {
+  const router = {
+    getActionCreators: () => ({}),
+    getStateForAction(action, lastState = {}) {
+      return lastState;
+    },
+  };
+
+  const dispatch = jest.fn();
+
+  const topNav = getNavigation(
+    router,
+    {},
+    dispatch,
+    new Set(),
+    () => ({}),
+    () => topNav
+  );
+
+  topNav.navigate('GreatRoute');
+
+  expect(dispatch.mock.calls.length).toBe(1);
+  expect(dispatch.mock.calls[0][0].type).toBe('Navigation/NAVIGATE');
+  expect(dispatch.mock.calls[0][0].routeName).toBe('GreatRoute');
+});
+
+test('getNavigation provides router action helpers', () => {
+  const router = {
+    getActionCreators: () => ({
+      foo: bar => ({ type: 'FooBarAction', bar }),
+    }),
+    getStateForAction(action, lastState = {}) {
+      return lastState;
+    },
+  };
+
+  const dispatch = jest.fn();
+
+  const topNav = getNavigation(
+    router,
+    {},
+    dispatch,
+    new Set(),
+    () => ({}),
+    () => topNav
+  );
+
+  topNav.foo('Great');
+
+  expect(dispatch.mock.calls.length).toBe(1);
+  expect(dispatch.mock.calls[0][0].type).toBe('FooBarAction');
+  expect(dispatch.mock.calls[0][0].bar).toBe('Great');
+});
+
+test('getNavigation get child navigation with router', () => {
+  const actionSubscribers = new Set();
+  let navigation = null;
+
+  const routerA = {
+    getActionCreators: () => ({}),
+    getStateForAction(action, lastState = {}) {
+      return lastState;
+    },
+  };
+  const router = {
+    childRouters: {
+      RouteA: routerA,
+    },
+    getActionCreators: () => ({}),
+    getStateForAction(action, lastState = {}) {
+      return lastState;
+    },
+  };
+
+  const initState = {
+    index: 0,
+    routes: [
+      { key: 'a', routeName: 'RouteA' },
+      { key: 'b', routeName: 'RouteB' },
+    ],
+  };
+
+  const topNav = getNavigation(
+    router,
+    initState,
+    () => {},
+    actionSubscribers,
+    () => ({}),
+    () => navigation
+  );
+
+  const childNavA = topNav.getChildNavigation('a');
+
+  expect(childNavA.router).toBe(routerA);
+});

--- a/src/getChildNavigation.js
+++ b/src/getChildNavigation.js
@@ -53,10 +53,6 @@ function getChildNavigation(navigation, childKey, getCurrentParentNavigation) {
     childKey
   );
 
-  function getCurrentNavigation() {
-    return getCurrentParentNavigation().getChildNavigation(childKey);
-  }
-
   children[childKey] = {
     ...actionHelpers,
 
@@ -66,10 +62,8 @@ function getChildNavigation(navigation, childKey, getCurrentParentNavigation) {
     getParam: createParamGetter(route),
 
     getChildNavigation: grandChildKey =>
-      getChildNavigation(
-        children[childKey],
-        grandChildKey,
-        getCurrentNavigation
+      getChildNavigation(children[childKey], grandChildKey, () =>
+        getCurrentParentNavigation().getChildNavigation(childKey)
       ),
 
     isFocused: childKey => {

--- a/src/getChildNavigation.js
+++ b/src/getChildNavigation.js
@@ -1,0 +1,94 @@
+import getChildEventSubscriber from './getChildEventSubscriber';
+import getChildRouter from './getChildRouter';
+
+const createParamGetter = route => (paramName, defaultValue) => {
+  const params = route.params;
+
+  if (params && paramName in params) {
+    return params[paramName];
+  }
+
+  return defaultValue;
+};
+
+function getChildNavigation(navigation, childKey, getCurrentParentNavigation) {
+  const children =
+    navigation._childrenNavigation || (navigation._childrenNavigation = {});
+
+  const route = navigation.state.routes.find(r => r.key === childKey);
+
+  if (children[childKey] && children[childKey].state === route) {
+    return children[childKey];
+  }
+
+  const childRouter = getChildRouter(navigation.router, route.routeName);
+
+  const actionCreators = {
+    ...navigation.actions,
+    ...navigation.router.getActionCreators(route, navigation.state.key),
+  };
+  const actionHelpers = {};
+  Object.keys(actionCreators).forEach(actionName => {
+    actionHelpers[actionName] = (...args) => {
+      const actionCreator = actionCreators[actionName];
+      const action = actionCreator(...args);
+      navigation.dispatch(action);
+    };
+  });
+
+  if (children[childKey]) {
+    children[childKey] = {
+      ...children[childKey],
+      ...actionHelpers,
+      state: route,
+      router: childRouter,
+      actions: actionCreators,
+      getParam: createParamGetter(route),
+    };
+    return children[childKey];
+  }
+
+  const childSubscriber = getChildEventSubscriber(
+    navigation.addListener,
+    childKey
+  );
+
+  function getCurrentNavigation() {
+    return getCurrentParentNavigation().getChildNavigation(childKey);
+  }
+
+  children[childKey] = {
+    ...actionHelpers,
+
+    state: route,
+    router: childRouter,
+    actions: actionCreators,
+    getParam: createParamGetter(route),
+
+    getChildNavigation: grandChildKey =>
+      getChildNavigation(
+        children[childKey],
+        grandChildKey,
+        getCurrentNavigation
+      ),
+
+    isFocused: childKey => {
+      const currentNavigation = getCurrentParentNavigation();
+      const { routes, index } = currentNavigation.state;
+      if (!currentNavigation.isFocused()) {
+        return false;
+      }
+      if (childKey == null || routes[index].key === childKey) {
+        return true;
+      }
+      return false;
+    },
+    dispatch: navigation.dispatch,
+    getScreenProps: navigation.getScreenProps,
+    dangerouslyGetParent: getCurrentParentNavigation,
+    addListener: childSubscriber.addListener,
+  };
+  return children[childKey];
+}
+
+export default getChildNavigation;

--- a/src/getChildRouter.js
+++ b/src/getChildRouter.js
@@ -1,0 +1,9 @@
+export default function getChildRouter(router, routeName) {
+  if (router.childRouters && router.childRouters[routeName]) {
+    return router.childRouters[routeName];
+  }
+
+  const Component = router.getComponentForRouteName(routeName);
+
+  return Component.router;
+}

--- a/src/getNavigation.js
+++ b/src/getNavigation.js
@@ -9,7 +9,10 @@ export default function getNavigation(
   getScreenProps,
   getCurrentNavigation
 ) {
+  const actions = router.getActionCreators(state, null);
+
   const navigation = {
+    actions,
     router,
     state,
     dispatch,
@@ -38,7 +41,10 @@ export default function getNavigation(
     dangerouslyGetParent: () => null,
   };
 
-  const actionCreators = getNavigationActionCreators(navigation.state);
+  const actionCreators = {
+    ...getNavigationActionCreators(navigation.state),
+    ...actions,
+  };
 
   Object.keys(actionCreators).forEach(actionName => {
     navigation[actionName] = (...args) =>

--- a/src/getNavigation.js
+++ b/src/getNavigation.js
@@ -21,7 +21,6 @@ export default function getNavigation(
       getChildNavigation(navigation, childKey, getCurrentNavigation),
     isFocused: childKey => {
       const { routes, index } = getCurrentNavigation().state;
-      console.log('Top level isFocused!', childKey, index, routes[index].key);
       if (childKey == null || routes[index].key === childKey) {
         return true;
       }

--- a/src/getNavigation.js
+++ b/src/getNavigation.js
@@ -1,0 +1,49 @@
+import getNavigationActionCreators from './routers/getNavigationActionCreators';
+import getChildNavigation from './getChildNavigation';
+
+export default function getNavigation(
+  router,
+  state,
+  dispatch,
+  actionSubscribers,
+  getScreenProps,
+  getCurrentNavigation
+) {
+  const navigation = {
+    router,
+    state,
+    dispatch,
+    getScreenProps,
+    getChildNavigation: childKey =>
+      getChildNavigation(navigation, childKey, getCurrentNavigation),
+    isFocused: childKey => {
+      const { routes, index } = getCurrentNavigation().state;
+      console.log('Top level isFocused!', childKey, index, routes[index].key);
+      if (childKey == null || routes[index].key === childKey) {
+        return true;
+      }
+      return false;
+    },
+    addListener: (eventName, handler) => {
+      if (eventName !== 'action') {
+        return { remove: () => {} };
+      }
+      actionSubscribers.add(handler);
+      return {
+        remove: () => {
+          actionSubscribers.delete(handler);
+        },
+      };
+    },
+    dangerouslyGetParent: () => null,
+  };
+
+  const actionCreators = getNavigationActionCreators(navigation.state);
+
+  Object.keys(actionCreators).forEach(actionName => {
+    navigation[actionName] = (...args) =>
+      navigation.dispatch(actionCreators[actionName](...args));
+  });
+
+  return navigation;
+}

--- a/src/navigators/createNavigator.js
+++ b/src/navigators/createNavigator.js
@@ -10,122 +10,48 @@ function createNavigator(NavigatorView, router, navigationConfig) {
 
     state = {
       descriptors: {},
-      childEventSubscribers: {},
     };
 
     static getDerivedStateFromProps(nextProps, prevState) {
+      const prevDescriptors = prevState.descriptors;
       const { navigation, screenProps } = nextProps;
       const { dispatch, state, addListener } = navigation;
       const { routes } = state;
+      const descriptors = {};
 
-      const descriptors = { ...prevState.descriptors };
-      const childEventSubscribers = { ...prevState.childEventSubscribers };
       routes.forEach(route => {
-        if (!descriptors[route.key] || descriptors[route.key].state !== route) {
-          const getComponent = () =>
-            router.getComponentForRouteName(route.routeName);
-
-          if (!childEventSubscribers[route.key]) {
-            childEventSubscribers[route.key] = getChildEventSubscriber(
-              addListener,
-              route.key
-            );
-          }
-
-          const actionCreators = {
-            ...navigation.actions,
-            ...router.getActionCreators(route, state.key),
-          };
-          const actionHelpers = {};
-          Object.keys(actionCreators).forEach(actionName => {
-            actionHelpers[actionName] = (...args) => {
-              const actionCreator = actionCreators[actionName];
-              const action = actionCreator(...args);
-              dispatch(action);
-            };
-          });
-          const childNavigation = {
-            ...actionHelpers,
-            actions: actionCreators,
-            dispatch,
-            state: route,
-            addListener: childEventSubscribers[route.key].addListener,
-            getParam: (paramName, defaultValue) => {
-              const params = route.params;
-
-              if (params && paramName in params) {
-                return params[paramName];
-              }
-
-              return defaultValue;
-            },
-          };
-
-          const options = router.getScreenOptions(childNavigation, screenProps);
-          descriptors[route.key] = {
-            key: route.key,
-            getComponent,
-            options,
-            state: route,
-            navigation: childNavigation,
-          };
+        if (
+          prevDescriptors &&
+          prevDescriptors[route.key] &&
+          route === prevDescriptors[route.key].state
+        ) {
+          descriptors[route.key] = prevDescriptors[route.key];
+          return;
         }
+        const getComponent = () =>
+          router.getComponentForRouteName(route.routeName);
+        const childNavigation = navigation.getChildNavigation(route.key);
+        const options = router.getScreenOptions(childNavigation, screenProps);
+        descriptors[route.key] = {
+          key: route.key,
+          getComponent,
+          options,
+          state: route,
+          navigation: childNavigation,
+        };
       });
 
-      return {
-        descriptors,
-        childEventSubscribers,
-      };
+      return { descriptors };
     }
-
-    // Cleanup subscriptions for routes that no longer exist
-    componentDidUpdate() {
-      const activeKeys = this.props.navigation.state.routes.map(r => r.key);
-      let childEventSubscribers = { ...this.state.childEventSubscribers };
-      Object.keys(childEventSubscribers).forEach(key => {
-        if (!activeKeys.includes(key)) {
-          delete childEventSubscribers[key];
-        }
-      });
-      if (
-        childEventSubscribers.length !== this.state.childEventSubscribers.length
-      ) {
-        this.setState({ childEventSubscribers });
-      }
-    }
-
-    _isRouteFocused = route => {
-      const { state } = this.props.navigation;
-      const focusedRoute = state.routes[state.index];
-      return route === focusedRoute;
-    };
-
-    _dangerouslyGetParent = () => {
-      return this.props.navigation;
-    };
 
     render() {
-      // Mutation in render 😩
-      // The problem:
-      // - We don't want to re-render each screen every time the parent navigator changes
-      // - But we need to be able to access the parent navigator from callbacks
-      // - These functions should only be used within callbacks, but they are passed in props,
-      //   which is what makes this awkward. What's a good way to pass in stuff that we don't
-      //   want people to depend on in render?
-      let descriptors = { ...this.state.descriptors };
-      Object.values(descriptors).forEach(descriptor => {
-        descriptor.navigation.isFocused = () =>
-          this._isRouteFocused(descriptor.state);
-        descriptor.navigation.dangerouslyGetParent = this._dangerouslyGetParent;
-      });
-
       return (
         <NavigatorView
           {...this.props}
           screenProps={this.props.screenProps}
           navigation={this.props.navigation}
           navigationConfig={navigationConfig}
-          descriptors={descriptors}
+          descriptors={this.state.descriptors}
         />
       );
     }

--- a/src/routers/StackRouter.js
+++ b/src/routers/StackRouter.js
@@ -149,6 +149,8 @@ export default (routeConfigs, stackConfig = {}) => {
   paths.sort((a, b) => b[1].priority - a[1].priority);
 
   return {
+    childRouters,
+
     getComponentForState(state) {
       const activeChildRoute = state.routes[state.index];
       const { routeName } = activeChildRoute;

--- a/src/routers/SwitchRouter.js
+++ b/src/routers/SwitchRouter.js
@@ -75,6 +75,8 @@ export default (routeConfigs, config = {}) => {
   }
 
   return {
+    childRouters,
+
     getInitialState() {
       const routes = order.map(resetChildRoute);
       return {


### PR DESCRIPTION
This fixes our descriptor caching issue, and unblocks explicit nested navigation options.

As a side effect, the following APIs are introduced to the navigation prop:

- navigation.getChildNavigation(routeKey) , which is useful for explicitly getting children config info
- navigation.router, access to the static router

And routers have a new way to statically expose children behavior. This is particularly important for getChildNavigation to access custom action creators on the child router.

- router.childRouters[routeName] , an optional way to access the children routers directly. If childRouters are not provided in a router, we will fall back on getComponentForRouteName(routeName).router, which is the previous external API for this (although it may be slower because it will require the whole screen component).

IMO, these are all safe and sensible APIs to include in the library
