### PR TITLE
Change 'React' import writing, Prevent warnings in old version React

### DIFF
--- a/src/navigators/createStackNavigator.js
+++ b/src/navigators/createStackNavigator.js
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import createNavigationContainer from '../createNavigationContainer';
 import createKeyboardAwareNavigator from './createKeyboardAwareNavigator';
 import createNavigator from './createNavigator';

--- a/src/views/StackView/StackView.js
+++ b/src/views/StackView/StackView.js
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { NativeModules } from 'react-native';
 
 import StackViewLayout from './StackViewLayout';

--- a/src/views/StackView/StackViewLayout.js
+++ b/src/views/StackView/StackViewLayout.js
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 import clamp from 'clamp';
 import {

--- a/src/views/__tests__/Transitioner-test.js
+++ b/src/views/__tests__/Transitioner-test.js
@@ -1,5 +1,5 @@
 /* eslint react/display-name:0 */
-import * as React from 'react';
+import React from 'react';
 import renderer from 'react-test-renderer';
 import Transitioner from '../Transitioner';
 


### PR DESCRIPTION
When use `createStackNavigator`, old version React will warning, look image below  
### BUG PERFORMANCE
**In debugger**  
![image](https://user-images.githubusercontent.com/7681138/40961852-629c4dda-68d6-11e8-9fc3-e14572afc63f.png)  
**In Simulator**  
![image](https://user-images.githubusercontent.com/7681138/40961861-692724a4-68d6-11e8-8866-41aba9c654a2.png)  
It's uncomfortable.

### THE REASON
Look at this comment  
https://github.com/react-navigation/react-navigation/issues/2019#issuecomment-347547140  
Because the import writing is
```javascript
import * as React from 'react'
```
In this writing, babel will traverse all property in package(react etc.), so the getter in react will be call, and then, the deprecated warning will be executed.  
![image](https://user-images.githubusercontent.com/7681138/40962679-c61b9c42-68d8-11e8-96fa-5fcd0ce6d442.png)
search the keywords in **react-navigation** project.
![image](https://user-images.githubusercontent.com/7681138/40961757-1d757722-68d6-11e8-896e-d9a5693e973e.png)  
Only four files contains this writing, and these four files is created 3 months ago.   
So I think it's a personal writing, but this writing cause the warnings.

