### PR TITLE
[Fix] DrawerView should Open/Close when a Navigation occurs while it is Animating.

### DIFF
--- a/src/views/Drawer/DrawerView.js
+++ b/src/views/Drawer/DrawerView.js
@@ -31,14 +31,30 @@ export default class DrawerView extends React.PureComponent {
     const { isDrawerOpen } = this.props.navigation.state;
     const wasDrawerOpen = prevProps.navigation.state.isDrawerOpen;
 
-    if (isDrawerOpen && !wasDrawerOpen && this._drawerState === 'closed') {
+    if (this._shouldOpen(isDrawerOpen, wasDrawerOpen)) {
       this._drawerState = 'opening';
       this._drawer.openDrawer();
-    } else if (wasDrawerOpen && !isDrawerOpen && this._drawerState === 'open') {
+    } else if (this._shouldClose(isDrawerOpen, wasDrawerOpen)) {
       this._drawerState = 'closing';
       this._drawer.closeDrawer();
     }
   }
+
+  _shouldOpen = (isDrawerOpen, wasDrawerOpen) => {
+    return (
+      isDrawerOpen &&
+      !wasDrawerOpen &&
+      (this._drawerState === 'closed' || this._drawerState === 'closing')
+    );
+  };
+
+  _shouldClose = (isDrawerOpen, wasDrawerOpen) => {
+    return (
+      wasDrawerOpen &&
+      !isDrawerOpen &&
+      (this._drawerState === 'open' || this._drawerState === 'opening')
+    );
+  };
 
   _handleDrawerOpen = () => {
     const { navigation } = this.props;


### PR DESCRIPTION
This PR is a follow-on from the fix provided by https://github.com/react-navigation/react-navigation/pull/4392 which resolved a pretty awful infinite loop issue with toggling the drawer while it is animating (e.g. by quickly pressing one of the drawer items while the drawer is opening).

### Motivation
After updating to get the fix from #4392, I observed another problem which is that when one opens the drawer and then quickly taps on a drawer item to navigate, the screen change occurs but the drawer remains open and will not automatically close after tapping any of the drawer items. Once in this state, you may tap on any number of drawer items but the drawer itself will remain open until you tap outside of it to dismiss.

### Explanation
The logic contained in this component's `componentDidUpdate` method does not account for the need to open/close the drawer _while it is animating_ because the two branches of the conditional require that the `_drawerState` be either `"open"` or `"closed"` in order to actually trigger `openDrawer` or `closeDrawer`.

### Tests / Formatting
I've attempted to maintain the existing style around this small change.
I did not see any tests for this component in the codebase and I haven't opted to add any - I'm just trying to get my other work done and noticed that this was some low hanging fruit.