### PR TITLE
Make the actions available on the navigator navigation prop the same as its children

### DIFF
--- a/src/__tests__/getNavigation-test.js
+++ b/src/__tests__/getNavigation-test.js
@@ -77,7 +77,12 @@ test('getNavigation get child navigation with router', () => {
   const initState = {
     index: 0,
     routes: [
-      { key: 'a', routeName: 'RouteA' },
+      {
+        key: 'a',
+        routeName: 'RouteA',
+        routes: [{ key: 'c', routeName: 'RouteC' }],
+        index: 0,
+      },
       { key: 'b', routeName: 'RouteB' },
     ],
   };

--- a/src/getChildNavigation.js
+++ b/src/getChildNavigation.js
@@ -26,6 +26,9 @@ function getChildNavigation(navigation, childKey, getCurrentParentNavigation) {
   const actionCreators = {
     ...navigation.actions,
     ...navigation.router.getActionCreators(route, navigation.state.key),
+    ...(childRouter
+      ? childRouter.getActionCreators(route.routes[route.index], route.key)
+      : {}),
   };
   const actionHelpers = {};
   Object.keys(actionCreators).forEach(actionName => {


### PR DESCRIPTION
# Motivation

Issues like https://github.com/react-navigation/react-navigation/issues/4440 where you expected to be able to access the same action creators from the `navigation` prop in `navigationOptions` but cannot are unintuitive and likely to cause confusion for most people at some point.

In #4440 we have a stack navigator with a drawer navigator inside of it, and we set
navigationOptions with drawer.navigationOptions. There are three navigation objects
to think about:
(1) inside stack view
(2) child routes of stack view (drawer view is one)
(3) child routes of drawer view

We want the navigation prop in (2) to have access to the action creators for the drawer router.
So we want the child navigation prop where the child is a navigator to include the action creators
from the router.

In (1) the stack navigator is at the root of the app, so the navigation object it is created through `getNavigation` and already has the action creators for the stack navigator applied to it.

As far as I can tell there is no downside to making this change. It will only impact the `navigation` prop available within a navigation view and inside of the `navigation`.
