### PR TITLE
Revert "Export getNavigationActionCreators (#4258)"

### DIFF
--- a/flow/react-navigation.js
+++ b/flow/react-navigation.js
@@ -503,10 +503,6 @@ declare module 'react-navigation' {
   };
 
   declare export type NavigationScreenProp<+S> = {
-    ...$ObjMap<
-      _DefaultActionCreators,
-      <Args>((...args: Args) => *) => (...args: Args) => boolean
-    >,
     +state: S,
     dispatch: NavigationDispatch,
     addListener: (
@@ -515,6 +511,21 @@ declare module 'react-navigation' {
     ) => NavigationEventSubscription,
     getParam: (paramName: string, fallback?: any) => any,
     isFocused: () => boolean,
+    // Shared action creators that exist for all routers
+    goBack: (routeKey?: ?string) => boolean,
+    navigate: (
+      routeName:
+        | string
+        | {
+            routeName: string,
+            params?: NavigationParams,
+            action?: NavigationNavigateAction,
+            key?: string,
+          },
+      params?: NavigationParams,
+      action?: NavigationNavigateAction
+    ) => boolean,
+    setParams: (newParams: NavigationParams) => boolean,
     // StackRouter action creators
     pop?: (n?: number, params?: { immediate?: boolean }) => boolean,
     popToTop?: (params?: { immediate?: boolean }) => boolean,
@@ -790,26 +801,6 @@ declare module 'react-navigation' {
       key?: string,
     }) => NavigationToggleDrawerAction,
   };
-
-  declare type _DefaultActionCreators = {|
-    goBack: (routeKey?: ?string) => NavigationBackAction,
-    navigate: (
-      routeName:
-        | string
-        | {
-            routeName: string,
-            params?: NavigationParams,
-            action?: NavigationNavigateAction,
-            key?: string,
-          },
-      params?: NavigationParams,
-      action?: NavigationNavigateAction
-    ) => NavigationNavigateAction,
-    setParams: (newParams: NavigationParams) => NavigationSetParamsAction,
-  |};
-  declare export function getNavigationActionCreators(
-    route: NavigationRoute | NavigationState
-  ): _DefaultActionCreators;
 
   declare type _RouterProp<S: NavigationState, O: {}> = {
     router: NavigationRouter<S, O>,

--- a/src/react-navigation.js
+++ b/src/react-navigation.js
@@ -74,9 +74,6 @@ module.exports = {
   get DrawerActions() {
     return require('react-navigation-drawer').DrawerActions;
   },
-  get getNavigationActionCreators() {
-    return require('./routers/getNavigationActionCreators').default;
-  },
 
   // Routers
   get StackRouter() {

--- a/src/react-navigation.web.js
+++ b/src/react-navigation.web.js
@@ -24,9 +24,6 @@ module.exports = {
   get DrawerActions() {
     return require('./routers/DrawerActions').default;
   },
-  get getNavigationActionCreators() {
-    return require('./routers/getNavigationActionCreators').default;
-  },
 
   // Routers
   get StackRouter() {


### PR DESCRIPTION
`react-navigation-redux-helpers` no longer needs `getNavigationActionCreators` to be exported, and it's best not to export things we don't want to support the import of.

Since support is already broken for anybody using a version of `react-navigation-redux-helpers` that calls `getNavigationActionCreators` in master, this PR should not break anybody's setup. It'll just replace a fatal error with another one.