### PR TITLE
Add possibility to define default params for a single route

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-navigation",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Routing and navigation for your React Native apps",
   "main": "src/react-navigation.js",
   "repository": {

--- a/src/routers/SwitchRouter.js
+++ b/src/routers/SwitchRouter.js
@@ -56,7 +56,7 @@ export default (routeConfigs, config = {}) => {
 
   function resetChildRoute(routeName) {
     const params =
-      routeName === initialRouteName ? initialRouteParams : undefined;
+      routeName === initialRouteName ? initialRouteParams : routeConfigs.params ? routeConfigs.params : undefined;
     const childRouter = childRouters[routeName];
     if (childRouter) {
       const childAction = NavigationActions.init();

--- a/src/routers/SwitchRouter.js
+++ b/src/routers/SwitchRouter.js
@@ -56,7 +56,11 @@ export default (routeConfigs, config = {}) => {
 
   function resetChildRoute(routeName) {
     const params =
-      routeName === initialRouteName ? initialRouteParams : routeConfigs.params ? routeConfigs.params : undefined;
+      routeName === initialRouteName
+        ? initialRouteParams
+        : routeConfigs[routeName].params
+          ? routeConfigs[routeName].params
+          : undefined;
     const childRouter = childRouters[routeName];
     if (childRouter) {
       const childAction = NavigationActions.init();


### PR DESCRIPTION
**Motivation**: i want to be able to set default param on a single route, not for entire stack of routes,
for now i can only set 'initialRouteParams' and need this workaround to solve my problem.

**Problem**: i have some categorized list of articles what are in different tabs, want to set header title from route params what i set in default route(tab) params.

**Now it's look like**:
```
Tab1: {
    index: 0,
    params: { title: 'Title 1', url: '/' },
    screen: props => (
      <NewsScreen {...props} />
    ),
 },
Tab2: {
    index: 1,
    params: { title: 'Title 2', url: '/' },
    screen: props => (
      <NewsScreen {...props} />
    ),
 },

```

