### PR TITLE
 createNavigationContainer: rethrow the error instead of creating a new one

### DIFF
--- a/src/createNavigationContainer.js
+++ b/src/createNavigationContainer.js
@@ -286,7 +286,7 @@ export default function createNavigationContainer(Component) {
         );
         this.dispatch(NavigationActions.init());
       } else {
-        throw new Error(e);
+        throw e;
       }
     }
 


### PR DESCRIPTION
Creating a new error makes the stack unreadable in sentry, because the stack is stringified when the error is cast to string to create a new one.
Is there another reason to do that ?
Alternative possible solution would be to add a method to be able to handle the error ourselves ?