### PR TITLE
Clean up PlatformHelpers

### DIFF
--- a/src/PlatformHelpers.native.js
+++ b/src/PlatformHelpers.native.js
@@ -1,9 +1,0 @@
-import {
-  BackAndroid as DeprecatedBackAndroid,
-  BackHandler as ModernBackHandler,
-  MaskedViewIOS,
-} from 'react-native';
-
-const BackHandler = ModernBackHandler || DeprecatedBackAndroid;
-
-export { BackHandler, MaskedViewIOS };

--- a/src/PlatformHelpers.web.js
+++ b/src/PlatformHelpers.web.js
@@ -1,6 +1,0 @@
-import React from 'react';
-import { BackHandler, View } from 'react-native';
-
-const MaskedViewIOS = () => <View>{this.props.children}</View>;
-
-export { BackHandler, MaskedViewIOS };

--- a/src/createNavigationContainer.js
+++ b/src/createNavigationContainer.js
@@ -1,8 +1,7 @@
 import React from 'react';
-import { AsyncStorage, Linking, Platform } from 'react-native';
+import { AsyncStorage, Linking, Platform, BackHandler } from 'react-native';
 import { polyfill } from 'react-lifecycles-compat';
 
-import { BackHandler } from './PlatformHelpers';
 import NavigationActions from './NavigationActions';
 import getNavigation from './getNavigation';
 import invariant from './utils/invariant';

--- a/src/views/Header/Header.js
+++ b/src/views/Header/Header.js
@@ -9,8 +9,8 @@ import {
   View,
   I18nManager,
   ViewPropTypes,
+  MaskedViewIOS,
 } from 'react-native';
-import { MaskedViewIOS } from '../../PlatformHelpers';
 import SafeAreaView from 'react-native-safe-area-view';
 
 import HeaderTitle from './HeaderTitle';


### PR DESCRIPTION
This hack had previously been required for old versions of react native and react-native-web

Now it just causes troubles because new versions of react-native-web do not export `BackAndroid` at all