### PR TITLE
Added withNavigationDebounce and added NavigationUtility which will support with functionalities which are required when redux integration is removed

### DIFF
--- a/flow/react-navigation.js
+++ b/flow/react-navigation.js
@@ -751,15 +751,10 @@ declare module 'react-navigation' {
   };
 
   declare export var NavigationUtils: {
-    setNavigatorReference: (navigator?: {
-      dispatch?: Function,
-      state?: { nav?: Object },
-    }),
     getKeyForNextRoute: (routeName?: string) => string,
     getKeyForRoute: (routeName?: string) => string,
     getCurrentRoute: (navigationState?: Object) => string,
     getCurrentRouteKey: (navigationState?: Object) => string,
-    dispatch: (action?: { type?: string }),
     getState: () => Object,
   };
 
@@ -1190,7 +1185,7 @@ declare module 'react-navigation' {
 
   declare export function withNavigationDebounce<Props: {}>(
     Component: React$ComponentType<Props>,
-    wait?: number,
+    wait?: number
   ): React$ComponentType<$Diff<Props, { isFocused: boolean | void }>>;
 
   declare export function getNavigation<State: NavigationState, Options: {}>(

--- a/flow/react-navigation.js
+++ b/flow/react-navigation.js
@@ -750,6 +750,19 @@ declare module 'react-navigation' {
     ) => NavigationState,
   };
 
+  declare export var NavigationUtils: {
+    setNavigatorReference: (navigator?: {
+      dispatch?: Function,
+      state?: { nav?: Object },
+    }),
+    getKeyForNextRoute: (routeName?: string) => string,
+    getKeyForRoute: (routeName?: string) => string,
+    getCurrentRoute: (navigationState?: Object) => string,
+    getCurrentRouteKey: (navigationState?: Object) => string,
+    dispatch: (action?: { type?: string }),
+    getState: () => Object,
+  };
+
   declare export var NavigationActions: {
     BACK: 'Navigation/BACK',
     INIT: 'Navigation/INIT',
@@ -1173,6 +1186,11 @@ declare module 'react-navigation' {
   >;
   declare export function withNavigationFocus<Props: {}>(
     Component: React$ComponentType<Props>
+  ): React$ComponentType<$Diff<Props, { isFocused: boolean | void }>>;
+
+  declare export function withNavigationDebounce<Props: {}>(
+    Component: React$ComponentType<Props>,
+    wait?: number,
   ): React$ComponentType<$Diff<Props, { isFocused: boolean | void }>>;
 
   declare export function getNavigation<State: NavigationState, Options: {}>(

--- a/src/NavigationUtils.js
+++ b/src/NavigationUtils.js
@@ -1,0 +1,131 @@
+const errorMessage = {
+  IMPROPER_NAVIGATION_STATE: 'Improper navigation state set as reference to Navigation Utility.',
+  UNDEFINED_PARAMETERS: 'Error in passing parameters.',
+  NO_EXISTING_ROUTE: 'There is no route existing in the stack with the route name',
+  NO_EXISTING_NEXT_ROUTE: 'There is no route existing in the stack next to the route with the route name',
+  IMPROPER_ACTION: 'Actions must be plain objects',
+};
+
+let Navigator = null;
+let debug = false;
+let keysList = [];
+
+const validate = (value, errMsg) => {
+  if (!value && debug) {
+    throw new Error(errMsg);
+  }
+};
+
+const setNavigatorReference = (Nav, debugFlag = false) => {
+  Navigator = Nav;
+  debug = debugFlag;
+};
+
+const searchForNextInState = (navigationState, routeName) => {
+  validate(navigationState, errorMessage.IMPROPER_NAVIGATION_STATE);
+  if (navigationState && navigationState.routeName === routeName) {
+    return true;
+  }
+  if (navigationState && navigationState.routes) {
+    const { length } = navigationState.routes;
+    for (let i = 0; i < length; i += 1) {
+      const found = searchForNextInState(navigationState.routes[i], routeName);
+      if ((i + 1) < length && found) {
+        keysList.push(navigationState.routes[i + 1].key);
+      } else if (found) {
+        return true;
+      }
+    }
+  }
+  return false;
+};
+
+const getKeyForNextRoute = (routeName) => {
+  validate(routeName, errorMessage.UNDEFINED_PARAMETERS);
+  if (routeName) {
+    keysList = [];
+    searchForNextInState(Navigator.state.nav, routeName);
+    if (keysList.length === 0) {
+      if (debug) {
+        throw new Error(`${errorMessage.NO_EXISTING_NEXT_ROUTE} ${routeName}.`);
+      }
+      return '';
+    }
+    return keysList[keysList.length - 1];
+  }
+  return '';
+};
+
+const searchInState = (navigationState, routeName) => {
+  validate(navigationState, errorMessage.IMPROPER_NAVIGATION_STATE);
+  if (navigationState && navigationState.routeName === routeName) {
+    keysList.push(navigationState.key);
+    return;
+  }
+  if (navigationState && navigationState.routes) {
+    const { length } = navigationState.routes;
+    for (let i = 0; i < length; i += 1) {
+      searchInState(navigationState.routes[i], routeName);
+    }
+  }
+};
+
+const getKeyForRoute = (routeName) => {
+  validate(routeName, errorMessage.UNDEFINED_PARAMETERS);
+  if (routeName) {
+    keysList = [];
+    searchInState(Navigator.state.nav, routeName);
+    if (keysList.length === 0) {
+      if (debug) {
+        throw new Error(`${errorMessage.NO_EXISTING_ROUTE} ${routeName}.`);
+      }
+      return '';
+    }
+    return keysList[keysList.length - 1];
+  }
+  return '';
+};
+
+const getCurrentRoute = (navigationState = Navigator.state.nav) => {
+  validate(navigationState, errorMessage.IMPROPER_NAVIGATION_STATE);
+  if (navigationState && navigationState.routes) {
+    const currentIndex = navigationState.index;
+    return getCurrentRoute(navigationState.routes[currentIndex]);
+  }
+  if (navigationState) {
+    return navigationState.routeName;
+  }
+  return '';
+};
+
+const getCurrentRouteKey = (navigationState = Navigator.state.nav) => {
+  validate(navigationState, errorMessage.IMPROPER_NAVIGATION_STATE);
+  if (navigationState && navigationState.routes) {
+    const currentIndex = navigationState.index;
+    return getCurrentRouteKey(navigationState.routes[currentIndex]);
+  }
+  if (navigationState) {
+    return navigationState.key;
+  }
+  return '';
+};
+
+const dispatch = (action) => {
+  if (typeof action === 'object') {
+    Navigator.dispatch(action);
+  } else if (debug) {
+    throw new Error(errorMessage.IMPROPER_ACTION);
+  }
+};
+
+const getState = () => Navigator.state.nav;
+
+export default {
+  setNavigatorReference,
+  getKeyForNextRoute,
+  getKeyForRoute,
+  getCurrentRoute,
+  getCurrentRouteKey,
+  dispatch,
+  getState,
+};

--- a/src/NavigationUtils.js
+++ b/src/NavigationUtils.js
@@ -1,8 +1,11 @@
 const errorMessage = {
-  IMPROPER_NAVIGATION_STATE: 'Improper navigation state set as reference to Navigation Utility.',
+  IMPROPER_NAVIGATION_STATE:
+    'Improper navigation state set as reference to Navigation Utility.',
   UNDEFINED_PARAMETERS: 'Error in passing parameters.',
-  NO_EXISTING_ROUTE: 'There is no route existing in the stack with the route name',
-  NO_EXISTING_NEXT_ROUTE: 'There is no route existing in the stack next to the route with the route name',
+  NO_EXISTING_ROUTE:
+    'There is no route existing in the stack with the route name',
+  NO_EXISTING_NEXT_ROUTE:
+    'There is no route existing in the stack next to the route with the route name',
   IMPROPER_ACTION: 'Actions must be plain objects',
 };
 
@@ -30,7 +33,7 @@ const searchForNextInState = (navigationState, routeName) => {
     const { length } = navigationState.routes;
     for (let i = 0; i < length; i += 1) {
       const found = searchForNextInState(navigationState.routes[i], routeName);
-      if ((i + 1) < length && found) {
+      if (i + 1 < length && found) {
         keysList.push(navigationState.routes[i + 1].key);
       } else if (found) {
         return true;
@@ -40,7 +43,7 @@ const searchForNextInState = (navigationState, routeName) => {
   return false;
 };
 
-const getKeyForNextRoute = (routeName) => {
+const getKeyForNextRoute = routeName => {
   validate(routeName, errorMessage.UNDEFINED_PARAMETERS);
   if (routeName) {
     keysList = [];
@@ -70,7 +73,7 @@ const searchInState = (navigationState, routeName) => {
   }
 };
 
-const getKeyForRoute = (routeName) => {
+const getKeyForRoute = routeName => {
   validate(routeName, errorMessage.UNDEFINED_PARAMETERS);
   if (routeName) {
     keysList = [];
@@ -110,7 +113,7 @@ const getCurrentRouteKey = (navigationState = Navigator.state.nav) => {
   return '';
 };
 
-const dispatch = (action) => {
+const dispatch = action => {
   if (typeof action === 'object') {
     Navigator.dispatch(action);
   } else if (debug) {

--- a/src/react-navigation.js
+++ b/src/react-navigation.js
@@ -178,5 +178,5 @@ module.exports = {
   },
   get withNavigationDebounce() {
     return require('./views/withNavigationDebounce').default;
-  }
+  },
 };

--- a/src/react-navigation.js
+++ b/src/react-navigation.js
@@ -161,6 +161,11 @@ module.exports = {
     return require('./views/NavigationEvents').default;
   },
 
+  // NavigationUtils
+  get NavigationUtils() {
+    return require('./NavigationUtils').default;
+  },
+
   // HOCs
   get withNavigation() {
     return require('./views/withNavigation').default;
@@ -171,4 +176,7 @@ module.exports = {
   get withOrientation() {
     return require('./views/withOrientation').default;
   },
+  get withNavigationDebounce() {
+    return require('./views/withNavigationDebounce').default;
+  }
 };

--- a/src/views/withNavigationDebounce.js
+++ b/src/views/withNavigationDebounce.js
@@ -1,0 +1,79 @@
+import React from 'react';
+import hoistStatics from 'hoist-non-react-statics';
+import invariant from '../utils/invariant';
+import withNavigation from './withNavigation';
+
+export default function withNavigationFocus(Component, wait = 200) {
+  class ComponentWithNavigationFocus extends React.Component {
+    static displayName = `withNavigationDebounce(${Component.displayName ||
+      Component.name})`;
+
+    constructor(props) {
+      super(props);
+
+      this.state = {
+        isFocused: props.navigation ? props.navigation.isFocused() : false,
+      };
+    }
+
+    componentDidMount() {
+      const { navigation } = this.props;
+      invariant(
+        !!navigation,
+        'withNavigationDebounce can only be used on a view hierarchy of a navigator. The wrapped component is unable to get access to navigation from props or context.'
+      );
+    }
+
+    lastCalled = Date.now();
+
+    goBack = (...args) => {
+      if (Date.now() - this.lastCalled <= wait) {
+        return;
+      }
+      this.lastCalled = Date.now();
+      this.props.navigation.goBack(...args);
+    }
+
+    pop = (...args) => {
+      if (Date.now() - this.lastCalled <= wait) {
+        return;
+      }
+      this.lastCalled = Date.now();
+      this.props.navigation.goBack(...args);
+    }
+
+    navigate = (...args) => {
+      if (Date.now() - this.lastCalled <= wait) {
+        return;
+      }
+      this.lastCalled = Date.now();
+      this.props.navigation.goBack(...args);
+    }
+
+    push = (...args) => {
+      if (Date.now() - this.lastCalled <= wait) {
+        return;
+      }
+      this.lastCalled = Date.now();
+      this.props.navigation.goBack(...args);
+    }
+
+    render() {
+      return (
+        <Component
+          {...this.props}
+          ref={this.props.onRef}
+          navigation={{
+            ...this.props.navigation,
+            goBack: this.goBack,
+            navigate: this.navigate,
+            push: this.push,
+            pop: this.pop,
+          }}
+        />
+      );
+    }
+  }
+
+  return hoistStatics(withNavigation(ComponentWithNavigationFocus), Component);
+}

--- a/src/views/withNavigationDebounce.js
+++ b/src/views/withNavigationDebounce.js
@@ -32,7 +32,7 @@ export default function withNavigationFocus(Component, wait = 200) {
       }
       this.lastCalled = Date.now();
       this.props.navigation.goBack(...args);
-    }
+    };
 
     pop = (...args) => {
       if (Date.now() - this.lastCalled <= wait) {
@@ -40,7 +40,7 @@ export default function withNavigationFocus(Component, wait = 200) {
       }
       this.lastCalled = Date.now();
       this.props.navigation.goBack(...args);
-    }
+    };
 
     navigate = (...args) => {
       if (Date.now() - this.lastCalled <= wait) {
@@ -48,7 +48,7 @@ export default function withNavigationFocus(Component, wait = 200) {
       }
       this.lastCalled = Date.now();
       this.props.navigation.goBack(...args);
-    }
+    };
 
     push = (...args) => {
       if (Date.now() - this.lastCalled <= wait) {
@@ -56,7 +56,7 @@ export default function withNavigationFocus(Component, wait = 200) {
       }
       this.lastCalled = Date.now();
       this.props.navigation.goBack(...args);
-    }
+    };
 
     render() {
       return (

--- a/src/views/withNavigationFocus.js
+++ b/src/views/withNavigationFocus.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import propTypes from 'prop-types';
 import hoistStatics from 'hoist-non-react-statics';
 import invariant from '../utils/invariant';
 import withNavigation from './withNavigation';


### PR DESCRIPTION
**NavigationUtility**
The intention behind adding this utility is the requirements that arise when the redux integration has been removed like dispatching actions and getting the navigation state at any component despite the fact that it has the navigation prop. Other requirements that are fulfilled through this utility are getting the current route or key, searching for any route or key and getting the key to the route next to the route name specified (which is used in a go back).

**withNavigationDebounce**
This is a HOC which has the same navigation methods debounced with the wait time passed as a parameter. This requirement could have been fulfilled through the redux integration using which we had a chance to change the navigation state at our end manually, but with the removal of redux integration, this can be used as an alternative.