### PR TITLE
Avoid crash when calling isFocused on old route

### DIFF
--- a/src/getChildNavigation.js
+++ b/src/getChildNavigation.js
@@ -19,6 +19,10 @@ function getChildNavigation(navigation, childKey, getCurrentParentNavigation) {
 
   const childRoute = navigation.state.routes.find(r => r.key === childKey);
 
+  if (!childRoute) {
+    return null;
+  }
+
   if (children[childKey] && children[childKey].state === childRoute) {
     return children[childKey];
   }
@@ -79,12 +83,16 @@ function getChildNavigation(navigation, childKey, getCurrentParentNavigation) {
     getParam: createParamGetter(childRoute),
 
     getChildNavigation: grandChildKey =>
-      getChildNavigation(children[childKey], grandChildKey, () =>
-        getCurrentParentNavigation().getChildNavigation(childKey)
-      ),
+      getChildNavigation(children[childKey], grandChildKey, () => {
+        const nav = getCurrentParentNavigation();
+        return nav && nav.getChildNavigation(childKey);
+      }),
 
     isFocused: () => {
       const currentNavigation = getCurrentParentNavigation();
+      if (!currentNavigation) {
+        return false;
+      }
       const { routes, index } = currentNavigation.state;
       if (!currentNavigation.isFocused()) {
         return false;


### PR DESCRIPTION
Provide protection against calling isFocused on the navigation prop of a route that is no longer in the navigation state

Fixes https://github.com/react-navigation/react-navigation/issues/4610