### PR TITLE
fix(header): fixing bug when header disappear when absolute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## Fixed
+- [Android] Fixing missing Header when give headerStyle a position absolute & Fixing missing header shadow.
+
 ## [2.6.0] - [2018-07-04](https://github.com/react-navigation/react-navigation/releases/tag/2.6.0)
 ### Added
 - [NavigationEvents](https://github.com/react-navigation/react-navigation/pull/4188) component as a declarative interface for subscribing to navigation focus events.

--- a/src/views/Header/Header.js
+++ b/src/views/Header/Header.js
@@ -500,12 +500,7 @@ class Header extends React.PureComponent {
     const forceInset = headerForceInset || { top: 'always', bottom: 'never' };
 
     return (
-      <Animated.View
-        style={[
-          this.props.layoutInterpolator(this.props),
-          { backgroundColor: DEFAULT_BACKGROUND_COLOR },
-        ]}
-      >
+      <Animated.View style={[this.props.layoutInterpolator(this.props)]}>
         <SafeAreaView forceInset={forceInset} style={containerStyles}>
           <View style={StyleSheet.absoluteFill}>
             {options.headerBackground}


### PR DESCRIPTION
## Motivation
There's a bug in Android header after version >= 2.5.4
Fixing:
- missing header when position absolute #4643 
- missing shadow in android. #4607