### PR TITLE
Fix #4608 - remove header left component only when a headerLeft optio…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - StackNavigator.replace method no longer requires a key param. If the key is left undefined, the last screen in the stack will be replaced.
 
 ### Fixed
-- Remove header left component only when the headerLeft option is not specified (#4608).
+- Support headerLeft component for the first screen in a stack (#4608).
 
 ## [2.6.2] - [2018-07-06](https://github.com/react-navigation/react-navigation/releases/tag/2.6.2)
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - StackNavigator.replace method no longer requires a key param. If the key is left undefined, the last screen in the stack will be replaced.
 
+### Fixed
+- Remove header left component only when the headerLeft option is not specified (#4608).
+
 ## [2.6.2] - [2018-07-06](https://github.com/react-navigation/react-navigation/releases/tag/2.6.2)
 ### Changed
 - Relax vertical padding warnings on header.

--- a/src/views/Header/Header.js
+++ b/src/views/Header/Header.js
@@ -141,7 +141,7 @@ class Header extends React.PureComponent {
       return options.headerLeft;
     }
 
-    if (props.scene.index === 0) {
+    if (!options.headerLeft && props.scene.index === 0) {
       return;
     }
 


### PR DESCRIPTION
## Motivation

Fix #4608 - remove header left component only when a headerLeft option is not specified

