### PR TITLE
Set borderBottom to transparent and of size 0 if headerTransparent is true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - Support headerLeft component for the first screen in a stack (#4608).
+- Removed bottomBorder when `headerTransparent` is set to true.
 
 ## [2.6.2] - [2018-07-06](https://github.com/react-navigation/react-navigation/releases/tag/2.6.2)
 ### Changed

--- a/src/views/Header/Header.js
+++ b/src/views/Header/Header.js
@@ -586,6 +586,8 @@ const styles = StyleSheet.create({
     left: 0,
     right: 0,
     ...platformContainerStyles,
+    borderBottomWidth: 0,
+    borderBottomColor: 'transparent',
     elevation: 0,
   },
   header: {


### PR DESCRIPTION
## Motivation

As explained in issue #4695, setting `headerTransparent` still leaves a borderBottom of width 0.5 and color of `#A7A7AA`. This PR aims to fix that issue.

## Test plan

Before: 
![img_1185](https://user-images.githubusercontent.com/17203119/42786547-b5935f2e-8924-11e8-87a2-a21967a0f29f.PNG )

After:
![img_1184](https://user-images.githubusercontent.com/17203119/42786544-b0283f32-8924-11e8-9cc7-7632aefa2d55.PNG)
