### PR TITLE
DeepLinking should trigger Push action instead of Navigate action whe…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- DeepLinking should trigger Push action instead of Navigate action when routes are the same but paths are differents (ex: message/1 => message/2).
+
 ### Changed
 - StackNavigator.replace method no longer requires a key param. If the key is left undefined, the last screen in the stack will be replaced.
 

--- a/src/createNavigationContainer.js
+++ b/src/createNavigationContainer.js
@@ -3,6 +3,7 @@ import { AsyncStorage, Linking, Platform, BackHandler } from 'react-native';
 import { polyfill } from 'react-lifecycles-compat';
 
 import NavigationActions from './NavigationActions';
+import StackActions from './routers/StackActions';
 import getNavigation from './getNavigation';
 import invariant from './utils/invariant';
 import docsUrl from './utils/docsUrl';
@@ -131,6 +132,7 @@ export default function createNavigationContainer(Component) {
 
     _handleOpenURL = ({ url }) => {
       const { enableURLHandling, uriPrefix } = this.props;
+      const { nav } = this.state;
       if (enableURLHandling === false) {
         return;
       }
@@ -138,7 +140,11 @@ export default function createNavigationContainer(Component) {
       if (parsedUrl) {
         const { path, params } = parsedUrl;
         const action = Component.router.getActionForPathAndParams(path, params);
+        const currentRoute = Component.router.getPathAndParamsForState(nav);
         if (action) {
+          if (currentRoute.path !== path) {
+            action.type = StackActions.PUSH;
+          }
           this.dispatch(action);
         }
       }


### PR DESCRIPTION
…n routes are the same but paths are differents (ex: message/1 => message/2)

## Motivations :

For example if I'm on a product page on a marketplace application, I could have a list of similar products, and clicking on it would push another screen, not replace the current one.

It should be the same when navigating from deeplink.
If my app is opened on a Product page A and I receive a message from a friend with a link to Product B and click on it, the App should also PUSH a new Screen, so I can go back to Product A.

The navigation does not push the new screen, and still use the Navigate action, which only replace the current screen with new parameters.
The navigation should use the PUSH action when the paths are differents.

