### PR TITLE
Fix typo in header transition preset check (uitkit -> uikit)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Typo in Header transition preset check.
+
 ## [2.9.0] - [2018-07-20](https://github.com/react-navigation/react-navigation/releases/tag/2.9.0)
 ### Added
 - `headerLayoutPreset: 'center' | 'left'` to provide an easy solution for [questions like this](https://github.com/react-navigation/react-navigation/issues/4615).

--- a/src/views/StackView/StackViewLayout.js
+++ b/src/views/StackView/StackViewLayout.js
@@ -490,7 +490,7 @@ class StackViewLayout extends React.Component {
     if (headerLayoutPreset) {
       if (__DEV__) {
         if (
-          this._getHeaderTransitionPreset() === 'uitkit' &&
+          this._getHeaderTransitionPreset() === 'uikit' &&
           headerLayoutPreset === 'left' &&
           Platform.OS === 'ios'
         ) {


### PR DESCRIPTION
## Motivation

The header transition preset check in `StackViewLayout` contains a typo, checking for `uitkit` instead of `uikit`.