### PR TITLE
Take into account correctly the presence of headerLeft  component when computing title offsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Take into account correctly the presence of `headerLeft` component when computing title offsets (#4754).
+
 ## [2.9.0] - [2018-07-20](https://github.com/react-navigation/react-navigation/releases/tag/2.9.0)
 ### Added
 - `headerLayoutPreset: 'center' | 'left'` to provide an easy solution for [questions like this](https://github.com/react-navigation/react-navigation/issues/4615).
-- `headerBackTitleEnabled` - this configuration option for stack navigator allows you to force back button titles to either be rendered or not (if you disagree with defaults for your platform and layout preset).
+- `headerBackTitleVisible` - this configuration option for stack navigator allows you to force back button titles to either be rendered or not (if you disagree with defaults for your platform and layout preset).
 
 ### Fixed
 - Android back button ripple is now appropriately sized (fixes [#3955](https://github.com/react-navigation/react-navigation/issues/3955)).

--- a/src/views/Header/Header.js
+++ b/src/views/Header/Header.js
@@ -26,12 +26,12 @@ const STATUSBAR_HEIGHT = Platform.OS === 'ios' ? 20 : 0;
 const TITLE_OFFSET_CENTER_ALIGN = Platform.OS === 'ios' ? 70 : 56;
 const TITLE_OFFSET_LEFT_ALIGN = Platform.OS === 'ios' ? 20 : 56;
 
-const getTitleOffsets = (
+const getTitleOffsets = ({
   layoutPreset,
   forceBackTitle,
   hasLeftComponent,
-  hasRightComponent
-) => {
+  hasRightComponent,
+}) => {
   if (layoutPreset === 'left') {
     // Maybe at some point we should do something different if the back title is
     // explicitly enabled, for now people can control it manually
@@ -303,11 +303,11 @@ class Header extends React.PureComponent {
     const { layoutPreset, transitionPreset } = this.props;
     let style = [
       { justifyContent: layoutPreset === 'center' ? 'center' : 'flex-start' },
-      getTitleOffsets(
+      getTitleOffsets({
         layoutPreset,
-        options.hasLeftComponent,
-        options.hasRightComponent
-      ),
+        hasLeftComponent: options.hasLeftComponent,
+        hasRightComponent: options.hasRightComponent,
+      }),
       options.headerTitleContainerStyle,
     ];
 


### PR DESCRIPTION
## Motivation

A `getTitleOffsets` function computes the title offsets for the header, but was called with 3 arguments instead of the required 4 (`forceBackTitle` was missing). 

I solved the bug by making the function accept an object as parameter, so now it works even if `forceBackTitle` is not passed. I took this route instead of giving it a value because it is currently not used in the function body, and I am not sure which value it would need to receive.

Fix #4754.

## Changelog

I inserted one entry for the fix in the changelog, and corrected release notes for 2.9.0 (the new prop is called `headerBackTitleVisible`, not `headerBackTitleEnabled`).
