### PR TITLE
Export StackViewTransitionConfigs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Export `StackViewTransitionConfigs` to allow you to extend default config in custom transition configs. [#4761](https://github.com/react-navigation/react-navigation/pull/4761)
+
 ## [2.9.1] - [2018-07-24](https://github.com/react-navigation/react-navigation/releases/tag/2.9.1)
 ### Fixed
 - Incorrect parameters passed to title offset calculation led to bug in header layout when no right component (https://github.com/react-navigation/react-navigation/issues/4754)

--- a/src/react-navigation.js
+++ b/src/react-navigation.js
@@ -99,6 +99,9 @@ module.exports = {
   get StackViewCard() {
     return require('./views/StackView/StackViewCard').default;
   },
+  get StackViewTransitionConfigs() {
+    return require('./views/StackView/StackViewTransitionConfigs').default;
+  },
   get SafeAreaView() {
     return require('react-native-safe-area-view').default;
   },

--- a/src/views/StackView/StackViewTransitionConfigs.js
+++ b/src/views/StackView/StackViewTransitionConfigs.js
@@ -107,4 +107,8 @@ function getTransitionConfig(
 export default {
   defaultTransitionConfig,
   getTransitionConfig,
+  SlideFromRightIOS,
+  ModalSlideFromBottomIOS,
+  FadeInFromBottomAndroid,
+  FadeOutToBottomAndroid,
 };


### PR DESCRIPTION
## Motivation

Export `StackViewTransitionConfigs` is very handy for custom `transitionConfig` in navigator options to reuse the default ones.

## Test plan

The code must pass tests.

## Code formatting

Done

## Changelog

Export `StackViewTransitionConfigs` to allow you to extend default config in custom transition configs.

[CHANGELOG.md](https://github.com/react-navigation/react-navigation/blob/master/CHANGELOG.md#unreleased)