### PR TITLE
Animate headerBackground between scene transitions

### DIFF
--- a/src/views/Header/Header.js
+++ b/src/views/Header/Header.js
@@ -80,6 +80,7 @@ class Header extends React.PureComponent {
     titleFromLeftInterpolator: HeaderStyleInterpolator.forCenterFromLeft,
     titleInterpolator: HeaderStyleInterpolator.forCenter,
     rightInterpolator: HeaderStyleInterpolator.forRight,
+    backgroundInterpolator: HeaderStyleInterpolator.forBackground,
   };
 
   static get HEIGHT() {
@@ -490,8 +491,43 @@ class Header extends React.PureComponent {
     }
   }
 
+  _renderBackground(props) {
+    const {
+      index,
+      descriptor: { options },
+    } = props.scene;
+
+    if (options.headerBackground === null) {
+      return null;
+    }
+
+    const offset = this.props.navigation.state.index - index;
+
+    if (Math.abs(offset) > 2) {
+      // Scene is far away from the active scene. Hides it to avoid unnecessary
+      // rendering.
+      return null;
+    }
+
+    return (
+      <Animated.View
+        style={[
+          StyleSheet.absoluteFill,
+          this.props.backgroundInterpolator({
+            // todo: determine if we really need to splat all this.props
+            ...this.props,
+            ...props,
+          }),
+        ]}
+      >
+        {options.headerBackground}
+      </Animated.View>
+    );
+  }
+
   render() {
     let appBar;
+    let background;
     const { mode, scene, isLandscape } = this.props;
 
     if (mode === 'float') {
@@ -505,12 +541,16 @@ class Header extends React.PureComponent {
         scene,
       }));
       appBar = scenesProps.map(this._renderHeader, this);
+      background = scenesProps.map(this._renderBackground, this);
     } else {
-      appBar = this._renderHeader({
+      const headerProps = {
         position: new Animated.Value(this.props.scene.index),
         progress: new Animated.Value(0),
         scene: this.props.scene,
-      });
+      };
+
+      appBar = this._renderHeader(headerProps);
+      background = this._renderBackground(headerProps);
     }
 
     const { options } = scene.descriptor;
@@ -590,9 +630,7 @@ class Header extends React.PureComponent {
         ]}
       >
         <SafeAreaView forceInset={forceInset} style={containerStyles}>
-          <View style={StyleSheet.absoluteFill}>
-            {options.headerBackground}
-          </View>
+          {background}
           <View style={styles.flexOne}>{appBar}</View>
         </SafeAreaView>
       </Animated.View>

--- a/src/views/Header/Header.js
+++ b/src/views/Header/Header.js
@@ -494,6 +494,7 @@ class Header extends React.PureComponent {
   _renderBackground(props) {
     const {
       index,
+      key,
       descriptor: { options },
     } = props.scene;
 
@@ -511,6 +512,7 @@ class Header extends React.PureComponent {
 
     return (
       <Animated.View
+        key={`background_${key}`}
         style={[
           StyleSheet.absoluteFill,
           this.props.backgroundInterpolator({

--- a/src/views/Header/HeaderStyleInterpolator.js
+++ b/src/views/Header/HeaderStyleInterpolator.js
@@ -325,6 +325,31 @@ function forCenterFromLeft(props) {
   };
 }
 
+const BACKGROUND_OFFSET = Dimensions.get('window').width;
+function forBackground(props) {
+  const { position, scene, scenes } = props;
+  const interpolate = getSceneIndicesForInterpolationInputRange(props);
+
+  if (!interpolate) return { opacity: 0 };
+
+  const { first, last } = interpolate;
+  const index = scene.index;
+  const offset = BACKGROUND_OFFSET;
+
+  const outputRange = [offset, 0, -offset];
+
+  return {
+    transform: [
+      {
+        translateX: position.interpolate({
+          inputRange: [first, index, last],
+          outputRange: I18nManager.isRTL ? outputRange.reverse() : outputRange,
+        }),
+      },
+    ],
+  };
+}
+
 export default {
   forLayout,
   forLeft,
@@ -333,4 +358,5 @@ export default {
   forCenterFromLeft,
   forCenter,
   forRight,
+  forBackground,
 };


### PR DESCRIPTION
Currently, headerBackground is sort of just plopped in place between scene changes which leads to it looking pretty jarring between transitions. What I'm proposing here is that we keep `headerBackground` rendered absolutely between scenes much like we do for the left, right and center. The default background interpolator transforms the x-axis moving it to the left and right as the scene transitions. This allows one to pull off the below in a much smoother fashion. 

![background](https://user-images.githubusercontent.com/59875/43374743-19442e86-9366-11e8-9ff2-ff185aab9ab2.gif)

As far as a complete implementation goes I'm not positive what I may be missing as I hacked this together generally quickly and have not tested it in places like android. Although the additions are pretty minimal and the current `headerBackground` option doesn't seem to be used outside of just placing it in the header container. If there is interest around getting this merged I'd be happy to see it to the finish line. What do you guys think?