### PR TITLE
Fixes bug where `null` doesn't work in routerOptions `paths` object for deeplinking

### DIFF
--- a/src/routers/__tests__/PathHandling-test.js
+++ b/src/routers/__tests__/PathHandling-test.js
@@ -547,6 +547,24 @@ const performRouterTest = createTestRouter => {
     expect(action.type).toEqual(NavigationActions.NAVIGATE);
     expect(action.routeName).toEqual('baz');
   });
+
+  test('paths option set as null on router overrides path from route config', () => {
+    const router = createTestRouter(
+      {
+        main: {
+          screen: MainNavigator,
+        },
+        baz: {
+          path: 'bazPath',
+          screen: FooNavigator,
+        },
+      },
+      { paths: { baz: null } }
+    );
+    const action = router.getActionForPathAndParams('b/noBaz', {});
+    expect(action.type).toEqual(NavigationActions.NAVIGATE);
+    expect(action.routeName).toEqual('baz');
+  });
 };
 
 describe('Path handling for stack router', () => {

--- a/src/routers/pathUtils.js
+++ b/src/routers/pathUtils.js
@@ -74,7 +74,14 @@ export const createPathParser = (
 
   // Build pathsByRouteNames, which includes a regex to match paths for each route. Keep in mind, the regex will pass for the route and all child routes. The code that uses pathsByRouteNames will need to also verify that the child router produces an action, in the case of isPathMatchable false (a null path).
   Object.keys(childRouters).forEach(routeName => {
-    let pathPattern = pathConfigs[routeName] || routeConfigs[routeName].path;
+    let pathPattern;
+
+    // First check for paths on the router, then check the route config
+    if (pathConfigs[routeName] !== undefined) {
+      pathPattern = pathConfigs[routeName];
+    } else {
+      pathPattern = routeConfigs[routeName].path;
+    }
 
     if (pathPattern === undefined) {
       // If the user hasn't specified a path at all, then we assume the routeName is an appropriate path


### PR DESCRIPTION
## Motivation

Fixes the deeplink bug where, if you specified `null` in the routerOptions `paths`, the logic would actually fall back to the `path` specified on the route. This was happening because the logic was `option1 || option2`, and the value we wanted to define with option1 was falsey.

This was especially confusing for me at first because the fallback option is likely to be undefined, and then the path would be set as the default of the `routeName`.

By the way, this is related to https://github.com/react-navigation/react-navigation/pull/4671 and https://github.com/react-navigation/react-navigation/pull/1811, where it became possible to pass `null` as the path for the child router to handle the whole path. Thanks so much for this deeplinking work! It was hard to find, though, so what is the best place to document this?

## Test plan

Added a test

## Changelog

I will add this later if you think this solution is good enough. Thanks!