### PR TITLE
Updated NavigationEvents to support children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Updated `NavigationEvents` to support children.
 
 ## [2.9.3] - [2018-07-26](https://github.com/react-navigation/react-navigation/releases/tag/2.9.3)
 ### Added

--- a/src/views/NavigationEvents.js
+++ b/src/views/NavigationEvents.js
@@ -50,7 +50,7 @@ class NavigationEvents extends React.Component {
   };
 
   render() {
-    return null;
+    return this.props.children || null;
   }
 }
 

--- a/src/views/__tests__/NavigationEvents-test.js
+++ b/src/views/__tests__/NavigationEvents-test.js
@@ -83,6 +83,15 @@ const NavigationEventsTestComp = ({
 };
 
 describe('NavigationEvents', () => {
+  it('Should wrap children', () => {
+    const children = <View />;
+    const { navigation } = createNavigationAndHelpers();
+    const component = renderer.create(
+      <NavigationEvents navigation={navigation}>{children}</NavigationEvents>
+    );
+    expect(component.toJSON().type).toBe('View');
+  });
+
   it('add all listeners with navigation prop', () => {
     const {
       navigation,


### PR DESCRIPTION
## Motivation

The current implementation requires the user to add a useless parent class if your own code is a neighbour of NavigationEvents.

```
import React from 'react';
import { View } from 'react-native';
import { NavigationEvents } from 'react-navigation';

const MyScreen = () => (
  <View>
    <NavigationEvents
      onWillFocus={payload => console.log('will focus',payload)}
      onDidFocus={payload => console.log('did focus',payload)}
      onWillBlur={payload => console.log('will blur',payload)}
      onDidBlur={payload => console.log('did blur',payload)}
    />
    {/* 
      Your view code
    */}
  </View>
);

export default MyScreen;
```
The new implementation would allow the user to get rid of this by adding the configuration without interfering with the layout of the component.

```
import React from 'react';
import { View } from 'react-native';
import { NavigationEvents } from 'react-navigation';

const MyScreen = () => (
  <NavigationEvents
    onWillFocus={payload => console.log('will focus',payload)}
    onDidFocus={payload => console.log('did focus',payload)}
    onWillBlur={payload => console.log('will blur',payload)}
    onDidBlur={payload => console.log('did blur',payload)}
  >
    {/* 
      Your view code
    */}
  </NavigationEvents>
);

export default MyScreen;
```