### PR TITLE
Updated HeaderTitle fontWeight to match current iOS11&12 style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Updated `HeaderTitle` fontWeight to match current iOS11&12 style.
 
 ## [2.10.0] - [2018-08-02](https://github.com/react-navigation/react-navigation/releases/tag/2.10.0)
 ### Added

--- a/src/navigators/__tests__/__snapshots__/NestedNavigator-test.js.snap
+++ b/src/navigators/__tests__/__snapshots__/NestedNavigator-test.js.snap
@@ -238,7 +238,7 @@ exports[`Nested navigators renders succesfully as direct child 1`] = `
                             Object {
                               "color": "rgba(0, 0, 0, .9)",
                               "fontSize": 17,
-                              "fontWeight": "700",
+                              "fontWeight": "600",
                               "marginHorizontal": 16,
                               "textAlign": "center",
                             }
@@ -348,7 +348,7 @@ exports[`Nested navigators renders succesfully as direct child 1`] = `
                     Object {
                       "color": "rgba(0, 0, 0, .9)",
                       "fontSize": 17,
-                      "fontWeight": "700",
+                      "fontWeight": "600",
                       "marginHorizontal": 16,
                       "textAlign": "center",
                     }

--- a/src/navigators/__tests__/__snapshots__/StackNavigator-test.js.snap
+++ b/src/navigators/__tests__/__snapshots__/StackNavigator-test.js.snap
@@ -168,7 +168,7 @@ exports[`StackNavigator applies correct values when headerRight is present 1`] =
                     Object {
                       "color": "rgba(0, 0, 0, .9)",
                       "fontSize": 17,
-                      "fontWeight": "700",
+                      "fontWeight": "600",
                       "marginHorizontal": 16,
                       "textAlign": "center",
                     }
@@ -372,7 +372,7 @@ exports[`StackNavigator renders successfully 1`] = `
                     Object {
                       "color": "rgba(0, 0, 0, .9)",
                       "fontSize": 17,
-                      "fontWeight": "700",
+                      "fontWeight": "600",
                       "marginHorizontal": 16,
                       "textAlign": "center",
                     }

--- a/src/views/Header/HeaderTitle.js
+++ b/src/views/Header/HeaderTitle.js
@@ -15,7 +15,7 @@ const HeaderTitle = ({ style, ...rest }) => (
 const styles = StyleSheet.create({
   title: {
     fontSize: Platform.OS === 'ios' ? 17 : 20,
-    fontWeight: Platform.OS === 'ios' ? '700' : '500',
+    fontWeight: Platform.OS === 'ios' ? '600' : '500',
     color: 'rgba(0, 0, 0, .9)',
     marginHorizontal: 16,
   },


### PR DESCRIPTION
## Motivation


In iOS 11 & the upcoming iOS12 the font of the "standard" Header Title became less thick.
As can be seen on: [NavigationBar Standard](https://developer.apple.com/design/human-interface-guidelines/ios/images/NavigationBar_Standard_2x.png)

https://developer.apple.com/design/resources/ & https://facebook.design/ios11