### PR TITLE
Add disableRouteNamePaths option to router configs

### DIFF
--- a/src/routers/StackRouter.js
+++ b/src/routers/StackRouter.js
@@ -107,7 +107,7 @@ export default (routeConfigs, stackConfig = {}) => {
   const {
     getPathAndParamsForRoute,
     getActionForPathAndParams,
-  } = createPathParser(childRouters, routeConfigs, stackConfig.paths);
+  } = createPathParser(childRouters, routeConfigs, stackConfig);
 
   return {
     childRouters,

--- a/src/routers/SwitchRouter.js
+++ b/src/routers/SwitchRouter.js
@@ -47,7 +47,7 @@ export default (routeConfigs, config = {}) => {
   const {
     getPathAndParamsForRoute,
     getActionForPathAndParams,
-  } = createPathParser(childRouters, routeConfigs, config.paths);
+  } = createPathParser(childRouters, routeConfigs, config);
 
   if (initialRouteIndex === -1) {
     throw new Error(

--- a/src/routers/__tests__/PathHandling-test.js
+++ b/src/routers/__tests__/PathHandling-test.js
@@ -609,10 +609,10 @@ const performRouteNameAsPathDisabledTest = createTestRouter => {
     {
       A: NestedNavigator,
     },
-    { routeNameAsPathDisabled: true }
+    { disableRouteNamePaths: true }
   );
 
-  test('routeNameAsPathDisabled option on router prevent the default path to be the routeName', () => {
+  test('disableRouteNamePaths option on router prevent the default path to be the routeName', () => {
     const action = router.getActionForPathAndParams('baz', {});
 
     expect(action.routeName).toBe('A');
@@ -620,14 +620,14 @@ const performRouteNameAsPathDisabledTest = createTestRouter => {
   });
 };
 
-describe('Stack router handles routeNameAsPathDisabled', () => {
+describe('Stack router handles disableRouteNamePaths', () => {
   performRouteNameAsPathDisabledTest(StackRouter);
 });
 
-describe('Switch router handles routeNameAsPathDisabled', () => {
+describe('Switch router handles disableRouteNamePaths', () => {
   performRouteNameAsPathDisabledTest(SwitchRouter);
 });
 
-describe('Tab router handles routeNameAsPathDisabled', () => {
+describe('Tab router handles disableRouteNamePaths', () => {
   performRouteNameAsPathDisabledTest(TabRouter);
 });

--- a/src/routers/__tests__/PathHandling-test.js
+++ b/src/routers/__tests__/PathHandling-test.js
@@ -4,6 +4,7 @@ import React from 'react';
 
 import SwitchRouter from '../SwitchRouter';
 import StackRouter from '../StackRouter';
+import TabRouter from '../TabRouter';
 import StackActions from '../StackActions';
 import NavigationActions from '../../NavigationActions';
 import { urlToPathAndParams } from '../pathUtils';
@@ -593,4 +594,40 @@ test('Handles nested switch routers', () => {
   expect(action.routeName).toEqual('Docs');
   expect(action.action.type).toEqual(NavigationActions.NAVIGATE);
   expect(action.action.routeName).toEqual('B');
+});
+
+const performRouteNameAsPathDisabledTest = createTestRouter => {
+  const BScreen = () => <div />;
+  const NestedNavigator = () => <div />;
+  NestedNavigator.router = createTestRouter({
+    B: {
+      screen: BScreen,
+      path: 'baz',
+    },
+  });
+  const router = createTestRouter(
+    {
+      A: NestedNavigator,
+    },
+    { routeNameAsPathDisabled: true }
+  );
+
+  test('routeNameAsPathDisabled option on router prevent the default path to be the routeName', () => {
+    const action = router.getActionForPathAndParams('baz', {});
+
+    expect(action.routeName).toBe('A');
+    expect(action.action.routeName).toBe('B');
+  });
+};
+
+describe('Stack router handles routeNameAsPathDisabled', () => {
+  performRouteNameAsPathDisabledTest(StackRouter);
+});
+
+describe('Switch router handles routeNameAsPathDisabled', () => {
+  performRouteNameAsPathDisabledTest(SwitchRouter);
+});
+
+describe('Tab router handles routeNameAsPathDisabled', () => {
+  performRouteNameAsPathDisabledTest(TabRouter);
 });

--- a/src/routers/__tests__/PathHandling-test.js
+++ b/src/routers/__tests__/PathHandling-test.js
@@ -558,7 +558,7 @@ const performRouterTest = createTestRouter => {
 };
 
 describe('Path handling for stack router', () => {
-    performRouterTest(StackRouter);
+  performRouterTest(StackRouter);
 });
 describe('Path handling for switch router', () => {
   performRouterTest(SwitchRouter);

--- a/src/routers/pathUtils.js
+++ b/src/routers/pathUtils.js
@@ -67,7 +67,7 @@ export const urlToPathAndParams = (url, uriPrefix) => {
 export const createPathParser = (
   childRouters,
   routeConfigs,
-  { paths: pathConfigs = {}, routeNameAsPathDisabled }
+  { paths: pathConfigs = {}, disableRouteNamePaths }
 ) => {
   const pathsByRouteNames = {};
   let paths = [];
@@ -84,8 +84,8 @@ export const createPathParser = (
     }
 
     if (pathPattern === undefined) {
-      // If the user hasn't specified a path at all nor routeNameAsPathDisabled, then we assume the routeName is an appropriate path
-      pathPattern = routeNameAsPathDisabled ? null : routeName;
+      // If the user hasn't specified a path at all nor disableRouteNamePaths, then we assume the routeName is an appropriate path
+      pathPattern = disableRouteNamePaths ? null : routeName;
     }
 
     invariant(

--- a/src/routers/pathUtils.js
+++ b/src/routers/pathUtils.js
@@ -67,7 +67,7 @@ export const urlToPathAndParams = (url, uriPrefix) => {
 export const createPathParser = (
   childRouters,
   routeConfigs,
-  pathConfigs = {}
+  { paths: pathConfigs = {}, routeNameAsPathDisabled }
 ) => {
   const pathsByRouteNames = {};
   let paths = [];
@@ -84,8 +84,8 @@ export const createPathParser = (
     }
 
     if (pathPattern === undefined) {
-      // If the user hasn't specified a path at all, then we assume the routeName is an appropriate path
-      pathPattern = routeName;
+      // If the user hasn't specified a path at all nor routeNameAsPathDisabled, then we assume the routeName is an appropriate path
+      pathPattern = routeNameAsPathDisabled ? null : routeName;
     }
 
     invariant(


### PR DESCRIPTION
## Motivation

Since `react-navigation@2.7.0`, the router lost a bit of the magic and to be able to deep link to a nested path we have to append each `routeName` we navigate through or make it explicit that paths are allowed to flow through with a `null` path, because routeName is used as default path.

So, I add `disableRouteNamePaths` to the router configs which is affecting the behavior here:
https://github.com/react-navigation/react-navigation/blob/73c76f1e4bbb015581eaae79a22e0076615ef392/src/routers/pathUtils.js#L86-L89

I find it more flexible than:

```javascript
const tabs = {
  ScreenA: screenGenerator('Screen A'),
  ScreenB: StackNavigator,
};

const TabNavigator = createTabNavigator(tabs, {
  paths: Object.keys(tabs).reduce((paths, path) => ({ ...paths, [path]: null }), {}),
});
```

## Test plan

I've added tests with Stack, Switch, and Tab router.

## Changelog

Add disableRouteNamePaths option to the router configs to disable the default behavior of using routeName as the default path.
