### PR TITLE
Add missing types

### DIFF
--- a/flow/react-navigation.js
+++ b/flow/react-navigation.js
@@ -143,6 +143,14 @@ declare module 'react-navigation' {
     +type: 'Navigation/TOGGLE_DRAWER',
     +key?: string,
   |};
+  declare export type NavigationDrawerOpenedAction = {|
+    +type: 'Navigation/DRAWER_OPENED',
+    +key?: string,
+  |};
+  declare export type NavigationDrawerClosedAction = {|
+    +type: 'Navigation/DRAWER_CLOSED',
+    +key?: string,
+  |};
 
   declare export type NavigationAction =
     | NavigationBackAction
@@ -157,7 +165,9 @@ declare module 'react-navigation' {
     | NavigationCompleteTransitionAction
     | NavigationOpenDrawerAction
     | NavigationCloseDrawerAction
-    | NavigationToggleDrawerAction;
+    | NavigationToggleDrawerAction
+    | NavigationDrawerOpenedAction
+    | NavigationDrawerClosedAction;
 
   /**
    * NavigationState is a tree of routes for a single navigator, where each
@@ -394,6 +404,8 @@ declare module 'react-navigation' {
     mode?: 'card' | 'modal',
     headerMode?: HeaderMode,
     headerTransitionPreset?: 'fade-in-place' | 'uikit',
+    headerLayoutPreset?: 'left' | 'center',
+    headerBackTitleVisible?: boolean,
     cardStyle?: ViewStyleProp,
     transitionConfig?: () => TransitionConfig,
     onTransitionStart?: () => void,

--- a/flow/react-navigation.js
+++ b/flow/react-navigation.js
@@ -825,6 +825,8 @@ declare module 'react-navigation' {
     OPEN_DRAWER: 'Navigation/OPEN_DRAWER',
     CLOSE_DRAWER: 'Navigation/CLOSE_DRAWER',
     TOGGLE_DRAWER: 'Navigation/TOGGLE_DRAWER',
+    DRAWER_OPENED: 'Navigation/DRAWER_OPENED',
+    DRAWER_CLOSED: 'Navigation/DRAWER_CLOSED',
 
     openDrawer: (payload: {
       key?: string,


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

## Motivation

There are types that I'm expecting to be available (based on docs and source code) but aren't present, so I get flow errors in my code.

## Test plan

``` js
import React from 'react';
import { createStackNavigator } from 'react-navigation';
import type { NavigationAction, NavigationState } from 'react-navigation';

const StackNavigator = createStackNavigator({ /* ... */ }, {
  headerLayoutPreset: 'center',    // <---- Flow Error
  headerBackTitleVisible: false    // <---- Flow Error
});

function handleNavigationStateChange(
  prevState: NavigationState,
  currentState: NavigationState,
  action: NavigationAction
) {
  switch (action.type) {
    case 'Navigation/DRAWER_OPENED':    // <---- Flow Error
      // do something...
      break;
    case 'Navigation/DRAWER_CLOSED':    // <---- Flow Error
      // do something...
      break;
    default:
      break;
  }
}

const RootNavigator = () => (
  <StackNavigator onNavigationStateChange={handleNavigationStateChange} />
);

```

## Changelog

Add an entry under the "Unreleased" heading in [CHANGELOG.md](https://github.com/react-navigation/react-navigation/blob/master/CHANGELOG.md#unreleased) which explains your change.