### PR TITLE
Backport react-native-safe-area-view bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "prop-types": "^15.5.10",
     "react-lifecycles-compat": "^3.0.2",
     "react-native-drawer-layout-polyfill": "^1.3.2",
-    "react-native-safe-area-view": "^0.7.0",
+    "react-native-safe-area-view": "^0.9.0",
     "react-native-tab-view": "github:react-navigation/react-native-tab-view"
   },
   "devDependencies": {


### PR DESCRIPTION
This backports https://github.com/react-navigation/react-navigation/pull/4810 to the 1.x branch.