### PR TITLE
[flow] Fix missing headerLayoutPreset option in StackNavigatorConfig

### DIFF
--- a/flow/react-navigation.js
+++ b/flow/react-navigation.js
@@ -394,6 +394,7 @@ declare module 'react-navigation' {
     mode?: 'card' | 'modal',
     headerMode?: HeaderMode,
     headerTransitionPreset?: 'fade-in-place' | 'uikit',
+    headerLayoutPreset?: 'left' | 'center',
     cardStyle?: ViewStyleProp,
     transitionConfig?: () => TransitionConfig,
     onTransitionStart?: () => void,


### PR DESCRIPTION
As specified in the [official docs](https://reactnavigation.org/docs/en/stack-navigator.html#stacknavigatorconfig), `StackNavigatorConfig` allows one to optionally set `headerLayoutPreset` to either `left` or `center`, but the current flow libdef doesn't reflect that so `const stack = createStackNavigator({}, { headerLayoutPreset: "center" });` raises a flow error.

## Test plan

`const stack = createStackNavigator({}, { headerLayoutPreset: "center" });` should no longer raise error.