### PR TITLE
Pin create-react-context at v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Pinned `create-react-context` dependency to `0.2.2` (https://github.com/react-navigation/react-navigation/issues/4934)
+
+
 ## [2.12.1] - [2018-08-23](https://github.com/react-navigation/react-navigation/releases/tag/2.12.1)
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "clamp": "^1.0.1",
-    "create-react-context": "^0.2.1",
+    "create-react-context": "0.2.2",
     "hoist-non-react-statics": "^2.2.0",
     "path-to-regexp": "^1.7.0",
     "query-string": "^6.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1584,7 +1584,7 @@ create-react-class@^15.5.2:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
-create-react-context@^0.2.1:
+create-react-context@0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.2.2.tgz#9836542f9aaa22868cd7d4a6f82667df38019dca"
   dependencies:


### PR DESCRIPTION
Because `create-react-context` updated its license from MIT (read: Open
Source) to a more-restrictive, non-Open Source license without
appropriately bumping its major version in violation of semver, the
`create-react-context` version within `react-navigation` necessarily
needs to have its version pinned to a version of `create-react-context`
before the license change.

v0.2.2 is the most recent version of `create-react-context` that still
retains an Open Source license.

Note: Another solution to this would be to require `react` `16.3.x` or
higher, which includes the official `React.createContext` API without
need to rely on a third-party library.

Closes #4934