### PR TITLE
Bump Safe-Area-View to remove circular dependency.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- Updated react-native-safe-area-view to 0.10.0 to solve circular dependency issue (fixes #4973)
 
 ## [2.13.0] - [2018-09-06](https://github.com/react-navigation/react-navigation/releases/tag/2.13.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-- Updated react-native-safe-area-view to 0.10.0 to solve circular dependency issue (fixes #4973)
+- Updated react-native-safe-area-view to 0.10.0 to solve circular dependency issue (fixes https://github.com/react-navigation/react-navigation/issues/4973)
 
 ## [2.13.0] - [2018-09-06](https://github.com/react-navigation/react-navigation/releases/tag/2.13.0)
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "path-to-regexp": "^1.7.0",
     "query-string": "^6.1.0",
     "react-lifecycles-compat": "^3",
-    "react-native-safe-area-view": "^0.9.0",
+    "react-native-safe-area-view": "^0.10.0",
     "react-navigation-deprecated-tab-navigator": "1.3.0",
     "react-navigation-drawer": "0.5.0",
     "react-navigation-stack": "0.3.0",


### PR DESCRIPTION
React Native 0.57 now adds a yellowbox warning due to this package, bumping to solve