### PR TITLE
add dangerouslyGetParent() to flow typings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- added `dangerouslyGetParent()` to flow typings
+
 ## [2.16.0] - [2018-09-19](https://github.com/react-navigation/react-navigation/releases/tag/2.16.0)
 
 ### Changed

--- a/flow/react-navigation.js
+++ b/flow/react-navigation.js
@@ -528,6 +528,7 @@ declare module 'react-navigation' {
       callback: NavigationEventCallback
     ) => NavigationEventSubscription,
     getParam: (paramName: string, fallback?: any) => any,
+    dangerouslyGetParent: () => NavigationScreenProp<*>,
     isFocused: () => boolean,
     // Shared action creators that exist for all routers
     goBack: (routeKey?: ?string) => boolean,


### PR DESCRIPTION
## Motivation

The typings do not include `dangerouslyGetParent()` on the navigation prop. One thing I'm not sure about is the asterisk.

this reminds me this function is not properly documented (will do)

## Test plan

flow does not complain locally

## Changelog

done - Add an entry under the "Unreleased" heading in [CHANGELOG.md](https://github.com/react-navigation/react-navigation/blob/master/CHANGELOG.md#unreleased) which explains your change.
