### PR TITLE
[flow] Mark `key` in `StackActions.replace` as optional

### DIFF
--- a/flow/react-navigation.js
+++ b/flow/react-navigation.js
@@ -812,7 +812,7 @@ declare module 'react-navigation' {
       actions: Array<NavigationNavigateAction>,
     }) => NavigationResetAction,
     replace: (payload: {
-      key: string,
+      key?: string,
       routeName: string,
       params?: NavigationParams,
       action?: NavigationNavigateAction,


### PR DESCRIPTION
## Motivation

Since `react-navigation@2.7.0` "StackNavigator.replace method no longer requires a key param. If the key is left undefined, the last screen in the stack will be replaced." With that, `StackActions.replace` no longer requires `key` property to be presented too.

## Test plan

`StackActions.replace({ routeName: 'someRouteName' })` just works.