### PR TITLE
add recursive function to return deeply nested actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- Updated `_handleOpenUrl` to get deeply nested actions
+
 ## [2.17.0] - [2018-09-25](https://github.com/react-navigation/react-navigation/releases/tag/2.17.0)
 
 ### Changed

--- a/src/createNavigationContainer.js
+++ b/src/createNavigationContainer.js
@@ -133,6 +133,13 @@ export default function createNavigationContainer(Component) {
       }
     }
 
+    _getNestedAction = action => {
+      if (!action.action) {
+        return action;
+      }
+      return this._getNestedAction(action.action);
+    };
+
     _handleOpenURL = ({ url }) => {
       const { enableURLHandling, uriPrefix } = this.props;
       if (enableURLHandling === false) {
@@ -143,7 +150,7 @@ export default function createNavigationContainer(Component) {
         const { path, params } = parsedUrl;
         const action = Component.router.getActionForPathAndParams(path, params);
         if (action) {
-          this.dispatch(action);
+          this.dispatch(this._getNestedAction(action));
         }
       }
     };


### PR DESCRIPTION
## Motivation
Adds out of the box support for #1527

Deep linking does not currently support navigating within nested navigators.

Example Navigator architecture:

```
StackNavigator {
  View1
  TabNavigator: {
    Stack1: {
      View2
      View3
    }
    Stack2
  }
}
```

Calling a deep link within `StackNav -> TabNav -> Stack1 -> View2` to move to `view3` does not dispatch the right action. If I were to call open the deep link from a view within `Stack2`, then it works.

## Test plan

I've tested on both `iOS` and `android`. Happy to have others test it within their use cases!

Existing tests pass