### PR TITLE
StackRouter.getStateForAction(reset()) should work without passing state 2nd arg

### DIFF
--- a/src/routers/StackRouter.js
+++ b/src/routers/StackRouter.js
@@ -109,7 +109,7 @@ export default (routeConfigs, stackConfig = {}) => {
     getActionForPathAndParams,
   } = createPathParser(childRouters, routeConfigs, stackConfig);
 
-  return {
+  const router = {
     childRouters,
 
     getComponentForState(state) {
@@ -184,7 +184,11 @@ export default (routeConfigs, stackConfig = {}) => {
     getStateForAction(action, state) {
       // Set up the initial state if needed
       if (!state) {
-        return getInitialState(action);
+        const initialState = getInitialState(action);
+        if (action.type === StackActions.RESET) {
+          return router.getStateForAction(action, initialState);
+        }
+        return initialState;
       }
 
       const activeChildRoute = state.routes[state.index];
@@ -569,4 +573,6 @@ export default (routeConfigs, stackConfig = {}) => {
       stackConfig.navigationOptions
     ),
   };
+
+  return router;
 };

--- a/src/routers/__tests__/StackRouter-test.js
+++ b/src/routers/__tests__/StackRouter-test.js
@@ -1471,6 +1471,38 @@ describe('StackRouter', () => {
     expect(state2 && state2.routes[1].routeName).toEqual('Bar');
   });
 
+  test('Handles the reset action without initial state', () => {
+    const router = StackRouter({
+      Foo: {
+        screen: () => <div />,
+      },
+      Bar: {
+        screen: () => <div />,
+      },
+    });
+    const state = router.getStateForAction({
+      type: StackActions.RESET,
+      actions: [
+        {
+          type: NavigationActions.NAVIGATE,
+          routeName: 'Foo',
+          params: { bar: '42' },
+          immediate: true,
+        },
+        {
+          type: NavigationActions.NAVIGATE,
+          routeName: 'Bar',
+          immediate: true,
+        },
+      ],
+      index: 1,
+    });
+    expect(state && state.index).toEqual(1);
+    expect(state && state.routes[0].params).toEqual({ bar: '42' });
+    expect(state && state.routes[0].routeName).toEqual('Foo');
+    expect(state && state.routes[1].routeName).toEqual('Bar');
+  });
+
   test('Handles the reset action only with correct key set', () => {
     const router = StackRouter({
       Foo: {


### PR DESCRIPTION
I just migrated from 1.0-beta to 2.18.1 and the behavior of StackRouter.getStateForAction changed regarding reset action.

Let's consider this navigator:

```
const AppNavigation = createStackNavigator(
  {
    HomeScreen: { screen: HomeScreen },
    SecondScreen: { screen: SecondScreen },
  },
);
```

Before, one could do:

```js
const SECOND_SCREEN_STATE = getStateForAction(
  StackActions.reset({
    index: 0,
    actions: [NavigationActions.navigate({ routeName: 'SecondScreen' })],
  }),
);
```

now, the 2nd arg is mandatory for the reset action to behave correctly. If you don't pass the initial state arg, getStateForAction always reset to the initial route name ("HomeScreen")

```js
const INITIAL_STATE = getStateForAction(
  NavigationActions.navigate({ routeName: 'HomeScreen' }),
);

const SECOND_SCREEN_STATE = getStateForAction(
  StackActions.reset({
    index: 0,
    actions: [NavigationActions.navigate({ routeName: 'SecondScreen' })],
  }),
  INITIAL_STATE, // => this is now needed
);
```

I think this behavior is confusing for the users that would expect reset to work without providing any state. For example: https://github.com/react-navigation/react-navigation/issues/3031#issuecomment-385751703

I don't know when this behavior changed, but as far as I know I don't remember seing it in breaking changes of 2.x.


About the PR: it is probably not a very elegant implementation. Maybe I should handle this in "getInitialState(action)" instead, not sure how however. Also there's the "replace" action to consider? If this change is approved, please tell me how to polish my PR
