### PR TITLE
[flow-typed] - Fix error "ParamName [1] is incompatible with string [2]."

### DIFF
--- a/flow/react-navigation.js
+++ b/flow/react-navigation.js
@@ -533,7 +533,7 @@ declare module 'react-navigation' {
       eventName: string,
       callback: NavigationEventCallback
     ) => NavigationEventSubscription,
-    getParam: <ParamName>(
+    getParam: <ParamName: string>(
       paramName: ParamName,
       fallback?: $ElementType<
         $PropertyType<


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

## Motivation

Fix Flow error:

```js
Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ flow-typed/npm/react-navigation_v2.x.x.js:539:16

ParamName [1] is incompatible with string [2].

 [2]  72│     [key: string]: mixed,
        :
     536│       eventName: string,
     537│       callback: NavigationEventCallback
     538│     ) => NavigationEventSubscription,
 [1] 539│     getParam: <ParamName>(
     540│       paramName: ParamName,
     541│       fallback?: $ElementType<
     542│         $PropertyType<
```

## Test plan

Before this change, you should get the error above when passing `NavigationStateRoute` to `NavigationScreenProp`. This PR should fix that.

```js
type Props = {
  navigation: NavigationScreenProp<NavigationStateRoute>,
};
```

## Context

This PR was submitted to the flow-typed repo first:
https://github.com/flow-typed/flow-typed/pull/2936
