### PR TITLE
add optional onPersistedStateLoaded prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- Add optional onPersistedStateLoaded prop to be used in conjunction with persistenceKey
+
 ## [2.18.2] - [2018-10-26](https://github.com/react-navigation/react-navigation/releases/tag/2.18.2)
 
 ### Fixed

--- a/src/createNavigationContainer.js
+++ b/src/createNavigationContainer.js
@@ -268,6 +268,10 @@ export default function createNavigationContainer(Component) {
       this.setState({ nav: startupState }, () => {
         _reactNavigationIsHydratingState = false;
         dispatchActions();
+
+        if (typeof this.props.onPersistedStateLoaded === 'function') {
+          this.props.onPersistedStateLoaded(startupState);
+        }
       });
     }
 


### PR DESCRIPTION
Sometimes it's necessary to dispatch a navigation action immediately after mounting the navigator. In my case, this necessity arises when a user opens the app by pressing on a notification -- a notification which is deep-linked to a particular screen in the app.

The problem is, you can't immediately dispatch a navigation action when your navigator uses the persistenceKey. The reason it fails is that the navigator needs time to load the previous nav state from AsyncStorage, and if you try to dispatch a navigation action before the state is loaded, you get an error -- 'should be set in constructor if stateful'.

I've been getting around the error by setting a timeout, sort of like this:

```
render() {
  return (
    <MyNavigator
      persistenceKey='nav'
      ref={navRef => {
        setTimeout(() => {
          navRef.dispatch(NavigationActions.navigate(/* notification screen */));
        }, 500);
      }}
    />
  );
}
```

The timeout gives the navigator time to load the previous nav state from AsyncStorage before the navigation action is dispatched. But obviously this isn't a great solution. 

My proposed change adds an optional `onPersistedStateLoaded` prop that fires once the navigator has loaded the previous state from AsyncStorage. So then I can do this:

```
render() {
  return (
    <MyNavigator
      persistenceKey='nav'
      ref={navRef => this.navRef = navRef}
      onPersistedStateLoaded={() => this.navRef.dispatch(NavigationActions.navigate(/* notification screen */))}
    />
  );
}
```

No more timeout!

Thanks much.
