### PR TITLE
feat(ref): use react-is to enable forwardRef on 2.x, fix #5193

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- Support React.forwardRef on createStackNavigator
+
 ## [2.18.2] - [2018-10-26](https://github.com/react-navigation/react-navigation/releases/tag/2.18.2)
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "hoist-non-react-statics": "^2.2.0",
     "path-to-regexp": "^1.7.0",
     "query-string": "^6.1.0",
+    "react-is": "^16.5.2",
     "react-lifecycles-compat": "^3",
     "react-native-safe-area-view": "0.11.0",
     "react-native-screens": "^1.0.0-alpha.11",
@@ -62,7 +63,7 @@
     "lint-staged": "^4.2.1",
     "prettier": "^1.12.1",
     "prettier-eslint": "^8.8.1",
-    "react": "16.2.0",
+    "react": "16.5.2",
     "react-native": "^0.52.0",
     "react-native-vector-icons": "^4.2.0",
     "react-test-renderer": "^16.0.0"

--- a/src/routers/__tests__/validateRouteConfigMap-test.js
+++ b/src/routers/__tests__/validateRouteConfigMap-test.js
@@ -12,6 +12,10 @@ ProfileNavigator.router = StackRouter({
   },
 });
 
+const ScreenWithForwardRef = React.forwardRef((props, ref) => (
+  <div ref={ref} />
+));
+
 describe('validateRouteConfigMap', () => {
   test('Fails on empty bare screen', () => {
     const invalidMap = {
@@ -54,6 +58,12 @@ describe('validateRouteConfigMap', () => {
         screen: ProfileNavigator,
       },
       Chat: ListScreen,
+    };
+    validateRouteConfigMap(validMap);
+  });
+  test('Succeeds on React.forwardRef', () => {
+    const validMap = {
+      Chat: ScreenWithForwardRef,
     };
     validateRouteConfigMap(validMap);
   });

--- a/src/routers/getScreenForRouteName.js
+++ b/src/routers/getScreenForRouteName.js
@@ -1,3 +1,4 @@
+import { isValidElementType } from 'react-is';
 import invariant from '../utils/invariant';
 
 /**
@@ -23,7 +24,7 @@ export default function getScreenForRouteName(routeConfigs, routeName) {
   if (typeof routeConfig.getScreen === 'function') {
     const screen = routeConfig.getScreen();
     invariant(
-      typeof screen === 'function',
+      isValidElementType(screen),
       `The getScreen defined for route '${routeName} didn't return a valid ` +
         'screen or navigator.\n\n' +
         'Please pass it like this:\n' +

--- a/src/routers/validateRouteConfigMap.js
+++ b/src/routers/validateRouteConfigMap.js
@@ -1,3 +1,4 @@
+import { isValidElementType } from 'react-is';
 import invariant from '../utils/invariant';
 
 /**
@@ -17,9 +18,7 @@ function validateRouteConfigMap(routeConfigs) {
 
     if (
       !screenComponent ||
-      (typeof screenComponent !== 'function' &&
-        typeof screenComponent !== 'string' &&
-        !routeConfig.getScreen)
+      (!isValidElementType(screenComponent) && !routeConfig.getScreen)
     ) {
       throw new Error(`The component for route '${routeName}' must be a React component. For example:
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5601,15 +5601,15 @@ react-transform-hmr@^1.0.4:
     global "^4.3.0"
     react-proxy "^1.1.7"
 
-react@16.2.0:
-  version "16.2.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.2.0.tgz#a31bd2dab89bff65d42134fa187f24d054c273ba"
-  integrity sha512-ZmIomM7EE1DvPEnSFAHZn9Vs9zJl5A9H7el0EGTE6ZbW9FKe/14IYAlPbC8iH25YarEQxZL+E8VW7Mi7kfQrDQ==
+react@16.5.2:
+  version "16.5.2"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.5.2.tgz#19f6b444ed139baa45609eee6dc3d318b3895d42"
+  integrity sha512-FDCSVd3DjVTmbEAjUNX6FgfAmQ+ypJfHUsqUJOYNCBUp1h8lqmtC+0mXJ+JjsWx4KAVTkk1vKd1hLQPvEviSuw==
   dependencies:
-    fbjs "^0.8.16"
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    prop-types "^15.6.0"
+    prop-types "^15.6.2"
+    schedule "^0.5.0"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
## Motivation

Until 3.x is not release as stable, it is good to support components with forwardRef in createStackNavigator.
this is based on this commit https://github.com/react-navigation/react-navigation-core/commit/e4857b6c24ffa8c657887250954490ce1d3fe925

## Test plan

I've added a test using React.forwardRef when validating route configs.
Make sure you test on both platforms if your change affects both platforms.

The code must pass tests.

## Code formatting

Lint-Staged handled

## Changelog

- [x] Add an entry under the "Unreleased" heading in [CHANGELOG.md](https://github.com/react-navigation/react-navigation/blob/master/CHANGELOG.md#unreleased) which explains your change.
