### PR TITLE
Fix typo "transtion" => "transition"

### DIFF
--- a/flow/react-navigation.js
+++ b/flow/react-navigation.js
@@ -678,8 +678,8 @@ declare module 'react-navigation' {
     // The value that represents the progress of the transition when navigation
     // state changes from one to another. Its numeric value will range from 0
     // to 1.
-    //  progress.__getAnimatedValue() < 1 : transtion is happening.
-    //  progress.__getAnimatedValue() == 1 : transtion completes.
+    //  progress.__getAnimatedValue() < 1 : transition is happening.
+    //  progress.__getAnimatedValue() == 1 : transition completes.
     progress: AnimatedValue,
 
     // All the scenes of the transitioner.


### PR DESCRIPTION
## Motivation

Fix minor typo: `transtion` => `transition`.
