### PR TITLE
Issue-5701: TabBarBottom -> BottomTabBar in type definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- fixed types for `BottomTabBar`
+
 ## Changed
 
 - Updated react-native-gesture-handler to ~3.1.0

--- a/flow/react-navigation.js
+++ b/flow/react-navigation.js
@@ -1200,7 +1200,7 @@ declare module 'react-navigation' {
   };
   declare export var TabBarTop: React$ComponentType<_TabBarTopProps>;
 
-  declare type _TabBarBottomProps = {
+  declare type _BottomTabBarProps = {
     activeTintColor: string,
     activeBackgroundColor: string,
     adaptive?: boolean,
@@ -1229,7 +1229,7 @@ declare module 'react-navigation' {
     tabStyle?: ViewStyleProp,
     showIcon?: boolean,
   };
-  declare export var TabBarBottom: React$ComponentType<_TabBarBottomProps>;
+  declare export var BottomTabBar: React$ComponentType<_BottomTabBarProps>;
 
   declare export function withNavigation<
     Props: {},

--- a/typescript/react-navigation.d.ts
+++ b/typescript/react-navigation.d.ts
@@ -1102,7 +1102,7 @@ declare module 'react-navigation' {
     iconStyle?: ViewStyle;
   }
 
-  export interface TabBarBottomProps {
+  export interface BottomTabBarProps {
     activeTintColor: string;
     activeBackgroundColor: string;
     adaptive?: boolean;
@@ -1132,7 +1132,7 @@ declare module 'react-navigation' {
   }
 
   export const TabBarTop: React.ComponentType<TabBarTopProps>;
-  export const TabBarBottom: React.ComponentType<TabBarBottomProps>;
+  export const BottomTabBar: React.ComponentType<BottomTabBarProps>;
 
   /**
    * NavigationActions


### PR DESCRIPTION
## Motivation
Type definitions for `TabBarBottom` should be `BottomTabBar`.

https://github.com/react-navigation/react-navigation/issues/5701

## Changelog
updated: ✅ 