### PR TITLE
fix: export NavigationContext in types

### DIFF
--- a/typescript/react-navigation.d.ts
+++ b/typescript/react-navigation.d.ts
@@ -1426,4 +1426,6 @@ declare module 'react-navigation' {
   }
 
   export const SafeAreaView: React.ComponentClass<SafeAreaViewProps>;
+
+  export const NavigationContext: React.Context<NavigationScreenProp<NavigationRoute>>;
 }


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

## Motivation

`NavigationContext` is exported but not part of the exported types. 

## Test plan

n/a

## Code formatting

Look around. Match the style of the rest of the codebase. Run `yarn format` before committing.

## Changelog

Add an entry under the "Unreleased" heading in [CHANGELOG.md](https://github.com/react-navigation/react-navigation/blob/master/CHANGELOG.md#unreleased) which explains your change.
