### PR TITLE
[TypeScript] export TabBarIconProps and TabBarLabelProps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- Export TabBarIconProps and TabBarLabelProps
+
 ## [3.5.1] - [2019-03-19](https://github.com/react-navigation/react-navigation/releases/tag/3.5.1)
 
 ## Added

--- a/typescript/react-navigation.d.ts
+++ b/typescript/react-navigation.d.ts
@@ -560,23 +560,28 @@ declare module 'react-navigation' {
     index: number;
     tintColor?: string;
   }
+
+  export interface TabBarIconProps {
+    tintColor: string | null;
+    focused: boolean;
+    horizontal: boolean;
+  }
+
+  export interface TabBarLabelProps {
+    tintColor: string | null;
+    focused: boolean;
+  }
+
   // tslint:disable-next-line:strict-export-declare-modifiers
   interface NavigationTabScreenOptionsBase {
     title?: string;
     tabBarIcon?:
       | React.ReactElement<any>
-      | ((options: {
-          tintColor: string | null;
-          focused: boolean;
-          horizontal: boolean;
-        }) => React.ReactElement<any> | null);
+      | ((options: TabBarIconProps) => React.ReactElement<any> | null);
     tabBarLabel?:
       | string
       | React.ReactElement<any>
-      | ((options: {
-          tintColor: string | null;
-          focused: boolean;
-        }) => React.ReactElement<any> | string | null);
+      | ((options: TabBarLabelProps) => React.ReactElement<any> | string | null);
     tabBarVisible?: boolean;
     tabBarTestIDProps?: { testID?: string; accessibilityLabel?: string };
   }


### PR DESCRIPTION
## Motivation

The props used in `tabBarIcon` and `tabBarLabel` are not exported, this PR fixes it.