### PR TITLE
[TypeScript] Export DrawerIconProps and DrawerLabelProps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-- Export TabBarIconProps and TabBarLabelProps
+- Export TabBarIconProps, TabBarLabelProps, DrawerIconProps and DrawerLabelProps.
 
 ## [3.5.1] - [2019-03-19](https://github.com/react-navigation/react-navigation/releases/tag/3.5.1)
 

--- a/typescript/react-navigation.d.ts
+++ b/typescript/react-navigation.d.ts
@@ -613,21 +613,25 @@ declare module 'react-navigation' {
 
   export type DrawerLockMode = 'unlocked' | 'locked-closed' | 'locked-open';
 
+  export interface DrawerIconProps {
+    tintColor: string | null;
+    focused: boolean;
+  }
+
+  export interface DrawerLabelProps {
+    tintColor: string | null;
+    focused: boolean;
+  }
+
   export interface NavigationDrawerScreenOptions {
     title?: string;
     drawerIcon?:
       | React.ReactElement<any>
-      | ((options: {
-          tintColor: string | null;
-          focused: boolean;
-        }) => React.ReactElement<any> | null);
+      | ((options: DrawerIconProps) => React.ReactElement<any> | null);
     drawerLabel?:
       | string
       | React.ReactElement<any>
-      | ((options: {
-          tintColor: string | null;
-          focused: boolean;
-        }) => React.ReactElement<any> | null);
+      | ((options: DrawerLabelProps) => React.ReactElement<any> | null);
     drawerLockMode?: DrawerLockMode;
   }
 


### PR DESCRIPTION
## Motivation

The props used in `drawerIcon` and `drawerLabel` are not exported, this PR fixes it.