### PR TITLE
unhandled promise rejection failed to delete storage directory

### DIFF
--- a/examples/NavigationPlayground/app/SwitchWithStacks.tsx
+++ b/examples/NavigationPlayground/app/SwitchWithStacks.tsx
@@ -5,6 +5,7 @@ import {
   StatusBar,
   StyleSheet,
   View,
+  Platform,
 } from 'react-native';
 import { createStackNavigator, createSwitchNavigator } from 'react-navigation';
 import { Button } from './commonComponents/ButtonWithMargin';
@@ -53,7 +54,7 @@ class HomeScreen extends React.Component<any, any> {
   };
 
   signOutAsync = async () => {
-    await AsyncStorage.clear();
+    Platform.OS === 'ios' ? await AsyncStorage.getAllKeys().then(AsyncStorage.multiRemove) : await AsyncStorage.clear()
     this.props.navigation.navigate('Auth');
   };
 }
@@ -73,7 +74,7 @@ class OtherScreen extends React.Component<any, any> {
   }
 
   signOutAsync = async () => {
-    await AsyncStorage.clear();
+    Platform.OS === 'ios' ? await AsyncStorage.getAllKeys().then(AsyncStorage.multiRemove) : await AsyncStorage.clear()
     this.props.navigation.navigate('Auth');
   };
 }


### PR DESCRIPTION
with:

await AsyncStorage.clear();

I'm getting this in ios:

unhandled promise rejection failed to delete storage directory

found this:

https://stackoverflow.com/questions/46736268/react-native-asyncstorage-clear-is-failing-on-ios

switched to use this instead:

await AsyncStorage.getAllKeys().then(AsyncStorage.multiRemove)

but that causes unhandled promise rejection in android.

this is working:

Platform.OS === 'ios' ? await AsyncStorage.getAllKeys().then(AsyncStorage.multiRemove) : await AsyncStorage.clear()

Please provide enough information so that others can review your pull request:

## Motivation

In: "Switch between routes" item in example app

Example does not sign out:

unhandled promise rejection failed to delete storage directory

## Test plan

I tested the app in both android and ios

## Code formatting

I am happy to reformat per any suggestions.
