### PR TITLE
[TypeScript] Export InitialLayout type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-- Export TabBarIconProps, TabBarLabelProps, DrawerIconProps, DrawerLabelProps and ScreenProps.
+- Export TabBarIconProps, TabBarLabelProps, DrawerIconProps, DrawerLabelProps, ScreenProps and InitialLayout.
 
 ## [3.5.1] - [2019-03-19](https://github.com/react-navigation/react-navigation/releases/tag/3.5.1)
 

--- a/typescript/react-navigation.d.ts
+++ b/typescript/react-navigation.d.ts
@@ -1054,20 +1054,25 @@ declare module 'react-navigation' {
     lazy?: boolean;
   }
 
+  export interface InitialLayout {
+    height: number;
+    width: number;
+  }
+
   // From navigators/TabNavigator.js
   export interface TabNavigatorConfig
     extends NavigationTabRouterConfig,
       TabViewConfig {
     lazy?: boolean;
     removeClippedSubviews?: boolean;
-    initialLayout?: { height: number; width: number };
+    initialLayout?: InitialLayout;
   }
   export interface BottomTabNavigatorConfig
     extends NavigationBottomTabRouterConfig,
       TabViewConfig {
     lazy?: boolean;
     removeClippedSubviews?: boolean;
-    initialLayout?: { height: number; width: number };
+    initialLayout?: InitialLayout;
   }
 
   // From navigators/TabNavigator.js


### PR DESCRIPTION
## Motivation

The type used in `initialLayout` is not exported, this PR fixes it.