### PR TITLE
Improved Type Definition for Navigator navigationOptions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Improved Type Definition For Navigator navigationOptions. 
 
 ## [3.6.1] - [2019-04-02](https://github.com/react-navigation/react-navigation/releases/tag/3.6.1)
 

--- a/typescript/react-navigation.d.ts
+++ b/typescript/react-navigation.d.ts
@@ -556,9 +556,7 @@ declare module 'react-navigation' {
     defaultNavigationOptions?: NavigationScreenConfig<
       NavigationBottomTabScreenOptions
     >;
-    navigationOptions?: NavigationScreenConfig<
-      any
-    >;
+    navigationOptions?: NavigationScreenConfig<any>;
   }
   export interface TabScene {
     route: NavigationRoute;

--- a/typescript/react-navigation.d.ts
+++ b/typescript/react-navigation.d.ts
@@ -549,7 +549,7 @@ declare module 'react-navigation' {
   export interface NavigationTabRouterConfig
     extends NavigationTabRouterConfigBase {
     defaultNavigationOptions?: NavigationScreenConfig<NavigationScreenOptions>;
-    navigationOptions?: NavigationScreenConfig<NavigationScreenOptions>;
+    navigationOptions?: NavigationScreenConfig<any>;
   }
   export interface NavigationBottomTabRouterConfig
     extends NavigationTabRouterConfigBase {
@@ -557,7 +557,7 @@ declare module 'react-navigation' {
       NavigationBottomTabScreenOptions
     >;
     navigationOptions?: NavigationScreenConfig<
-      NavigationBottomTabScreenOptions
+      any
     >;
   }
   export interface TabScene {


### PR DESCRIPTION
`NavigationTabRouterConfigBase` as a type  made no sense for `navigationOtions` updated it  appropriately for the two tabNavigators.