### PR TITLE
[Typescript] Add type for 'enableURLHandling'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- Add missing type for `enableURLHandling`
+
 ## [3.6.1] - [2019-04-02](https://github.com/react-navigation/react-navigation/releases/tag/3.6.1)
 
 ## Fixed

--- a/typescript/react-navigation.d.ts
+++ b/typescript/react-navigation.d.ts
@@ -882,6 +882,12 @@ declare module 'react-navigation' {
 
   export interface NavigationContainerProps<S = {}, O = {}> {
     uriPrefix?: string | RegExp;
+    /**
+     * Controls whether the navigation container handles URLs opened via 'Linking'
+     * @see https://facebook.github.io/react-native/docs/linking
+     * @see https://reactnavigation.org/docs/en/deep-linking.html
+     */
+    enableURLHandling?: boolean; // defaults to true
     onNavigationStateChange?: (
       prevNavigationState: NavigationState,
       nextNavigationState: NavigationState,


### PR DESCRIPTION
`enableURLHandling` was missing from the Typescript definitions. Added it in with a short description

Fixes https://github.com/react-navigation/react-navigation/issues/5793