### PR TITLE
[flow] Update for Flow 0.92

### DIFF
--- a/flow/react-navigation.js
+++ b/flow/react-navigation.js
@@ -353,12 +353,8 @@ declare module 'react-navigation' {
   declare export type NavigationScreenComponent<
     Route: NavigationRoute,
     Options: {},
-    Props: {}
-  > = React$ComponentType<{
-    ...Props,
-    ...NavigationNavigatorProps<Options, Route>,
-  }> &
-    withOptionalNavigationOptions<Options>;
+    Props: NavigationNavigatorProps<Options, Route>
+  > = React$ComponentType<Props> & withOptionalNavigationOptions<Options>;
 
   declare interface withRouter<State, Options> {
     router: NavigationRouter<State, Options>;
@@ -367,11 +363,8 @@ declare module 'react-navigation' {
   declare export type NavigationNavigator<
     State: NavigationState,
     Options: {},
-    Props: {}
-  > = React$StatelessFunctionalComponent<{
-    ...Props,
-    ...NavigationNavigatorProps<Options, State>,
-  }> &
+    Props: NavigationNavigatorProps<Options, State>
+  > = React$ComponentType<Props> &
     withRouter<State, Options> &
     withOptionalNavigationOptions<Options>;
 
@@ -463,8 +456,14 @@ declare module 'react-navigation' {
       prevTransitionProps: ?NavigationTransitionProps,
       isModal: boolean
     ) => TransitionConfig,
-    onTransitionStart?: () => void,
-    onTransitionEnd?: () => void,
+    onTransitionStart?: (
+      transitionProps: NavigationTransitionProps,
+      prevTransitionProps: ?NavigationTransitionProps
+    ) => void,
+    onTransitionEnd?: (
+      transitionProps: NavigationTransitionProps,
+      prevTransitionProps: ?NavigationTransitionProps
+    ) => void,
     transparentCard?: boolean,
     disableKeyboardHandling?: boolean,
   |};
@@ -589,8 +588,8 @@ declare module 'react-navigation' {
       fallback?: $ElementType<
         $PropertyType<
           {|
-            ...{| params: {| [ParamName]: void |} |},
             ...$Exact<S>,
+            ...{| params: {| [ParamName]: void |} |},
           |},
           'params'
         >,
@@ -599,14 +598,14 @@ declare module 'react-navigation' {
     ) => $ElementType<
       $PropertyType<
         {|
-          ...{| params: {| [ParamName]: void |} |},
           ...$Exact<S>,
+          ...{| params: {| [ParamName]: void |} |},
         |},
         'params'
       >,
       ParamName
     >,
-    dangerouslyGetParent: () => NavigationScreenProp<*>,
+    dangerouslyGetParent: () => ?NavigationScreenProp<NavigationState>,
     isFocused: () => boolean,
     // Shared action creators that exist for all routers
     goBack: (routeKey?: ?string) => boolean,
@@ -672,11 +671,8 @@ declare module 'react-navigation' {
   declare export type NavigationContainer<
     State: NavigationState,
     Options: {},
-    Props: {}
-  > = React$ComponentType<{
-    ...Props,
-    ...NavigationContainerProps<State, Options>,
-  }> &
+    Props: NavigationContainerProps<Options, State>
+  > = React$ComponentType<Props> &
     withRouter<State, Options> &
     withOptionalNavigationOptions<Options>;
 
@@ -936,6 +932,7 @@ declare module 'react-navigation' {
   declare type NavigationView<O, S> = React$ComponentType<{
     descriptors: { [key: string]: NavigationDescriptor },
     navigation: NavigationScreenProp<S>,
+    navigationConfig: *,
   }>;
 
   declare export function createNavigator<O: *, S: *, NavigatorConfig: *>(


### PR DESCRIPTION
Changes:

1. We can now type React components with static members as `React.ComponentType` (instead of requiring the `StatelessFunctionalComponent`) hack.
2. We can now type-parameterize React components on all of their props, instead of just the ones we care about. Not sure why this wasn't previously. Note: this is a breaking change, in the sense that people's parameterization of `NavigationScreenComponent`, `NavigationNavigator`, and `NavigationContainer` may need to change.
3. The order of object-type-spread in the `getParam` definition has been switched. It was giving errors with the old order.
4. Avoid recursive type inference `NavigationScreenProp`. This was yielding an "*** Recursion limit exceeded ***" error, which was rather difficult to debug. We can just use a `NavigationState` and let the user cast.
5. Fix `onTransitionStart`/`onTransitionEnd` types in `NavigationStackViewConfig`.
6. Add `navigationConfig` property to `NavigationView`.