### PR TITLE
chore: remove createTabNavigator out of ts definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## Fixes
+
+- Remove `createTabNavigator` from type definitions.
+
 ## [3.8.1] - [2019-04-12](https://github.com/react-navigation/react-navigation/releases/tag/3.8.1)
 
 ## Changed

--- a/typescript/react-navigation.d.ts
+++ b/typescript/react-navigation.d.ts
@@ -1088,11 +1088,6 @@ declare module 'react-navigation' {
     drawConfig?: TabNavigatorConfig
   ): NavigationContainer;
 
-  export function createTabNavigator(
-    routeConfigMap: NavigationRouteConfigMap,
-    drawConfig?: TabNavigatorConfig
-  ): NavigationContainer;
-
   export function createBottomTabNavigator(
     routeConfigMap: NavigationRouteConfigMap,
     drawConfig?: BottomTabNavigatorConfig


### PR DESCRIPTION
## Motivation

Remove `createTabNavigator` out of ts definition in v3 since it is removed in the source

