### PR TITLE
Add missing type definitions for DrawerNavigatorConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Fixes
 
-- Remove `createTabNavigator` from type definitions.
+- Remove `createTabNavigator` from type definitions
+- Add missing types for `DrawerNavigatorConfig`
 
 ## [3.8.1] - [2019-04-12](https://github.com/react-navigation/react-navigation/releases/tag/3.8.1)
 

--- a/typescript/react-navigation.d.ts
+++ b/typescript/react-navigation.d.ts
@@ -1016,7 +1016,11 @@ declare module 'react-navigation' {
       style?: StyleProp<ViewStyle>;
       labelStyle?: StyleProp<TextStyle>;
     };
+    drawerType?: 'front' | 'back' | 'slide';
     drawerLockMode?: DrawerLockMode;
+    edgeWidth?: number;
+    hideStatusBar?: boolean;
+    overlayColor?: string;
   }
 
   export function DrawerNavigator(


### PR DESCRIPTION
Noticed that some definitions were missing when using `drawerType`: https://reactnavigation.org/docs/en/drawer-navigator.html#drawernavigatorconfig

First PR here, let me know if I need to change anything :)