### PR TITLE
Removes duplicate NavigationInjectedProps export

### DIFF
--- a/typescript/react-navigation.d.ts
+++ b/typescript/react-navigation.d.ts
@@ -1391,10 +1391,6 @@ declare module 'react-navigation' {
     navigation: NavigationScreenProp<NavigationRoute<P>, P>;
   }
 
-  export interface NavigationInjectedProps<P = NavigationParams> {
-    navigation: NavigationScreenProp<NavigationRoute<P>, P>;
-  }
-
   // If the wrapped component is a class, we can get a ref to it
   export function withNavigation<
     P extends NavigationInjectedProps,


### PR DESCRIPTION
## Motivation

I just noticed that `NavigationInjectedProps` is defined the same way twice so I think we can remove one of them.

## Changelog

Didn't know if this warranted an entry in the changelog but let me know if it does and I'll gladly add it!
