### PR TITLE
[flow] Fix NavigationScreenProp.getParam type

### DIFF
--- a/flow/react-navigation.js
+++ b/flow/react-navigation.js
@@ -588,8 +588,8 @@ declare module 'react-navigation' {
       fallback?: $ElementType<
         $PropertyType<
           {|
+            ...{| params: {} |},
             ...$Exact<S>,
-            ...{| params: {| [ParamName]: void |} |},
           |},
           'params'
         >,
@@ -598,8 +598,8 @@ declare module 'react-navigation' {
     ) => $ElementType<
       $PropertyType<
         {|
+          ...{| params: {} |},
           ...$Exact<S>,
-          ...{| params: {| [ParamName]: void |} |},
         |},
         'params'
       >,


### PR DESCRIPTION
In my last PR I flipped the order of these around to fix an error, but turns out that was just crippling the type. The correct solution here, to guarantee that the `$PropertyType` won't error if its type parameter don't have the property, is to use an unsealed object type.

Some additional context in discussion on #5806.