### PR TITLE
Remove `any ` from `NavigationComponent`

### DIFF
--- a/typescript/react-navigation.d.ts
+++ b/typescript/react-navigation.d.ts
@@ -250,8 +250,7 @@ declare module 'react-navigation' {
 
   export type NavigationComponent =
     | NavigationScreenComponent<NavigationParams, any, any>
-    | NavigationNavigator<any, any, any>
-    | any;
+    | NavigationNavigator<any, any, any>;
 
   export type NavigationScreenComponent<
     Params = NavigationParams,


### PR DESCRIPTION
This PR ensure safe typing of `NavigationRouteConfigMap`.

## Motivation

Without the change this doesnt throw a type error, even though `true` isnt valid.

```js
const routeMap : NavigationRouteConfigMap = {
  ScreenName: true
}
```
