### PR TITLE
[Typescript] `TabBarTop` is `MaterialTopTabBar` now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## Fixes
+
+- Update typescript - `TabBarTop` is now `MaterialTopTabBar`
+
 ## [3.9.0] - [2019-04-23](https://github.com/react-navigation/react-navigation/releases/tag/3.9.0)
 
 ## Fixes

--- a/typescript/react-navigation.d.ts
+++ b/typescript/react-navigation.d.ts
@@ -1102,7 +1102,7 @@ declare module 'react-navigation' {
     drawConfig?: TabNavigatorConfig
   ): NavigationContainer;
 
-  export interface TabBarTopProps {
+  export interface MaterialTopTabBarProps {
     activeTintColor: string;
     inactiveTintColor: string;
     indicatorStyle: StyleProp<ViewStyle>;
@@ -1157,7 +1157,7 @@ declare module 'react-navigation' {
     showIcon?: boolean;
   }
 
-  export const TabBarTop: React.ComponentType<TabBarTopProps>;
+  export const MaterialTopTabBar: React.ComponentType<MaterialTopTabBarProps>;
   export const BottomTabBar: React.ComponentType<BottomTabBarProps>;
 
   /**


### PR DESCRIPTION
The export of type `TabBarTop` does not match the actual export of `MaterialTopTabBar`.
This fixes the issue where <TabBarTop {...props} /> would fail as it wasn't being exported.

(It is basically #5800 for typescript)