### PR TITLE
correct getLabel to getLabelText

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Fixes
 
 - Update typescript - `TabBarTop` is now `MaterialTopTabBar`
+- Update typescript - `getLabel` is now `getLabelText` in BottomTabProps and TopTabProps
 
 ## [3.9.0] - [2019-04-23](https://github.com/react-navigation/react-navigation/releases/tag/3.9.0)
 

--- a/typescript/react-navigation.d.ts
+++ b/typescript/react-navigation.d.ts
@@ -1116,7 +1116,7 @@ declare module 'react-navigation' {
     tabBarPosition: string;
     navigation: NavigationScreenProp<NavigationState>;
     jumpToIndex: (index: number) => void;
-    getLabel: (scene: TabScene) => React.ReactNode | string;
+    getLabelText: (scene: TabScene) => React.ReactNode | string;
     getOnPress: (
       previousScene: NavigationRoute,
       scene: TabScene
@@ -1141,7 +1141,7 @@ declare module 'react-navigation' {
     position: AnimatedValue;
     navigation: NavigationScreenProp<NavigationState>;
     jumpToIndex: (index: number) => void;
-    getLabel: (scene: TabScene) => React.ReactNode | string;
+    getLabelText: (scene: TabScene) => React.ReactNode | string;
     getOnPress: (
       previousScene: NavigationRoute,
       scene: TabScene


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

## Motivation

In react-navigation-tabs, I can see in the flow typings there using `getLabelText` instead of the ts def showing `getLabel`
