### PR TITLE
remove old exports and add export for SceneView and SwitchRouter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Fixes
 
 - Update typescript - `TabBarTop` is now `MaterialTopTabBar`
+- Update typescript - Remove `SwitchNavigator`, `TabNavigator` and `StackNavigator`. Added exports for `SceneView` and `SwitchRouter`
 
 ## [3.9.0] - [2019-04-23](https://github.com/react-navigation/react-navigation/releases/tag/3.9.0)
 

--- a/typescript/react-navigation.d.ts
+++ b/typescript/react-navigation.d.ts
@@ -1460,7 +1460,7 @@ declare module 'react-navigation' {
   export interface SceneViewProps {
     component: React.ComponentType;
     screenProps: ScreenProps;
-    navigation: NavigationScreenProp;
+    navigation: NavigationScreenProp<NavigationRoute>;
   }
 
   export class SceneView extends React.Component {}

--- a/typescript/react-navigation.d.ts
+++ b/typescript/react-navigation.d.ts
@@ -440,6 +440,8 @@ declare module 'react-navigation' {
    * Switch Navigator
    */
 
+  export interface SwitchRouter extends NavigationRouter {}
+
   export interface NavigationSwitchRouterConfig {
     initialRouteName?: string;
     initialRouteParams?: NavigationParams;
@@ -931,12 +933,6 @@ declare module 'react-navigation' {
     containerOptions?: any;
   }
 
-  // Return createNavigationContainer
-  export function StackNavigator(
-    routeConfigMap: NavigationRouteConfigMap,
-    stackConfig?: StackNavigatorConfig
-  ): NavigationContainer;
-
   export function createStackNavigator(
     routeConfigMap: NavigationRouteConfigMap,
     stackConfig?: StackNavigatorConfig
@@ -951,11 +947,6 @@ declare module 'react-navigation' {
 
   // Return createNavigationContainer
   export type _SwitchNavigatorConfig = NavigationSwitchRouterConfig;
-
-  export function SwitchNavigator(
-    routeConfigMap: NavigationRouteConfigMap,
-    switchConfig?: SwitchNavigatorConfig
-  ): NavigationContainer;
 
   export function createSwitchNavigator(
     routeConfigMap: NavigationRouteConfigMap,
@@ -1087,12 +1078,6 @@ declare module 'react-navigation' {
     removeClippedSubviews?: boolean;
     initialLayout?: InitialLayout;
   }
-
-  // From navigators/TabNavigator.js
-  export function TabNavigator(
-    routeConfigMap: NavigationRouteConfigMap,
-    drawConfig?: TabNavigatorConfig
-  ): NavigationContainer;
 
   export function createBottomTabNavigator(
     routeConfigMap: NavigationRouteConfigMap,
@@ -1467,4 +1452,16 @@ declare module 'react-navigation' {
   export const NavigationContext: React.Context<NavigationScreenProp<NavigationRoute>>;
   export const StackGestureContext: React.Context<React.Ref<PanGestureHandler>>;
   export const DrawerGestureContext: React.Context<React.Ref<PanGestureHandler>>;
+  
+  /**
+   * SceneView
+   */
+
+  export interface SceneViewProps {
+    component: React.ComponentType;
+    screenProps: ScreenProps;
+    navigation: NavigationScreenProp;
+  }
+
+  export class SceneView extends React.Component {}
 }


### PR DESCRIPTION

## Motivation

I removed some old export such as `StackNavigator`, `TabNavigator`, `SwitchNavigator`. Also, this typedef updates will help me to fulfill this issue: https://github.com/react-navigation/animated-switch/issues/4 since I will need the typedefs for `SceneView` and `SwitchRouter`

## Test plan

Tried to export those newly added in my own personal project to see if it is compatible
