### PR TITLE
Add resetOnBlur type to BottomTabNavigatorConfig

### DIFF
--- a/typescript/react-navigation.d.ts
+++ b/typescript/react-navigation.d.ts
@@ -1084,6 +1084,7 @@ declare module 'react-navigation' {
     extends NavigationBottomTabRouterConfig,
       TabViewConfig {
     lazy?: boolean;
+    resetOnBlur?: boolean;
     removeClippedSubviews?: boolean;
     initialLayout?: InitialLayout;
   }


### PR DESCRIPTION
Add missed type

## Motivation

I did added this type on DefinitelyTyped, but this module override types from there.
[Original pull request.](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/35163)