### PR TITLE
Add safeAreaInset type to BottomTabBarProps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 - Update typescript with headerLeftContainerStyle and headerRightContainerStyle
+- Update typescript - Add `safeAreaInset` to `BottomTabBarProps`
 
 ## Fixes
 

--- a/typescript/react-navigation.d.ts
+++ b/typescript/react-navigation.d.ts
@@ -1158,6 +1158,12 @@ declare module 'react-navigation' {
     labelStyle?: TextStyle;
     tabStyle?: ViewStyle;
     showIcon?: boolean;
+    safeAreaInset?: {
+      top?: SafeAreaViewForceInsetValue,
+      bottom?: SafeAreaViewForceInsetValue,
+      left?: SafeAreaViewForceInsetValue,
+      right?: SafeAreaViewForceInsetValue
+    };
   }
 
   export const MaterialTopTabBar: React.ComponentType<MaterialTopTabBarProps>;


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

## Motivation

`safeAreaInset` is [documented](https://reactnavigation.org/docs/en/bottom-tab-navigator.html#bottomtabnavigatorconfig), but missing from the typescript definition.

## Changelog

Add an entry under the "Unreleased" heading in [CHANGELOG.md](https://github.com/react-navigation/react-navigation/blob/master/CHANGELOG.md#unreleased) which explains your change.
