### PR TITLE
Add cardShadowEnabled and cardOverlayEnabled to NavigationStackViewConfig flow type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## Fixes
+
+- Update Flow types - Add `cardShadowEnabled` and `cardOverlayEnabled` to NavigationStackViewConfig
+
 ## [3.10.0] - [2019-05-16](https://github.com/react-navigation/react-navigation/releases/tag/3.10.0)
 
 ## Removed

--- a/flow/react-navigation.js
+++ b/flow/react-navigation.js
@@ -451,6 +451,8 @@ declare module 'react-navigation' {
     headerLayoutPreset?: 'left' | 'center',
     headerBackTitleVisible?: boolean,
     cardStyle?: ViewStyleProp,
+    cardShadowEnabled?: boolean,
+    cardOverlayEnabled?: boolean,
     transitionConfig?: (
       transitionProps: NavigationTransitionProps,
       prevTransitionProps: ?NavigationTransitionProps,


### PR DESCRIPTION
Fixes #5917

## Motivation

Both `cardShadowEnabled` and `cardOverlayEnabled` are supported in `StackNavigatorConfig`. This updates the type defs in the react-navigation repo to match. Note that the typescript defs already contain these fields.

## Test plan

Import new typedefs into flow project and specify `cardShadowEnabled` in stack navigator options. Run flow, ensure there are no errors.
