### PR TITLE
fix: add reset to navigation screen prop TypeScript def

### DIFF
--- a/typescript/react-navigation.d.ts
+++ b/typescript/react-navigation.d.ts
@@ -749,6 +749,7 @@ declare module 'react-navigation' {
       params?: NavigationParams,
       action?: NavigationNavigateAction
     ) => boolean;
+    reset: (actions: NavigationAction[], index: number) => boolean;
     pop: (n?: number, params?: { immediate?: boolean }) => boolean;
     popToTop: (params?: { immediate?: boolean }) => boolean;
     isFocused: () => boolean;


### PR DESCRIPTION
## Motivation

Stop TypeScript compiler errors for usage of `reset` which is described at:

<https://reactnavigation.org/docs/en/navigation-prop.html#reset>

## Test plan

I've been using this in a real world project and it stopped the tsc errors when adding this change.