### PR TITLE
fix: update StackActions.popToTop type to make options arg optional

### DIFF
--- a/flow/react-navigation.js
+++ b/flow/react-navigation.js
@@ -882,7 +882,7 @@ declare module 'react-navigation' {
       n?: number,
       immediate?: boolean,
     }) => NavigationPopAction,
-    popToTop: (payload: {
+    popToTop: (payload?: {
       immediate?: boolean,
     }) => NavigationPopToTopAction,
     push: (payload: {

--- a/flow/react-navigation.js
+++ b/flow/react-navigation.js
@@ -883,6 +883,7 @@ declare module 'react-navigation' {
       immediate?: boolean,
     }) => NavigationPopAction,
     popToTop: (payload?: {
+      key?: string,
       immediate?: boolean,
     }) => NavigationPopToTopAction,
     push: (payload: {

--- a/typescript/react-navigation.d.ts
+++ b/typescript/react-navigation.d.ts
@@ -1226,7 +1226,7 @@ declare module 'react-navigation' {
 
     function pop(options: NavigationPopActionPayload): NavigationPopAction;
     function popToTop(
-      options: NavigationPopToTopActionPayload
+      options?: NavigationPopToTopActionPayload
     ): NavigationPopToTopAction;
 
     function push(options: NavigationPushActionPayload): NavigationPushAction;


### PR DESCRIPTION
## Motivation
- Typing is wrong. https://github.com/react-navigation/core/blob/master/src/routers/StackActions.js#L13 doesn't require an options arg as it just spread the args, https://github.com/react-navigation/core/blob/94c6ffa4e477e43533ed388e770e5144179cc83b/src/routers/StackRouter.js#L400-L418 doesn't try to access any properties of objects that may be undefined, and the example at https://reactnavigation.org/docs/en/stack-actions.html#poptotop shows it with no args.
- Added `key` to flow type to make it consistent with TS

## Test plan
None. This is trivial. I'm not sure if a CI test/lint would cover this.

## Code formatting
Should be good.

## Changelog
>Add an entry under the "Unreleased" heading in [CHANGELOG.md](https://github.com/react-navigation/react-navigation/blob/master/CHANGELOG.md#unreleased) which explains your change.

I don't see a `Unreleased` heading. If you have docs showing where to add it, I'll do that.