### PR TITLE
fix: fix navigationOptions type in NavigationScreenConfig<Options>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+## Fixes
+- Fix `navigationOptions` type from `NavigationScreenProp<NavigationRoute>` to `NavigationScreenConfig<Options>`.
+
 ## [3.11.0]
 
 ## New Features

--- a/typescript/react-navigation.d.ts
+++ b/typescript/react-navigation.d.ts
@@ -244,7 +244,7 @@ declare module 'react-navigation' {
     | Options
     | ((
         navigationOptionsContainer: NavigationScreenConfigProps & {
-          navigationOptions: NavigationScreenProp<NavigationRoute>;
+          navigationOptions: NavigationScreenConfig<Options>;
         }
       ) => Options);
 


### PR DESCRIPTION
## Motivation

Explain the **motivation** for making this change. What existing problem does the pull request solve?

- `NavigationScreenProp<NavigationRoute>` is the type of `navigation` property which contains `state` and such. This is not applicable to `navigationOptions` at all.
- To be used for `static navigationOptions` in a `NavigationScreenComponent`.
```javascript
static navigationOptions = ({navigationOptions, navigation}) => {} // navigationOptions from the function argument is wrongly typed. It currently contains the same type as navigation prop.
```

## Test plan
Typings change.

## Code formatting

Should be good.

## Changelog
- Fix `navigationOptions` type from `NavigationScreenProp<NavigationRoute>` to `NavigationScreenConfig<Options>`.

Add an entry under the "Unreleased" heading in [CHANGELOG.md](https://github.com/react-navigation/react-navigation/blob/master/CHANGELOG.md#unreleased) which explains your change.
