### PR TITLE
fix: add headerTitleContainerStyle to NavigationStackScreenOptions type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -289,6 +289,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - [2.x](https://github.com/react-navigation/react-navigation/blob/2.x/CHANGELOG.md)
 
+[Unreleased]: Fixed NavigationStackScreenOptions types by adding headerTitleContainerStyle
 [Unreleased]: https://github.com/react-navigation/react-navigation/compare/3.10.0...HEAD
 [3.10.0]: https://github.com/react-navigation/react-navigation/compare/3.10.0...3.9.0
 [3.9.0]: https://github.com/react-navigation/react-navigation/compare/3.8.1...3.9.0

--- a/typescript/react-navigation.d.ts
+++ b/typescript/react-navigation.d.ts
@@ -476,6 +476,7 @@ declare module 'react-navigation' {
     headerTitle?: string | React.ReactElement<any>;
     headerTitleStyle?: StyleProp<TextStyle>;
     headerTitleAllowFontScaling?: boolean;
+    headerTitleContainerStyle?: StyleProp<TextStyle>;
     headerTintColor?: string;
     headerLeft?:
       | React.ReactElement<any>


### PR DESCRIPTION
## Motivation

Stop TypeScript compiler errors for usage of `headerTitleContainerStyle` which is described at:

https://reactnavigation.org/docs/en/headers.html

## Test plan
I've been using this in a real world project and it stopped the tsc errors when adding this change.
