### PR TITLE
Integrated deprecated createTabNavigator in react-navigation@3.x

### DIFF
--- a/src/react-navigation.js
+++ b/src/react-navigation.js
@@ -123,7 +123,14 @@ module.exports = {
   get createDrawerNavigator() {
     return require('react-navigation-drawer').createDrawerNavigator;
   },
-
+  get createTabNavigator() {
+    console.warn('createTabNavigator is deprecated. Please use the createBottomTabNavigator or createMaterialTopTabNavigator instead.')
+    return require('react-navigation-deprecated-tab-navigator').createTabNavigator
+  },
+  get TabNavigator() {
+    console.warn('TabNavigator is deprecated. Please use the createBottomTabNavigator or createMaterialTopTabNavigator instead.')
+    return require('react-navigation-deprecated-tab-navigator').createTabNavigator
+  },
   // Gesture contexts
 
   get StackGestureContext() {


### PR DESCRIPTION
## Motivation
BottomTabNavigator has crash issues in order to avoid inconvenience this provides an alternate way of using tabNavigator.