### PR TITLE
fix: add missing isFirstRouteInParent type in typescript and flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Fixes
 - Fix `navigationOptions` type from `NavigationScreenProp<NavigationRoute>` to `NavigationScreenConfig<Options>`.
+- Fix missing `isFirstRouteInParent` type in typescript and flow.
 
 ## [3.11.0]
 

--- a/flow/react-navigation.js
+++ b/flow/react-navigation.js
@@ -616,6 +616,7 @@ declare module 'react-navigation' {
     >,
     dangerouslyGetParent: () => ?NavigationScreenProp<NavigationState>,
     isFocused: () => boolean,
+    isFirstRouteInParent: () => boolean,
     // Shared action creators that exist for all routers
     goBack: (routeKey?: ?string) => boolean,
     navigate: (

--- a/typescript/react-navigation.d.ts
+++ b/typescript/react-navigation.d.ts
@@ -754,6 +754,7 @@ declare module 'react-navigation' {
     pop: (n?: number, params?: { immediate?: boolean }) => boolean;
     popToTop: (params?: { immediate?: boolean }) => boolean;
     isFocused: () => boolean;
+    isFirstRouteInParent: () => boolean;
     router?: NavigationRouter;
     dangerouslyGetParent: () => NavigationScreenProp<S> | undefined;
   }


### PR DESCRIPTION
## Motivation

Using method isFirstRouteInParent in typescript or flow.
