### PR TITLE
fix: SceneView type to set the PropTypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Fixes
 - Fix `navigationOptions` type from `NavigationScreenProp<NavigationRoute>` to `NavigationScreenConfig<Options>`.
 - Fix missing `isFirstRouteInParent` type in typescript and flow.
+- Fix `SceneView` type to set the PropTypes
 
 ## [3.11.0]
 

--- a/typescript/react-navigation.d.ts
+++ b/typescript/react-navigation.d.ts
@@ -1510,9 +1510,9 @@ declare module 'react-navigation' {
 
   export interface SceneViewProps {
     component: React.ComponentType;
-    screenProps: ScreenProps;
+    screenProps?: ScreenProps;
     navigation: NavigationScreenProp<NavigationRoute>;
   }
 
-  export class SceneView extends React.Component {}
+  export class SceneView extends React.Component<SceneViewProps> {}
 }


### PR DESCRIPTION
Updated SceneView Props Type.
ScreenProps need to be optional (?) as in createNavigator function typing.
