### PR TITLE
fix: add missing backTitleVisible for typescript, disabled and backTitleVisible for flow definitions in type HeaderBackButtonProps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Fixes
 - Fix `navigationOptions` type from `NavigationScreenProp<NavigationRoute>` to `NavigationScreenConfig<Options>`.
 - Fix missing `isFirstRouteInParent` type in typescript and flow.
+- Add missing `backTitleVisible` for typescript, `disabled` and `backTitleVisible` for flow definitions in type `HeaderBackButtonProps`
 
 ## [3.11.0]
 

--- a/flow/react-navigation.js
+++ b/flow/react-navigation.js
@@ -1129,6 +1129,8 @@ declare module 'react-navigation' {
     tintColor?: ?string,
     truncatedTitle?: ?string,
     width?: ?number,
+    disabled?: boolean,
+    backTitleVisible?: boolean,
   };
   declare export var HeaderBackButton: React$ComponentType<_HeaderBackButtonProps>;
 

--- a/typescript/react-navigation.d.ts
+++ b/typescript/react-navigation.d.ts
@@ -1397,6 +1397,7 @@ declare module 'react-navigation' {
     truncatedTitle?: string;
     width?: number;
     disabled?: boolean;
+    backTitleVisible?: boolean;
   }
 
   export const HeaderBackButton: React.ComponentClass<HeaderBackButtonProps>;


### PR DESCRIPTION
## Motivation

Using `backTitleVisible` and `disabled` props in `HeaderBackButton` component both in typescript and flow.