### PR TITLE
fix: add missing TS definition for keyboardHidesTabBar in TabViewConf…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix `navigationOptions` type from `NavigationScreenProp<NavigationRoute>` to `NavigationScreenConfig<Options>`.
 - Fix missing `isFirstRouteInParent` type in typescript and flow.
 - Add missing `backTitleVisible` for typescript, `disabled` and `backTitleVisible` for flow definitions in type `HeaderBackButtonProps`
+- Add missing `keyboardHidesTabBar` for TypeScript to `TabViewConfig.tabBarOptions`
 
 ## [3.11.0]
 

--- a/typescript/react-navigation.d.ts
+++ b/typescript/react-navigation.d.ts
@@ -1082,6 +1082,7 @@ declare module 'react-navigation' {
       scrollEnabled?: boolean;
       tabStyle?: StyleProp<ViewStyle>;
       indicatorStyle?: StyleProp<ViewStyle>;
+      keyboardHidesTabBar?: boolean;
     };
     swipeEnabled?: boolean;
     animationEnabled?: boolean;


### PR DESCRIPTION
Add missing `keyboardHidesTabBar` for TypeScript to `TabViewConfig.tabBarOptions`

Please provide enough information so that others can review your pull request:

## Motivation

Missing properties in TS definition
https://reactnavigation.org/docs/en/bottom-tab-navigator.html#bottomtabnavigatorconfig
