### PR TITLE
Export NavigationContext and ScrollView in flow types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+- Add missing Flow type exports for `ScrollView` and `NavigationContext`
+
 ## [3.11.1]
 
 ## Fixes
@@ -245,7 +247,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Fix drawer accessibility label when drawer label is not a string
 
-
 ## [3.0.5] - [2018-12-03](https://github.com/react-navigation/react-navigation/releases/tag/3.0.5)
 
 ## Fixes
@@ -267,7 +268,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Added
 
 - Accessibility labels on drawer items (https://github.com/react-navigation/react-navigation-drawer/pull/30)
-
 
 ## [3.0.3] - [2018-11-30](https://github.com/react-navigation/react-navigation/releases/tag/3.0.3)
 

--- a/flow/react-navigation.js
+++ b/flow/react-navigation.js
@@ -1303,4 +1303,8 @@ declare module 'react-navigation' {
     navigation: NavigationScreenProp<State>,
     screenProps?: {}
   ): Options;
+
+  declare export var NavigationContext: React$Context<{}>;
+
+  declare export var ScrollView: React$ComponentType<{}>;
 }


### PR DESCRIPTION
These two types are missing entirely from the flow definition, while they're incomplete they at least prevent flow from complaining that they're not defined at all.

I decided against copying the `ScrollView` types from `react-native` as they're really quite complex and likely to fall out-of-sync with the implementation in `react-native`. So instead I'd recommend overriding the types when  consuming using something like:

```js

import {ScrollView as NativeScrollView} from 'react-native';
import {ScrollView as NavigationScrollView} from 'react-navigation';

const ScrollView: React.ComponentType<typeof NativeScrollView>) = NavigationScrollView;
```