### PR TITLE
Fix DrawerNavigatorConfig.contentOptions TypeScript definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add missing `backTitleVisible` for typescript, `disabled` and `backTitleVisible` for flow definitions in type `HeaderBackButtonProps`
 - Add missing `keyboardHidesTabBar` for TypeScript to `TabViewConfig.tabBarOptions`
 - Add missing `unmountInactiveRoutes` for TypeScript to `DrawerNavigatorConfig`
+- Fix `contentOptions`in `DrawerNavigatorConfig` TypeScript definition
 
 ## [3.11.0]
 

--- a/typescript/react-navigation.d.ts
+++ b/typescript/react-navigation.d.ts
@@ -989,23 +989,25 @@ declare module 'react-navigation' {
   // DrawerItems
   export const DrawerItems: React.ComponentType<DrawerItemsProps>;
 
-  export interface DrawerItemsProps {
-    navigation: NavigationScreenProp<DrawerNavigationState>;
-    items: NavigationRoute[];
-    activeItemKey?: string;
+  export interface DrawerItemsOptions {
     activeTintColor?: string;
     activeBackgroundColor?: string;
     inactiveTintColor?: string;
     inactiveBackgroundColor?: string;
-    getLabel: (scene: DrawerScene) => React.ReactNode | string;
-    renderIcon: (scene: DrawerScene) => React.ReactNode;
-    onItemPress: (info: DrawerItem) => void;
     itemsContainerStyle?: StyleProp<ViewStyle>;
     itemStyle?: StyleProp<ViewStyle>;
     labelStyle?: StyleProp<TextStyle>;
     activeLabelStyle?: StyleProp<TextStyle>;
     inactiveLabelStyle?: StyleProp<TextStyle>;
     iconContainerStyle?: StyleProp<ViewStyle>;
+  }
+  export interface DrawerItemsProps {
+    navigation: NavigationScreenProp<DrawerNavigationState>;
+    items: NavigationRoute[];
+    activeItemKey?: string;
+    getLabel: (scene: DrawerScene) => React.ReactNode | string;
+    renderIcon: (scene: DrawerScene) => React.ReactNode;
+    onItemPress: (info: DrawerItem) => void;
     drawerPosition: 'left' | 'right';
   }
   export interface DrawerScene {
@@ -1027,21 +1029,13 @@ declare module 'react-navigation' {
     drawerWidth?: number;
     drawerPosition?: 'left' | 'right';
     contentComponent?: React.ComponentType<DrawerItemsProps>;
-    contentOptions?: any;
+    contentOptions?: DrawerItemsOptions;
     style?: StyleProp<ViewStyle>;
   }
   export interface DrawerNavigatorConfig
     extends NavigationTabRouterConfig,
       DrawerViewConfig {
     containerConfig?: any;
-    contentOptions?: {
-      activeTintColor?: string;
-      activeBackgroundColor?: string;
-      inactiveTintColor?: string;
-      inactiveBackgroundColor?: string;
-      style?: StyleProp<ViewStyle>;
-      labelStyle?: StyleProp<TextStyle>;
-    };
     drawerType?: 'front' | 'back' | 'slide';
     drawerLockMode?: DrawerLockMode;
     edgeWidth?: number;


### PR DESCRIPTION
## Motivation

The definition of the `DrawerNavigatorConfig` interface does not appear to match the documentation [here](https://reactnavigation.org/docs/en/drawer-navigator.html#contentoptions-for-draweritems). Specifically, the `contentOptions` property contains a subset of the documented options.

My specific instance of this bug is adding `itemsContainerStyle` to `contentOptions` e.g.

```ts

createDrawerNavigator({
  {...},
  {
    contentOptions: {
      itemsContainerStyle: {...}
    }
})
```

## Implementation

I've made a small refactor to the structure of the interfaces related to `DrawerNavigatorConfig`; obviously I need a maintainer to help decide if it's the best approach 🙂

## Test plan

I haven't provided a repro of this issue because it's a bug with the TypeScript definitions, so should hopefully be demonstrable without one.

I've tested my updated config in my project and it fixes the TypeScript build error I was getting.

I've run `yarn test` in this repository and all is well, though I don't think there is anything to cover this change.
