### PR TITLE
Add navigationOptions and defaultNavigationOptions for SwitchNavigatorConfig

### DIFF
--- a/typescript/react-navigation.d.ts
+++ b/typescript/react-navigation.d.ts
@@ -973,6 +973,8 @@ declare module 'react-navigation' {
 
   export interface SwitchNavigatorConfig {
     initialRouteName: string;
+    navigationOptions?: object;
+    defaultNavigationOptions?: object;
     resetOnBlur?: boolean;
     paths?: NavigationPathsConfig;
     backBehavior?: 'none' | 'initialRoute';

--- a/typescript/react-navigation.d.ts
+++ b/typescript/react-navigation.d.ts
@@ -971,13 +971,9 @@ declare module 'react-navigation' {
     stackConfig?: StackNavigatorConfig
   ): NavigationContainer;
 
-  export interface SwitchNavigatorConfig {
-    initialRouteName: string;
-    navigationOptions?: object;
-    defaultNavigationOptions?: object;
-    resetOnBlur?: boolean;
-    paths?: NavigationPathsConfig;
-    backBehavior?: 'none' | 'initialRoute';
+  export interface SwitchNavigatorConfig
+    extends NavigationSwitchRouterConfig {
+      navigationOptions?: NavigationScreenConfig<NavigationScreenOptions>;
   }
 
   // Return createNavigationContainer


### PR DESCRIPTION
This PR aims to fix issue #6047 by adding navigationOptions and defaultNavigationOptions to SwitchNavigatorConfig interface. I don't know if this is the right solution of if the solution I found is applied correctly.

My first question is:
1. Do I need to follow the example from [StackNavigatorConfig](https://github.com/react-navigation/react-navigation/blob/master/typescript/react-navigation.d.ts#L963) and redo the whole SwitchNavigatorConfig interface object or the approach I have is sufficient?

2. The solution from this PR adds the two properties in to the interface object with type `object`. Is this correct.

Please advice on further directions. Thanks