### PR TITLE
Typescript: Mark "params" in NavigationState as possibly undefined

### DIFF
--- a/typescript/react-navigation.d.ts
+++ b/typescript/react-navigation.d.ts
@@ -124,7 +124,7 @@ declare module 'react-navigation' {
     routes: NavigationRoute[];
     isTransitioning: boolean;
     key: string;
-    params: NavigationParams;
+    params: NavigationParams | undefined;
   }
 
   export interface DrawerNavigationState extends NavigationState {


### PR DESCRIPTION
## Motivation
Unless I'm declaring the type of my Props wrong (I'm still new to Typescript), this change is required to prevent issues where no errors are thrown when accessing any properties on the "params" field in the NavigationState.

```ts
function MyScene(props: {
  navigation: NavigationScreenProp<NavigationState, { userId: number }>
}) {

	// Should warn about params being possibly undefined.
	const { userId } = props.navigation.state.params;

	// ...
}
```

