### PR TITLE
Add generic to navigation screen config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+- Add generic for NavigationScreenConfig to be able to pass custom NavigationParams
 - Add missing Flow type exports for `ScrollView` and `NavigationContext`
 
 ## [3.11.1]

--- a/typescript/react-navigation.d.ts
+++ b/typescript/react-navigation.d.ts
@@ -235,15 +235,15 @@ declare module 'react-navigation' {
     NavigationTabScreenOptions &
     NavigationDrawerScreenOptions;
 
-  export interface NavigationScreenConfigProps {
-    navigation: NavigationScreenProp<NavigationRoute>;
+  export interface NavigationScreenConfigProps<Params = NavigationParams> {
+    navigation: NavigationScreenProp<NavigationRoute, Params>;
     screenProps: ScreenProps;
   }
 
-  export type NavigationScreenConfig<Options> =
+  export type NavigationScreenConfig<Options, Params = NavigationParams> =
     | Options
     | ((
-        navigationOptionsContainer: NavigationScreenConfigProps & {
+        navigationOptionsContainer: NavigationScreenConfigProps<Params> & {
           navigationOptions: NavigationScreenConfig<Options>;
         }
       ) => Options);

--- a/typescript/react-navigation.d.ts
+++ b/typescript/react-navigation.d.ts
@@ -258,7 +258,7 @@ declare module 'react-navigation' {
     Options = {},
     Props = {}
   > = React.ComponentType<NavigationScreenProps<Params, Options> & Props> & {
-    navigationOptions?: NavigationScreenConfig<Options>;
+    navigationOptions?: NavigationScreenConfig<Options, Params>;
   };
 
   export type NavigationNavigator<


### PR DESCRIPTION
## Motivation

To be able to have strongly typed NavigationParams inside NavigationScreenConfig function
while dynamically setting NavigationScreenOptions based on NavigationParams


## Test plan

![image](https://user-images.githubusercontent.com/25801332/63020517-a55daa00-be9e-11e9-972c-e4962a778400.png)

Update:
![image](https://user-images.githubusercontent.com/25801332/63053867-0c04b700-bee3-11e9-8bd7-f6f7134a3be5.png)



## Changelog

Add generic for NavigationScreenConfig to be able to pass custom NavigationParams