### PR TITLE
fix: fix the type of NavigationJumpToActionPayload

### DIFF
--- a/typescript/react-navigation.d.ts
+++ b/typescript/react-navigation.d.ts
@@ -398,7 +398,7 @@ declare module 'react-navigation' {
 
   export interface NavigationJumpToActionPayload {
     routeName: string;
-    key: string;
+    key?: string;
     params?: NavigationParams;
   }
 


### PR DESCRIPTION
As mentioned in https://reactnavigation.org/docs/en/switch-actions.html
the param which's name is `key` of `SwitchActions.jumpTo()`  should be optional

Please provide enough information so that others can review your pull request:

## Motivation

Explain the **motivation** for making this change. What existing problem does the pull request solve?

There is something wrong with the type of NavigationJumpToActionPayload

## Test plan

Demonstrate the code is solid. Example: the exact commands you ran and their output, screenshots / videos if the pull request changes UI.

Make sure you test on both platforms if your change affects both platforms.

The code must pass tests.

## Code formatting

Look around. Match the style of the rest of the codebase. Run `yarn format` before committing.

## Changelog

Add an entry under the "Unreleased" heading in [CHANGELOG.md](https://github.com/react-navigation/react-navigation/blob/master/CHANGELOG.md#unreleased) which explains your change.
