### PR TITLE
Fix(d.ts): Introduce TabBarRoute for TabBarLabelProps.route

### DIFF
--- a/typescript/react-navigation.d.ts
+++ b/typescript/react-navigation.d.ts
@@ -594,7 +594,14 @@ declare module 'react-navigation' {
     horizontal: boolean;
   }
 
+  export interface TabBarRoute {
+    key: string;
+    routeName: string;
+    params?: NavigationParams;
+  }
+
   export interface TabBarLabelProps {
+    route: TabBarRoute;
     tintColor: string | null;
     focused: boolean;
   }


### PR DESCRIPTION
Hey!

## Motivation

It's missed form typescript definition

## Test plan

Runtime proff for types

![image](https://user-images.githubusercontent.com/572096/63684887-b09dc780-c806-11e9-8888-a57487bd3308.png)
![image](https://user-images.githubusercontent.com/572096/63684901-b85d6c00-c806-11e9-8cda-33c008240be4.png)

## Changelog

Fix: Add missed `route` field to `TabBarLabelProps` type 

Thanks
