### PR TITLE
fix(deprecations) typo in package name

### DIFF
--- a/src/deprecations.js
+++ b/src/deprecations.js
@@ -52,7 +52,7 @@ module.exports = {
 
   get DrawerGestureContext() {
     throwError(
-      '`DrawerGestureContext` has been moved to `react-navigation-drawe`',
+      '`DrawerGestureContext` has been moved to `react-navigation-drawer`',
       'stack-navigator'
     );
   },
@@ -68,7 +68,7 @@ module.exports = {
 
   get DrawerActions() {
     throwError(
-      '`DrawerActions` has been moved to `react-navigation-drawe`',
+      '`DrawerActions` has been moved to `react-navigation-drawer`',
       'drawer-navigator'
     );
   },


### PR DESCRIPTION
## Motivation

fixes a typo from `react-navigation-drawe` -> `react-navigation-drawer`

## Test plan

N/A

## Code formatting

N/A