### PR TITLE
docs: add the readme back into example

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -1,0 +1,14 @@
+# Navigation Playground Example
+
+The NavigationPlayground example app includes a variety of patterns and is used as a simple way for contributors to manually integration test changes.
+
+## Usage
+
+```bash
+yarn # in the react-navigation root directory
+cd example
+yarn
+yarn start
+```
+
+You can view this example application directly on Android phones by visiting scanning the QR code on [this site](https://exp.host/@react-navigation/NavigationPlayground) with the [Expo app](https://play.google.com/store/apps/details?id=host.exp.exponent&hl=en).

--- a/example/README.md
+++ b/example/README.md
@@ -5,10 +5,8 @@ The NavigationPlayground example app includes a variety of patterns and is used 
 ## Usage
 
 ```bash
-yarn # in the react-navigation root directory
-cd example
-yarn
-yarn start
+yarn bootstrap # in the react-navigation root directory
+yarn example start
 ```
 
 You can view this example application directly on Android phones by visiting scanning the QR code on [this site](https://exp.host/@react-navigation/NavigationPlayground) with the [Expo app](https://play.google.com/store/apps/details?id=host.exp.exponent&hl=en).


### PR DESCRIPTION
## Motivation

I was trying to learn how to contribute to React Navigation and the docs at [https://reactnavigation.org/docs/en/contributing.html](https://reactnavigation.org/docs/en/contributing.html) referred to an example app with a README.md file giving instructions on how to run it. I later found out that this file was removed in d8130dd0d4bf3eb905f7aa67cd7f3b2f67ef6871. Could not find any reason why this was removed, so perhaps it was overlooked.

I definitely think it is essential, even if the commands are basic, to show exactly how to get the example app up and running.

I plan on updating the website docs if this PR is accepted.

## Test plan

Commands in file were run and still work
