### PR TITLE
Update react-navigation.d.ts

### DIFF
--- a/typescript/react-navigation.d.ts
+++ b/typescript/react-navigation.d.ts
@@ -192,7 +192,7 @@ declare module 'react-navigation' {
 
   export interface NavigationScreenConfigProps<NavigationScreenPropType> {
     navigation: NavigationScreenPropType;
-    screenProps: unknown;
+    screenProps: any;
     theme: SupportedThemes;
   }
 


### PR DESCRIPTION
Example : 

```tsx
export default createStackNavigator(
  {
    [AppScreens.MenuSummary]: Summary,
    [AppScreens.MenuChangeMyTeam]: {
      params: {
        isMenuContext: true,
      },
      screen: SelectTeam,
    },
    [AppScreens.MenuNotifications]: Notifications,
    [AppScreens.MenuPartners]: Partners,
    [AppScreens.MenuPrivacy]: Privacy,
    [AppScreens.MenuHelpFAQ]: HelpFAQ,
  },
  {
    header: props => {
      return <Header title={props.scene.descriptor.options.headerTitle} />;
    },
    initialRouteName: AppScreens.MenuSummary,
    navigationOptions: (props) => ({
      title: props.screenProps.t("nav.menu.root"),
    }),
  },
);
```

In my 
```navigationOptions: (props) => ({
      title: props.screenProps.t("nav.menu.root"),
    }),
```

`screenProps` is of unknown type, this is too restrictive and block the compiler, put any awaiting in Genericity