### PR TITLE
fix: make params required in NavigationSetParamsActionPayload

### DIFF
--- a/typescript/react-navigation.d.ts
+++ b/typescript/react-navigation.d.ts
@@ -269,7 +269,7 @@ declare module 'react-navigation' {
     key: string;
 
     // The new params to merge into the existing route params
-    params?: NavigationParams;
+    params: NavigationParams;
   }
 
   export interface NavigationSetParamsAction


### PR DESCRIPTION
As mentioned in https://reactnavigation.org/docs/en/navigation-actions.html#setparams 
the param which's name is key of NavigationActions.setParams() should be required

Please provide enough information so that others can review your pull request:

## Motivation

Explain the **motivation** for making this change. What existing problem does the pull request solve?

There is something wrong with the type of NavigationSetParamsActionPayload

## Test plan

Demonstrate the code is solid. Example: the exact commands you ran and their output, screenshots / videos if the pull request changes UI.

Make sure you test on both platforms if your change affects both platforms.

The code must pass tests.

## Code formatting

Look around. Match the style of the rest of the codebase. Run `yarn format` before committing.

Thanks.