### PR TITLE
type fix: allow withNavigationFocus argument to take in a subset of focus props

### DIFF
--- a/typescript/react-navigation.d.ts
+++ b/typescript/react-navigation.d.ts
@@ -916,7 +916,7 @@ declare module 'react-navigation' {
 
   // If the wrapped component is a class, we can get a ref to it
   export function withNavigationFocus<
-    P extends NavigationFocusInjectedProps,
+    P extends Partial<NavigationFocusInjectedProps>,
     T extends React.ComponentClass<P>
   >(
     Component: T & React.ComponentClass<P>
@@ -926,7 +926,9 @@ declare module 'react-navigation' {
     }
   >;
 
-  export function withNavigationFocus<P extends NavigationFocusInjectedProps>(
+  export function withNavigationFocus<
+    P extends Partial<NavigationFocusInjectedProps>
+  >(
     Component: React.ComponentType<P>
   ): React.ComponentType<Omit<P, keyof NavigationFocusInjectedProps>>;
 


### PR DESCRIPTION
This PR makes the types for `withNavigationFocus` slightly more forgiving. Instead of making components that get wrapped in `withNavigationFocus`  have both `isFocused` and `navigation` in their props type, they now get to have one or neither.

This change shouldn't cause any new type errors, since it just widens existing type parameters. There also shouldn't be any kinds of runtime errors that were stopped by TS before, but now are possible thanks to this PR.