### PR TITLE
fix: remove params in NavigationJumpToAction

### DIFF
--- a/typescript/react-navigation.d.ts
+++ b/typescript/react-navigation.d.ts
@@ -369,12 +369,14 @@ declare module 'react-navigation' {
   export interface NavigationJumpToActionPayload {
     routeName: string;
     key?: string;
+    preserveFocus?: boolean;
   }
 
   export interface NavigationJumpToAction {
     type: 'Navigation/JUMP_TO';
     routeName: string;
     key: string;
+    preserveFocus?: boolean;
   }
 
   export interface NavigationDrawerOpenedAction {

--- a/typescript/react-navigation.d.ts
+++ b/typescript/react-navigation.d.ts
@@ -369,15 +369,12 @@ declare module 'react-navigation' {
   export interface NavigationJumpToActionPayload {
     routeName: string;
     key?: string;
-    params?: NavigationParams;
   }
 
   export interface NavigationJumpToAction {
     type: 'Navigation/JUMP_TO';
-    preserveFocus: boolean;
     routeName: string;
     key: string;
-    params?: NavigationParams;
   }
 
   export interface NavigationDrawerOpenedAction {


### PR DESCRIPTION
As mentioned in https://reactnavigation.org/docs/en/switch-actions.html#jumpto.
I removed the params of SwitchActions.jumpTo().


## Motivation
There is something wrong with the type of SwitchActions.jumpTo().
## Test plan


## Code formatting
