### PR TITLE
feat: allow navigation params to be typed in navigate method

### DIFF
--- a/typescript/react-navigation.d.ts
+++ b/typescript/react-navigation.d.ts
@@ -564,22 +564,23 @@ declare module 'react-navigation' {
     dispatch: NavigationDispatch;
     goBack: (routeKey?: string | null) => boolean;
     dismiss: () => boolean;
-    navigate(options: {
+    navigate<T extends NavigationParams>(options: {
       routeName:
         | string
         | {
             routeName: string;
-            params?: NavigationParams;
+            params?: T;
             action?: NavigationNavigateAction;
             key?: string;
           };
-      params?: NavigationParams;
+      params?: T;
       action?: NavigationAction;
       key?: string;
     }): boolean;
-    navigate(
+
+    navigate<T extends NavigationParams>(
       routeNameOrOptions: string,
-      params?: NavigationParams,
+      params?: T,
       action?: NavigationAction
     ): boolean;
     openDrawer: () => any;


### PR DESCRIPTION
## Motivation

We can type navigation params in component by writing something like this in component props declaration : 

``` ts
export interface SomeNavigationParams {
  foo: string;
  bar: number;
}

export interface Props {
  navigation: NavigationScreenProp<any, SomeNavigationParams>;
}
``` 

But when we are navigating to this screen, we only call navigate method without any type checking.

``` ts
// Next line doesn't trigger ts error
this.props.navigation.navigate('MyRouteName', { foo: "foo", bar: "bar"})
``` 

By making navigate a generic method, we can type those params correctly

``` ts
import { SomeNavigationParams } from '@Screens/....../SomeScreen.types.ts'

......
// Next line triggers an error
this.props.navigation.navigate<SomeNavigationParams>('MyRouteName', { foo: "foo", bar: "bar"});
......
``` 

## Test plan

No .js code so it's can't be breaking anything. Plus, can't also break typing as changes are seamless for react-navigation API. 

