### PR TITLE
fix: wrong type in react-navigation.d.ts

### DIFF
--- a/typescript/react-navigation.d.ts
+++ b/typescript/react-navigation.d.ts
@@ -291,7 +291,7 @@ declare module 'react-navigation' {
     newKey?: string;
     routeName: string;
     params?: NavigationParams;
-    action?: NavigationNavigateAction;
+    action?: NavigationAction;
   }
 
   export interface NavigationReplaceAction {
@@ -299,7 +299,7 @@ declare module 'react-navigation' {
     key: string;
     routeName: string;
     params?: NavigationParams;
-    action?: NavigationNavigateAction;
+    action?: NavigationAction;
   }
 
   export interface NavigationCompleteTransitionActionPayload {


### PR DESCRIPTION
## Motivation

This code is actually throwing a type error because of a wrong type declaration with the action expecting to be only a `NavigationNavigateAction` while in reality any action can be dispatched not only the `navigate`.
```jsx
      StackActions.replace({
        routeName: 'MyRoute1',
        // this action is throwing a type error
        action: StackActions.push({
          routeName: 'MyRoute2',
        }),
      }),
```

## Test plan

## Code formatting

It's just a simple type fix, I edited it in the GitHub UI, I didn't run any test locally

