### PR TITLE
feat: make `ScreenProps` parametrizable in TypeScript

### DIFF
--- a/typescript/react-navigation.d.ts
+++ b/typescript/react-navigation.d.ts
@@ -482,7 +482,7 @@ declare module 'react-navigation' {
     | NavigationSwitchAction
     | { type: 'CHILD_ACTION'; key?: string };
 
-  export type NavigationRouteConfig<Options, NavigationScreenPropType> =
+  export type NavigationRouteConfig<Options, NavigationScreenPropType, ScreenProps = unknown> =
     | NavigationComponent<Options, NavigationScreenPropType>
     | (
         | { screen: NavigationComponent<Options, NavigationScreenPropType> }
@@ -494,7 +494,8 @@ declare module 'react-navigation' {
           }) & {
         navigationOptions?: NavigationScreenConfig<
           Options,
-          NavigationScreenPropType
+          NavigationScreenPropType,
+          ScreenProps
         >;
         params?: { [key: string]: any };
         path?: string;
@@ -514,10 +515,11 @@ declare module 'react-navigation' {
     resetOnBlur?: boolean;
   }
 
-  export interface NavigationRouteConfigMap<Options, NavigationScreenPropType> {
+  export interface NavigationRouteConfigMap<Options, NavigationScreenPropType, ScreenProps = unknown> {
     [routeName: string]: NavigationRouteConfig<
       Options,
-      NavigationScreenPropType
+      NavigationScreenPropType,
+      ScreenProps
     >;
   }
 


### PR DESCRIPTION
This change allows for the following to be written:

```tsx
const TreatmentPlanDrawerItem = createStackNavigator(
  {
    Screen: {
      screen: Screen,
     // t is of type i18next.TFunction via the type casting below.
      navigationOptions: ({ screenProps }) => ({
        title: screenProps.t('title'),
      })
    },
  } as NavigationRouteConfigMap<
    NavigationStackOptions,
    NavigationStackProp<NavigationRoute, any>,
    { t: i18next.TFunction }
  >
);
```

Please provide enough information so that others can review your pull request:

## Motivation

Explain the **motivation** for making this change. What existing problem does the pull request solve?

## Test plan

Demonstrate the code is solid. Example: the exact commands you ran and their output, screenshots / videos if the pull request changes UI.

Make sure you test on both platforms if your change affects both platforms.

The code must pass tests.

## Code formatting

Look around. Match the style of the rest of the codebase. Run `yarn format` before committing.
