### PR TITLE
fix: wrong type in react-navigation.d.ts

### DIFF
--- a/typescript/react-navigation.d.ts
+++ b/typescript/react-navigation.d.ts
@@ -596,6 +596,19 @@ declare module 'react-navigation' {
       eventName: string,
       callback: NavigationEventCallback
     ) => NavigationEventSubscription;
+    push: (
+      routeName: string,
+      params?: NavigationParams,
+      action?: NavigationNavigateAction
+    ) => boolean;
+    replace: (
+      routeName: string,
+      params?: NavigationParams,
+      action?: NavigationNavigateAction
+    ) => boolean;
+    reset: (actions: NavigationAction[], index: number) => boolean;
+    pop: (n?: number, params?: { immediate?: boolean }) => boolean;
+    popToTop: (params?: { immediate?: boolean }) => boolean;
     isFocused: () => boolean;
     isFirstRouteInParent: () => boolean;
     router?: NavigationRouter;


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

## Motivation

I find method `replace` is missing in types, but this can be used in js.

## Test plan

won't need to, I just past the types from v3.11.1

## Code formatting

Look around. Match the style of the rest of the codebase. Run `yarn format` before committing.

I run `yarn format` with error: `Command "format" not found`
