### PR TITLE
fix: wrong type in react-navigation.d.ts

### DIFF
--- a/typescript/react-navigation.d.ts
+++ b/typescript/react-navigation.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for react-navigation 3.0.0
+// Type definitions for react-navigation 4.0.10
 // Project: https://github.com/react-navigation/react-navigation
 // Definitions by: Huhuanming <https://github.com/huhuanming>
 //                 mhcgrq <https://github.com/mhcgrq>

--- a/typescript/react-navigation.d.ts
+++ b/typescript/react-navigation.d.ts
@@ -601,6 +601,7 @@ declare module 'react-navigation' {
       params?: NavigationParams,
       action?: NavigationNavigateAction
     ) => boolean;
+    // https://reactnavigation.org/docs/en/typescript.html
     replace: (
       routeName: string,
       params?: NavigationParams,

--- a/typescript/react-navigation.d.ts
+++ b/typescript/react-navigation.d.ts
@@ -596,6 +596,19 @@ declare module 'react-navigation' {
       eventName: string,
       callback: NavigationEventCallback
     ) => NavigationEventSubscription;
+    push: (
+      routeName: string,
+      params?: NavigationParams,
+      action?: NavigationNavigateAction
+    ) => boolean;
+    replace: (
+      routeName: string,
+      params?: NavigationParams,
+      action?: NavigationNavigateAction
+    ) => boolean;
+    reset: (actions: NavigationAction[], index: number) => boolean;
+    pop: (n?: number, params?: { immediate?: boolean }) => boolean;
+    popToTop: (params?: { immediate?: boolean }) => boolean;
     isFocused: () => boolean;
     isFirstRouteInParent: () => boolean;
     router?: NavigationRouter;


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

## Motivation

I find method `replace` is missing in types, but this can be used in js.

## Test plan

won't need to, I just past the types from v3.11.1

## Code formatting

Look around. Match the style of the rest of the codebase. Run `yarn format` before committing.

I run `yarn format` with error: `Command "format" not found`

see https://github.com/react-navigation/react-navigation/pull/6525
