### PR TITLE
feat: useScrollToTop accepts an optional offset param for scrollables where the "top" is not at 0

### DIFF
--- a/packages/native/src/useScrollToTop.tsx
+++ b/packages/native/src/useScrollToTop.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useNavigation, useRoute, EventArg } from '@react-navigation/core';
 
-type ScrollOptions = { y?: number; animated?: boolean };
+type ScrollOptions = { offset?: number; animated?: boolean };
 
 type ScrollableView =
   | { scrollToTop(): void }
@@ -43,7 +43,8 @@ function getScrollableNode(ref: React.RefObject<ScrollableWrapper>) {
 }
 
 export default function useScrollToTop(
-  ref: React.RefObject<ScrollableWrapper>
+  ref: React.RefObject<ScrollableWrapper>,
+  offset: number = 0
 ) {
   const navigation = useNavigation();
   const route = useRoute();
@@ -82,14 +83,17 @@ export default function useScrollToTop(
           const scrollable = getScrollableNode(ref);
 
           if (isFocused && isFirst && scrollable && !e.defaultPrevented) {
-            if ('scrollToTop' in scrollable) {
-              scrollable.scrollToTop();
-            } else if ('scrollTo' in scrollable) {
-              scrollable.scrollTo({ y: 0, animated: true });
+            if ('scrollTo' in scrollable) {
+              scrollable.scrollTo({ offset, animated: true });
             } else if ('scrollToOffset' in scrollable) {
-              scrollable.scrollToOffset({ y: 0, animated: true });
+              scrollable.scrollToOffset({ offset, animated: true });
             } else if ('scrollResponderScrollTo' in scrollable) {
-              scrollable.scrollResponderScrollTo({ y: 0, animated: true });
+              scrollable.scrollResponderScrollTo({
+                offset,
+                animated: true,
+              });
+            } else if ('scrollToTop' in scrollable) {
+              scrollable.scrollToTop();
             }
           }
         });
@@ -97,5 +101,5 @@ export default function useScrollToTop(
     );
 
     return unsubscribe;
-  }, [navigation, ref, route.key]);
+  }, [navigation, ref, route.key, offset]);
 }


### PR DESCRIPTION
I have a FlatList component in my app that extends the full height of the device to achieve the iOS "frosted glass" effect. I had to do a bunch of tricks to get all the content to align correctly. One of those tricks was passing contentOffset to the FlatList to have it initialize to where I want the top of my list to be. Currently, there is no way to pass an offset value to useScrollToTop hook in React Navigation. I added a second parameter (after ref) that accepts an offset.

christianjuth/react-navigation-1.git#react-navigation-native-v5.0.0-gitpkg

```tsx
let contentInsets = {
  top: TopTabBar.useHeight({ safe: true }),
  bottom: Footer.useHeight({ safe: true })
};

let scrollIndicatorInsets = {
  top: TopTabBar.useHeight({ safe: false }),
  bottom: Footer.useHeight({ safe: false })
};

// tap tab to scroll to top
let ref = useRef();
useScrollToTop(ref, -contentInsets.top);

return(
  <FlatList
    contentContainerStyle={{
      paddingTop: 6,
      paddingBottom: 6
    }}
    contentInset={contentInsets}
    contentOffset={{
      y: -contentInsets.top,
      x: 0
    }}
    automaticallyAdjustContentInsets={false}
    scrollIndicatorInsets={scrollIndicatorInsets}
    contentInsetAdjustmentBehavior="never"
  />
);
```

![Usage Example](https://user-images.githubusercontent.com/5768801/73881103-c1c71780-482d-11ea-9c03-0f97b24d76ae.gif)