### PR TITLE
feat: add headerLeft prop to native-stack

### DIFF
--- a/packages/native-stack/src/types.tsx
+++ b/packages/native-stack/src/types.tsx
@@ -107,6 +107,12 @@ export type NativeStackNavigationOptions = {
    */
   headerLargeTitle?: boolean;
   /**
+   * Function which returns a React Element to display on the left side of the header.
+   *
+   * @platform ios
+   */
+  headerLeft?: () => React.ReactNode;
+  /**
    * Function which returns a React Element to display on the right side of the header.
    */
   headerRight?: () => React.ReactNode;

--- a/packages/native-stack/src/views/HeaderConfig.tsx
+++ b/packages/native-stack/src/views/HeaderConfig.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Platform } from 'react-native';
 import {
   ScreenStackHeaderConfig,
   ScreenStackHeaderLeftView,
@@ -73,7 +74,7 @@ export default function HeaderConfig(props: Props) {
           : colors.card
       }
     >
-      {headerLeft !== undefined ? (
+      {headerLeft !== undefined && Platform.OS === 'ios' ? (
         <ScreenStackHeaderLeftView>{headerLeft()}</ScreenStackHeaderLeftView>
       ) : null}
 

--- a/packages/native-stack/src/views/HeaderConfig.tsx
+++ b/packages/native-stack/src/views/HeaderConfig.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import {
   ScreenStackHeaderConfig,
+  ScreenStackHeaderLeftView,
   ScreenStackHeaderRightView,
   // eslint-disable-next-line import/no-unresolved
 } from 'react-native-screens';
@@ -16,6 +17,7 @@ export default function HeaderConfig(props: Props) {
   const {
     route,
     title,
+    headerLeft,
     headerRight,
     headerTitle,
     headerBackTitle,
@@ -71,6 +73,10 @@ export default function HeaderConfig(props: Props) {
           : colors.card
       }
     >
+      {headerLeft !== undefined ? (
+        <ScreenStackHeaderLeftView>{headerLeft()}</ScreenStackHeaderLeftView>
+      ) : null}
+
       {headerRight !== undefined ? (
         <ScreenStackHeaderRightView>{headerRight()}</ScreenStackHeaderRightView>
       ) : null}


### PR DESCRIPTION
I've added `headerLeft` prop for `native-stack` package. However, it will not work correctly on Android because of [this code](https://github.com/kmagiera/react-native-screens/blob/fd7fcfbc5bd67875bbbf29d270a8579894fd6e1d/android/src/main/java/com/swmansion/rnscreens/ScreenStackHeaderConfig.java#L216) inside `react-native-screens`, but for iOS it works correctly as far as I've tested, but maybe I'm missing something important here.

EDIT: 

There is possibility to actually show title "properly" sticked to left side with something like this:
```js
      {headerLeft !== undefined ? (
        <ScreenStackHeaderLeftView>
          {headerLeft()}
          <Text style={...}>{
            headerTitle !== undefined
              ? headerTitle
              : title !== undefined
                ? title
                : route.name
          }</Text>
        </ScreenStackHeaderLeftView>
      ) : null}
```

I'm not experienced enough to try do something inside java but, it seems like some workaround. Also, there should be some condition for `ScreenStackHeaderCenterView` if someone would like to render centred title. I can add this, but I would like to know what you guys think about this approach.