### PR TITLE
Fix `keyboardHidesTabBar` initialization typo

### DIFF
--- a/packages/bottom-tabs/src/views/BottomTabBar.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabBar.tsx
@@ -56,7 +56,7 @@ export default function BottomTabBar({
   });
   const [keyboardShown, setKeyboardShown] = React.useState(false);
 
-  const [visible] = React.useState(() => new Animated.Value(0));
+  const [visible] = React.useState(() => new Animated.Value(1));
 
   const { routes } = state;
 


### PR DESCRIPTION
Issues #6740, #6799

**Summary**: when `keybordHidesTabBar` is true, the TabBar should **start visible**. (Assume keyboard is not shown initially)

Looks like a run-of-the-mill refactor typo introduced in commit 38a38b021a3764d3977e83fe6c2d2be115e03e56 during a refactor to `FunctionComponent` for `v5.0.0-alpha.26`.

Before: `Animated.Value(1)` - https://github.com/react-navigation/react-navigation/commit/38a38b021a3764d3977e83fe6c2d2be115e03e56#diff-01c572697c6280aebeef0ce66da6ac66L47

After: `Animated.Value(0)` - https://github.com/react-navigation/react-navigation/commit/38a38b021a3764d3977e83fe6c2d2be115e03e56#diff-01c572697c6280aebeef0ce66da6ac66R48

The rest of the initial state data stayed the same, and it doesn't look like any changes were made to the animated value's meaning (0 -> hidden -> translate down offscreen // 1 -> shown -> zero translation). So almost definitely an accident.

---

I do not experience this issue in Development mode -- probably due to Keyboard or Layout events resetting/fixing the state. Also, rotating the phone to landscape & back has the same fixing effect.

Since react-native-web does not provide the Keyboard module, the issue can be observed in the "Web" mode of the Snack shared by @deniscreamer in #6799: https://snack.expo.io/@densch1/tab-navigation-%C2%B7-react-navigation. 

I tried to use `gitpkg` to bundle up a package with this change, but had several issues with getting it to work. This issue seems pretty clear-cut though.

---

Thanks for reviewing. And great job releasing `5.0` proper! :tada: 