### PR TITLE
fix: static container memo check

### DIFF
--- a/packages/core/src/StaticContainer.tsx
+++ b/packages/core/src/StaticContainer.tsx
@@ -8,12 +8,19 @@ function StaticContainer(props: any) {
 }
 
 export default React.memo(StaticContainer, (prevProps: any, nextProps: any) => {
-  for (const prop in prevProps) {
-    if (prop === 'children') {
+  const prevPropKeys = Object.keys(prevProps);
+  const nextPropKeys = Object.keys(nextProps);
+
+  if (prevPropKeys.length !== nextPropKeys.length) {
+    return false;
+  }
+
+  for (const key of prevPropKeys) {
+    if (key === 'children') {
       continue;
     }
 
-    if (prevProps[prop] !== nextProps[prop]) {
+    if (prevProps[key] !== nextProps[key]) {
       return false;
     }
   }

--- a/packages/core/src/__tests__/StaticContainer.test.tsx
+++ b/packages/core/src/__tests__/StaticContainer.test.tsx
@@ -49,3 +49,27 @@ it('updates element if any props changed', () => {
 
   expect(root).toMatchInlineSnapshot(`"second"`);
 });
+
+it('updates element if any props are added', () => {
+  expect.assertions(2);
+
+  const Test = ({ label }: any) => {
+    return label;
+  };
+
+  const root = render(
+    <StaticContainer count={42}>
+      <Test label="first" />
+    </StaticContainer>
+  );
+
+  expect(root).toMatchInlineSnapshot(`"first"`);
+
+  root.update(
+    <StaticContainer count={42} moreCounts={12}>
+      <Test label="second" />
+    </StaticContainer>
+  );
+
+  expect(root).toMatchInlineSnapshot(`"second"`);
+});


### PR DESCRIPTION
### What were the changes?
- Memo check compared elements of `prevProps` to `nextProps` but failed to take new props into account.
- Fixed the logic and added a new test.

### Repro steps
- Memoize a component and add a new prop. Memo returns previous result instead of re-rendering the component.

PS: I couldn't find a PR template, please let me know if I missed it. I'll update my description as per the template.