### PR TITLE
feat: add ScreenNavigationProps and ScreenOptionsCallback types

### DIFF
--- a/packages/core/src/types.tsx
+++ b/packages/core/src/types.tsx
@@ -17,7 +17,9 @@ export type ScreenNavigationProps<
   navigation: any;
 };
 
-export type ScreenOptionsCallback<ScreenOptions extends object = object> = (props: ScreenNavigationProps) => ScreenOptions;
+export type ScreenOptionsCallback<ScreenOptions extends object = object> = (
+  props: ScreenNavigationProps
+) => ScreenOptions;
 
 export type DefaultNavigatorOptions<
   ScreenOptions extends object
@@ -30,9 +32,7 @@ export type DefaultNavigatorOptions<
   /**
    * Default options for all screens under this navigator.
    */
-  screenOptions?:
-    | ScreenOptions
-    | ScreenOptionsCallback<ScreenOptions>;
+  screenOptions?: ScreenOptions | ScreenOptionsCallback<ScreenOptions>;
 };
 
 export type EventMapBase = Record<
@@ -377,9 +377,7 @@ export type RouteConfig<
   /**
    * Navigator options for this screen.
    */
-  options?:
-    | ScreenOptions
-    | ScreenOptionsCallback<ScreenOptions>;
+  options?: ScreenOptions | ScreenOptionsCallback<ScreenOptions>;
 
   /**
    * Initial params object for the route.
@@ -440,9 +438,7 @@ export type TypedNavigator<
       /**
        * Default options for all screens under this navigator.
        */
-      screenOptions?:
-        | ScreenOptions
-        | ScreenOptionsCallback<ScreenOptions>;
+      screenOptions?: ScreenOptions | ScreenOptionsCallback<ScreenOptions>;
     }
   >;
   /**

--- a/packages/core/src/types.tsx
+++ b/packages/core/src/types.tsx
@@ -9,6 +9,16 @@ import {
   ParamListBase,
 } from '@react-navigation/routers';
 
+export type ScreenNavigationProps<
+  ParamList extends ParamListBase = ParamListBase,
+  RouteName extends keyof ParamList = string
+> = {
+  route: RouteProp<ParamList, RouteName>;
+  navigation: any;
+};
+
+export type ScreenOptionsCallback<ScreenOptions extends object = object> = (props: ScreenNavigationProps) => ScreenOptions;
+
 export type DefaultNavigatorOptions<
   ScreenOptions extends object
 > = DefaultRouterOptions & {
@@ -22,10 +32,7 @@ export type DefaultNavigatorOptions<
    */
   screenOptions?:
     | ScreenOptions
-    | ((props: {
-        route: RouteProp<ParamListBase, string>;
-        navigation: any;
-      }) => ScreenOptions);
+    | ScreenOptionsCallback<ScreenOptions>;
 };
 
 export type EventMapBase = Record<
@@ -372,10 +379,7 @@ export type RouteConfig<
    */
   options?:
     | ScreenOptions
-    | ((props: {
-        route: RouteProp<ParamList, RouteName>;
-        navigation: any;
-      }) => ScreenOptions);
+    | ScreenOptionsCallback<ScreenOptions>;
 
   /**
    * Initial params object for the route.
@@ -392,10 +396,7 @@ export type RouteConfig<
       /**
        * Render callback to render content of this screen.
        */
-      children: (props: {
-        route: RouteProp<ParamList, RouteName>;
-        navigation: any;
-      }) => React.ReactNode;
+      children: (props: ScreenNavigationProps) => React.ReactNode;
     }
 );
 
@@ -441,10 +442,7 @@ export type TypedNavigator<
        */
       screenOptions?:
         | ScreenOptions
-        | ((props: {
-            route: RouteProp<ParamList, keyof ParamList>;
-            navigation: any;
-          }) => ScreenOptions);
+        | ScreenOptionsCallback<ScreenOptions>;
     }
   >;
   /**


### PR DESCRIPTION
# Motivation

When the typescript configuration require typedef for callback and params to write
```diff
<Stack.Screen
        name={NavigationScreensEnum.LOCATIONS}
        component={LocationsScreen}
-        options={({ navigation }: { route: RouteProp<ParamList, RouteName>; navigation: any }): 
+.      options={({ navigation }: ScreenNavigationProps): 
StackNavigationOptions => ({
          headerLeft: (): React.ReactElement => (
            <HeaderLeft
              onPress={(): void => void navigation.toggleDrawer()}
              svgConfig={{
                iconId: 'MENU',
                style: { marginLeft: 15 },
              }}
            />)
        })}
      />
```

I had some errors installing with gitpkg 
```
npm i https://github.com/strdr4605/react-navigation.git#react-navigation-core-v5.1.1-gitpkg
```

But I copied files and it works ok.