### PR TITLE
fix: useScrollToTop and offset

### DIFF
--- a/packages/native/src/useScrollToTop.tsx
+++ b/packages/native/src/useScrollToTop.tsx
@@ -2,11 +2,12 @@ import * as React from 'react';
 import { useNavigation, useRoute, EventArg } from '@react-navigation/core';
 
 type ScrollOptions = { y?: number; animated?: boolean };
+type ScrollOffsetOptions = { offset?: number; animated?: boolean };
 
 type ScrollableView =
   | { scrollToTop(): void }
   | { scrollTo(options: ScrollOptions): void }
-  | { scrollToOffset(options: ScrollOptions): void }
+  | { scrollToOffset(options: ScrollOffsetOptions): void }
   | { scrollResponderScrollTo(options: ScrollOptions): void };
 
 type ScrollableWrapper =
@@ -87,7 +88,7 @@ export default function useScrollToTop(
             } else if ('scrollTo' in scrollable) {
               scrollable.scrollTo({ y: 0, animated: true });
             } else if ('scrollToOffset' in scrollable) {
-              scrollable.scrollToOffset({ y: 0, animated: true });
+              scrollable.scrollToOffset({ offset: 0, animated: true });
             } else if ('scrollResponderScrollTo' in scrollable) {
               scrollable.scrollResponderScrollTo({ y: 0, animated: true });
             }

--- a/packages/native/src/useScrollToTop.tsx
+++ b/packages/native/src/useScrollToTop.tsx
@@ -83,14 +83,16 @@ export default function useScrollToTop(
           const scrollable = getScrollableNode(ref);
 
           if (isFocused && isFirst && scrollable && !e.defaultPrevented) {
+            const contentOffsetY = scrollable.props.contentOffset?.y || 0;
+            
             if ('scrollToTop' in scrollable) {
               scrollable.scrollToTop();
             } else if ('scrollTo' in scrollable) {
-              scrollable.scrollTo({ y: 0, animated: true });
+              scrollable.scrollTo({ y: contentOffsetY, animated: true });
             } else if ('scrollToOffset' in scrollable) {
-              scrollable.scrollToOffset({ offset: 0, animated: true });
+              scrollable.scrollToOffset({ offset: contentOffsetY, animated: true });
             } else if ('scrollResponderScrollTo' in scrollable) {
-              scrollable.scrollResponderScrollTo({ y: 0, animated: true });
+              scrollable.scrollResponderScrollTo({ y: contentOffsetY, animated: true });
             }
           }
         });


### PR DESCRIPTION
Hello, two things on this PR:

- `scrollToOffset` should use `offset` and not `y` in options https://facebook.github.io/react-native/docs/virtualizedlist#scrolltooffset
- get the `contentOffset.y` from the scrollable props instead of using `0`. The definition of `contentOffset` is 

> Used to manually set the starting scroll offset

So I think it's ok to use it to prevent unwanted behavior if we use `contentOffset`/`contentInset` on iOS to achieve some effects, and avoiding the need to give the offset as a param for `useScrollToTop `