### PR TITLE
chore: remove background when stackPresentation is transparentModal

### DIFF
--- a/packages/native-stack/src/views/NativeStackView.tsx
+++ b/packages/native-stack/src/views/NativeStackView.tsx
@@ -73,7 +73,12 @@ export default function NativeStackView({
             <View
               style={[
                 styles.container,
-                { backgroundColor: colors.background },
+                {
+                  backgroundColor:
+                    stackPresentation !== 'transparentModal'
+                      ? colors.background
+                      : undefined,
+                },
                 contentStyle,
               ]}
             >


### PR DESCRIPTION
## Summary
Fixes https://github.com/react-navigation/react-navigation/issues/6877

## Before / After
<div style="display: flex;">
<img src="https://user-images.githubusercontent.com/11046907/74785321-fc0acd00-52a1-11ea-9a20-b3fd248145d8.gif" width="280" height="500">
<img src="https://user-images.githubusercontent.com/11046907/74785315-fa410980-52a1-11ea-8f68-48a08224d7a4.gif" width="280" height="500">
</div>