### PR TITLE
fix: prevent fast back events while emitting POP with source but no target

### DIFF
--- a/packages/routers/src/StackRouter.tsx
+++ b/packages/routers/src/StackRouter.tsx
@@ -245,7 +245,8 @@ export default function StackRouter(options: StackRouterOptions) {
 
         case 'POP': {
           const index =
-            action.target === state.key && action.source
+            (action.target === state.key || action.target === undefined) &&
+            action.source
               ? state.routes.findIndex(r => r.key === action.source)
               : state.index;
 


### PR DESCRIPTION
Fixes https://github.com/react-navigation/react-navigation/issues/6820#issuecomment-590265449