### PR TITLE
fix: fix back gesture cancellation

### DIFF
--- a/packages/stack/src/views/Stack/Card.tsx
+++ b/packages/stack/src/views/Stack/Card.tsx
@@ -267,8 +267,7 @@ export default class Card extends React.Component<Props> {
         }
 
         const closing =
-          Math.abs(translation + velocity * gestureVelocityImpact) >
-          distance / 2
+          translation + velocity * gestureVelocityImpact > distance / 2
             ? velocity !== 0 || translation !== 0
             : false;
 


### PR DESCRIPTION
This will fix https://github.com/react-navigation/react-navigation/issues/6782
The problem here is that when we scroll back really fast, even though velocity is negative, `Math.abs(translation + velocity * gestureVelocityImpact)` will end up bigger than `distance / 2`.

I removed the `Math.abs`, I think it's not necessary. When `translation + velocity * gestureVelocityImpact` is negative, it's also < `distance / 2` and we should just close the screen.