### PR TITLE
fix: fix android header title font weight

### DIFF
--- a/packages/stack/src/views/Header/HeaderTitle.tsx
+++ b/packages/stack/src/views/Header/HeaderTitle.tsx
@@ -32,7 +32,8 @@ const styles = StyleSheet.create({
     },
     android: {
       fontSize: 20,
-      fontWeight: '500',
+      fontFamily: 'sans-serif-medium',
+      fontWeight: 'normal',
     },
     default: {
       fontSize: 18,


### PR DESCRIPTION
the previously used fort weight of 500 would effectively be converted to `fontWeight: bold`. Because of https://github.com/facebook/react-native/pull/25341 that does not happen as of 0.61 - fontWeight 500 for roboto actually is the same as 400 in latest RN. Because of that the title font doesn't look right (to me at least 😄 ) - it certainly looks different than before.

this fixes the title appearance to look as customary (it's thicker than now, but not as thick as it used to be).

images: old behavior, master, my branch

<span>

<img src="https://user-images.githubusercontent.com/1566403/76115300-384f6480-5fe8-11ea-8ad9-68bb1ff98d82.jpg" width="200"  /> 

<img src="https://user-images.githubusercontent.com/1566403/76114925-74ce9080-5fe7-11ea-8061-5ffbe26ecac7.jpg" width="200"  />


<img src="https://user-images.githubusercontent.com/1566403/76114923-7304cd00-5fe7-11ea-8407-95be79ac6c4a.jpg" width="200"  />


</span>





