### PR TITLE
fix typo: correcting spelling 'Supress' > 'Suppress'

### DIFF
--- a/jest/setup.js
+++ b/jest/setup.js
@@ -1,7 +1,7 @@
 const error = console.error;
 
 console.error = (...args) =>
-  // Supress error messages regarding error boundary in tests
+  // Suppress error messages regarding error boundary in tests
   /(Consider adding an error boundary to your tree to customize error handling behavior|React will try to recreate this component tree from scratch using the error boundary you provided|Error boundaries should implement getDerivedStateFromError)/m.test(
     args[0]
   )


### PR DESCRIPTION
I ran a spellchecker over the code, this was the only spelling error I was able to find :)