### PR TITLE
feat: add basic Link component in React Native

### DIFF
--- a/example/src/Screens/LinkComponent.tsx
+++ b/example/src/Screens/LinkComponent.tsx
@@ -1,0 +1,131 @@
+import * as React from 'react';
+import { View, StyleSheet, ScrollView } from 'react-native';
+import { Button } from 'react-native-paper';
+import { Link, RouteProp, ParamListBase } from '@react-navigation/native';
+import {
+  createStackNavigator,
+  StackNavigationProp,
+} from '@react-navigation/stack';
+import Article from '../Shared/Article';
+import Albums from '../Shared/Albums';
+
+type SimpleStackParams = {
+  Article: { author: string };
+  Album: undefined;
+};
+
+type SimpleStackNavigation = StackNavigationProp<SimpleStackParams>;
+
+const ArticleScreen = ({
+  navigation,
+  route,
+}: {
+  navigation: SimpleStackNavigation;
+  route: RouteProp<SimpleStackParams, 'Article'>;
+}) => {
+  return (
+    <ScrollView>
+      <View style={styles.buttons}>
+        <Link<SimpleStackNavigation>
+          to="Album"
+          style={[styles.button, { padding: 8 }]}
+        >
+          Go to album
+        </Link>
+        <Link<SimpleStackNavigation> to="Album">
+          {props => (
+            <Button {...props} mode="contained" style={styles.button}>
+              Go to album
+            </Button>
+          )}
+        </Link>
+        <Button
+          mode="outlined"
+          onPress={() => navigation.goBack()}
+          style={styles.button}
+        >
+          Go back
+        </Button>
+      </View>
+      <Article author={{ name: route.params.author }} scrollEnabled={false} />
+    </ScrollView>
+  );
+};
+
+const AlbumsScreen = ({
+  navigation,
+}: {
+  navigation: SimpleStackNavigation;
+}) => {
+  return (
+    <ScrollView>
+      <View style={styles.buttons}>
+        <Link<SimpleStackNavigation>
+          to="Article"
+          params={{ author: 'Babel fish' }}
+          style={[styles.button, { padding: 8 }]}
+        >
+          Go to article
+        </Link>
+        <Link<SimpleStackNavigation>
+          to="Article"
+          params={{ author: 'Luke Skywalker' }}
+        >
+          {props => (
+            <Button {...props} mode="contained" style={styles.button}>
+              Go to article
+            </Button>
+          )}
+        </Link>
+        <Button
+          mode="outlined"
+          onPress={() => navigation.goBack()}
+          style={styles.button}
+        >
+          Go back
+        </Button>
+      </View>
+      <Albums scrollEnabled={false} />
+    </ScrollView>
+  );
+};
+
+const SimpleStack = createStackNavigator<SimpleStackParams>();
+
+type Props = Partial<React.ComponentProps<typeof SimpleStack.Navigator>> & {
+  navigation: StackNavigationProp<ParamListBase>;
+};
+
+export default function SimpleStackScreen({ navigation, ...rest }: Props) {
+  navigation.setOptions({
+    headerShown: false,
+  });
+
+  return (
+    <SimpleStack.Navigator {...rest}>
+      <SimpleStack.Screen
+        name="Article"
+        component={ArticleScreen}
+        options={({ route }) => ({
+          title: `Article by ${route.params.author}`,
+        })}
+        initialParams={{ author: 'Gandalf' }}
+      />
+      <SimpleStack.Screen
+        name="Album"
+        component={AlbumsScreen}
+        options={{ title: 'Album' }}
+      />
+    </SimpleStack.Navigator>
+  );
+}
+
+const styles = StyleSheet.create({
+  buttons: {
+    flexDirection: 'row',
+    padding: 8,
+  },
+  button: {
+    margin: 8,
+  },
+});

--- a/example/src/index.tsx
+++ b/example/src/index.tsx
@@ -51,6 +51,7 @@ import MaterialBottomTabs from './Screens/MaterialBottomTabs';
 import DynamicTabs from './Screens/DynamicTabs';
 import AuthFlow from './Screens/AuthFlow';
 import CompatAPI from './Screens/CompatAPI';
+import LinkComponent from './Screens/LinkComponent';
 import SettingsItem from './Shared/SettingsItem';
 
 YellowBox.ignoreWarnings(['Require cycle:', 'Warning: Async Storage']);
@@ -102,6 +103,10 @@ const SCREENS = {
   CompatAPI: {
     title: 'Compat Layer',
     component: CompatAPI,
+  },
+  LinkComponent: {
+    title: '<Link />',
+    component: LinkComponent,
   },
 };
 

--- a/packages/native/src/Link.tsx
+++ b/packages/native/src/Link.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react';
+import {
+  useNavigation,
+  NavigationProp,
+  ParamListBase,
+} from '@react-navigation/core';
+import { Text, TextProps } from 'react-native';
+
+type TouchableProps = {
+  accessibilityRole?: 'link';
+  onPress?: () => void;
+};
+
+type Props<
+  Navigation extends NavigationProp<ParamListBase>,
+  ParamList extends ParamListBase = Navigation extends NavigationProp<infer P>
+    ? P
+    : {},
+  RouteName extends keyof ParamList = keyof ParamList
+> = {
+  to: Extract<RouteName, string>;
+} & (
+  | (TextProps & { children: React.ReactNode })
+  | { children: (props: TouchableProps) => React.ReactNode }
+) &
+  (ParamList[RouteName] extends undefined | any
+    ? { params?: ParamList[RouteName] }
+    : { params: ParamList[RouteName] });
+
+export default function Link<Navigation extends NavigationProp<ParamListBase>>({
+  to,
+  params,
+  children,
+  ...rest
+}: Props<Navigation>) {
+  const navigation = useNavigation<Navigation>();
+  const onPress = () => {
+    navigation.navigate(to, params);
+  };
+
+  const props = {
+    onPress,
+    accessibilityRole: 'link' as const,
+    ...rest,
+  };
+
+  if (typeof children === 'function') {
+    return children(props);
+  }
+
+  return <Text {...props}>{children}</Text>;
+}

--- a/packages/native/src/index.tsx
+++ b/packages/native/src/index.tsx
@@ -11,3 +11,5 @@ export { default as DefaultTheme } from './theming/DefaultTheme';
 export { default as DarkTheme } from './theming/DarkTheme';
 export { default as ThemeProvider } from './theming/ThemeProvider';
 export { default as useTheme } from './theming/useTheme';
+
+export { default as Link } from './Link';


### PR DESCRIPTION
Basic `Link` component which only supports React Native for now.

Usage:

```js
<Link to="Article" params={{ author: "Babel Fish" }}>
  Go to article
</Link>
```

Custom component:

```js
<Link to="Article" params={{ author: "Babel Fish" }}>
  {props => (
    <Button {...props} mode="contained">
      Go to article
    </Button>
  )}
</Link>
```

I'm not happy with the API for custom component right now. Ideally I'd want something like this:

```js
<Link
  as={Button}
  mode="contained"
  to="Article"
  params={{ author: "Babel Fish" }}
>
  Go to article
</Link>
```

But it seems challenging to properly type-check this.