### PR TITLE
feat: emit gesture navigation events from stack view

### DIFF
--- a/example/src/index.tsx
+++ b/example/src/index.tsx
@@ -51,7 +51,6 @@ import MaterialBottomTabs from './Screens/MaterialBottomTabs';
 import DynamicTabs from './Screens/DynamicTabs';
 import AuthFlow from './Screens/AuthFlow';
 import CompatAPI from './Screens/CompatAPI';
-import LinkComponent from './Screens/LinkComponent';
 import MasterDetail from './Screens/MasterDetail';
 import LinkComponent from './Screens/LinkComponent';
 

--- a/example/src/index.tsx
+++ b/example/src/index.tsx
@@ -51,6 +51,7 @@ import MaterialBottomTabs from './Screens/MaterialBottomTabs';
 import DynamicTabs from './Screens/DynamicTabs';
 import AuthFlow from './Screens/AuthFlow';
 import CompatAPI from './Screens/CompatAPI';
+import LinkComponent from './Screens/LinkComponent';
 import MasterDetail from './Screens/MasterDetail';
 import LinkComponent from './Screens/LinkComponent';
 

--- a/packages/stack/src/types.tsx
+++ b/packages/stack/src/types.tsx
@@ -27,6 +27,18 @@ export type StackNavigationEventMap = {
    * Event which fires when a transition animation ends.
    */
   transitionEnd: { data: { closing: boolean } };
+  /**
+   * Event which fires when a page change gesture starts.
+   */
+  gestureStart: {};
+  /**
+   * Event which fires when a page change gesture is completed.
+   */
+  gestureEnd: {};
+  /**
+   * Event which fires when a page change gesture is cancelled.
+   */
+  gestureCancel: {};
 };
 
 export type StackNavigationHelpers = NavigationHelpers<

--- a/packages/stack/src/views/Stack/StackView.tsx
+++ b/packages/stack/src/views/Stack/StackView.tsx
@@ -403,6 +403,36 @@ export default class StackView extends React.Component<Props, State> {
       target: route.key,
     });
 
+  private handleGestureStart = () => {
+    const { navigation, state } = this.props;
+    const currentRoute = state.routes[state.index];
+    navigation.emit({
+      type: 'gestureStart',
+      data: {},
+      target: currentRoute.key,
+    });
+  };
+
+  private handleGestureEnd = () => {
+    const { navigation, state } = this.props;
+    const currentRoute = state.routes[state.index];
+    navigation.emit({
+      type: 'gestureEnd',
+      data: {},
+      target: currentRoute.key,
+    });
+  };
+
+  private handleGestureCancel = () => {
+    const { navigation, state } = this.props;
+    const currentRoute = state.routes[state.index];
+    navigation.emit({
+      type: 'gestureCancel',
+      data: {},
+      target: currentRoute.key,
+    });
+  };
+
   render() {
     const {
       state,
@@ -448,7 +478,18 @@ export default class StackView extends React.Component<Props, State> {
                       state={state}
                       descriptors={descriptors}
                       {...rest}
-                      {...props}
+                      onPageChangeStart={() => {
+                        props.onPageChangeStart();
+                        this.handleGestureStart();
+                      }}
+                      onPageChangeConfirm={() => {
+                        props.onPageChangeConfirm();
+                        this.handleGestureEnd();
+                      }}
+                      onPageChangeCancel={() => {
+                        props.onPageChangeCancel();
+                        this.handleGestureCancel();
+                      }}
                     />
                   )}
                 </KeyboardManager>


### PR DESCRIPTION
Allows you to subscribe to gesture navigation events, we have a custom keyboard that we want to hide and show when gesture is being used to navigate (same as native keyboard)