### PR TITLE
feat: add Link component as useLinkTo hook for navigating to links

### DIFF
--- a/example/src/Screens/LinkComponent.tsx
+++ b/example/src/Screens/LinkComponent.tsx
@@ -1,0 +1,140 @@
+import * as React from 'react';
+import { View, StyleSheet, ScrollView } from 'react-native';
+import { Button } from 'react-native-paper';
+import {
+  Link,
+  RouteProp,
+  ParamListBase,
+  useLinkTo,
+} from '@react-navigation/native';
+import {
+  createStackNavigator,
+  StackNavigationProp,
+} from '@react-navigation/stack';
+import Article from '../Shared/Article';
+import Albums from '../Shared/Albums';
+
+type SimpleStackParams = {
+  Article: { author: string };
+  Album: undefined;
+};
+
+type SimpleStackNavigation = StackNavigationProp<SimpleStackParams>;
+
+const LinkButton = ({
+  to,
+  ...rest
+}: React.ComponentProps<typeof Button> & { to: string }) => {
+  const linkTo = useLinkTo();
+
+  return <Button onPress={() => linkTo(to)} {...rest} />;
+};
+
+const ArticleScreen = ({
+  navigation,
+  route,
+}: {
+  navigation: SimpleStackNavigation;
+  route: RouteProp<SimpleStackParams, 'Article'>;
+}) => {
+  return (
+    <ScrollView>
+      <View style={styles.buttons}>
+        <Link
+          to="/link-component/Album"
+          style={[styles.button, { padding: 8 }]}
+        >
+          Go to /link-component/Album
+        </Link>
+        <LinkButton
+          to="/link-component/Album"
+          mode="contained"
+          style={styles.button}
+        >
+          Go to /link-component/Album
+        </LinkButton>
+        <Button
+          mode="outlined"
+          onPress={() => navigation.goBack()}
+          style={styles.button}
+        >
+          Go back
+        </Button>
+      </View>
+      <Article author={{ name: route.params.author }} scrollEnabled={false} />
+    </ScrollView>
+  );
+};
+
+const AlbumsScreen = ({
+  navigation,
+}: {
+  navigation: SimpleStackNavigation;
+}) => {
+  return (
+    <ScrollView>
+      <View style={styles.buttons}>
+        <Link
+          to="/link-component/Article?author=Babel"
+          style={[styles.button, { padding: 8 }]}
+        >
+          Go to /link-component/Article
+        </Link>
+        <LinkButton
+          to="/link-component/Article?author=Babel"
+          mode="contained"
+          style={styles.button}
+        >
+          Go to /link-component/Article
+        </LinkButton>
+        <Button
+          mode="outlined"
+          onPress={() => navigation.goBack()}
+          style={styles.button}
+        >
+          Go back
+        </Button>
+      </View>
+      <Albums scrollEnabled={false} />
+    </ScrollView>
+  );
+};
+
+const SimpleStack = createStackNavigator<SimpleStackParams>();
+
+type Props = Partial<React.ComponentProps<typeof SimpleStack.Navigator>> & {
+  navigation: StackNavigationProp<ParamListBase>;
+};
+
+export default function SimpleStackScreen({ navigation, ...rest }: Props) {
+  navigation.setOptions({
+    headerShown: false,
+  });
+
+  return (
+    <SimpleStack.Navigator {...rest}>
+      <SimpleStack.Screen
+        name="Article"
+        component={ArticleScreen}
+        options={({ route }) => ({
+          title: `Article by ${route.params.author}`,
+        })}
+        initialParams={{ author: 'Gandalf' }}
+      />
+      <SimpleStack.Screen
+        name="Album"
+        component={AlbumsScreen}
+        options={{ title: 'Album' }}
+      />
+    </SimpleStack.Navigator>
+  );
+}
+
+const styles = StyleSheet.create({
+  buttons: {
+    padding: 8,
+  },
+  button: {
+    margin: 8,
+  },
+});

--- a/packages/core/src/__tests__/index.test.tsx
+++ b/packages/core/src/__tests__/index.test.tsx
@@ -1006,6 +1006,95 @@ it('navigates to nested child in a navigator with initial: false', () => {
     stale: false,
     type: 'test',
   });
+
+  const third = render(
+    <BaseNavigationContainer
+      ref={navigation}
+      initialState={{
+        index: 1,
+        routes: [
+          { name: 'foo' },
+          {
+            name: 'bar',
+            params: { initial: false, params: { test: 42 }, screen: 'bar-b' },
+            state: {
+              index: 1,
+              key: '7',
+              routes: [
+                {
+                  name: 'bar-a',
+                  params: { lol: 'why' },
+                },
+                {
+                  name: 'bar-b',
+                  params: { some: 'stuff' },
+                },
+              ],
+              type: 'test',
+            },
+          },
+        ],
+        type: 'test',
+      }}
+    >
+      <TestNavigator>
+        <Screen name="foo" component={TestComponent} />
+        <Screen name="bar">
+          {() => (
+            <TestNavigator initialRouteName="bar-a">
+              <Screen
+                name="bar-a"
+                component={TestComponent}
+                initialParams={{ lol: 'why' }}
+              />
+              <Screen
+                name="bar-b"
+                component={TestComponent}
+                initialParams={{ some: 'stuff' }}
+              />
+            </TestNavigator>
+          )}
+        </Screen>
+      </TestNavigator>
+    </BaseNavigationContainer>
+  );
+
+  expect(third).toMatchInlineSnapshot(`"[bar-b, {\\"some\\":\\"stuff\\"}]"`);
+
+  expect(navigation.current?.getRootState()).toEqual({
+    index: 1,
+    key: '11',
+    routeNames: ['foo', 'bar'],
+    routes: [
+      { key: 'foo-9', name: 'foo' },
+      {
+        key: 'bar-10',
+        name: 'bar',
+        params: { initial: false, params: { test: 42 }, screen: 'bar-b' },
+        state: {
+          index: 1,
+          key: '14',
+          routeNames: ['bar-a', 'bar-b'],
+          routes: [
+            {
+              key: 'bar-a-12',
+              name: 'bar-a',
+              params: { lol: 'why' },
+            },
+            {
+              key: 'bar-b-13',
+              name: 'bar-b',
+              params: { some: 'stuff' },
+            },
+          ],
+          stale: false,
+          type: 'test',
+        },
+      },
+    ],
+    stale: false,
+    type: 'test',
+  });
 });
 
 it('gives access to internal state', () => {

--- a/packages/native/src/Link.tsx
+++ b/packages/native/src/Link.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import { Text, TextProps, GestureResponderEvent, Platform } from 'react-native';
+import useLinkTo from './useLinkTo';
+
+type Props = {
+  to: string;
+  target?: string;
+} & (TextProps & { children: React.ReactNode });
+
+export default function Link({ to, children, ...rest }: Props) {
+  const linkTo = useLinkTo();
+
+  const onPress = (e: GestureResponderEvent | undefined) => {
+    if ('onPress' in rest) {
+      rest.onPress?.(e as GestureResponderEvent);
+    }
+
+    const event = (e?.nativeEvent as any) as
+      | React.MouseEvent<HTMLAnchorElement, MouseEvent>
+      | undefined;
+
+    if (Platform.OS !== 'web' || !event) {
+      linkTo(to);
+      return;
+    }
+
+    event.preventDefault();
+
+    if (
+      !event.defaultPrevented && // onPress prevented default
+      !(event.metaKey || event.altKey || event.ctrlKey || event.shiftKey) && // ignore clicks with modifier keys
+      (event.button == null || event.button === 0) && // ignore everything but left clicks
+      (rest.target == null || rest.target === '_self') // let browser handle "target=_blank" etc.
+    ) {
+      event.preventDefault();
+      linkTo(to);
+    }
+  };
+
+  const props = {
+    href: to,
+    onPress,
+    accessibilityRole: 'link' as const,
+    ...rest,
+  };
+
+  return <Text {...props}>{children}</Text>;
+}

--- a/packages/native/src/LinkingContext.tsx
+++ b/packages/native/src/LinkingContext.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import { LinkingOptions } from './types';
+
+const LinkingContext = React.createContext<() => LinkingOptions | undefined>(
+  () => {
+    throw new Error(
+      "Couldn't find a linking context. Have you wrapped your app with 'NavigationContainer'?"
+    );
+  }
+);
+
+export default LinkingContext;

--- a/packages/native/src/NavigationContainer.tsx
+++ b/packages/native/src/NavigationContainer.tsx
@@ -6,38 +6,76 @@ import {
 } from '@react-navigation/core';
 import ThemeProvider from './theming/ThemeProvider';
 import DefaultTheme from './theming/DefaultTheme';
+import LinkingContext from './LinkingContext';
+import useThenable from './useThenable';
+import useLinking from './useLinking';
 import useBackButton from './useBackButton';
-import { Theme } from './types';
+import { Theme, LinkingOptions } from './types';
 
 type Props = NavigationContainerProps & {
   theme?: Theme;
+  linking?: LinkingOptions;
+  fallback?: React.ReactNode;
 };
 
 /**
- * Container component which holds the navigation state
- * designed for mobile apps.
+ * Container component which holds the navigation state designed for React Native apps.
  * This should be rendered at the root wrapping the whole app.
  *
- * @param props.initialState Initial state object for the navigation tree.
+ * @param props.initialState Initial state object for the navigation tree. When deep link handling is enabled, this will be ignored if there's an incoming link.
  * @param props.onStateChange Callback which is called with the latest navigation state when it changes.
  * @param props.theme Theme object for the navigators.
+ * @param props.linking Options for deep linking. Deep link handling is enabled when this prop is provided, unless `linking.enabled` is `false`.
+ * @param props.fallback Fallback component to render until we have finished getting initial state when linking is enabled. Defaults to `null`.
  * @param props.children Child elements to render the content.
  * @param props.ref Ref object which refers to the navigation object containing helper methods.
  */
 const NavigationContainer = React.forwardRef(function NavigationContainer(
-  { theme = DefaultTheme, ...rest }: Props,
+  { theme = DefaultTheme, linking, fallback = null, ...rest }: Props,
   ref?: React.Ref<NavigationContainerRef | null>
 ) {
+  const isLinkingEnabled = linking ? linking.enabled !== false : false;
+
   const refContainer = React.useRef<NavigationContainerRef>(null);
 
   useBackButton(refContainer);
 
+  const { getInitialState } = useLinking(refContainer, {
+    enabled: isLinkingEnabled,
+    prefixes: [],
+    ...linking,
+  });
+
+  const [isReady, initialState = rest.initialState] = useThenable(
+    getInitialState
+  );
+
   React.useImperativeHandle(ref, () => refContainer.current);
 
+  const linkingOptionsRef = React.useRef(linking);
+
+  React.useEffect(() => {
+    linkingOptionsRef.current = linking;
+  });
+
+  const linkingContext = React.useCallback(() => linkingOptionsRef.current, []);
+
+  if (!isReady) {
+    // This is temporary until we have Suspense for data-fetching
+    // Then the fallback will be handled by a parent `Suspense` component
+    return fallback as React.ReactElement;
+  }
+
   return (
-    <ThemeProvider value={theme}>
-      <BaseNavigationContainer {...rest} ref={refContainer} />
-    </ThemeProvider>
+    <LinkingContext.Provider value={linkingContext}>
+      <ThemeProvider value={theme}>
+        <BaseNavigationContainer
+          {...rest}
+          initialState={initialState}
+          ref={refContainer}
+        />
+      </ThemeProvider>
+    </LinkingContext.Provider>
   );
 });
 

--- a/packages/native/src/NavigationNativeContainer.tsx
+++ b/packages/native/src/NavigationNativeContainer.tsx
@@ -1,5 +1,0 @@
-export default function () {
-  throw new Error(
-    "'NavigationNativeContainer' has been renamed to 'NavigationContainer"
-  );
-}

--- a/packages/native/src/index.tsx
+++ b/packages/native/src/index.tsx
@@ -1,13 +1,15 @@
 export * from '@react-navigation/core';
 
 export { default as NavigationContainer } from './NavigationContainer';
-export { default as NavigationNativeContainer } from './NavigationNativeContainer';
 
 export { default as useBackButton } from './useBackButton';
-export { default as useLinking } from './useLinking';
 export { default as useScrollToTop } from './useScrollToTop';
 
 export { default as DefaultTheme } from './theming/DefaultTheme';
 export { default as DarkTheme } from './theming/DarkTheme';
 export { default as ThemeProvider } from './theming/ThemeProvider';
 export { default as useTheme } from './theming/useTheme';
+
+export { default as Link } from './Link';
+export { default as useLinking } from './useLinking';
+export { default as useLinkTo } from './useLinkTo';

--- a/packages/native/src/types.tsx
+++ b/packages/native/src/types.tsx
@@ -16,6 +16,11 @@ export type Theme = {
 
 export type LinkingOptions = {
   /**
+   * Whether deep link handling should be enabled.
+   * Defaults to true.
+   */
+  enabled?: boolean;
+  /**
    * The prefixes are stripped from the URL before parsing them.
    * Usually they are the `scheme` + `host` (e.g. `myapp://chat?user=jane`)
    * Only applicable on Android and iOS.

--- a/packages/native/src/useLinkTo.tsx
+++ b/packages/native/src/useLinkTo.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+import {
+  useNavigation,
+  getStateFromPath,
+  getActionFromState,
+} from '@react-navigation/core';
+import LinkingContext from './LinkingContext';
+
+export default function useLinkTo() {
+  const navigation = useNavigation();
+  const getOptions = React.useContext(LinkingContext);
+
+  const linkTo = React.useCallback(
+    (path: string) => {
+      if (!path.startsWith('/')) {
+        throw new Error(`The path must start with '/' (${path}).`);
+      }
+
+      const options = getOptions();
+
+      const state = options?.getStateFromPath
+        ? options.getStateFromPath(path, options.config)
+        : getStateFromPath(path, options?.config);
+
+      if (state) {
+        let root = navigation;
+        let current;
+
+        // Traverse up to get the root navigation
+        while ((current = root.dangerouslyGetParent())) {
+          root = current;
+        }
+
+        const action = getActionFromState(state);
+
+        if (action !== undefined) {
+          root.dispatch(action);
+        } else {
+          root.reset(state);
+        }
+      } else {
+        throw new Error('Failed to parse the path to a navigation state.');
+      }
+    },
+    [getOptions, navigation]
+  );
+
+  return linkTo;
+}

--- a/packages/native/src/useThenable.tsx
+++ b/packages/native/src/useThenable.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+
+export default function useThenable<T>(
+  create: () => {
+    then(success: (result: T) => void, error?: (error: any) => void): void;
+  }
+) {
+  const [promise] = React.useState(create);
+
+  // Check if our thenable is synchronous
+  let resolved = false;
+  let value: T | undefined;
+
+  promise.then((result) => {
+    resolved = true;
+    value = result;
+  });
+
+  const [state, setState] = React.useState<[boolean, T | undefined]>([
+    resolved,
+    value,
+  ]);
+
+  React.useEffect(() => {
+    let cancelled = false;
+
+    if (!resolved) {
+      promise.then(
+        (result) => {
+          if (!cancelled) {
+            setState([true, result]);
+          }
+        },
+        (error) => {
+          if (!cancelled) {
+            console.error(error);
+            setState([true, undefined]);
+          }
+        }
+      );
+    }
+
+    return () => {
+      cancelled = true;
+    };
+  }, [promise, resolved]);
+
+  return state;
+}


### PR DESCRIPTION
The `Link` component can be used to navigate to URLs. On web, it'll use an `a` tag for proper accessibility. On React Native, it'll use a `Text`.

Example:

```js
<Link to="/feed/hot">Go to 🔥</Link>
```

Sometimes we might want more complex styling and more control over the behaviour, or navigate to a URL programmatically. The `useLinkTo` hook can be used for that.

Example:

```js
function LinkButton({ to, ...rest }) {
  const linkTo = useLinkTo();

  return (
    <Button
      {...rest}
      href={to}
      onPress={(e) => {
        e.preventDefault();
        linkTo(to);
      }}
    />
  );
}
```