### PR TITLE
feat: add an option to change use a custom card overlay

### DIFF
--- a/packages/stack/src/types.tsx
+++ b/packages/stack/src/types.tsx
@@ -314,9 +314,9 @@ export type StackNavigationOptions = StackHeaderOptions &
       left?: number;
     };
     /**
-     * Function that given `style` returns a React Element to display as a overlay.
+     * Function that` returns a React Element to display as a overlay.
      */
-    overlay?: (style: StyleProp<ViewStyle>) => React.ReactNode;
+    overlay?: (props: { style: StyleProp<ViewStyle> }) => React.ReactNode;
   };
 
 export type StackNavigationConfig = {

--- a/packages/stack/src/types.tsx
+++ b/packages/stack/src/types.tsx
@@ -314,9 +314,9 @@ export type StackNavigationOptions = StackHeaderOptions &
       left?: number;
     };
     /**
-     * todo
+     * Function that given `style` returns a React Element to display as a overlay.
      */
-    renderOverlay?: (style: StyleProp<ViewStyle>) => React.ReactNode;
+    overlay?: (style: StyleProp<ViewStyle>) => React.ReactNode;
   };
 
 export type StackNavigationConfig = {

--- a/packages/stack/src/types.tsx
+++ b/packages/stack/src/types.tsx
@@ -313,6 +313,10 @@ export type StackNavigationOptions = StackHeaderOptions &
       bottom?: number;
       left?: number;
     };
+    /**
+     * todo
+     */
+    renderOverlay?: (style: StyleProp<ViewStyle>) => React.ReactNode;
   };
 
 export type StackNavigationConfig = {

--- a/packages/stack/src/types.tsx
+++ b/packages/stack/src/types.tsx
@@ -261,6 +261,10 @@ export type StackNavigationOptions = StackHeaderOptions &
      */
     cardOverlayEnabled?: boolean;
     /**
+     * Function that returns a React Element to display as a overlay for the card.
+     */
+    cardOverlay?: (props: { style: StyleProp<ViewStyle> }) => React.ReactNode;
+    /**
      * Style object for the card in stack.
      * You can provide a custom background color to use instead of the default background here.
      *
@@ -313,10 +317,6 @@ export type StackNavigationOptions = StackHeaderOptions &
       bottom?: number;
       left?: number;
     };
-    /**
-     * Function that returns a React Element to display as a overlay.
-     */
-    overlay?: (props: { style: StyleProp<ViewStyle> }) => React.ReactNode;
   };
 
 export type StackNavigationConfig = {

--- a/packages/stack/src/types.tsx
+++ b/packages/stack/src/types.tsx
@@ -314,7 +314,7 @@ export type StackNavigationOptions = StackHeaderOptions &
       left?: number;
     };
     /**
-     * Function that` returns a React Element to display as a overlay.
+     * Function that returns a React Element to display as a overlay.
      */
     overlay?: (props: { style: StyleProp<ViewStyle> }) => React.ReactNode;
   };

--- a/packages/stack/src/views/Stack/Card.tsx
+++ b/packages/stack/src/views/Stack/Card.tsx
@@ -59,7 +59,7 @@ type Props = ViewProps & {
   styleInterpolator: StackCardStyleInterpolator;
   containerStyle?: StyleProp<ViewStyle>;
   contentStyle?: StyleProp<ViewStyle>;
-  renderOverlay: (style: StyleProp<ViewStyle>) => React.ReactNode;
+  overlay: (style: StyleProp<ViewStyle>) => React.ReactNode;
 };
 
 const GESTURE_VELOCITY_IMPACT = 0.3;
@@ -81,7 +81,7 @@ export default class Card extends React.Component<Props> {
     shadowEnabled: true,
     gestureEnabled: true,
     gestureVelocityImpact: GESTURE_VELOCITY_IMPACT,
-    renderOverlay: (style: StyleProp<View>) => (
+    overlay: (style: StyleProp<View>) => (
       <Animated.View pointerEvents="none" style={[styles.overlay, style]} />
     ),
   };
@@ -476,7 +476,7 @@ export default class Card extends React.Component<Props> {
     return (
       <View pointerEvents="box-none" {...rest}>
         {overlayEnabled && overlayStyle
-          ? this.props.renderOverlay(overlayStyle)
+          ? this.props.overlay(overlayStyle)
           : null}
         <Animated.View
           style={[styles.container, containerStyle, customContainerStyle]}

--- a/packages/stack/src/views/Stack/Card.tsx
+++ b/packages/stack/src/views/Stack/Card.tsx
@@ -59,6 +59,7 @@ type Props = ViewProps & {
   styleInterpolator: StackCardStyleInterpolator;
   containerStyle?: StyleProp<ViewStyle>;
   contentStyle?: StyleProp<ViewStyle>;
+  renderOverlay: (style: StyleProp<ViewStyle>) => React.ReactNode;
 };
 
 const GESTURE_VELOCITY_IMPACT = 0.3;
@@ -80,6 +81,9 @@ export default class Card extends React.Component<Props> {
     shadowEnabled: true,
     gestureEnabled: true,
     gestureVelocityImpact: GESTURE_VELOCITY_IMPACT,
+    renderOverlay: (style: StyleProp<View>) => (
+      <Animated.View pointerEvents="none" style={[styles.overlay, style]} />
+    ),
   };
 
   componentDidMount() {
@@ -471,12 +475,9 @@ export default class Card extends React.Component<Props> {
 
     return (
       <View pointerEvents="box-none" {...rest}>
-        {overlayEnabled && overlayStyle ? (
-          <Animated.View
-            pointerEvents="none"
-            style={[styles.overlay, overlayStyle]}
-          />
-        ) : null}
+        {overlayEnabled && overlayStyle
+          ? this.props.renderOverlay(overlayStyle)
+          : null}
         <Animated.View
           style={[styles.container, containerStyle, customContainerStyle]}
           pointerEvents="box-none"

--- a/packages/stack/src/views/Stack/Card.tsx
+++ b/packages/stack/src/views/Stack/Card.tsx
@@ -59,7 +59,7 @@ type Props = ViewProps & {
   styleInterpolator: StackCardStyleInterpolator;
   containerStyle?: StyleProp<ViewStyle>;
   contentStyle?: StyleProp<ViewStyle>;
-  overlay: (style: StyleProp<ViewStyle>) => React.ReactNode;
+  overlay: (props: { style: StyleProp<ViewStyle> }) => React.ReactNode;
 };
 
 const GESTURE_VELOCITY_IMPACT = 0.3;
@@ -81,7 +81,7 @@ export default class Card extends React.Component<Props> {
     shadowEnabled: true,
     gestureEnabled: true,
     gestureVelocityImpact: GESTURE_VELOCITY_IMPACT,
-    overlay: (style: StyleProp<View>) => (
+    overlay: ({ style }: { style: StyleProp<View> }) => (
       <Animated.View pointerEvents="none" style={[styles.overlay, style]} />
     ),
   };

--- a/packages/stack/src/views/Stack/Card.tsx
+++ b/packages/stack/src/views/Stack/Card.tsx
@@ -44,6 +44,7 @@ type Props = ViewProps & {
   onGestureCanceled?: () => void;
   onGestureEnd?: () => void;
   children: React.ReactNode;
+  overlay: (props: { style: StyleProp<ViewStyle> }) => React.ReactNode;
   overlayEnabled: boolean;
   shadowEnabled: boolean;
   gestureEnabled: boolean;
@@ -59,7 +60,6 @@ type Props = ViewProps & {
   styleInterpolator: StackCardStyleInterpolator;
   containerStyle?: StyleProp<ViewStyle>;
   contentStyle?: StyleProp<ViewStyle>;
-  overlay: (props: { style: StyleProp<ViewStyle> }) => React.ReactNode;
 };
 
 const GESTURE_VELOCITY_IMPACT = 0.3;
@@ -81,9 +81,10 @@ export default class Card extends React.Component<Props> {
     shadowEnabled: true,
     gestureEnabled: true,
     gestureVelocityImpact: GESTURE_VELOCITY_IMPACT,
-    overlay: ({ style }: { style: StyleProp<View> }) => (
-      <Animated.View pointerEvents="none" style={[styles.overlay, style]} />
-    ),
+    overlay: ({ style }: { style: StyleProp<ViewStyle> }) =>
+      style ? (
+        <Animated.View pointerEvents="none" style={[styles.overlay, style]} />
+      ) : null,
   };
 
   componentDidMount() {
@@ -413,6 +414,7 @@ export default class Card extends React.Component<Props> {
       next,
       layout,
       insets,
+      overlay,
       overlayEnabled,
       shadowEnabled,
       gestureEnabled,
@@ -474,52 +476,54 @@ export default class Card extends React.Component<Props> {
       : false;
 
     return (
-      <View pointerEvents="box-none" {...rest}>
-        {overlayEnabled && overlayStyle
-          ? this.props.overlay(overlayStyle)
-          : null}
-        <Animated.View
-          style={[styles.container, containerStyle, customContainerStyle]}
-          pointerEvents="box-none"
-        >
-          <PanGestureHandler
-            ref={this.gestureRef}
-            enabled={layout.width !== 0 && gestureEnabled}
-            onGestureEvent={handleGestureEvent}
-            onHandlerStateChange={this.handleGestureStateChange}
-            {...this.gestureActivationCriteria()}
+      <CardAnimationContext.Provider value={animationContext}>
+        <View pointerEvents="box-none" {...rest}>
+          {overlayEnabled ? (
+            <View style={StyleSheet.absoluteFill}>
+              {overlay({ style: overlayStyle })}
+            </View>
+          ) : null}
+          <Animated.View
+            style={[styles.container, containerStyle, customContainerStyle]}
+            pointerEvents="box-none"
           >
-            <Animated.View style={[styles.container, cardStyle]}>
-              {shadowEnabled && shadowStyle && !isTransparent ? (
-                <Animated.View
-                  style={[
-                    styles.shadow,
-                    gestureDirection === 'horizontal'
-                      ? [styles.shadowHorizontal, styles.shadowLeft]
-                      : gestureDirection === 'horizontal-inverted'
-                      ? [styles.shadowHorizontal, styles.shadowRight]
-                      : gestureDirection === 'vertical'
-                      ? [styles.shadowVertical, styles.shadowTop]
-                      : [styles.shadowVertical, styles.shadowBottom],
-                    shadowStyle,
-                  ]}
-                  pointerEvents="none"
-                />
-              ) : null}
-              <View
-                ref={this.contentRef}
-                style={[styles.content, contentStyle]}
-              >
-                <StackGestureRefContext.Provider value={this.gestureRef}>
-                  <CardAnimationContext.Provider value={animationContext}>
+            <PanGestureHandler
+              ref={this.gestureRef}
+              enabled={layout.width !== 0 && gestureEnabled}
+              onGestureEvent={handleGestureEvent}
+              onHandlerStateChange={this.handleGestureStateChange}
+              {...this.gestureActivationCriteria()}
+            >
+              <Animated.View style={[styles.container, cardStyle]}>
+                {shadowEnabled && shadowStyle && !isTransparent ? (
+                  <Animated.View
+                    style={[
+                      styles.shadow,
+                      gestureDirection === 'horizontal'
+                        ? [styles.shadowHorizontal, styles.shadowLeft]
+                        : gestureDirection === 'horizontal-inverted'
+                        ? [styles.shadowHorizontal, styles.shadowRight]
+                        : gestureDirection === 'vertical'
+                        ? [styles.shadowVertical, styles.shadowTop]
+                        : [styles.shadowVertical, styles.shadowBottom],
+                      shadowStyle,
+                    ]}
+                    pointerEvents="none"
+                  />
+                ) : null}
+                <View
+                  ref={this.contentRef}
+                  style={[styles.content, contentStyle]}
+                >
+                  <StackGestureRefContext.Provider value={this.gestureRef}>
                     {children}
-                  </CardAnimationContext.Provider>
-                </StackGestureRefContext.Provider>
-              </View>
-            </Animated.View>
-          </PanGestureHandler>
-        </Animated.View>
-      </View>
+                  </StackGestureRefContext.Provider>
+                </View>
+              </Animated.View>
+            </PanGestureHandler>
+          </Animated.View>
+        </View>
+      </CardAnimationContext.Provider>
     );
   }
 }
@@ -533,7 +537,6 @@ const styles = StyleSheet.create({
     overflow: 'hidden',
   },
   overlay: {
-    ...StyleSheet.absoluteFillObject,
     backgroundColor: '#000',
   },
   shadow: {

--- a/packages/stack/src/views/Stack/CardContainer.tsx
+++ b/packages/stack/src/views/Stack/CardContainer.tsx
@@ -52,6 +52,7 @@ type Props = TransitionPreset & {
     route: Route<string>;
     height: number;
   }) => void;
+  renderOverlay?: (style: StyleProp<ViewStyle>) => React.ReactNode;
 };
 
 const EPSILON = 0.1;
@@ -95,6 +96,7 @@ function CardContainer({
   safeAreaInsetTop,
   scene,
   transitionSpec,
+  renderOverlay,
 }: Props) {
   React.useEffect(() => {
     onPageChangeConfirm?.();
@@ -182,6 +184,7 @@ function CardContainer({
       }
       contentStyle={[{ backgroundColor: colors.background }, cardStyle]}
       style={StyleSheet.absoluteFill}
+      renderOverlay={renderOverlay}
     >
       <View style={styles.container}>
         <View style={styles.scene}>

--- a/packages/stack/src/views/Stack/CardContainer.tsx
+++ b/packages/stack/src/views/Stack/CardContainer.tsx
@@ -19,6 +19,7 @@ type Props = TransitionPreset & {
   safeAreaInsetRight: number;
   safeAreaInsetBottom: number;
   safeAreaInsetLeft: number;
+  cardOverlay?: (props: { style: StyleProp<ViewStyle> }) => React.ReactNode;
   cardOverlayEnabled?: boolean;
   cardShadowEnabled?: boolean;
   cardStyle?: StyleProp<ViewStyle>;
@@ -52,13 +53,13 @@ type Props = TransitionPreset & {
     route: Route<string>;
     height: number;
   }) => void;
-  overlay?: (props: { style: StyleProp<ViewStyle> }) => React.ReactNode;
 };
 
 const EPSILON = 0.1;
 
 function CardContainer({
   active,
+  cardOverlay,
   cardOverlayEnabled,
   cardShadowEnabled,
   cardStyle,
@@ -96,7 +97,6 @@ function CardContainer({
   safeAreaInsetTop,
   scene,
   transitionSpec,
-  overlay,
 }: Props) {
   React.useEffect(() => {
     onPageChangeConfirm?.();
@@ -164,6 +164,7 @@ function CardContainer({
       closing={closing}
       onOpen={handleOpen}
       onClose={handleClose}
+      overlay={cardOverlay}
       overlayEnabled={cardOverlayEnabled}
       shadowEnabled={cardShadowEnabled}
       onTransitionStart={handleTransitionStart}
@@ -184,7 +185,6 @@ function CardContainer({
       }
       contentStyle={[{ backgroundColor: colors.background }, cardStyle]}
       style={StyleSheet.absoluteFill}
-      overlay={overlay}
     >
       <View style={styles.container}>
         <View style={styles.scene}>

--- a/packages/stack/src/views/Stack/CardContainer.tsx
+++ b/packages/stack/src/views/Stack/CardContainer.tsx
@@ -52,7 +52,7 @@ type Props = TransitionPreset & {
     route: Route<string>;
     height: number;
   }) => void;
-  renderOverlay?: (style: StyleProp<ViewStyle>) => React.ReactNode;
+  overlay?: (style: StyleProp<ViewStyle>) => React.ReactNode;
 };
 
 const EPSILON = 0.1;
@@ -96,7 +96,7 @@ function CardContainer({
   safeAreaInsetTop,
   scene,
   transitionSpec,
-  renderOverlay,
+  overlay,
 }: Props) {
   React.useEffect(() => {
     onPageChangeConfirm?.();
@@ -184,7 +184,7 @@ function CardContainer({
       }
       contentStyle={[{ backgroundColor: colors.background }, cardStyle]}
       style={StyleSheet.absoluteFill}
-      renderOverlay={renderOverlay}
+      overlay={overlay}
     >
       <View style={styles.container}>
         <View style={styles.scene}>

--- a/packages/stack/src/views/Stack/CardContainer.tsx
+++ b/packages/stack/src/views/Stack/CardContainer.tsx
@@ -52,7 +52,7 @@ type Props = TransitionPreset & {
     route: Route<string>;
     height: number;
   }) => void;
-  overlay?: (style: StyleProp<ViewStyle>) => React.ReactNode;
+  overlay?: (props: { style: StyleProp<ViewStyle> }) => React.ReactNode;
 };
 
 const EPSILON = 0.1;

--- a/packages/stack/src/views/Stack/CardStack.tsx
+++ b/packages/stack/src/views/Stack/CardStack.tsx
@@ -431,13 +431,13 @@ export default class CardStack extends React.Component<Props, State> {
               headerTransparent,
               cardShadowEnabled,
               cardOverlayEnabled,
+              cardOverlay,
               cardStyle,
               animationEnabled,
               gestureResponseDistance,
               gestureVelocityImpact,
               gestureDirection = defaultTransitionPreset.gestureDirection,
               transitionSpec = defaultTransitionPreset.transitionSpec,
-              overlay,
               cardStyleInterpolator = animationEnabled === false
                 ? forNoAnimationCard
                 : defaultTransitionPreset.cardStyleInterpolator,
@@ -529,6 +529,7 @@ export default class CardStack extends React.Component<Props, State> {
                   safeAreaInsetRight={safeAreaInsetRight}
                   safeAreaInsetBottom={safeAreaInsetBottom}
                   safeAreaInsetLeft={safeAreaInsetLeft}
+                  cardOverlay={cardOverlay}
                   cardOverlayEnabled={cardOverlayEnabled}
                   cardShadowEnabled={cardShadowEnabled}
                   cardStyle={cardStyle}
@@ -551,7 +552,6 @@ export default class CardStack extends React.Component<Props, State> {
                   onTransitionEnd={onTransitionEnd}
                   gestureEnabled={index !== 0 && getGesturesEnabled({ route })}
                   gestureVelocityImpact={gestureVelocityImpact}
-                  overlay={overlay}
                   {...transitionConfig}
                 />
               </MaybeScreen>

--- a/packages/stack/src/views/Stack/CardStack.tsx
+++ b/packages/stack/src/views/Stack/CardStack.tsx
@@ -437,7 +437,7 @@ export default class CardStack extends React.Component<Props, State> {
               gestureVelocityImpact,
               gestureDirection = defaultTransitionPreset.gestureDirection,
               transitionSpec = defaultTransitionPreset.transitionSpec,
-              renderOverlay,
+              overlay,
               cardStyleInterpolator = animationEnabled === false
                 ? forNoAnimationCard
                 : defaultTransitionPreset.cardStyleInterpolator,
@@ -551,7 +551,7 @@ export default class CardStack extends React.Component<Props, State> {
                   onTransitionEnd={onTransitionEnd}
                   gestureEnabled={index !== 0 && getGesturesEnabled({ route })}
                   gestureVelocityImpact={gestureVelocityImpact}
-                  renderOverlay={renderOverlay}
+                  overlay={overlay}
                   {...transitionConfig}
                 />
               </MaybeScreen>

--- a/packages/stack/src/views/Stack/CardStack.tsx
+++ b/packages/stack/src/views/Stack/CardStack.tsx
@@ -437,6 +437,7 @@ export default class CardStack extends React.Component<Props, State> {
               gestureVelocityImpact,
               gestureDirection = defaultTransitionPreset.gestureDirection,
               transitionSpec = defaultTransitionPreset.transitionSpec,
+              renderOverlay,
               cardStyleInterpolator = animationEnabled === false
                 ? forNoAnimationCard
                 : defaultTransitionPreset.cardStyleInterpolator,
@@ -550,6 +551,7 @@ export default class CardStack extends React.Component<Props, State> {
                   onTransitionEnd={onTransitionEnd}
                   gestureEnabled={index !== 0 && getGesturesEnabled({ route })}
                   gestureVelocityImpact={gestureVelocityImpact}
+                  renderOverlay={renderOverlay}
                   {...transitionConfig}
                 />
               </MaybeScreen>


### PR DESCRIPTION
I find it sometimes useful to define overlay renderer on my own. Eg. I needed to replace the background with BlurView and with this API I find it quite easy