### PR TITLE
fix: fix closing stack using inverted gesture.

### DIFF
--- a/packages/stack/src/views/Stack/Card.tsx
+++ b/packages/stack/src/views/Stack/Card.tsx
@@ -276,7 +276,7 @@ export default class Card extends React.Component<Props> {
           gestureDirection === 'vertical-inverted'
         ) {
           translation = Math.abs(translation);
-          velocity = Math.abs(translation);
+          velocity = Math.abs(velocity);
         }
 
         const closing =

--- a/packages/stack/src/views/Stack/Card.tsx
+++ b/packages/stack/src/views/Stack/Card.tsx
@@ -275,8 +275,8 @@ export default class Card extends React.Component<Props> {
           gestureDirection === 'horizontal-inverted' ||
           gestureDirection === 'vertical-inverted'
         ) {
-          translation = Math.abs(translation);
-          velocity = Math.abs(velocity);
+          translation *= -1;
+          velocity *= -1;
         }
 
         const closing =

--- a/packages/stack/src/views/Stack/Card.tsx
+++ b/packages/stack/src/views/Stack/Card.tsx
@@ -271,6 +271,14 @@ export default class Card extends React.Component<Props> {
           velocity = nativeEvent.velocityX;
         }
 
+        if (
+          gestureDirection === 'horizontal-inverted' ||
+          gestureDirection === 'vertical-inverted'
+        ) {
+          translation = Math.abs(translation);
+          velocity = Math.abs(translation);
+        }
+
         const closing =
           translation + velocity * gestureVelocityImpact > distance / 2
             ? velocity !== 0 || translation !== 0


### PR DESCRIPTION
Allow you to close Stack that has inverted gesture config using correct closing bool calculation. 