### PR TITLE
feat: add swipeEnabled option to disable swipe gesture in drawer

### DIFF
--- a/packages/drawer/src/types.tsx
+++ b/packages/drawer/src/types.tsx
@@ -115,6 +115,11 @@ export type DrawerNavigationOptions = {
    */
   gestureEnabled?: boolean;
   /**
+   * Whether you can close the drawer with tap gesture.
+   * Defaults to `true`
+   */
+  closeDrawerOnTap?: boolean;
+  /**
    * Whether this screen should be unmounted when navigating away from it.
    * Defaults to `false`.
    */

--- a/packages/drawer/src/types.tsx
+++ b/packages/drawer/src/types.tsx
@@ -115,10 +115,10 @@ export type DrawerNavigationOptions = {
    */
   gestureEnabled?: boolean;
   /**
-   * Whether you can close the drawer with tap gesture.
+   * Whether you can use swipe gestures to open or close the drawer
    * Defaults to `true`
    */
-  closeDrawerOnTap?: boolean;
+  swipeEnabled?: boolean;
   /**
    * Whether this screen should be unmounted when navigating away from it.
    * Defaults to `false`.

--- a/packages/drawer/src/views/Drawer.tsx
+++ b/packages/drawer/src/views/Drawer.tsx
@@ -80,6 +80,7 @@ type Props = {
   onClose: () => void;
   onGestureRef?: (ref: PanGestureHandler | null) => void;
   gestureEnabled: boolean;
+  closeDrawerOnTap: boolean;
   drawerPosition: 'left' | 'right';
   drawerType: 'front' | 'back' | 'slide' | 'permanent';
   keyboardDismissMode: 'none' | 'on-drag';
@@ -120,6 +121,7 @@ export default class DrawerView extends React.PureComponent<Props> {
     drawerPostion: I18nManager.isRTL ? 'left' : 'right',
     drawerType: 'front',
     gestureEnabled: shouldEnableGesture(),
+    closeDrawerOnTap: true,
     swipeEdgeWidth: 32,
     swipeVelocityThreshold: 500,
     keyboardDismissMode: 'on-drag',
@@ -554,6 +556,7 @@ export default class DrawerView extends React.PureComponent<Props> {
     const {
       open,
       gestureEnabled,
+      closeDrawerOnTap,
       drawerPosition,
       drawerType,
       swipeEdgeWidth,
@@ -639,7 +642,7 @@ export default class DrawerView extends React.PureComponent<Props> {
             {// Disable overlay if sidebar is permanent
             drawerType === 'permanent' ? null : (
               <TapGestureHandler
-                enabled={gestureEnabled}
+                enabled={gestureEnabled || closeDrawerOnTap}
                 onHandlerStateChange={this.handleTapStateChange}
               >
                 <Overlay progress={progress} style={overlayStyle} />

--- a/packages/drawer/src/views/Drawer.tsx
+++ b/packages/drawer/src/views/Drawer.tsx
@@ -608,7 +608,7 @@ export default class DrawerView extends React.PureComponent<Props> {
         onGestureEvent={this.handleGestureEvent}
         onHandlerStateChange={this.handleGestureStateChange}
         hitSlop={hitSlop}
-        enabled={drawerType !== 'permanent' && gestureEnabled}
+        enabled={drawerType !== 'permanent' && gestureEnabled && swipeEnabled}
         {...gestureHandlerProps}
       >
         <Animated.View
@@ -642,7 +642,7 @@ export default class DrawerView extends React.PureComponent<Props> {
             {// Disable overlay if sidebar is permanent
             drawerType === 'permanent' ? null : (
               <TapGestureHandler
-                enabled={swipeEnabled}
+                enabled={gestureEnabled}
                 onHandlerStateChange={this.handleTapStateChange}
               >
                 <Overlay progress={progress} style={overlayStyle} />

--- a/packages/drawer/src/views/Drawer.tsx
+++ b/packages/drawer/src/views/Drawer.tsx
@@ -80,7 +80,7 @@ type Props = {
   onClose: () => void;
   onGestureRef?: (ref: PanGestureHandler | null) => void;
   gestureEnabled: boolean;
-  closeDrawerOnTap: boolean;
+  swipeEnabled: boolean;
   drawerPosition: 'left' | 'right';
   drawerType: 'front' | 'back' | 'slide' | 'permanent';
   keyboardDismissMode: 'none' | 'on-drag';
@@ -121,7 +121,7 @@ export default class DrawerView extends React.PureComponent<Props> {
     drawerPostion: I18nManager.isRTL ? 'left' : 'right',
     drawerType: 'front',
     gestureEnabled: shouldEnableGesture(),
-    closeDrawerOnTap: true,
+    swipeEnabled: true,
     swipeEdgeWidth: 32,
     swipeVelocityThreshold: 500,
     keyboardDismissMode: 'on-drag',
@@ -556,7 +556,7 @@ export default class DrawerView extends React.PureComponent<Props> {
     const {
       open,
       gestureEnabled,
-      closeDrawerOnTap,
+      swipeEnabled,
       drawerPosition,
       drawerType,
       swipeEdgeWidth,
@@ -642,7 +642,7 @@ export default class DrawerView extends React.PureComponent<Props> {
             {// Disable overlay if sidebar is permanent
             drawerType === 'permanent' ? null : (
               <TapGestureHandler
-                enabled={gestureEnabled || closeDrawerOnTap}
+                enabled={swipeEnabled}
                 onHandlerStateChange={this.handleTapStateChange}
               >
                 <Overlay progress={progress} style={overlayStyle} />

--- a/packages/drawer/src/views/DrawerView.tsx
+++ b/packages/drawer/src/views/DrawerView.tsx
@@ -200,7 +200,7 @@ export default function DrawerView({
   };
 
   const activeKey = state.routes[state.index].key;
-  const { gestureEnabled } = descriptors[activeKey].options;
+  const { gestureEnabled, closeDrawerOnTap } = descriptors[activeKey].options;
 
   return (
     <GestureHandlerWrapper style={styles.content}>
@@ -210,6 +210,7 @@ export default function DrawerView({
             <Drawer
               open={isDrawerOpen}
               gestureEnabled={gestureEnabled}
+              closeDrawerOnTap={closeDrawerOnTap}
               onOpen={handleDrawerOpen}
               onClose={handleDrawerClose}
               onGestureRef={ref => {

--- a/packages/drawer/src/views/DrawerView.tsx
+++ b/packages/drawer/src/views/DrawerView.tsx
@@ -200,7 +200,7 @@ export default function DrawerView({
   };
 
   const activeKey = state.routes[state.index].key;
-  const { gestureEnabled, closeDrawerOnTap } = descriptors[activeKey].options;
+  const { gestureEnabled, swipeEnabled } = descriptors[activeKey].options;
 
   return (
     <GestureHandlerWrapper style={styles.content}>
@@ -210,7 +210,7 @@ export default function DrawerView({
             <Drawer
               open={isDrawerOpen}
               gestureEnabled={gestureEnabled}
-              closeDrawerOnTap={closeDrawerOnTap}
+              swipeEnabled={swipeEnabled}
               onOpen={handleDrawerOpen}
               onClose={handleDrawerClose}
               onGestureRef={ref => {


### PR DESCRIPTION
Commit to fix this issue https://github.com/react-navigation/react-navigation/issues/6475#issuecomment-587539763

I added separate prop `closeDrawerOnTap` which is `true` by default to close drawer by tap even when `enableGesture` is `false`.