### PR TITLE
fix: use the correct velocity value in closing animation

### DIFF
--- a/packages/stack/src/views/Stack/Card.tsx
+++ b/packages/stack/src/views/Stack/Card.tsx
@@ -271,16 +271,15 @@ export default class Card extends React.Component<Props> {
           velocity = nativeEvent.velocityX;
         }
 
-        if (
-          gestureDirection === 'horizontal-inverted' ||
-          gestureDirection === 'vertical-inverted'
-        ) {
-          translation *= -1;
-          velocity *= -1;
-        }
+        const gestureDirectionFactor =
+          gestureDirection === 'horizontal' || gestureDirection === 'vertical'
+            ? 1
+            : -1;
 
         const closing =
-          translation + velocity * gestureVelocityImpact > distance / 2
+          gestureDirectionFactor *
+            (translation + velocity * gestureVelocityImpact) >
+          distance / 2
             ? velocity !== 0 || translation !== 0
             : false;
 


### PR DESCRIPTION
In this commit https://github.com/react-navigation/react-navigation/commit/f24d3a3461ee8a566c25ce7d13f31035b4be2691 we modified the `velocity` in inverted gesture, but since we also use this value in the closing animation, the change in that commit also introduced a new bug:
![Mar-20-2020 03-40-05](https://user-images.githubusercontent.com/57227217/77113229-006f0500-6a5d-11ea-97b5-571e8301cd87.gif)

This PR fixes the issue by keeping the original velocity value.