### PR TITLE
feat: add more info to useLinking error

### DIFF
--- a/packages/native/src/useLinking.native.tsx
+++ b/packages/native/src/useLinking.native.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Linking } from 'react-native';
+import { Linking, Platform } from 'react-native';
 import {
   getActionFromState,
   getStateFromPath as getStateFromPathDefault,
@@ -20,7 +20,9 @@ export default function useLinking(
   React.useEffect(() => {
     if (isUsingLinking) {
       throw new Error(
-        "Looks like you are using 'useLinking' in multiple components. This is likely an error since deep links should only be handled in one place to avoid conflicts."
+        Platform.OS === 'android'
+          ? "Ensure that you set 'android:launchMode=singleTask' in the '<activity />' of your AndroidManifest.xml file. Also be sure you are not using 'useLinking' in multiple components. Deep links should only be handled in one place to avoid conflicts."
+          : "Looks like you are using 'useLinking' in multiple components. This is likely an error since deep links should only be handled in one place to avoid conflicts."
       );
     } else {
       isUsingLinking = true;

--- a/packages/native/src/useLinking.tsx
+++ b/packages/native/src/useLinking.tsx
@@ -40,7 +40,7 @@ export default function useLinking(
   React.useEffect(() => {
     if (isUsingLinking) {
       throw new Error(
-        "Looks like you are using 'useLinking' in multiple components. This is likely an error since URL integration should only be handled in one place to avoid conflicts."
+        "Looks like you are using 'useLinking' in multiple components. This is likely an error since URL integration should only be handled in one place to avoid conflicts. Also ensure that you set your android activity launchMode to single task in your AndroiManifest.xml file."
       );
     } else {
       isUsingLinking = true;

--- a/packages/native/src/useLinking.tsx
+++ b/packages/native/src/useLinking.tsx
@@ -40,7 +40,7 @@ export default function useLinking(
   React.useEffect(() => {
     if (isUsingLinking) {
       throw new Error(
-        "Looks like you are using 'useLinking' in multiple components. This is likely an error since URL integration should only be handled in one place to avoid conflicts. Also ensure that you set your android activity launchMode to single task in your AndroiManifest.xml file."
+        "Looks like you are using 'useLinking' in multiple components. This is likely an error since URL integration should only be handled in one place to avoid conflicts."
       );
     } else {
       isUsingLinking = true;


### PR DESCRIPTION
I had this error thrown, and I only declared useLinking once.  I was only getting the error on Android.
I realized that I had declared `android:launchMode="singleTask"` in the `application` section of the Android Manifest file,  instead of the `activity` section.

This should hopefully give users a little more direction if they didn't declare it in the manifest or implemented it incorrectly. 