### PR TITLE
defining type for rendorIndicator in types of material-top-tab package

### DIFF
--- a/packages/material-top-tabs/src/types.tsx
+++ b/packages/material-top-tabs/src/types.tsx
@@ -177,7 +177,7 @@ export type MaterialTopTabBarOptions = Partial<
    */
   allowFontScaling?: boolean; 
   /**
-   * Whether label font should scale to respect Text Size accessibility settings.
+   * rendor indicator as a custom component
    */
   renderIndicator?:any 
 };

--- a/packages/material-top-tabs/src/types.tsx
+++ b/packages/material-top-tabs/src/types.tsx
@@ -144,6 +144,7 @@ export type MaterialTopTabBarOptions = Partial<
     | 'getTestID'
     | 'onTabPress'
     | 'onTabLongPress'
+    | 'renderIndicator'
     | keyof SceneRendererProps
   >
 > & {
@@ -174,7 +175,11 @@ export type MaterialTopTabBarOptions = Partial<
   /**
    * Whether label font should scale to respect Text Size accessibility settings.
    */
-  allowFontScaling?: boolean;
+  allowFontScaling?: boolean; 
+  /**
+   * Whether label font should scale to respect Text Size accessibility settings.
+   */
+  renderIndicator?:any 
 };
 
 export type MaterialTopTabBarProps = MaterialTopTabBarOptions &

--- a/packages/material-top-tabs/src/types.tsx
+++ b/packages/material-top-tabs/src/types.tsx
@@ -175,11 +175,11 @@ export type MaterialTopTabBarOptions = Partial<
   /**
    * Whether label font should scale to respect Text Size accessibility settings.
    */
-  allowFontScaling?: boolean; 
+  allowFontScaling?: boolean;
   /**
    * rendor indicator as a custom component
    */
-  renderIndicator?:any 
+  renderIndicator?: any;
 };
 
 export type MaterialTopTabBarProps = MaterialTopTabBarOptions &


### PR DESCRIPTION
**Motivation**
As pointed by @philippeauriach in issue #7250 that when programming in typescript renderIdicator should be allowed , there was no type present for it in packages/material-top-tabs/src/types.tsx while defining MaterialTopTabBarOptions so i defined one 
**Test plan**
i tested it by
-yarn typescript 
-by passing prop in example app
tests passed
**Code formatting**
i commented as well