### PR TITLE
fix: add pointerEvents=box-none to overlay View

### DIFF
--- a/packages/stack/src/views/Stack/Card.tsx
+++ b/packages/stack/src/views/Stack/Card.tsx
@@ -480,7 +480,10 @@ export default class Card extends React.Component<Props> {
       <CardAnimationContext.Provider value={animationContext}>
         <View pointerEvents="box-none" {...rest}>
           {overlayEnabled ? (
-            <View style={StyleSheet.absoluteFill}>
+            <View
+              pointerEvents="none"
+              style={StyleSheet.absoluteFill}
+            >
               {overlay({ style: overlayStyle })}
             </View>
           ) : null}

--- a/packages/stack/src/views/Stack/Card.tsx
+++ b/packages/stack/src/views/Stack/Card.tsx
@@ -481,7 +481,7 @@ export default class Card extends React.Component<Props> {
         <View pointerEvents="box-none" {...rest}>
           {overlayEnabled ? (
             <View
-              pointerEvents="none"
+              pointerEvents="box-none"
               style={StyleSheet.absoluteFill}
             >
               {overlay({ style: overlayStyle })}

--- a/packages/stack/src/views/Stack/Card.tsx
+++ b/packages/stack/src/views/Stack/Card.tsx
@@ -480,10 +480,7 @@ export default class Card extends React.Component<Props> {
       <CardAnimationContext.Provider value={animationContext}>
         <View pointerEvents="box-none" {...rest}>
           {overlayEnabled ? (
-            <View
-              pointerEvents="box-none"
-              style={StyleSheet.absoluteFill}
-            >
+            <View pointerEvents="box-none" style={StyleSheet.absoluteFill}>
               {overlay({ style: overlayStyle })}
             </View>
           ) : null}


### PR DESCRIPTION
This `pointerEvents='none'` was present in the View before the introduction of overlayRender.
Without it, all interactions are blocked for 1-2 seconds after closing the screen.

It can be found in diff here: https://github.com/react-navigation/react-navigation/pull/7809/files