### PR TITLE
fix: undefined pattern allows path building (#7893)

### DIFF
--- a/packages/core/src/getPathFromState.tsx
+++ b/packages/core/src/getPathFromState.tsx
@@ -105,7 +105,7 @@ export default function getPathFromState(
     }
 
     // we don't add empty path strings to path
-    if (pattern !== '') {
+    if (pattern) {
       const config =
         currentOptions[route.name] !== undefined
           ? (currentOptions[route.name] as { stringify?: StringifyConfig })


### PR DESCRIPTION
Resolves #7893

Expand conditional check of `pattern` from checking for an empty string to checking for a falsey value. This solves use cases where `pattern` may be undefined. See #7893 for more details.