### PR TITLE
docs: fixes typo

### DIFF
--- a/packages/bottom-tabs/src/types.tsx
+++ b/packages/bottom-tabs/src/types.tsx
@@ -138,7 +138,7 @@ export type BottomTabBarOptions = {
    */
   inactiveTintColor?: string;
   /**
-   * Background olor for the active tab.
+   * Background color for the active tab.
    */
   activeBackgroundColor?: string;
   /**


### PR DESCRIPTION
This PR fixes a typo in activeBackgroundColor's [description](https://github.com/react-navigation/react-navigation/blob/master/packages/bottom-tabs/src/types.tsx#L141) that was mentioned here #7827 