### PR TITLE
fix: separate out type import and export

### DIFF
--- a/packages/routers/src/index.tsx
+++ b/packages/routers/src/index.tsx
@@ -1,34 +1,49 @@
 import * as CommonActions from './CommonActions';
 
-export { CommonActions };
-
-export { default as BaseRouter } from './BaseRouter';
-
-export {
-  default as StackRouter,
-  StackActions,
+import type {
   StackActionHelpers,
   StackActionType,
   StackRouterOptions,
   StackNavigationState,
 } from './StackRouter';
 
-export {
-  default as TabRouter,
-  TabActions,
+import type {
   TabActionHelpers,
   TabActionType,
   TabRouterOptions,
   TabNavigationState,
 } from './TabRouter';
 
-export {
-  default as DrawerRouter,
-  DrawerActions,
+import type {
   DrawerActionHelpers,
   DrawerActionType,
   DrawerRouterOptions,
   DrawerNavigationState,
 } from './DrawerRouter';
+
+export type {
+  StackActionHelpers,
+  StackActionType,
+  StackRouterOptions,
+  StackNavigationState,
+  TabActionHelpers,
+  TabActionType,
+  TabRouterOptions,
+  TabNavigationState,
+  DrawerActionHelpers,
+  DrawerActionType,
+  DrawerRouterOptions,
+  DrawerNavigationState,
+};
+
+export { CommonActions };
+
+export { default as BaseRouter } from './BaseRouter';
+
+export { default as StackRouter, StackActions } from './StackRouter';
+
+export { default as TabRouter, TabActions } from './TabRouter';
+
+export { default as DrawerRouter, DrawerActions } from './DrawerRouter';
 
 export * from './types';


### PR DESCRIPTION
Fix https://github.com/react-navigation/react-navigation/issues/6757

Separated the type import and export.
Ran `yarn prepare` in `/packages/routers/`
Copied all the files in `lib` to another project to test.

The react native web project ran successfully (Vanilla react native & expo 37)