### PR TITLE
fix: use 1 as default in compat pop action

### DIFF
--- a/packages/compat/src/helpers.tsx
+++ b/packages/compat/src/helpers.tsx
@@ -57,7 +57,7 @@ export function push(routeName: string, params?: object, action?: never) {
   });
 }
 
-export function pop(n: number) {
+export function pop(n: number = 1) {
   return StackActions.pop(typeof n === 'number' ? { n } : n);
 }
 


### PR DESCRIPTION
resolves #7956 

Not sure if this is the best fix, but I think this should resolve the problem. Maybe the better way is to give `{}` to `StackActions.pop` instead of `n`. But I'm not sure if people are already putting objects into `pop` (which they shouldn't, I guess). 