### PR TITLE
feat: allow hiding of routes in DrawerItemList

### DIFF
--- a/packages/drawer/src/views/DrawerItemList.tsx
+++ b/packages/drawer/src/views/DrawerItemList.tsx
@@ -30,11 +30,11 @@ export default function DrawerItemList({
   inactiveBackgroundColor,
   itemStyle,
   labelStyle,
-  visibleRoutes
+  hiddenRoutes
 }: Props) {
-  if (!visibleRoutes) visibleRoutes = state.routeNames;
+  const hidden = hiddenRoutes ? hiddenRoutes : [];
   
-  return (state.routes.filter(route => visibleRoutes.includes(route.name)).map((route, i) => {
+  return (state.routes.filter(route => !hidden.includes(route.name)).map((route, i) => {
     const focused = i === state.index;
     const { title, drawerLabel, drawerIcon } = descriptors[route.key].options;
 

--- a/packages/drawer/src/views/DrawerItemList.tsx
+++ b/packages/drawer/src/views/DrawerItemList.tsx
@@ -30,8 +30,11 @@ export default function DrawerItemList({
   inactiveBackgroundColor,
   itemStyle,
   labelStyle,
+  visibleRoutes
 }: Props) {
-  return (state.routes.map((route, i) => {
+  if (!visibleRoutes) visibleRoutes = state.routeNames;
+  
+  return (state.routes.filter(route => visibleRoutes.includes(route.name)).map((route, i) => {
     const focused = i === state.index;
     const { title, drawerLabel, drawerIcon } = descriptors[route.key].options;
 


### PR DESCRIPTION
I made this based on my own issue #7962 ([plus it seems like a lot of people have wanted this for a while](https://www.google.com/search?q=react+navigation+hide+drawer+item)).

What this proposes is that now users can define a list of routes they want to be visible when defining a custom `drawerContent` component:
```
function CustomDrawerContent(props) {
  return (
    <DrawerContentScrollView {...props}>
      <DrawerItemList {...props} visibleRoutes={["Home", "Login", "Settings"]} />
    </DrawerContentScrollView>
  );
}
```

This would then filter out any routes not in the `visibleRoutes` prop. If `visibleRoutes` is not set, it will fallback to using `state.routeNames` and display all the routes.