### PR TITLE
fix(Drawer/types): add missing drawer methods to DrawerContentComponentProps type

### DIFF
--- a/packages/bottom-tabs/src/navigators/createBottomTabNavigator.tsx
+++ b/packages/bottom-tabs/src/navigators/createBottomTabNavigator.tsx
@@ -6,6 +6,8 @@ import {
   TabRouter,
   TabRouterOptions,
   TabNavigationState,
+  TabActionHelpers,
+  ParamListBase,
 } from '@react-navigation/native';
 import BottomTabView from '../views/BottomTabView';
 import {
@@ -29,7 +31,8 @@ function BottomTabNavigator({
     TabNavigationState,
     TabRouterOptions,
     BottomTabNavigationOptions,
-    BottomTabNavigationEventMap
+    BottomTabNavigationEventMap,
+    TabActionHelpers<ParamListBase>
   >(TabRouter, {
     initialRouteName,
     backBehavior,

--- a/packages/compat/src/createSwitchNavigator.tsx
+++ b/packages/compat/src/createSwitchNavigator.tsx
@@ -15,6 +15,7 @@ function SwitchNavigator(props: Props) {
     TabNavigationState,
     TabRouterOptions,
     {},
+    {},
     {}
   >(TabRouter, props);
 

--- a/packages/core/src/__tests__/useDescriptors.test.tsx
+++ b/packages/core/src/__tests__/useDescriptors.test.tsx
@@ -23,6 +23,7 @@ it('sets options with options prop as an object', () => {
       NavigationState,
       any,
       { title?: string },
+      any,
       any
     >(MockRouter, props);
     const { render, options } = descriptors[state.routes[state.index].key];
@@ -68,6 +69,7 @@ it('sets options with options prop as a fuction', () => {
       NavigationState,
       any,
       { title?: string },
+      any,
       any
     >(MockRouter, props);
     const { render, options } = descriptors[state.routes[state.index].key];
@@ -114,6 +116,7 @@ it('sets options with screenOptions prop as an object', () => {
       NavigationState,
       any,
       { title?: string },
+      any,
       any
     >(MockRouter, props);
 
@@ -174,6 +177,7 @@ it('sets options with screenOptions prop as a fuction', () => {
       NavigationState,
       any,
       { title?: string },
+      any,
       any
     >(MockRouter, props);
 
@@ -249,6 +253,7 @@ it('sets initial options with setOptions', () => {
         title?: string;
         color?: string;
       },
+      any,
       any
     >(MockRouter, props);
     const { render, options } = descriptors[state.routes[state.index].key];
@@ -300,6 +305,7 @@ it('updates options with setOptions', () => {
   const TestNavigator = (props: any) => {
     const { state, descriptors } = useNavigationBuilder<
       NavigationState,
+      any,
       any,
       any,
       any
@@ -379,6 +385,7 @@ it("returns correct value for canGoBack when it's not overridden", () => {
       NavigationState,
       any,
       { title?: string },
+      any,
       any
     >(MockRouter, props);
     const { render, options } = descriptors[state.routes[state.index].key];
@@ -441,6 +448,7 @@ it(`returns false for canGoBack when current router doesn't handle GO_BACK`, () 
       NavigationState,
       any,
       any,
+      any,
       any
     >(TestRouter, props);
 
@@ -492,6 +500,7 @@ it('returns true for canGoBack when current router handles GO_BACK', () => {
       NavigationState,
       any,
       { title?: string },
+      any,
       any
     >(ParentRouter, props);
     return descriptors[state.routes[state.index].key].render();
@@ -502,6 +511,7 @@ it('returns true for canGoBack when current router handles GO_BACK', () => {
       NavigationState,
       any,
       { title?: string },
+      any,
       any
     >(MockRouter, props);
 
@@ -559,6 +569,7 @@ it('returns true for canGoBack when parent router handles GO_BACK', () => {
       NavigationState,
       any,
       { title?: string },
+      any,
       any
     >(OverrodeRouter, props);
     return descriptors[state.routes[state.index].key].render();
@@ -569,6 +580,7 @@ it('returns true for canGoBack when parent router handles GO_BACK', () => {
       NavigationState,
       any,
       { title?: string },
+      any,
       any
     >(MockRouter, props);
 

--- a/packages/core/src/useNavigationBuilder.tsx
+++ b/packages/core/src/useNavigationBuilder.tsx
@@ -166,7 +166,8 @@ export default function useNavigationBuilder<
   State extends NavigationState,
   RouterOptions extends DefaultRouterOptions,
   ScreenOptions extends object,
-  EventMap extends Record<string, any>
+  EventMap extends Record<string, any>,
+  SpecificNavigatorMethod
 >(
   createRouter: RouterFactory<State, any, RouterOptions>,
   options: DefaultNavigatorOptions<ScreenOptions> & RouterOptions
@@ -464,7 +465,12 @@ export default function useNavigationBuilder<
     setState,
   });
 
-  const navigation = useNavigationHelpers<State, NavigationAction, EventMap>({
+  const navigation = useNavigationHelpers<
+    State,
+    NavigationAction,
+    EventMap,
+    SpecificNavigatorMethod
+  >({
     onAction,
     getState,
     emitter,

--- a/packages/core/src/useNavigationHelpers.tsx
+++ b/packages/core/src/useNavigationHelpers.tsx
@@ -31,7 +31,8 @@ type Options<State extends NavigationState, Action extends NavigationAction> = {
 export default function useNavigationHelpers<
   State extends NavigationState,
   Action extends NavigationAction,
-  EventMap extends Record<string, any>
+  EventMap extends Record<string, any>,
+  SpecificNavigatorMethod
 >({ onAction, getState, emitter, router }: Options<State, Action>) {
   const parentNavigationHelpers = React.useContext(NavigationContext);
 
@@ -115,6 +116,7 @@ export default function useNavigationHelpers<
       dangerouslyGetParent: () => parentNavigationHelpers as any,
       dangerouslyGetState: getState,
     } as NavigationHelpers<ParamListBase, EventMap> &
-      (NavigationProp<ParamListBase, string, any, any, any> | undefined);
+      (NavigationProp<ParamListBase, string, any, any, any> | undefined) &
+      SpecificNavigatorMethod;
   }, [router, getState, parentNavigationHelpers, emitter.emit, onAction]);
 }

--- a/packages/drawer/src/navigators/createDrawerNavigator.tsx
+++ b/packages/drawer/src/navigators/createDrawerNavigator.tsx
@@ -6,6 +6,8 @@ import {
   DrawerNavigationState,
   DrawerRouterOptions,
   DrawerRouter,
+  DrawerActionHelpers,
+  ParamListBase,
 } from '@react-navigation/native';
 
 import DrawerView from '../views/DrawerView';
@@ -31,7 +33,8 @@ function DrawerNavigator({
     DrawerNavigationState,
     DrawerRouterOptions,
     DrawerNavigationOptions,
-    DrawerNavigationEventMap
+    DrawerNavigationEventMap,
+    DrawerActionHelpers<ParamListBase>
   >(DrawerRouter, {
     initialRouteName,
     openByDefault,

--- a/packages/drawer/src/types.tsx
+++ b/packages/drawer/src/types.tsx
@@ -195,7 +195,8 @@ export type DrawerNavigationEventMap = {
 export type DrawerNavigationHelpers = NavigationHelpers<
   ParamListBase,
   DrawerNavigationEventMap
->;
+> &
+  DrawerActionHelpers<ParamListBase>;
 
 export type DrawerNavigationProp<
   ParamList extends ParamListBase,

--- a/packages/material-bottom-tabs/src/navigators/createMaterialBottomTabNavigator.tsx
+++ b/packages/material-bottom-tabs/src/navigators/createMaterialBottomTabNavigator.tsx
@@ -30,7 +30,8 @@ function MaterialBottomTabNavigator({
     TabNavigationState,
     TabRouterOptions,
     MaterialBottomTabNavigationOptions,
-    MaterialBottomTabNavigationEventMap
+    MaterialBottomTabNavigationEventMap,
+    {}
   >(TabRouter, {
     initialRouteName,
     backBehavior,

--- a/packages/material-top-tabs/src/navigators/createMaterialTopTabNavigator.tsx
+++ b/packages/material-top-tabs/src/navigators/createMaterialTopTabNavigator.tsx
@@ -29,7 +29,8 @@ function MaterialTopTabNavigator({
     TabNavigationState,
     TabRouterOptions,
     MaterialTopTabNavigationOptions,
-    MaterialTopTabNavigationEventMap
+    MaterialTopTabNavigationEventMap,
+    {}
   >(TabRouter, {
     initialRouteName,
     backBehavior,

--- a/packages/stack/src/navigators/createStackNavigator.tsx
+++ b/packages/stack/src/navigators/createStackNavigator.tsx
@@ -36,7 +36,8 @@ function StackNavigator({
     StackNavigationState,
     StackRouterOptions,
     StackNavigationOptions,
-    StackNavigationEventMap
+    StackNavigationEventMap,
+    {}
   >(StackRouter, {
     initialRouteName,
     children,


### PR DESCRIPTION
Hi,

Thank you for your hard work!




As stated in the issue #6790, the drawer methods (`toggleDrawer`, `openDrawer`, `closeDrawer`) are missing from the type definition.

To reproduce, create a new app with:
```
import 'react-native-gesture-handler';
import React from 'react';
import {View, Button, SafeAreaView} from 'react-native';
import {NavigationContainer} from '@react-navigation/native';
import {
  createDrawerNavigator,
  DrawerContentComponentProps,
  DrawerNavigationProp,
} from '@react-navigation/drawer';

function Drawer({navigation}: DrawerContentComponentProps) {
  console.log('Drawer -> navigation', navigation);
  return (
    <SafeAreaView>
      <Button title="Close Drawer" onPress={() => navigation.closeDrawer()} />
    </SafeAreaView>
  );
}

function HomeScreen({navigation}: {navigation: DrawerNavigationProp<{}>}) {
  return (
    <View style={{flex: 1, alignItems: 'center', justifyContent: 'center'}}>
      <Button onPress={() => navigation.openDrawer()} title="Open Drawer" />
    </View>
  );
}

const DrawerNavigator = createDrawerNavigator();

export default function App() {
  return (
    <NavigationContainer>
      <DrawerNavigator.Navigator initialRouteName="Home" drawerContent={Drawer}>
        <DrawerNavigator.Screen name="Home" component={HomeScreen} />
      </DrawerNavigator.Navigator>
    </NavigationContainer>
  );
}
```

You'll see that these methods are available:
![image](https://user-images.githubusercontent.com/17070498/78840160-539ffc00-79fa-11ea-9844-68722e50c2b5.png)

But they are missing from type definition:
![image](https://user-images.githubusercontent.com/17070498/78840208-77fbd880-79fa-11ea-9792-048adf1d079c.png)


This change solves the error, but please tell me if you see a better way, or need anything more