### PR TITLE
fix: Unexpected Token Error

### DIFF
--- a/packages/stack/src/index.tsx
+++ b/packages/stack/src/index.tsx
@@ -48,7 +48,7 @@ export { default as useGestureHandlerRef } from './utils/useGestureHandlerRef';
 /**
  * Types
  */
-export type {
+export {
   StackNavigationOptions,
   StackNavigationProp,
   StackHeaderProps,


### PR DESCRIPTION
The last version was crashing with the `Unexpected Token Error`. This commit fixes it.

```
SyntaxError: /Users/vadim/Projects/Fitenium/fitenium-mobile/node_modules/@react-navigation/stack/src/index.tsx: Unexpected token (51:12)

  52 |   StackNavigationOptions,
  49 |  * Types
  53 |   StackNavigationProp,
  50 |  */
> 51 | export type {
```