### PR TITLE
fix: webkit style error in overlay

### DIFF
--- a/packages/drawer/src/views/Overlay.tsx
+++ b/packages/drawer/src/views/Overlay.tsx
@@ -29,22 +29,24 @@ const Overlay = React.forwardRef(function Overlay(
     <Animated.View
       {...props}
       ref={ref}
-      style={[styles.overlay, animatedStyle, style]}
+      style={[styles.overlay, overlayStyle, animatedStyle, style]}
     />
   );
+});
+
+const overlayStyle = Platform.select<Record<string, string>>({
+  web: {
+    // Disable touch highlight on mobile Safari.
+    // WebkitTapHighlightColor must be used outside of StyleSheet.create because react-native-web will omit the property.
+    WebkitTapHighlightColor: 'transparent',
+  },
+  default: {},
 });
 
 const styles = StyleSheet.create({
   overlay: {
     ...StyleSheet.absoluteFillObject,
     backgroundColor: 'rgba(0, 0, 0, 0.5)',
-    ...Platform.select({
-      web: {
-        // Disable touch highlight on mobile Safari.
-        WebkitTapHighlightColor: 'transparent',
-      },
-      default: {},
-    }),
   },
 });
 


### PR DESCRIPTION
Moved `WebkitTapHighlightColor` out of `StyleSheet.create()`. We may want to remove this in favor of the global style (which is in the react-native-web reset). But that would assume this package is being used with `react-native-web`, which is probably fine. 