### PR TITLE
feat: use anchor elements on web for a11y features

### DIFF
--- a/packages/drawer/src/views/DrawerItem.tsx
+++ b/packages/drawer/src/views/DrawerItem.tsx
@@ -5,6 +5,7 @@ import {
   StyleSheet,
   StyleProp,
   ViewStyle,
+  Platform,
   TextStyle,
 } from 'react-native';
 import { useTheme } from '@react-navigation/native';
@@ -12,6 +13,11 @@ import Color from 'color';
 import TouchableItem from './TouchableItem';
 
 type Props = {
+  /**
+   * The route to use when linking on web.
+   * This is currently only used for the aria popup and copy actions.
+   */
+  href: string;
   /**
    * The label text of the item.
    */
@@ -76,6 +82,7 @@ export default function DrawerItem(props: Props) {
     activeBackgroundColor = Color(activeTintColor).alpha(0.12).rgb().string(),
     inactiveBackgroundColor = 'transparent',
     style,
+    href,
     onPress,
     ...rest
   } = props;
@@ -100,7 +107,8 @@ export default function DrawerItem(props: Props) {
         style={[styles.wrapper, { borderRadius }]}
         accessibilityTraits={focused ? ['button', 'selected'] : 'button'}
         accessibilityComponentType="button"
-        accessibilityRole="button"
+        accessibilityRole={Platform.select({ default: 'button', web: 'link' })}
+        href={href}
         accessibilityStates={focused ? ['selected'] : []}
       >
         <React.Fragment>

--- a/packages/drawer/src/views/DrawerItemList.tsx
+++ b/packages/drawer/src/views/DrawerItemList.tsx
@@ -53,6 +53,7 @@ export default function DrawerItemList({
         inactiveBackgroundColor={inactiveBackgroundColor}
         labelStyle={labelStyle}
         style={itemStyle}
+        href={route.name}
         onPress={() => {
           navigation.dispatch({
             ...(focused

--- a/packages/drawer/src/views/TouchableItem.tsx
+++ b/packages/drawer/src/views/TouchableItem.tsx
@@ -21,6 +21,7 @@ const ANDROID_VERSION_LOLLIPOP = 21;
 type Props = React.ComponentProps<typeof TouchableWithoutFeedback> & {
   pressColor: string;
   borderless: boolean;
+  href?: string;
 };
 
 export default class TouchableItem extends React.Component<Props> {
@@ -56,7 +57,6 @@ export default class TouchableItem extends React.Component<Props> {
         </TouchableNativeFeedback>
       );
     }
-
     return (
       <TouchableOpacity {...this.props}>{this.props.children}</TouchableOpacity>
     );


### PR DESCRIPTION
Using `<a />` elements for the drawer items, this adds the popup on hover and right-click actions. The actual href isn't used for linking because it would cause the page to completely re-render.

There is a problem in the example where `Root` is used for the route name but the actual path is `/` which means the hover preview is partially incorrect. Open to feedback on how to get the path for a route.

<img width="380" alt="Screen Shot 2020-04-12 at 5 44 14 PM" src="https://user-images.githubusercontent.com/9664363/79083882-b8eb3a00-7ce5-11ea-8511-4c5d904f57c6.png">
