### PR TITLE
feat: add ability to define a default screen

### DIFF
--- a/example/src/Screens/NotFound.tsx
+++ b/example/src/Screens/NotFound.tsx
@@ -1,0 +1,40 @@
+import { StackNavigationProp } from '@react-navigation/stack';
+import * as React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { Button } from 'react-native-paper';
+
+const NotFoundScreen = ({
+  navigation,
+}: {
+  navigation: StackNavigationProp<{}>;
+}) => {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>404 Not Found</Text>
+      <Button
+        mode="outlined"
+        onPress={() => navigation.goBack()}
+        style={styles.button}
+      >
+        Go back
+      </Button>
+    </View>
+  );
+};
+
+export default NotFoundScreen;
+
+const styles = StyleSheet.create({
+  title: {
+    fontSize: 36,
+  },
+  container: {
+    flex: 1,
+    justifyContent: 'space-around',
+    alignItems: 'center',
+    padding: 8,
+  },
+  button: {
+    margin: 8,
+  },
+});

--- a/example/src/index.tsx
+++ b/example/src/index.tsx
@@ -50,6 +50,7 @@ import StackHeaderCustomization from './Screens/StackHeaderCustomization';
 import BottomTabs from './Screens/BottomTabs';
 import MaterialTopTabsScreen from './Screens/MaterialTopTabs';
 import MaterialBottomTabs from './Screens/MaterialBottomTabs';
+import NotFound from './Screens/NotFound';
 import DynamicTabs from './Screens/DynamicTabs';
 import AuthFlow from './Screens/AuthFlow';
 import CompatAPI from './Screens/CompatAPI';
@@ -104,6 +105,10 @@ const SCREENS = {
   CompatAPI: {
     title: 'Compat Layer',
     component: CompatAPI,
+  },
+  '*': {
+    title: 'Not Found',
+    component: NotFound,
   },
 };
 

--- a/packages/core/src/getStateFromPath.tsx
+++ b/packages/core/src/getStateFromPath.tsx
@@ -256,7 +256,9 @@ function createConfigItem(
   parse?: ParseConfig
 ): RouteConfig {
   const match = new RegExp(
-    '^' + escape(pattern).replace(/:[a-z0-9]+/gi, '([^/]+)') + '/?'
+    pattern === '*'
+      ? '.*'
+      : '^' + escape(pattern).replace(/:[a-z0-9]+/gi, '([^/]+)') + '/?'
   );
 
   return {


### PR DESCRIPTION
## Why

fix #6914 and [how-do-i-specify-a-404-page](https://react-navigation.canny.io/feature-requests/p/how-do-i-specify-a-404-page).

## How

When the screen key is `*` the component will be used for any unspecified paths. This has a lot of problems. I don't care for this approach and I'm open to suggestions. 

I think something like this might make more sense:

```tsx
<Stack.Navigator>
  <Stack.Screen name="home" component={Home} />
  <Stack.Screen component={NotFound} />
</Stack.Navigator>
```

## Test Plan

Added a 404 page to the example, visit a random path.

<img width="1055" alt="Screen Shot 2020-04-12 at 6 25 04 PM" src="https://user-images.githubusercontent.com/9664363/79085030-c277a080-7ceb-11ea-865c-121d7b8847a7.png">
