### PR TITLE
feat: ability to change text case for material top tabs

### DIFF
--- a/packages/material-top-tabs/src/types.tsx
+++ b/packages/material-top-tabs/src/types.tsx
@@ -175,6 +175,10 @@ export type MaterialTopTabBarOptions = Partial<
    * Whether label font should scale to respect Text Size accessibility settings.
    */
   allowFontScaling?: boolean;
+  /**
+   * Whether to make label uppercase, default is true.
+   */
+  upperCaseLabel?: boolean;
 };
 
 export type MaterialTopTabBarProps = MaterialTopTabBarOptions &

--- a/packages/material-top-tabs/src/views/MaterialTopTabBar.tsx
+++ b/packages/material-top-tabs/src/views/MaterialTopTabBar.tsx
@@ -18,6 +18,7 @@ export default function TabBarTop(props: MaterialTopTabBarProps) {
     allowFontScaling = true,
     showIcon = false,
     showLabel = true,
+    upperCaseLabel = true,
     pressColor = Color(activeTintColor).alpha(0.08).rgb().string(),
     iconStyle,
     labelStyle,
@@ -90,7 +91,7 @@ export default function TabBarTop(props: MaterialTopTabBarProps) {
               style={[styles.label, { color }, labelStyle]}
               allowFontScaling={allowFontScaling}
             >
-              {label}
+              {upperCaseLabel ? label.toUpperCase() : label}
             </Text>
           );
         }
@@ -108,7 +109,6 @@ const styles = StyleSheet.create({
   },
   label: {
     textAlign: 'center',
-    textTransform: 'uppercase',
     fontSize: 13,
     margin: 4,
     backgroundColor: 'transparent',


### PR DESCRIPTION
Fix https://github.com/react-navigation/react-navigation/issues/8090

Added the `upperCaseLabel` prop for material top tabbar which was available in version 4.