### PR TITLE
feat: add `useLinkBuilder` hook to build links

### DIFF
--- a/example/src/Screens/BottomTabs.tsx
+++ b/example/src/Screens/BottomTabs.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Platform } from 'react-native';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import TouchableBounce from '../Shared/TouchableBounce';
@@ -28,7 +29,10 @@ export default function BottomTabsScreen() {
   return (
     <BottomTabs.Navigator
       screenOptions={{
-        tabBarButton: (props) => <TouchableBounce {...props} />,
+        tabBarButton:
+          Platform.OS === 'web'
+            ? undefined
+            : (props) => <TouchableBounce {...props} />,
       }}
     >
       <BottomTabs.Screen

--- a/packages/bottom-tabs/src/types.tsx
+++ b/packages/bottom-tabs/src/types.tsx
@@ -4,6 +4,7 @@ import {
   StyleProp,
   TextStyle,
   ViewStyle,
+  GestureResponderEvent,
 } from 'react-native';
 import {
   NavigationHelpers,
@@ -196,6 +197,13 @@ export type BottomTabBarProps = BottomTabBarOptions & {
   navigation: NavigationHelpers<ParamListBase, BottomTabNavigationEventMap>;
 };
 
-export type BottomTabBarButtonProps = TouchableWithoutFeedbackProps & {
+export type BottomTabBarButtonProps = Omit<
+  TouchableWithoutFeedbackProps,
+  'onPress'
+> & {
+  href?: string;
   children: React.ReactNode;
+  onPress?: (
+    e: React.MouseEvent<HTMLAnchorElement, MouseEvent> | GestureResponderEvent
+  ) => void;
 };

--- a/packages/bottom-tabs/src/views/BottomTabBar.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabBar.tsx
@@ -14,6 +14,7 @@ import {
   NavigationRouteContext,
   CommonActions,
   useTheme,
+  useLinkBuilder,
 } from '@react-navigation/native';
 import { useSafeArea } from 'react-native-safe-area-context';
 
@@ -50,6 +51,7 @@ export default function BottomTabBar({
   tabStyle,
 }: Props) {
   const { colors } = useTheme();
+  const buildLink = useLinkBuilder({ navigation });
 
   const [dimensions, setDimensions] = React.useState(() => {
     const { height = 0, width = 0 } = Dimensions.get('window');
@@ -260,6 +262,7 @@ export default function BottomTabBar({
                   onPress={onPress}
                   onLongPress={onLongPress}
                   accessibilityLabel={accessibilityLabel}
+                  href={buildLink(route.name, route.params)}
                   testID={options.tabBarTestID}
                   allowFontScaling={allowFontScaling}
                   activeTintColor={activeTintColor}

--- a/packages/core/src/types.tsx
+++ b/packages/core/src/types.tsx
@@ -193,6 +193,20 @@ type NavigationHelpersCommon<
    * Note that this method doesn't re-render screen when the result changes. So don't use it in `render`.
    */
   canGoBack(): boolean;
+
+  /**
+   * Returns the parent navigator, if any. Reason why the function is called
+   * dangerouslyGetParent is to warn developers against overusing it to eg. get parent
+   * of parent and other hard-to-follow patterns.
+   */
+  dangerouslyGetParent<T = NavigationProp<ParamListBase> | undefined>(): T;
+
+  /**
+   * Returns the navigator's state. Reason why the function is called
+   * dangerouslyGetState is to discourage developers to use internal navigation's state.
+   * Note that this method doesn't re-render screen when the result changes. So don't use it in `render`.
+   */
+  dangerouslyGetState(): State;
 } & PrivateValueStore<ParamList, keyof ParamList, {}>;
 
 export type NavigationHelpers<
@@ -254,20 +268,6 @@ export type NavigationProp<
    * @param options Options object for the route.
    */
   setOptions(options: Partial<ScreenOptions>): void;
-
-  /**
-   * Returns the parent navigator, if any. Reason why the function is called
-   * dangerouslyGetParent is to warn developers against overusing it to eg. get parent
-   * of parent and other hard-to-follow patterns.
-   */
-  dangerouslyGetParent<T = NavigationProp<ParamListBase> | undefined>(): T;
-
-  /**
-   * Returns the navigator's state. Reason why the function is called
-   * dangerouslyGetState is to discourage developers to use internal navigation's state.
-   * Note that this method doesn't re-render screen when the result changes. So don't use it in `render`.
-   */
-  dangerouslyGetState(): State;
 } & EventConsumer<EventMap & EventMapCore<State>> &
   PrivateValueStore<ParamList, RouteName, EventMap>;
 

--- a/packages/core/src/useNavigationCache.tsx
+++ b/packages/core/src/useNavigationCache.tsx
@@ -7,7 +7,6 @@ import {
   Router,
 } from '@react-navigation/routers';
 import { NavigationEventEmitter } from './useEventEmitter';
-import NavigationContext from './NavigationContext';
 
 import { NavigationHelpers, NavigationProp } from './types';
 
@@ -49,12 +48,10 @@ export default function useNavigationCache<
   // Cache object which holds navigation objects for each screen
   // We use `React.useMemo` instead of `React.useRef` coz we want to invalidate it when deps change
   // In reality, these deps will rarely change, if ever
-  const parentNavigation = React.useContext(NavigationContext);
-
   const cache = React.useMemo(
     () => ({ current: {} as NavigationCache<State, ScreenOptions> }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [getState, navigation, setOptions, router, emitter, parentNavigation]
+    [getState, navigation, setOptions, router, emitter]
   );
 
   const actions = {
@@ -99,8 +96,6 @@ export default function useNavigationCache<
           ...rest,
           ...helpers,
           ...emitter.create(route.key),
-          dangerouslyGetParent: () => parentNavigation as any,
-          dangerouslyGetState: getState,
           dispatch,
           setOptions: (options: object) =>
             setOptions((o) => ({

--- a/packages/core/src/useNavigationHelpers.tsx
+++ b/packages/core/src/useNavigationHelpers.tsx
@@ -112,6 +112,8 @@ export default function useNavigationHelpers<
           false
         );
       },
+      dangerouslyGetParent: () => parentNavigationHelpers as any,
+      dangerouslyGetState: getState,
     } as NavigationHelpers<ParamListBase, EventMap> &
       (NavigationProp<ParamListBase, string, any, any, any> | undefined);
   }, [router, getState, parentNavigationHelpers, emitter.emit, onAction]);

--- a/packages/drawer/src/views/DrawerItemList.tsx
+++ b/packages/drawer/src/views/DrawerItemList.tsx
@@ -3,6 +3,7 @@ import {
   CommonActions,
   DrawerActions,
   DrawerNavigationState,
+  useLinkBuilder,
 } from '@react-navigation/native';
 import DrawerItem from './DrawerItem';
 import {
@@ -31,6 +32,8 @@ export default function DrawerItemList({
   itemStyle,
   labelStyle,
 }: Props) {
+  const buildLink = useLinkBuilder({ navigation });
+
   return (state.routes.map((route, i) => {
     const focused = i === state.index;
     const { title, drawerLabel, drawerIcon } = descriptors[route.key].options;
@@ -53,6 +56,7 @@ export default function DrawerItemList({
         inactiveBackgroundColor={inactiveBackgroundColor}
         labelStyle={labelStyle}
         style={itemStyle}
+        href={buildLink(route.name, route.params)}
         onPress={() => {
           navigation.dispatch({
             ...(focused

--- a/packages/native/src/Link.tsx
+++ b/packages/native/src/Link.tsx
@@ -1,46 +1,58 @@
 import * as React from 'react';
-import { Text, TextProps, GestureResponderEvent, Platform } from 'react-native';
+import { Text, TextProps, Platform, GestureResponderEvent } from 'react-native';
 import useLinkTo from './useLinkTo';
 
 type Props = {
   to: string;
   target?: string;
+  onLink?: (
+    e: React.MouseEvent<HTMLAnchorElement, MouseEvent> | GestureResponderEvent
+  ) => void;
 } & (TextProps & { children: React.ReactNode });
 
-export default function Link({ to, children, ...rest }: Props) {
+export default function Link({ to, children, onLink, ...rest }: Props) {
   const linkTo = useLinkTo();
 
-  const onPress = (e: GestureResponderEvent | undefined) => {
+  const onPress = (
+    e: React.MouseEvent<HTMLAnchorElement, MouseEvent> | GestureResponderEvent
+  ) => {
     if ('onPress' in rest) {
-      rest.onPress?.(e as GestureResponderEvent);
+      // @ts-ignore
+      rest.onPress?.(e);
     }
 
-    const event = (e?.nativeEvent as any) as
-      | React.MouseEvent<HTMLAnchorElement, MouseEvent>
-      | undefined;
+    let shouldHandle = false;
 
     if (Platform.OS !== 'web' || !event) {
-      linkTo(to);
-      return;
-    }
-
-    event.preventDefault();
-
-    if (
+      shouldHandle = event ? !event.defaultPrevented : true;
+    } else if (
       !event.defaultPrevented && // onPress prevented default
+      // @ts-ignore
       !(event.metaKey || event.altKey || event.ctrlKey || event.shiftKey) && // ignore clicks with modifier keys
+      // @ts-ignore
       (event.button == null || event.button === 0) && // ignore everything but left clicks
       (rest.target == null || rest.target === '_self') // let browser handle "target=_blank" etc.
     ) {
       event.preventDefault();
-      linkTo(to);
+      shouldHandle = true;
+    }
+
+    if (shouldHandle) {
+      if (onLink) {
+        onLink(e);
+      } else {
+        linkTo(to);
+      }
     }
   };
 
   const props = {
     href: to,
-    onPress,
     accessibilityRole: 'link' as const,
+    ...Platform.select({
+      web: { onClick: onPress } as any,
+      default: { onPress },
+    }),
     ...rest,
   };
 

--- a/packages/native/src/LinkingContext.tsx
+++ b/packages/native/src/LinkingContext.tsx
@@ -1,12 +1,8 @@
 import * as React from 'react';
 import { LinkingOptions } from './types';
 
-const LinkingContext = React.createContext<() => LinkingOptions | undefined>(
-  () => {
-    throw new Error(
-      "Couldn't find a linking context. Have you wrapped your app with 'NavigationContainer'?"
-    );
-  }
-);
+const LinkingContext = React.createContext<{
+  options: LinkingOptions | undefined;
+}>({ options: undefined });
 
 export default LinkingContext;

--- a/packages/native/src/NavigationContainer.tsx
+++ b/packages/native/src/NavigationContainer.tsx
@@ -52,13 +52,7 @@ const NavigationContainer = React.forwardRef(function NavigationContainer(
 
   React.useImperativeHandle(ref, () => refContainer.current);
 
-  const linkingOptionsRef = React.useRef(linking);
-
-  React.useEffect(() => {
-    linkingOptionsRef.current = linking;
-  });
-
-  const linkingContext = React.useCallback(() => linkingOptionsRef.current, []);
+  const linkingContext = React.useMemo(() => ({ options: linking }), [linking]);
 
   if (!isReady) {
     // This is temporary until we have Suspense for data-fetching

--- a/packages/native/src/index.tsx
+++ b/packages/native/src/index.tsx
@@ -13,3 +13,4 @@ export { default as useTheme } from './theming/useTheme';
 export { default as Link } from './Link';
 export { default as useLinking } from './useLinking';
 export { default as useLinkTo } from './useLinkTo';
+export { default as useLinkBuilder } from './useLinkBuilder';

--- a/packages/native/src/useLinkBuilder.tsx
+++ b/packages/native/src/useLinkBuilder.tsx
@@ -1,0 +1,75 @@
+import * as React from 'react';
+import {
+  NavigationHelpers,
+  NavigationProp,
+  ParamListBase,
+  EventMapBase,
+  getPathFromState,
+} from '@react-navigation/core';
+import LinkingContext from './LinkingContext';
+
+type NavigationObject =
+  | NavigationHelpers<ParamListBase>
+  | NavigationProp<ParamListBase>;
+
+type MinimalState = {
+  index: number;
+  routes: { name: string; params?: object; state?: MinimalState }[];
+};
+
+const getRootState = (
+  navigation: NavigationObject,
+  state: MinimalState
+): MinimalState => {
+  const parent = navigation.dangerouslyGetParent();
+
+  if (parent) {
+    const parentState = parent.dangerouslyGetState();
+
+    return getRootState(parent, {
+      index: 0,
+      routes: [
+        {
+          ...parentState.routes[parentState.index],
+          state: state,
+        },
+      ],
+    });
+  }
+
+  return state;
+};
+
+/**
+ * Build destination link for a navigate action.
+ * Useful for showing anchor tags on the web for buttons that perform navigation.
+ *
+ * @param options.navigation Navigation object for the navigator.
+ */
+export default function useLinkBuilder({
+  navigation,
+}: {
+  navigation: NavigationHelpers<ParamListBase, EventMapBase>;
+}) {
+  const linking = React.useContext(LinkingContext);
+
+  const buildLink = React.useCallback(
+    (name: string, params?: object) => {
+      const { options } = linking;
+
+      const state = getRootState(navigation, {
+        index: 0,
+        routes: [{ name, params }],
+      });
+
+      const path = options?.getPathFromState
+        ? options.getPathFromState(state, options?.config)
+        : getPathFromState(state, options?.config);
+
+      return path;
+    },
+    [linking, navigation]
+  );
+
+  return buildLink;
+}

--- a/packages/native/src/useLinkTo.tsx
+++ b/packages/native/src/useLinkTo.tsx
@@ -1,14 +1,14 @@
 import * as React from 'react';
 import {
-  useNavigation,
   getStateFromPath,
   getActionFromState,
+  NavigationContext,
 } from '@react-navigation/core';
 import LinkingContext from './LinkingContext';
 
 export default function useLinkTo() {
-  const navigation = useNavigation();
-  const getOptions = React.useContext(LinkingContext);
+  const navigation = React.useContext(NavigationContext);
+  const linking = React.useContext(LinkingContext);
 
   const linkTo = React.useCallback(
     (path: string) => {
@@ -16,7 +16,13 @@ export default function useLinkTo() {
         throw new Error(`The path must start with '/' (${path}).`);
       }
 
-      const options = getOptions();
+      if (navigation === undefined) {
+        throw new Error(
+          "Couldn't find a navigation object. Is your component inside a screen in a navigator?"
+        );
+      }
+
+      const { options } = linking;
 
       const state = options?.getStateFromPath
         ? options.getStateFromPath(path, options.config)
@@ -42,7 +48,7 @@ export default function useLinkTo() {
         throw new Error('Failed to parse the path to a navigation state.');
       }
     },
-    [getOptions, navigation]
+    [linking, navigation]
   );
 
   return linkTo;


### PR DESCRIPTION
We need to be able to create links from a navigate action to have accessible links in the built-in components such as drawer and tabs.