### PR TITLE
fix: backBehavior with initialRoute

### DIFF
--- a/packages/routers/src/TabRouter.tsx
+++ b/packages/routers/src/TabRouter.tsx
@@ -64,15 +64,13 @@ const getRouteHistory = (
   const history = [{ type: TYPE_ROUTE, key: routes[index].key }];
 
   switch (backBehavior) {
-    case 'initialRoute':
-      if (index !== 0) {
-        history.unshift({ type: TYPE_ROUTE, key: routes[0].key });
-      }
-      break;
     case 'order':
       for (let i = index; i > 0; i--) {
         history.unshift({ type: TYPE_ROUTE, key: routes[i - 1].key });
       }
+      break;
+    case 'initialRoute':
+      // The history always begin with the initial route (see changeIndex)
       break;
     case 'history':
       // The history will fill up on navigation
@@ -95,6 +93,13 @@ const changeIndex = (
     history = state.history
       .filter((it) => (it.type === 'route' ? it.key !== currentKey : false))
       .concat({ type: TYPE_ROUTE, key: currentKey });
+  } else if (backBehavior === 'initialRoute') {
+    const currentKey = state.routes[index].key;
+
+    history = [state.history[0]];
+    if (state.history[0].key !== currentKey) {
+      history.push({ type: TYPE_ROUTE, key: currentKey });
+    }
   } else {
     history = getRouteHistory(state.routes, index, backBehavior);
   }

--- a/packages/routers/src/__tests__/TabRouter.test.tsx
+++ b/packages/routers/src/__tests__/TabRouter.test.tsx
@@ -695,6 +695,78 @@ it('handles back action with backBehavior: initialRoute', () => {
   ).toEqual(null);
 });
 
+it('handles back action with backBehavior: initialRoute and initialRouteName', () => {
+  const router = TabRouter({
+    backBehavior: 'initialRoute',
+    initialRouteName: 'baz',
+  });
+
+  const options = {
+    routeNames: ['bar', 'baz', 'qux'],
+    routeParamList: {},
+  };
+
+  let state = router.getInitialState(options);
+
+  expect(
+    router.getStateForAction(state, CommonActions.goBack(), options)
+  ).toEqual(null);
+
+  state = router.getStateForAction(
+    state,
+    TabActions.jumpTo('qux'),
+    options
+  ) as TabNavigationState;
+
+  expect(
+    router.getStateForAction(state, CommonActions.goBack(), options)
+  ).toEqual({
+    stale: false,
+    type: 'tab',
+    key: 'tab-test',
+    index: 1,
+    routeNames: ['bar', 'baz', 'qux'],
+    routes: [
+      { key: 'bar-test', name: 'bar' },
+      { key: 'baz-test', name: 'baz' },
+      { key: 'qux-test', name: 'qux' },
+    ],
+    history: [{ type: 'route', key: 'baz-test' }],
+  });
+
+  state = router.getStateForAction(
+    state,
+    TabActions.jumpTo('bar'),
+    options
+  ) as TabNavigationState;
+
+  expect(
+    router.getStateForAction(state, CommonActions.goBack(), options)
+  ).toEqual({
+    stale: false,
+    type: 'tab',
+    key: 'tab-test',
+    index: 1,
+    routeNames: ['bar', 'baz', 'qux'],
+    routes: [
+      { key: 'bar-test', name: 'bar' },
+      { key: 'baz-test', name: 'baz' },
+      { key: 'qux-test', name: 'qux' },
+    ],
+    history: [{ type: 'route', key: 'baz-test' }],
+  });
+
+  state = router.getStateForAction(
+    state,
+    TabActions.jumpTo('baz'),
+    options
+  ) as TabNavigationState;
+
+  expect(
+    router.getStateForAction(state, CommonActions.goBack(), options)
+  ).toEqual(null);
+});
+
 it('handles back action with backBehavior: none', () => {
   const router = TabRouter({ backBehavior: 'none' });
   const options = {


### PR DESCRIPTION
I corrected the behavior when we push the back button and we defined an initialRouteName. (https://github.com/react-navigation/react-navigation/issues/7317) Before, back button always got back to the first route, even if the initial route was not the first.

I added relevant tests to check the correct behavior.