### PR TITLE
feat: pass deep linking url to getStateFromPath

### DIFF
--- a/packages/core/src/__tests__/getStateFromPath.test.tsx
+++ b/packages/core/src/__tests__/getStateFromPath.test.tsx
@@ -88,6 +88,61 @@ it('converts path string to initial state with config', () => {
   );
 });
 
+it('converts path string to initial state with config and url', () => {
+  const path = '/foo/bar/sweet/apple/baz/jane?count=10&answer=42&valid=true';
+  const config = {
+    Foo: 'foo',
+    Bar: 'bar/:type/:fruit',
+    Baz: {
+      path: 'baz/:author',
+      parse: {
+        author: (author: string) =>
+          author.replace(/^\w/, (c) => c.toUpperCase()),
+        count: Number,
+        valid: Boolean,
+      },
+      stringify: {
+        author: (author: string) => author.toLowerCase(),
+      },
+    },
+  };
+  const url = `https://www.example.com${path}`;
+
+  const state = {
+    routes: [
+      {
+        name: 'Foo',
+        state: {
+          routes: [
+            {
+              name: 'Bar',
+              params: { fruit: 'apple', type: 'sweet' },
+              state: {
+                routes: [
+                  {
+                    name: 'Baz',
+                    params: {
+                      author: 'Jane',
+                      count: 10,
+                      answer: '42',
+                      valid: true,
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getStateFromPath(path, config, url)).toEqual(state);
+  expect(
+    getStateFromPath(getPathFromState(state, config), config, url)
+  ).toEqual(state);
+});
+
 it('handles leading slash when converting', () => {
   expect(getStateFromPath('/foo/bar/?count=42')).toEqual({
     routes: [

--- a/packages/core/src/getStateFromPath.tsx
+++ b/packages/core/src/getStateFromPath.tsx
@@ -54,7 +54,7 @@ type ResultState = PartialState<NavigationState> & {
  * ```
  * @param path Path string to parse and convert, e.g. /foo/bar?count=42.
  * @param options Extra options to fine-tune how to parse the path.
- * @param _url Full URL that the path was parsed from, e.g. https://www.example.com/foo/bar?count=42.
+ * @param _url Full URL that the path was extracted from, e.g. https://www.example.com/foo/bar?count=42.
  */
 export default function getStateFromPath(
   path: string,

--- a/packages/core/src/getStateFromPath.tsx
+++ b/packages/core/src/getStateFromPath.tsx
@@ -48,15 +48,18 @@ type ResultState = PartialState<NavigationState> & {
  *       path: 'chat/:author/:id',
  *       parse: { id: Number }
  *     }
- *   }
+ *   },
+ *   'https://www.example.com/chat/jane/42'
  * )
  * ```
  * @param path Path string to parse and convert, e.g. /foo/bar?count=42.
  * @param options Extra options to fine-tune how to parse the path.
+ * @param _url Full URL that the path was parsed from, e.g. https://www.example.com/foo/bar?count=42.
  */
 export default function getStateFromPath(
   path: string,
-  options: Options = {}
+  options: Options = {},
+  _url?: string
 ): ResultState | undefined {
   if (path === '') {
     return undefined;

--- a/packages/core/src/getStateFromPath.tsx
+++ b/packages/core/src/getStateFromPath.tsx
@@ -54,7 +54,7 @@ type ResultState = PartialState<NavigationState> & {
  * ```
  * @param path Path string to parse and convert, e.g. /foo/bar?count=42.
  * @param options Extra options to fine-tune how to parse the path.
- * @param _url Full URL that the path was extracted from, e.g. https://www.example.com/foo/bar?count=42.
+ * @param _url URL string that the path was extracted from, e.g. https://www.example.com/foo/bar?count=42.
  */
 export default function getStateFromPath(
   path: string,

--- a/packages/native/src/useLinking.native.tsx
+++ b/packages/native/src/useLinking.native.tsx
@@ -61,8 +61,8 @@ export default function useLinking(
     const url = await Linking.getInitialURL();
     const path = url ? extractPathFromURL(url) : null;
 
-    if (path) {
-      return getStateFromPathRef.current(path, configRef.current);
+    if (path && url) {
+      return getStateFromPathRef.current(path, configRef.current, url);
     } else {
       return undefined;
     }
@@ -74,7 +74,7 @@ export default function useLinking(
       const navigation = ref.current;
 
       if (navigation && path) {
-        const state = getStateFromPathRef.current(path, configRef.current);
+        const state = getStateFromPathRef.current(path, configRef.current, url);
 
         if (state) {
           const action = getActionFromState(state);

--- a/packages/native/src/useLinking.tsx
+++ b/packages/native/src/useLinking.tsx
@@ -69,7 +69,11 @@ export default function useLinking(
     const path = location.pathname + location.search;
 
     if (path) {
-      return getStateFromPathRef.current(path, configRef.current);
+      return getStateFromPathRef.current(
+        path,
+        configRef.current,
+        location.href
+      );
     } else {
       return undefined;
     }
@@ -152,7 +156,8 @@ export default function useLinking(
 
         const state = getStateFromPathRef.current(
           location.pathname + location.search,
-          configRef.current
+          configRef.current,
+          location.href
         );
 
         pendingStateMultiUpdateRef.current = true;


### PR DESCRIPTION
# Overview
I would like to pass the full URL to the `getStateFromPath()` function so that my custom `useLinking()` `getStateFromPath` param can use the`url` when determining the state. 

## Background
I want my app to support deep links from multiple TLDs and I want to show different screens for certain TLDs.  As a result, I cannot rely on only the `path` when calculating the state (i.e. the path can be the same, but the TLDs are different).

Please let me know if this is acceptable or if there is a preferred way to achieve supporting different states based on different TLDs.