### PR TITLE
support screen options reset tabBarOptions

### DIFF
--- a/packages/bottom-tabs/src/types.tsx
+++ b/packages/bottom-tabs/src/types.tsx
@@ -96,6 +96,11 @@ export type BottomTabNavigationOptions = {
    * Defaults to `false`.
    */
   unmountOnBlur?: boolean;
+  
+  /**
+   * support screen reset Navigator.props.tabBarOptions
+   */
+  tabBarOptions?: BottomTabBarOptions;
 };
 
 export type BottomTabDescriptor = Descriptor<

--- a/packages/bottom-tabs/src/views/BottomTabBar.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabBar.tsx
@@ -35,23 +35,38 @@ export default function BottomTabBar({
   state,
   navigation,
   descriptors,
-  activeBackgroundColor,
-  activeTintColor,
-  adaptive = true,
-  allowFontScaling,
-  inactiveBackgroundColor,
-  inactiveTintColor,
-  keyboardHidesTabBar = false,
-  labelPosition,
-  labelStyle,
-  safeAreaInsets,
-  showIcon,
-  showLabel,
   style,
   tabStyle,
+  labelStyle,
+  ...DefaultTabBarOptions
 }: Props) {
+  const { index, routes } = state;
   const { colors } = useTheme();
   const buildLink = useLinkBuilder();
+
+  // support options.tabBarOptions
+  const {
+    style:screenStyle, 
+    tabStyle:screenTabStyle, 
+    labelStyle:screenLabelStyle,
+    ...screenTabBarOptions
+  } = descriptors[routes[index].key].options.tabBarOptions||{};
+  let {
+    activeBackgroundColor,
+    activeTintColor,
+    adaptive = true,
+    allowFontScaling,
+    inactiveBackgroundColor,
+    inactiveTintColor,
+    keyboardHidesTabBar = false,
+    labelPosition,
+    safeAreaInsets,
+    showIcon,
+    showLabel
+  } = {...DefaultTabBarOptions, ...screenTabBarOptions};
+  style = [style, screenStyle];
+  tabStyle = [tabStyle, screenTabStyle];
+  labelStyle = [labelStyle, screenLabelStyle];
 
   const [dimensions, setDimensions] = React.useState(() => {
     const { height = 0, width = 0 } = Dimensions.get('window');
@@ -67,7 +82,6 @@ export default function BottomTabBar({
 
   const [visible] = React.useState(() => new Animated.Value(1));
 
-  const { routes } = state;
 
   React.useEffect(() => {
     if (keyboardShown) {
@@ -175,6 +189,10 @@ export default function BottomTabBar({
     left: safeAreaInsets?.left ?? defaultInsets.left,
   };
 
+  // add insets.bottom to custom style.height
+  const {height, ...tabBarStyle} = StyleSheet.flatten(style);
+  const tabBarHeight = typeof height === 'number' ? height : DEFAULT_TABBAR_HEIGHT;
+
   return (
     <Animated.View
       style={[
@@ -200,11 +218,11 @@ export default function BottomTabBar({
             }
           : null,
         {
-          height: DEFAULT_TABBAR_HEIGHT + insets.bottom,
+          height: tabBarHeight + insets.bottom,
           paddingBottom: insets.bottom,
           paddingHorizontal: Math.max(insets.left, insets.right),
         },
-        style,
+        tabBarStyle,
       ]}
       pointerEvents={keyboardHidesTabBar && keyboardShown ? 'none' : 'auto'}
     >


### PR DESCRIPTION
when i make bottom tab bar like this

![tabbar](https://user-images.githubusercontent.com/15194457/80615328-203d1400-8a72-11ea-93ec-3fb25eb72d85.png)

1. switch first page, tab bar is transparent
2. switch other page, tab bar background is black

i found it's difficult to do with current api

so, i add code, support screen options reset tabBarOptions, and it's very easy to do this, it's not  break change

--------------------
another change is add  insets.bottom to custom style.height auto.

this may not be compatible with the original, but it is more logical, because `style.padding` is add insets.bottom auto

if you think it is inappropriate, i can remove this change, this change is not the point

