### PR TITLE
[v4.x] fix: change old docUrl to new docUrl due v5

### DIFF
--- a/packages/core/src/utils/docsUrl.ts
+++ b/packages/core/src/utils/docsUrl.ts
@@ -1,3 +1,3 @@
 export default function docsUrl(path: string) {
-  return `https://reactnavigation.org/docs/${path}`;
+  return `https://reactnavigation.org/docs/4.x/${path}`;
 }

--- a/packages/react-navigation/src/utils/docsUrl.js
+++ b/packages/react-navigation/src/utils/docsUrl.js
@@ -1,3 +1,3 @@
 export default function docsUrl(path) {
-  return `https://reactnavigation.org/docs/${path}`;
+  return `https://reactnavigation.org/docs/4.x/${path}`;
 }


### PR DESCRIPTION
This PRs fixes the docs URLs shown on some warns to guide us to the right path on docs, following it you should get stuck here:

<img width="350" alt="Page Not Found | React Navigation 2020-04-30 04-01-49" src="https://user-images.githubusercontent.com/36987863/80683550-c4d34c00-8a9a-11ea-9365-644755727197.png">

With this PR, we can reach the URL for the v4 documentation, since v5 is out.