### PR TITLE
fix: make sure the address bar hides when scrolling on web

### DIFF
--- a/packages/drawer/src/views/Drawer.tsx
+++ b/packages/drawer/src/views/Drawer.tsx
@@ -731,6 +731,11 @@ const styles = StyleSheet.create({
   },
   main: {
     flex: 1,
-    overflow: 'hidden',
+    ...Platform.select({
+      // FIXME: We need to hide `overflowX` on Web so the translated content doesn't show offscreen.
+      // But adding `overflowX: 'hidden'` prevents content from collapsing the URL bar.
+      web: null,
+      default: { overflow: 'hidden' },
+    }),
   },
 });

--- a/packages/drawer/src/views/ResourceSavingScene.tsx
+++ b/packages/drawer/src/views/ResourceSavingScene.tsx
@@ -29,7 +29,7 @@ export default class ResourceSavingScene extends React.Component<Props> {
           styles.container,
           Platform.OS === 'web'
             ? { display: isVisible ? 'flex' : 'none' }
-            : null,
+            : { overflow: 'hidden' },
           style,
         ]}
         collapsable={false}
@@ -52,7 +52,6 @@ export default class ResourceSavingScene extends React.Component<Props> {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    overflow: 'hidden',
   },
   attached: {
     flex: 1,

--- a/packages/stack/src/views/Stack/Card.tsx
+++ b/packages/stack/src/views/Stack/Card.tsx
@@ -12,6 +12,7 @@ import {
 import { EdgeInsets } from 'react-native-safe-area-context';
 import Color from 'color';
 
+import CardSheet from './CardSheet';
 import {
   PanGestureHandler,
   GestureState,
@@ -36,6 +37,7 @@ type Props = ViewProps & {
   gesture: Animated.Value;
   layout: Layout;
   insets: EdgeInsets;
+  pageOverflowEnabled: boolean;
   gestureDirection: GestureDirection;
   onOpen: () => void;
   onClose: () => void;
@@ -428,6 +430,7 @@ export default class Card extends React.Component<Props> {
       shadowEnabled,
       gestureEnabled,
       gestureDirection,
+      pageOverflowEnabled,
       children,
       containerStyle: customContainerStyle,
       contentStyle,
@@ -520,12 +523,14 @@ export default class Card extends React.Component<Props> {
                     pointerEvents="none"
                   />
                 ) : null}
-                <View
+                <CardSheet
                   ref={this.contentRef}
-                  style={[styles.content, contentStyle]}
+                  enabled={pageOverflowEnabled}
+                  layout={layout}
+                  style={contentStyle}
                 >
                   {children}
-                </View>
+                </CardSheet>
               </Animated.View>
             </PanGestureHandler>
           </Animated.View>
@@ -538,10 +543,6 @@ export default class Card extends React.Component<Props> {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-  },
-  content: {
-    flex: 1,
-    overflow: 'hidden',
   },
   overlay: {
     flex: 1,

--- a/packages/stack/src/views/Stack/CardContainer.tsx
+++ b/packages/stack/src/views/Stack/CardContainer.tsx
@@ -4,7 +4,13 @@ import { Route, useTheme } from '@react-navigation/native';
 import { Props as HeaderContainerProps } from '../Header/HeaderContainer';
 import Card from './Card';
 import HeaderHeightContext from '../../utils/HeaderHeightContext';
-import { Scene, Layout, StackHeaderMode, TransitionPreset } from '../../types';
+import {
+  Scene,
+  Layout,
+  StackHeaderMode,
+  StackCardMode,
+  TransitionPreset,
+} from '../../types';
 
 type Props = TransitionPreset & {
   index: number;
@@ -45,6 +51,7 @@ type Props = TransitionPreset & {
     horizontal?: number;
   };
   gestureVelocityImpact?: number;
+  mode: StackCardMode;
   headerMode: StackHeaderMode;
   headerShown?: boolean;
   headerTransparent?: boolean;
@@ -73,6 +80,7 @@ function CardContainer({
   gestureVelocityImpact,
   getPreviousRoute,
   getFocusedRoute,
+  mode,
   headerMode,
   headerShown,
   headerStyleInterpolator,
@@ -178,6 +186,7 @@ function CardContainer({
       accessibilityElementsHidden={!focused}
       importantForAccessibility={focused ? 'auto' : 'no-hide-descendants'}
       pointerEvents={active ? 'box-none' : pointerEvents}
+      pageOverflowEnabled={headerMode === 'screen' && mode === 'card'}
       containerStyle={
         headerMode === 'float' && !headerTransparent && headerShown !== false
           ? { marginTop: headerHeight }

--- a/packages/stack/src/views/Stack/CardSheet.tsx
+++ b/packages/stack/src/views/Stack/CardSheet.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+import { View, ViewProps, StyleSheet } from 'react-native';
+
+type Props = ViewProps & {
+  enabled: boolean;
+  layout: { width: number; height: number };
+  children: React.ReactNode;
+};
+
+// This component will render a page which overflows the screen
+// if the container fills the body by comparing the size
+// This lets the document.body handle scrolling of the content
+// It's necessary for mobile browsers to be able to hide address bar on scroll
+export default React.forwardRef<View, Props>(function CardSheet(
+  { enabled, layout, style, ...rest },
+  ref
+) {
+  const [fill, setFill] = React.useState(false);
+
+  React.useEffect(() => {
+    if (typeof document === 'undefined' || !document.body) {
+      // Only run when DOM is available
+      return;
+    }
+
+    const width = document.body.clientWidth;
+    const height = document.body.clientHeight;
+
+    setFill(width === layout.width && height === layout.height);
+  }, [layout.height, layout.width]);
+
+  return (
+    <View
+      {...rest}
+      ref={ref}
+      style={[enabled && fill ? styles.page : styles.card, style]}
+    />
+  );
+});
+
+const styles = StyleSheet.create({
+  page: {
+    minHeight: '100%',
+  },
+  card: {
+    flex: 1,
+    overflow: 'hidden',
+  },
+});

--- a/packages/stack/src/views/Stack/CardStack.tsx
+++ b/packages/stack/src/views/Stack/CardStack.tsx
@@ -519,6 +519,7 @@ export default class CardStack extends React.Component<Props, State> {
                   onHeaderHeightChange={this.handleHeaderLayout}
                   getPreviousRoute={getPreviousRoute}
                   getFocusedRoute={this.getFocusedRoute}
+                  mode={mode}
                   headerMode={headerMode}
                   headerShown={headerShown}
                   headerTransparent={headerTransparent}
@@ -564,7 +565,6 @@ export default class CardStack extends React.Component<Props, State> {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    overflow: 'hidden',
   },
   floating: {
     position: 'absolute',

--- a/packages/stack/src/views/Stack/StackView.tsx
+++ b/packages/stack/src/views/Stack/StackView.tsx
@@ -420,7 +420,7 @@ export default class StackView extends React.Component<Props, State> {
     } = this.state;
 
     const headerMode =
-      mode !== 'modal' && Platform.OS === 'ios' ? 'float' : 'screen';
+      mode === 'card' && Platform.OS === 'ios' ? 'float' : 'screen';
 
     return (
       <NavigationHelpersContext.Provider value={navigation}>


### PR DESCRIPTION
This commit adds a check to detect if the screen content fills the available body, and if yes, then it adjusts the styles so that scrolling triggers a scroll on the body which hides the address bar in browser.

Tested on Safari in iOS and Chrome on Android.

This behavior can be overridden by the user by specifying `cardStyle: { flex: 1 }`, which will keep both the header and the address bar always visible.

![ezgif-5-124613a47508](https://user-images.githubusercontent.com/1174278/80727690-4f04ca00-8b06-11ea-9672-83fdccea81f7.gif)
