### PR TITLE
feat: add iconStyle prop to bottom tab bar options

### DIFF
--- a/packages/bottom-tabs/src/types.tsx
+++ b/packages/bottom-tabs/src/types.tsx
@@ -163,6 +163,10 @@ export type BottomTabBarOptions = {
    */
   labelStyle?: StyleProp<TextStyle>;
   /**
+   * Style object for the tab icon.
+   */
+  iconStyle?: StyleProp<TextStyle>;
+  /**
    * Style object for the tab container.
    */
   tabStyle?: StyleProp<ViewStyle>;

--- a/packages/bottom-tabs/src/views/BottomTabBar.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabBar.tsx
@@ -44,6 +44,7 @@ export default function BottomTabBar({
   keyboardHidesTabBar = false,
   labelPosition,
   labelStyle,
+  iconStyle,
   safeAreaInsets,
   showIcon,
   showLabel,
@@ -275,6 +276,7 @@ export default function BottomTabBar({
                   showIcon={showIcon}
                   showLabel={showLabel}
                   labelStyle={labelStyle}
+                  iconStyle={iconStyle}
                   style={tabStyle}
                 />
               </NavigationRouteContext.Provider>

--- a/packages/bottom-tabs/src/views/BottomTabItem.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabItem.tsx
@@ -105,7 +105,7 @@ type Props = {
   /**
    * Style object for the icon element.
    */
-  iconStyle?: StyleProp<TextStyle>;
+  iconStyle?: StyleProp<ViewStyle>;
   /**
    * Style object for the wrapper element.
    */

--- a/packages/bottom-tabs/src/views/BottomTabItem.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabItem.tsx
@@ -103,6 +103,10 @@ type Props = {
    */
   labelStyle?: StyleProp<TextStyle>;
   /**
+   * Style object for the icon element.
+   */
+  iconStyle?: StyleProp<TextStyle>;
+  /**
    * Style object for the wrapper element.
    */
   style?: StyleProp<ViewStyle>;
@@ -168,6 +172,7 @@ export default function BottomTabBarItem({
   showIcon = true,
   allowFontScaling,
   labelStyle,
+  iconStyle,
   style,
 }: Props) {
   const { colors } = useTheme();
@@ -230,7 +235,10 @@ export default function BottomTabBarItem({
         activeTintColor={activeTintColor}
         inactiveTintColor={inactiveTintColor}
         renderIcon={icon}
-        style={horizontal ? styles.iconHorizontal : styles.iconVertical}
+        style={[
+          horizontal ? styles.iconHorizontal : styles.iconVertical,
+          iconStyle,
+        ]}
       />
     );
   };


### PR DESCRIPTION
Currently, if I make the bottom bar higher it'll expand the icon height and keep the label at the bottom and there's [no way to customize that](https://github.com/gfpacheco/react-navigation/blob/master/packages/bottom-tabs/src/views/BottomTabItem.tsx#L233) aside from replacing the whole tabBar component because BottomTabItem doesn't take an `iconStyle` prop.

This PR addresses that by creating a `iconStyle` option. That way I can set `flex: 0` and have both icon and label vertically centered in my tall bar.

Other options like adding bottom margin or negative top to the labels don't seem right to me.

Please let me know if that's something you'd want on your library or if I need to make any changes.