### PR TITLE
fix: return a promise-like from getInitialState

### DIFF
--- a/packages/native/src/useLinking.tsx
+++ b/packages/native/src/useLinking.tsx
@@ -95,18 +95,17 @@ export default function useLinking(
       }
     }
 
-    const then = (callback: (state: ResultState | undefined) => void) =>
-      Promise.resolve(callback(value));
-
     // Make it a thenable to keep consistent with the native impl
     const thenable = {
-      then,
+      then(onfulfilled?: (state: ResultState | undefined) => void) {
+        return Promise.resolve(onfulfilled ? onfulfilled(value) : value);
+      },
       catch() {
         return thenable;
       },
     };
 
-    return thenable;
+    return thenable as PromiseLike<ResultState | undefined>;
   }, []);
 
   const previousStateLengthRef = React.useRef<number | undefined>(undefined);

--- a/packages/native/src/useThenable.tsx
+++ b/packages/native/src/useThenable.tsx
@@ -1,8 +1,6 @@
 import * as React from 'react';
 
-type Thenable<T> = { then(cb: (result: T) => void): void };
-
-export default function useThenable<T>(create: () => Thenable<T>) {
+export default function useThenable<T>(create: () => PromiseLike<T>) {
   const [promise] = React.useState(create);
 
   // Check if our thenable is synchronous


### PR DESCRIPTION
Before this change, the typings for `getInitialState` got very... _interesting_ 😁 

```ts
export default function useLinking(ref: React.RefObject<NavigationContainerRef>, { enabled, config, getStateFromPath, getPathFromState, }: LinkingOptions): {
    getInitialState: () => {
        then: (callback: (state: (Partial<Pick<NavigationState, "index" | "history">> & {
            stale?: true | undefined;
            type?: string | undefined;
            routes: (Pick<import("@react-navigation/core").Route<string>, "name" | "params"> & {
                key?: string | undefined;
                state?: import("@react-navigation/core").InitialState | undefined;
            })[];
        } & {
            state?: (Partial<Pick<NavigationState, "index" | "history">> & {
                stale?: true | undefined;
                type?: string | undefined;
                routes: (Pick<import("@react-navigation/core").Route<string>, "name" | "params"> & {
                    key?: string | undefined;
                    state?: import("@react-navigation/core").InitialState | undefined;
                })[];
            } & any) | undefined;
        }) | undefined) => void) => Promise<void>;
        catch(): any;
    };
};
```

This led to a lot of errors when trying to use it as a promise:

<img width="321" alt="Screenshot 2020-05-07 at 18 19 55" src="https://user-images.githubusercontent.com/189580/81324775-5b9d9b00-908f-11ea-8321-e86c45e86396.png">

<img width="425" alt="Screenshot 2020-05-07 at 18 21 07" src="https://user-images.githubusercontent.com/189580/81324893-87208580-908f-11ea-9850-bd31470883dd.png">

-----

This patch changes the return to simply return `Promise<ResultState | undefined>`, instead of a custom thenable.
