### PR TITLE
fix: focus/blur events emitted with slight delay

### DIFF
--- a/packages/core/src/useFocusEvents.tsx
+++ b/packages/core/src/useFocusEvents.tsx
@@ -37,7 +37,7 @@ export default function useFocusEvents({ state, emitter }: Options) {
     [currentFocusedKey, emitter, navigation]
   );
 
-  React.useEffect(() => {
+  React.useLayoutEffect(() => {
     const lastFocusedKey = lastFocusedKeyRef.current;
 
     lastFocusedKeyRef.current = currentFocusedKey;


### PR DESCRIPTION
## Why

The lifecycle ‘focus’ and ‘blur’ events are called with a slight delay and in the next animation-frame on react-native; and after the DOM is updated on web.

This causes problems with applications which want to use the underlying animated-value upon receiving focus of a screen, such as shared-element transitions.

## How

This fix solves that by running the event-emitter code directly after the mutations have been applied using `useLayoutEffect`.

## Test plan

```jsx
class TestScreen extends React.Component {
  componentDidMount() {
    const { navigation } = this.props;
    console.log('componentDidMount');
    navigation.addListener("transitionStart", () => console.log('navigation.transitionStart'));
    navigation.addListener("focus", () => console.log('navigation.focus'));
  }

  ...
}
```

### Before

![image](https://user-images.githubusercontent.com/6184593/81472199-be5d7680-91f6-11ea-983f-32340c279be4.png)

### After

![image](https://user-images.githubusercontent.com/6184593/81472180-8eae6e80-91f6-11ea-85a5-53580b02a594.png)

## Shared element transitions

This fixes intial jank witnessed when performing a shared-element transition using react-navigation 5

### Before

> Sometimes a jank is witnessed because the navigator slide animation has already progressed, but before the focus/blur events have been emitted.

![useEffect](https://user-images.githubusercontent.com/6184593/81472357-e1d4f100-91f7-11ea-8e34-99ff1bc0134a.gif)

### After

> No more janks

![useLayoutEffect](https://user-images.githubusercontent.com/6184593/81472359-e4374b00-91f7-11ea-8f3d-aa97e914c6b6.gif)
