### PR TITLE
feat: Theme types add custom key

### DIFF
--- a/packages/native/src/types.tsx
+++ b/packages/native/src/types.tsx
@@ -11,6 +11,7 @@ export type Theme = {
     card: string;
     text: string;
     border: string;
+    [key: string]: string;
   };
 };
 


### PR DESCRIPTION
```js
const MyTheme = {
  ...DefaultTheme,
  colors: {
    ...DefaultTheme.colors,
    headerTintColor: '#fff',// custom
    primary: '#FF2D55',
  },
};

 const { colors } = useTheme();
```