### PR TITLE
Work around bug in getInitialURL on Expo SDK <= 37

### DIFF
--- a/packages/native/src/useLinking.native.tsx
+++ b/packages/native/src/useLinking.native.tsx
@@ -71,7 +71,7 @@ export default function useLinking(
       return undefined;
     }
 
-    const url = await (Promise.race([
+    let url = await (Promise.race([
       Linking.getInitialURL(),
       new Promise((resolve) =>
         // Timeout in 150ms if `getInitialState` doesn't resolve
@@ -79,6 +79,10 @@ export default function useLinking(
         setTimeout(resolve, 150)
       ),
     ]) as Promise<string | null | undefined>);
+
+    // Expo versions <= 37 has a bug that sends "exps" instead of "https" when a universal link launches the app
+    // https://github.com/expo/expo/issues/6609
+    url = url?.replace(/^exps:\/\//, 'https://');
 
     const path = url ? extractPathFromURL(url) : null;
 


### PR DESCRIPTION
This adds a workaround for the current version of Expo, that sends the wrong scheme when opening a universal link.

Issue on Expo: https://github.com/expo/expo/issues/6609
Merged PR w/ fix: https://github.com/expo/expo/pull/7508

`Linking.addEventListener('url', ...)` is not affected by this bug.

I don't know what the "policy" is on working around bugs in others code is here 😅 But it would much appreciated as it's quite inconvenient to work around in your own app, since you cannot use `<NavigationContainer linking={...} />` if you want to get between the call to `getInitialUrl` and the dispatch navigation action.