### PR TITLE
feat: merge path patterns for nested screens

### DIFF
--- a/packages/core/src/__tests__/getPathFromState.test.tsx
+++ b/packages/core/src/__tests__/getPathFromState.test.tsx
@@ -122,7 +122,10 @@ it('handles state with config with nested screens', () => {
     Foo: {
       path: 'foo',
       screens: {
-        Foe: 'foe',
+        Foe: {
+          path: 'foe',
+          exact: true,
+        },
       },
     },
     Bar: 'bar/:type/:fruit',
@@ -188,7 +191,10 @@ it('handles state with config with nested screens and unused configs', () => {
     Foo: {
       path: 'foo',
       screens: {
-        Foe: 'foe',
+        Foe: {
+          path: 'foe',
+          exact: true,
+        },
       },
     },
     Baz: {
@@ -252,7 +258,6 @@ it('handles nested object with stringify in it', () => {
     },
     Bar: 'bar/:type/:fruit',
     Baz: {
-      path: 'baz',
       screens: {
         Bos: 'bos',
         Bis: {
@@ -322,7 +327,10 @@ it('handles nested object for second route depth', () => {
         Bar: {
           path: 'bar',
           screens: {
-            Baz: 'baz',
+            Baz: {
+              path: 'baz',
+              exact: true,
+            },
           },
         },
       },
@@ -370,7 +378,10 @@ it('handles nested object for second route depth and and path and stringify in r
             id: Number,
           },
           screens: {
-            Baz: 'baz',
+            Baz: {
+              path: 'baz',
+              exact: true,
+            },
           },
         },
       },
@@ -470,7 +481,7 @@ it('keeps query params if path is empty', () => {
 });
 
 it('cuts nested configs too', () => {
-  const path = '/baz';
+  const path = '/foo/baz';
   const config = {
     Foo: {
       path: 'foo',
@@ -478,7 +489,9 @@ it('cuts nested configs too', () => {
         Bar: '',
       },
     },
-    Baz: { path: 'baz' },
+    Baz: {
+      path: 'baz',
+    },
   };
 
   const state = {
@@ -504,7 +517,7 @@ it('cuts nested configs too', () => {
 });
 
 it('handles empty path at the end', () => {
-  const path = '/bar';
+  const path = '/foo/bar';
   const config = {
     Foo: {
       path: 'foo',
@@ -641,7 +654,6 @@ it('strips undefined query params', () => {
     },
     Bar: 'bar/:type/:fruit',
     Baz: {
-      path: 'baz',
       screens: {
         Bos: 'bos',
         Bis: {
@@ -714,7 +726,6 @@ it('handles stripping all query params', () => {
     },
     Bar: 'bar/:type/:fruit',
     Baz: {
-      path: 'baz',
       screens: {
         Bos: 'bos',
         Bis: {
@@ -753,9 +764,6 @@ it('handles stripping all query params', () => {
                           name: 'Bis',
                           params: {
                             author: 'Jane',
-                            count: undefined,
-                            answer: undefined,
-                            valid: undefined,
                           },
                         },
                       ],

--- a/packages/core/src/__tests__/getStateFromPath.test.tsx
+++ b/packages/core/src/__tests__/getStateFromPath.test.tsx
@@ -147,7 +147,10 @@ it('converts path string to initial state with config with nested screens', () =
     Foo: {
       path: 'foo',
       screens: {
-        Foe: 'foe',
+        Foe: {
+          path: 'foe',
+          exact: true,
+        },
       },
     },
     Bar: 'bar/:type/:fruit',
@@ -213,7 +216,10 @@ it('converts path string to initial state with config with nested screens and un
     Foo: {
       path: 'foo',
       screens: {
-        Foe: 'foe',
+        Foe: {
+          path: 'foe',
+          exact: true,
+        },
       },
     },
     Baz: {
@@ -268,16 +274,23 @@ it('handles nested object with unused configs and with parse in it', () => {
     Foo: {
       path: 'foo',
       screens: {
-        Foe: 'foe',
+        Foe: {
+          path: 'foe',
+          exact: true,
+        },
       },
     },
     Bar: 'bar/:type/:fruit',
     Baz: {
       path: 'baz',
       screens: {
-        Bos: 'bos',
+        Bos: {
+          path: 'bos',
+          exact: true,
+        },
         Bis: {
           path: 'bis/:author',
+          exact: true,
           stringify: {
             author: (author: string) =>
               author.replace(/^\w/, (c) => c.toLowerCase()),
@@ -348,11 +361,18 @@ it('handles parse in nested object for second route depth', () => {
     Foo: {
       path: 'foo',
       screens: {
-        Foe: 'foe',
+        Foe: {
+          path: 'foe',
+          exact: true,
+        },
         Bar: {
           path: 'bar',
+          exact: true,
           screens: {
-            Baz: 'baz',
+            Baz: {
+              path: 'baz',
+              exact: true,
+            },
           },
         },
       },
@@ -519,16 +539,23 @@ it('handles two initialRouteNames', () => {
     Foo: {
       path: 'foo',
       screens: {
-        Foe: 'foe',
+        Foe: {
+          path: 'foe',
+          exact: true,
+        },
       },
     },
     Bar: 'bar/:type/:fruit',
     Baz: {
       initialRouteName: 'Bos',
       screens: {
-        Bos: 'bos',
+        Bos: {
+          path: 'bos',
+          exact: true,
+        },
         Bis: {
           path: 'bis/:author',
+          exact: true,
           stringify: {
             author: (author: string) =>
               author.replace(/^\w/, (c) => c.toLowerCase()),
@@ -601,16 +628,23 @@ it('accepts initialRouteName without config for it', () => {
     Foo: {
       path: 'foo',
       screens: {
-        Foe: 'foe',
+        Foe: {
+          path: 'foe',
+          exact: true,
+        },
       },
     },
     Bar: 'bar/:type/:fruit',
     Baz: {
       initialRouteName: 'Bas',
       screens: {
-        Bos: 'bos',
+        Bos: {
+          path: 'bos',
+          exact: true,
+        },
         Bis: {
           path: 'bis/:author',
+          exact: true,
           stringify: {
             author: (author: string) =>
               author.replace(/^\w/, (c) => c.toLowerCase()),
@@ -1765,6 +1799,44 @@ it('handle optional params in the beginning v2', () => {
             {
               name: 'Bas',
               params: { nip: 5, pwd: 10, id: 15 },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getStateFromPath(path, config)).toEqual(state);
+  expect(getStateFromPath(getPathFromState(state, config), config)).toEqual(
+    state
+  );
+});
+
+it('merges parent patterns if needed', () => {
+  const path = 'foo/42/baz/babel';
+
+  const config = {
+    Foo: {
+      path: 'foo/:bar',
+      parse: {
+        bar: Number,
+      },
+      screens: {
+        Baz: 'baz/:qux',
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: 'Foo',
+        params: { bar: 42 },
+        state: {
+          routes: [
+            {
+              name: 'Baz',
+              params: { qux: 'babel' },
             },
           ],
         },

--- a/packages/core/src/getPathFromState.tsx
+++ b/packages/core/src/getPathFromState.tsx
@@ -9,15 +9,14 @@ type State = NavigationState | Omit<PartialState<NavigationState>, 'stale'>;
 
 type StringifyConfig = Record<string, (value: any) => string>;
 
-type Options = {
-  [routeName: string]:
-    | string
-    | {
-        path?: string;
-        stringify?: StringifyConfig;
-        screens?: Options;
-      };
+type OptionsItem = {
+  path?: string;
+  exact?: boolean;
+  stringify?: StringifyConfig;
+  screens?: Options;
 };
+
+type Options = Record<string, string | OptionsItem>;
 
 /**
  * Utility to serialize a navigation state object to a path string.
@@ -53,83 +52,82 @@ export default function getPathFromState(
   if (state === undefined) {
     throw Error('NavigationState not passed');
   }
-  let path = '/';
 
+  // Create a normalized configs array which will be easier to use
+  const configs: Record<string, ConfigItem> = Object.fromEntries(
+    Object.keys(options).map((screen) => [
+      screen,
+      createNormalizedConfig(options[screen]),
+    ])
+  );
+
+  let path = '/';
   let current: State | undefined = state;
+
+  const allParams: Record<string, any> = {};
 
   while (current) {
     let index = typeof current.index === 'number' ? current.index : 0;
     let route = current.routes[index] as Route<string> & {
       state?: State;
     };
-    let currentOptions = options;
-    let pattern = route.name;
-    // we keep all the route names that appeared during going deeper in config in case the pattern is resolved to undefined
-    let nestedRouteNames = '';
 
-    while (route.name in currentOptions) {
-      if (typeof currentOptions[route.name] === 'string') {
-        pattern = currentOptions[route.name] as string;
-        break;
-      } else if (typeof currentOptions[route.name] === 'object') {
-        // if there is no `screens` property, we return pattern
-        if (
-          !(currentOptions[route.name] as {
-            screens: Options;
-          }).screens
-        ) {
-          pattern = (currentOptions[route.name] as { path: string }).path;
-          nestedRouteNames = `${nestedRouteNames}/${route.name}`;
-          break;
+    let pattern: string | undefined;
+
+    let currentParams: Record<string, any> = { ...route.params };
+    let currentOptions = configs;
+
+    // Keep all the route names that appeared during going deeper in config in case the pattern is resolved to undefined
+    let nestedRouteNames = [];
+
+    let hasNext = true;
+
+    while (route.name in currentOptions && hasNext) {
+      pattern = currentOptions[route.name].pattern;
+
+      nestedRouteNames.push(route.name);
+
+      if (route.params) {
+        const stringify = currentOptions[route.name]?.stringify;
+
+        currentParams = Object.fromEntries(
+          Object.entries(route.params).map(([key, value]) => [
+            key,
+            stringify?.[key] ? stringify[key](value) : String(value),
+          ])
+        );
+
+        if (pattern) {
+          Object.assign(allParams, currentParams);
+        }
+      }
+
+      // If there is no `screens` property or no nested state, we return pattern
+      if (!currentOptions[route.name].screens || route.state === undefined) {
+        hasNext = false;
+      } else {
+        index =
+          typeof route.state.index === 'number'
+            ? route.state.index
+            : route.state.routes.length - 1;
+
+        const nextRoute = route.state.routes[index];
+        const nestedConfig = currentOptions[route.name].screens;
+
+        // if there is config for next route name, we go deeper
+        if (nestedConfig && nextRoute.name in nestedConfig) {
+          route = nextRoute as Route<string> & { state?: State };
+          currentOptions = nestedConfig;
         } else {
-          // if it is the end of state, we return pattern
-          if (route.state === undefined) {
-            pattern = (currentOptions[route.name] as { path: string }).path;
-            nestedRouteNames = `${nestedRouteNames}/${route.name}`;
-            break;
-          } else {
-            index =
-              typeof route.state.index === 'number' ? route.state.index : 0;
-            const nextRoute = route.state.routes[index];
-            const deeperConfig = (currentOptions[route.name] as {
-              screens: Options;
-            }).screens;
-            // if there is config for next route name, we go deeper
-            if (nextRoute.name in deeperConfig) {
-              nestedRouteNames = `${nestedRouteNames}/${route.name}`;
-              route = nextRoute as Route<string> & { state?: State };
-              currentOptions = deeperConfig;
-            } else {
-              // if not, there is no sense in going deeper in config
-              pattern = (currentOptions[route.name] as { path: string }).path;
-              nestedRouteNames = `${nestedRouteNames}/${route.name}`;
-              break;
-            }
-          }
+          // If not, there is no sense in going deeper in config
+          hasNext = false;
         }
       }
     }
 
     if (pattern === undefined) {
-      // cut the first `/`
-      pattern = nestedRouteNames.substring(1);
+      pattern = nestedRouteNames.join('/');
     }
-
-    const config =
-      currentOptions[route.name] !== undefined
-        ? (currentOptions[route.name] as { stringify?: StringifyConfig })
-            .stringify
-        : undefined;
-
-    const params = route.params
-      ? // Stringify all of the param values before we use them
-        Object.entries(route.params).reduce<{
-          [key: string]: string;
-        }>((acc, [key, value]) => {
-          acc[key] = config?.[key] ? config[key](value) : String(value);
-          return acc;
-        }, {})
-      : undefined;
 
     if (currentOptions[route.name] !== undefined) {
       path += pattern
@@ -138,16 +136,21 @@ export default function getPathFromState(
           const name = p.replace(/^:/, '').replace(/\?$/, '');
 
           // If the path has a pattern for a param, put the param in the path
-          if (params && name in params && p.startsWith(':')) {
-            const value = params[name];
+          if (name in allParams && p.startsWith(':')) {
+            const value = allParams[name];
+
             // Remove the used value from the params object since we'll use the rest for query string
-            // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
-            delete params[name];
+            if (currentParams) {
+              // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+              delete currentParams[name];
+            }
+
             return encodeURIComponent(value);
           } else if (p.endsWith('?')) {
-            // optional params without value assigned in route.params should be ignored
+            // Optional params without value assigned in route.params should be ignored
             return '';
           }
+
           return encodeURIComponent(p);
         })
         .join('/');
@@ -157,14 +160,15 @@ export default function getPathFromState(
 
     if (route.state) {
       path += '/';
-    } else if (params) {
-      for (let param in params) {
-        if (params[param] === 'undefined') {
+    } else if (currentParams) {
+      for (let param in currentParams) {
+        if (currentParams[param] === 'undefined') {
           // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
-          delete params[param];
+          delete currentParams[param];
         }
       }
-      const query = queryString.stringify(params);
+
+      const query = queryString.stringify(currentParams);
 
       if (query) {
         path += `?${query}`;
@@ -179,4 +183,53 @@ export default function getPathFromState(
   path = path.length > 1 ? path.replace(/\/$/, '') : path;
 
   return path;
+}
+
+type ConfigItem = {
+  pattern?: string;
+  stringify?: StringifyConfig;
+  screens?: Record<string, ConfigItem>;
+};
+
+function joinPaths(...paths: string[]): string {
+  return paths
+    .map((p) => p.split('/'))
+    .flat()
+    .filter(Boolean)
+    .join('/');
+}
+
+function createNormalizedConfig(
+  config: OptionsItem | string,
+  parentPattern?: string
+): ConfigItem {
+  if (typeof config === 'string') {
+    // If a string is specified as the value of the key(e.g. Foo: '/path'), use it as the pattern
+    const pattern = parentPattern ? joinPaths(parentPattern, config) : config;
+
+    return { pattern };
+  }
+
+  // If an object is specified as the value (e.g. Foo: { ... }),
+  // It can have `path` property and `screens` prop which has nested configs
+  const pattern =
+    config.exact !== true && parentPattern && config.path
+      ? joinPaths(parentPattern, config.path)
+      : config.path;
+
+  const screens = config.screens
+    ? Object.fromEntries(
+        Object.entries(config.screens).map(([name, c]) => {
+          const result = createNormalizedConfig(c, pattern);
+
+          return [name, result];
+        })
+      )
+    : undefined;
+
+  return {
+    pattern,
+    stringify: config.stringify,
+    screens,
+  };
 }


### PR DESCRIPTION
Currently, when we define `path` patterns in the linking config, they ignore the parent screen's `path` when parsing, for example, say we have this config:

```js
{
  Home: {
    path: 'home',
    screens: {
      Profile: 'u/:id',
    },
  },
}
```

If we parse the URL `/home`, we'll get this state:

```js
{
  routes: [{ name: 'Home' }],
}
```

If we parse the URL `/home/u/cal`, we'll get this state:

```js
{
  routes: [
    {
      name: 'Home',
      state: {
        routes: [
          {
            name: 'Home',
            state: {
              routes: [
                {
                  name: 'Profile',
                  params: { id: 'cal' },
                },
              ],
            },
          },
        ],
      },
    },
  ],
}
```

Note how we have 2 `Home` screens nested inside each other. This is not something people usually expect and it seems to trip up a lot of people. Something like following will be more intuitive:

```js
{
  routes: [
    {
      name: 'Home',
      state: {
        routes: [
          {
            name: 'Profile',
            params: { id: 'cal' },
          },
        ],
      },
    },
  ],
}
```

Essentially, we're treating patterns as relative to their parent rather than matching the `exact` segments. This PR changes the behavior of parsing links to treat configs like so. I hope it'll be easier to understand for people.

There is also a new option, `exact`, which brings back the olde behavior of matching the exact pattern:

```js
{
  Home: {
    path: 'home',
    screens: {
      Profile: {
        path: 'u/:id',
        exact: true,
      },
    },
  },
}
```

Which will be useful if `home` is not in the URL, e.g. `/u/cal`.

This change only affects situations where both parent and child screen configuration have a pattern defined. If the parent didn't have a pattern defined, nothing changes from previous behavior:

```js
{
  Home: {
    screens: {
      Profile: {
        path: 'u/:id',
      },
    },
  },
}
```