### PR TITLE
refactor: memoize initializedState in useNavigationBuilder

### DIFF
--- a/packages/core/src/useNavigationBuilder.tsx
+++ b/packages/core/src/useNavigationBuilder.tsx
@@ -264,38 +264,36 @@ export default function useNavigationBuilder<
     getKey,
   } = React.useContext(NavigationStateContext);
 
-  const previousStateRef = React.useRef<
-    NavigationState | PartialState<NavigationState> | undefined
-  >();
-  const initializedStateRef = React.useRef<State>();
-
-  let isFirstStateInitialization = false;
-
-  if (
-    initializedStateRef.current === undefined ||
-    currentState !== previousStateRef.current
-  ) {
+  const [initializedState, isFirstStateInitialization] = React.useMemo(() => {
     // If the current state isn't initialized on first render, we initialize it
     // We also need to re-initialize it if the state passed from parent was changed (maybe due to reset)
     // Otherwise assume that the state was provided as initial state
     // So we need to rehydrate it to make it usable
     if (currentState === undefined || !isStateValid(currentState)) {
-      isFirstStateInitialization = true;
-      initializedStateRef.current = router.getInitialState({
-        routeNames,
-        routeParamList,
-      });
-    } else {
-      initializedStateRef.current = router.getRehydratedState(
-        currentState as PartialState<State>,
-        {
+      return [
+        router.getInitialState({
           routeNames,
           routeParamList,
-        }
-      );
+        }),
+        true,
+      ];
+    } else {
+      return [
+        router.getRehydratedState(currentState as PartialState<State>, {
+          routeNames,
+          routeParamList,
+        }),
+        false,
+      ];
     }
-  }
-  previousStateRef.current = currentState;
+    // We explicitly don't include routeNames/routeParamList in the dep list
+    // below. We want to avoid forcing a new state to be calculated in cases
+    // where routeConfigs change without affecting routeNames/routeParamList.
+    // Instead, we handle changes to these in the nextState code below. Note
+    // that some changes to routeConfigs are explicitly ignored, such as changes
+    // to initialParams
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentState, router, isStateValid]);
 
   let state =
     // If the state isn't initialized, or stale, use the state we initialized instead
@@ -303,7 +301,7 @@ export default function useNavigationBuilder<
     // So it'll be `undefined` or stale untill the first navigation event happens
     isStateInitialized(currentState)
       ? (currentState as State)
-      : (initializedStateRef.current as State);
+      : (initializedState as State);
 
   let nextState: State = state;
 
@@ -370,6 +368,12 @@ export default function useNavigationBuilder<
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // We initialize this ref here to avoid a new getState getting initialized
+  // whenever initializedState changes. We want getState to have access to the
+  // latest initializedState, but don't need it to change when that happens
+  const initializedStateRef = React.useRef<State>();
+  initializedStateRef.current = initializedState;
 
   const getState = React.useCallback((): State => {
     const currentState = getCurrentState();

--- a/packages/core/src/useNavigationBuilder.tsx
+++ b/packages/core/src/useNavigationBuilder.tsx
@@ -295,10 +295,7 @@ export default function useNavigationBuilder<
       );
     }
   }
-
-  React.useEffect(() => {
-    previousStateRef.current = currentState;
-  }, [currentState]);
+  previousStateRef.current = currentState;
 
   let state =
     // If the state isn't initialized, or stale, use the state we initialized instead


### PR DESCRIPTION
The current code can lead to an infinite render loop if a custom navigator implemented as a hook calls `setState` directly in its body.

This owes to a rather quirky edge case of how hooks work. The [recommended pattern](https://reactjs.org/docs/hooks-faq.html#how-do-i-implement-getderivedstatefromprops) for implementing derived data for a transitioner component implemented as a hook is to call `setState` directly within the body. When you do this, React will immediately rerender the component, *without calling any effects*.

This means that if a custom navigator calls `setState` within its body, `previousStateRef` will not get updated between the subsequent renders. This forces a new call to `router.getRehydratedState` every time, delivering a new state object. The custom navigator sees the new state and calls `setState` again to update it internal derived data, leading to the infinite loop.

As a more general comment - in the case of a `prev` ref initialized to do a comparison, it's safest to update it immediately after the comparison occurs.