### PR TITLE
chore: ignore __tests__ in prod builds

### DIFF
--- a/packages/bottom-tabs/package.json
+++ b/packages/bottom-tabs/package.json
@@ -20,7 +20,8 @@
   "types": "lib/typescript/src/index.d.ts",
   "files": [
     "src",
-    "lib"
+    "lib",
+    "!**/__tests__"
   ],
   "sideEffects": false,
   "publishConfig": {

--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -15,7 +15,8 @@
   "types": "lib/typescript/src/index.d.ts",
   "files": [
     "src",
-    "lib"
+    "lib",
+    "!**/__tests__"
   ],
   "sideEffects": false,
   "publishConfig": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,7 +20,8 @@
   "types": "lib/typescript/src/index.d.ts",
   "files": [
     "src",
-    "lib"
+    "lib",
+    "!**/__tests__"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/drawer/package.json
+++ b/packages/drawer/package.json
@@ -25,7 +25,8 @@
   "types": "lib/typescript/src/index.d.ts",
   "files": [
     "src",
-    "lib"
+    "lib",
+    "!**/__tests__"
   ],
   "sideEffects": false,
   "publishConfig": {

--- a/packages/material-bottom-tabs/package.json
+++ b/packages/material-bottom-tabs/package.json
@@ -25,7 +25,8 @@
   "types": "lib/typescript/src/index.d.ts",
   "files": [
     "src",
-    "lib"
+    "lib",
+    "!**/__tests__"
   ],
   "sideEffects": false,
   "publishConfig": {

--- a/packages/material-top-tabs/package.json
+++ b/packages/material-top-tabs/package.json
@@ -25,7 +25,8 @@
   "types": "lib/typescript/src/index.d.ts",
   "files": [
     "src",
-    "lib"
+    "lib",
+    "!**/__tests__"
   ],
   "sideEffects": false,
   "publishConfig": {

--- a/packages/native/package.json
+++ b/packages/native/package.json
@@ -21,7 +21,8 @@
   "types": "lib/typescript/src/index.d.ts",
   "files": [
     "src",
-    "lib"
+    "lib",
+    "!**/__tests__"
   ],
   "sideEffects": false,
   "publishConfig": {

--- a/packages/routers/package.json
+++ b/packages/routers/package.json
@@ -20,7 +20,8 @@
   "types": "lib/typescript/src/index.d.ts",
   "files": [
     "src",
-    "lib"
+    "lib",
+    "!**/__tests__"
   ],
   "sideEffects": false,
   "publishConfig": {

--- a/packages/stack/package.json
+++ b/packages/stack/package.json
@@ -24,7 +24,8 @@
   "types": "lib/typescript/src/index.d.ts",
   "files": [
     "src",
-    "lib"
+    "lib",
+    "!**/__tests__"
   ],
   "sideEffects": false,
   "publishConfig": {


### PR DESCRIPTION
The tests are being bundled and shipped in prod, this adds a bit of unneeded weight to npm installs. Now they won't be included.

```
@react-navigation/core
- before: 274 files - pkg: 211.0 kB - unpkg: 1 MB
- after: 238 files - pkg: 192.1 kB - unpkg: 827.3 kB
```

Opened a similar PR upstream as well https://github.com/react-native-community/bob/pull/50