### PR TITLE
fix: wrong use of `type` keyword for exported stack types

### DIFF
--- a/packages/stack/src/index.tsx
+++ b/packages/stack/src/index.tsx
@@ -48,7 +48,7 @@ export { default as useGestureHandlerRef } from './utils/useGestureHandlerRef';
 /**
  * Types
  */
-export type {
+export {
   StackNavigationOptions,
   StackNavigationProp,
   StackScreenProps,


### PR DESCRIPTION
When exporting types in TypeScript the keyword `type` should not be used.