### PR TITLE
Revert "fix: allow HeaderBackground's subViews to be touchable"

### DIFF
--- a/packages/stack/src/views/Header/HeaderSegment.tsx
+++ b/packages/stack/src/views/Header/HeaderSegment.tsx
@@ -312,7 +312,7 @@ export default class HeaderSegment extends React.Component<Props, State> {
     return (
       <React.Fragment>
         <Animated.View
-          pointerEvents="box-none"
+          pointerEvents="none"
           style={[StyleSheet.absoluteFill, backgroundStyle]}
         >
           {headerBackground ? (


### PR DESCRIPTION
Reverts react-navigation/react-navigation#8314