### PR TITLE
fix: allow HeaderBackground's subViews to be touchable

### DIFF
--- a/packages/stack/src/views/Header/HeaderSegment.tsx
+++ b/packages/stack/src/views/Header/HeaderSegment.tsx
@@ -313,7 +313,7 @@ export default class HeaderSegment extends React.Component<Props, State> {
       <React.Fragment>
         <Animated.View
           pointerEvents="box-none"
-          style={[StyleSheet.absoluteFill, backgroundStyle, { zIndex: 0 }]}
+          style={[StyleSheet.absoluteFill, { zIndex: 0 }, backgroundStyle]}
         >
           {headerBackground ? (
             headerBackground({ style: safeStyles })

--- a/packages/stack/src/views/Header/HeaderSegment.tsx
+++ b/packages/stack/src/views/Header/HeaderSegment.tsx
@@ -312,8 +312,8 @@ export default class HeaderSegment extends React.Component<Props, State> {
     return (
       <React.Fragment>
         <Animated.View
-          pointerEvents="none"
-          style={[StyleSheet.absoluteFill, backgroundStyle]}
+          pointerEvents="box-none"
+          style={[StyleSheet.absoluteFill, backgroundStyle, { zIndex: 0 }]}
         >
           {headerBackground ? (
             headerBackground({ style: safeStyles })


### PR DESCRIPTION
This was merged https://github.com/react-navigation/react-navigation/pull/8314 but reverted because it made Android header disappear. 

After some tests, the problem was `elevation: 4` on `HeaderBackground` component, which is likely making a problem when you use `absolute + elevation + pointerEvent: everything else except "none"`. If I remove `elevation: 4`, the header is ok. 
It seems to be an old bug of RN Android. I found several similar issues.
- https://github.com/facebook/react-native/issues/19894
- https://github.com/facebook/react-native/issues/27548 
- https://react-native.canny.io/feature-requests/p/zindex--positionabsolute-breaks-with-dynamic-components-on-android
- https://github.com/react-native-community/react-native-linear-gradient/issues/370

#### Solution
And adding `zIndex: 0` without deleting `elevation: 4` did a trick.

### Original issue
When you're using the following options on `Stack`, the touch event goes to the behind of the Header and we can't really solve this problem in given `headerBackground` component level.
```
 options={{
          headerTransparent: true,
          headerBackground: 
```

### Before
![before](https://user-images.githubusercontent.com/916690/82738811-e098dd80-9d3a-11ea-979a-bf6154fa2b0a.gif)

![May-23-2020 09-31-01](https://user-images.githubusercontent.com/916690/82738758-826bfa80-9d3a-11ea-8312-428f1e9f5bac.gif)

### After
![after](https://user-images.githubusercontent.com/916690/82738813-e42c6480-9d3a-11ea-925c-c42512ac1b47.gif)
