### PR TITLE
feat: add ref to get current options in `ServerContainer`

### DIFF
--- a/packages/core/src/CurrentRenderContext.tsx
+++ b/packages/core/src/CurrentRenderContext.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+
+/**
+ * Context which holds the values for the current navigation tree.
+ * Intended for use in SSR. This is not safe to use on the client.
+ */
+const CurrentRenderContext = React.createContext<
+  { options?: object } | undefined
+>(undefined);
+
+export default CurrentRenderContext;

--- a/packages/core/src/index.tsx
+++ b/packages/core/src/index.tsx
@@ -7,6 +7,8 @@ export { default as NavigationHelpersContext } from './NavigationHelpersContext'
 export { default as NavigationContext } from './NavigationContext';
 export { default as NavigationRouteContext } from './NavigationRouteContext';
 
+export { default as CurrentRenderContext } from './CurrentRenderContext';
+
 export { default as useNavigationBuilder } from './useNavigationBuilder';
 export { default as useNavigation } from './useNavigation';
 export { default as useRoute } from './useRoute';

--- a/packages/core/src/useCurrentRender.tsx
+++ b/packages/core/src/useCurrentRender.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import { NavigationState, ParamListBase } from '@react-navigation/routers';
+import CurrentRenderContext from './CurrentRenderContext';
+import { Descriptor, NavigationHelpers } from './types';
+
+type Options = {
+  state: NavigationState;
+  navigation: NavigationHelpers<ParamListBase>;
+  descriptors: {
+    [key: string]: Descriptor<ParamListBase, string, NavigationState, object>;
+  };
+};
+
+/**
+ * Write the current options, so that server renderer can get current values
+ * Mutating values like this is not safe in async mode, but it doesn't apply to SSR
+ */
+export default function useCurrentRender({
+  state,
+  navigation,
+  descriptors,
+}: Options) {
+  const current = React.useContext(CurrentRenderContext);
+
+  if (current && navigation.isFocused()) {
+    current.options = descriptors[state.routes[state.index].key].options;
+  }
+}

--- a/packages/core/src/useNavigationBuilder.tsx
+++ b/packages/core/src/useNavigationBuilder.tsx
@@ -33,6 +33,7 @@ import {
 import useStateGetters from './useStateGetters';
 import useOnGetState from './useOnGetState';
 import useScheduleUpdate from './useScheduleUpdate';
+import useCurrentRender from './useCurrentRender';
 
 // This is to make TypeScript compiler happy
 // eslint-disable-next-line babel/no-unused-expressions
@@ -496,6 +497,12 @@ export default function useNavigationBuilder<
     addStateGetter,
     router,
     emitter,
+  });
+
+  useCurrentRender({
+    state,
+    navigation,
+    descriptors,
   });
 
   return {

--- a/packages/native/package.json
+++ b/packages/native/package.json
@@ -38,9 +38,11 @@
   "devDependencies": {
     "@react-native-community/bob": "^0.14.3",
     "@types/react": "^16.9.34",
+    "@types/react-dom": "^16.9.8",
     "@types/react-native": "^0.62.7",
     "del-cli": "^3.0.0",
     "react": "~16.9.0",
+    "react-dom": "^16.13.1",
     "react-native": "~0.61.5",
     "react-native-testing-library": "^1.13.2",
     "typescript": "^3.8.3"

--- a/packages/native/src/ServerContainer.tsx
+++ b/packages/native/src/ServerContainer.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
+import { CurrentRenderContext } from '@react-navigation/core';
 import ServerContext, { ServerContextType } from './ServerContext';
+import { ServerContainerRef } from './types';
 
 type Props = ServerContextType & {
   children: React.ReactNode;
@@ -10,11 +12,44 @@ type Props = ServerContextType & {
  *
  * @param props.location Location object to base the initial URL for SSR.
  * @param props.children Child elements to render the content.
+ * @param props.ref Ref object which contains helper methods.
  */
-export default function ServerContainer({ location, children }: Props) {
+export default React.forwardRef(function ServerContainer(
+  { children, location }: Props,
+  ref: React.Ref<ServerContainerRef>
+) {
+  React.useEffect(() => {
+    console.error(
+      "'ServerContainer' should only be used on the server with 'react-dom/server' for SSR."
+    );
+  }, []);
+
+  const current: { options?: object } = {};
+
+  if (ref) {
+    const value = {
+      getCurrentOptions() {
+        return current.options;
+      },
+    };
+
+    // We write to the `ref` during render instead of `React.useImperativeHandle`
+    // This is because `useImperativeHandle` will update the ref after 'commit',
+    // and there's no 'commit' phase during SSR.
+    // Mutating ref during render is unsafe in concurrent mode, but we don't care about it for SSR.
+    if (typeof ref === 'function') {
+      ref(value);
+    } else {
+      // @ts-ignore: the TS types are incorrect and say that ref.current is readonly
+      ref.current = value;
+    }
+  }
+
   return (
     <ServerContext.Provider value={{ location }}>
-      {children}
+      <CurrentRenderContext.Provider value={current}>
+        {children}
+      </CurrentRenderContext.Provider>
     </ServerContext.Provider>
   );
-}
+});

--- a/packages/native/src/ServerContext.tsx
+++ b/packages/native/src/ServerContext.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 export type ServerContextType = {
-  location: {
+  location?: {
     pathname: string;
     search: string;
   };

--- a/packages/native/src/types.tsx
+++ b/packages/native/src/types.tsx
@@ -51,3 +51,7 @@ export type LinkingOptions = {
    */
   getPathFromState?: typeof getPathFromStateDefault;
 };
+
+export type ServerContainerRef = {
+  getCurrentOptions(): object | undefined;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -3964,6 +3964,13 @@
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.1.tgz#937fab3194766256ee09fcd40b781740758617e7"
   integrity sha512-lhbQXx9HKZAPgBkISrBcmAcMpZsmpe/Cd/hY7LGZS5OfkySUBItnPZHgQPssWYUET8elF+yCFBbP1Q0RZPTdaw==
 
+"@types/react-dom@^16.9.8":
+  version "16.9.8"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.8.tgz#fe4c1e11dfc67155733dfa6aa65108b4971cb423"
+  integrity sha512-ykkPQ+5nFknnlU6lDd947WbQ6TE3NNzbQAkInC2EKY1qeYdTKp7onFusmYZb+ityzx2YviqT6BXSu+LyWWJwcA==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-is@^16.7.1":
   version "16.7.1"
   resolved "https://registry.yarnpkg.com/@types/react-is/-/react-is-16.7.1.tgz#d3f1c68c358c00ce116b55ef5410cf486dd08539"
@@ -15209,6 +15216,16 @@ react-devtools-core@^3.6.3:
   dependencies:
     shell-quote "^1.6.1"
     ws "^3.3.1"
+
+react-dom@^16.13.1:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.13.1.tgz#c1bd37331a0486c078ee54c4740720993b2e0e7f"
+  integrity sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    scheduler "^0.19.1"
 
 react-dom@~16.9.0:
   version "16.9.0"


### PR DESCRIPTION
User can pass a `ref` to the container to get current options, like they can with `NavigationContainer`:

```js
const ref = React.createRef();

const html = renderToString(
  <ServerContainer ref={ref}>
    <App />
  </ServerContainer>
);

ref.current.getCurrentOptions(); // Options for screen
```