### PR TITLE
refactor: remove unnecessary check for type of bottom tab bar label

### DIFF
--- a/packages/bottom-tabs/src/views/BottomTabItem.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabItem.tsx
@@ -206,10 +206,6 @@ export default function BottomTabBarItem({
       );
     }
 
-    if (typeof label === 'string') {
-      return label;
-    }
-
     return label({ focused, color });
   };
 


### PR DESCRIPTION
The check `typeof label === 'string'` is already done in the previous line and returned, so this line is  unnecessary.