### PR TITLE
fix: typo on drawerPosition default props

### DIFF
--- a/packages/drawer/src/views/Drawer.tsx
+++ b/packages/drawer/src/views/Drawer.tsx
@@ -100,7 +100,7 @@ type Props = {
 
 export default class DrawerView extends React.Component<Props> {
   static defaultProps = {
-    drawerPostion: I18nManager.isRTL ? 'left' : 'right',
+    drawerPosition: I18nManager.isRTL ? 'left' : 'right',
     drawerType: 'front',
     gestureEnabled: true,
     swipeEnabled: Platform.OS !== 'web',

--- a/packages/drawer/src/views/DrawerView.tsx
+++ b/packages/drawer/src/views/DrawerView.tsx
@@ -238,7 +238,6 @@ export default function DrawerView({
               renderDrawerContent={renderNavigationView}
               renderSceneContent={renderContent}
               keyboardDismissMode={keyboardDismissMode}
-              drawerPostion={drawerPosition}
               dimensions={dimensions}
             />
           </DrawerOpenContext.Provider>


### PR DESCRIPTION
Fix a minor typo from `drawerPostion` to `drawerPosition` :)

Fix https://github.com/react-navigation/react-navigation/issues/8358