### PR TITLE
fix: tapping overlay should update drawer state properly

### DIFF
--- a/packages/drawer/src/views/Drawer.tsx
+++ b/packages/drawer/src/views/Drawer.tsx
@@ -516,7 +516,7 @@ export default class DrawerView extends React.Component<Props> {
         oldState: (s: Animated.Value<number>) =>
           cond(
             eq(s, GestureState.ACTIVE),
-            set(this.manuallyTriggerSpring, TRUE)
+            call([], () => this.toggleDrawer(false))
           ),
       },
     },


### PR DESCRIPTION
There is an issue when tapping on the drawer overlay that is reported in https://github.com/react-navigation/react-navigation/issues/7944 and we've experience in our app.  

To reproduce it, you can use any non-web app that uses the drawer.  The issue is that tapping on the overlay (outside of the drawer) will indeed close the drawer.  But subsequent swipes to _open_ the drawer will immediately close the drawer.  I believe this is because the internal drawer state is not being updated properly.  

This PR simply calls `toggleDrawer(false)` to use already available methods to close the drawer.  When using the method in this PR, internal state is properly updated and the user can swipe/tap/toggle the drawer and experience the correct behavior.