### PR TITLE
Fix type of headerBackTitle in stack navigation

### DIFF
--- a/packages/stack/src/types.tsx
+++ b/packages/stack/src/types.tsx
@@ -135,7 +135,7 @@ export type StackHeaderOptions = {
   /**
    * Title string used by the back button on iOS, or `null` to disable label. Defaults to the previous scene's `headerTitle`.
    */
-  headerBackTitle?: string;
+  headerBackTitle?: string | null;
   /**
    * Style object for the back title.
    */


### PR DESCRIPTION
As per documentation, `headerBackTitle` treats `null` as a special value to disable the title, however `null` is not assignable to `headerBackTitle` due to its type.