### PR TITLE
fix: pass gestureRef to PanGestureHandlerNative

### DIFF
--- a/packages/stack/src/views/GestureHandler.native.tsx
+++ b/packages/stack/src/views/GestureHandler.native.tsx
@@ -10,7 +10,7 @@ export function PanGestureHandler(props: PanGestureHandlerProperties) {
 
   return (
     <GestureHandlerRefContext.Provider value={gestureRef}>
-      <PanGestureHandlerNative {...props} />
+      <PanGestureHandlerNative {...props} ref={gestureRef} />
     </GestureHandlerRefContext.Provider>
   );
 }


### PR DESCRIPTION
In the current implementation the ref is unused, resulting in a constant `current: {null}` on the context. 