### PR TITLE
Allow bottomTabsBar height override

### DIFF
--- a/packages/bottom-tabs/src/views/BottomTabBar.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabBar.tsx
@@ -181,7 +181,10 @@ export default function BottomTabBar({
   };
 
   const defaultInsets = useSafeArea();
-
+  
+  const {styleHeight ...restStyles} = styles;
+  const height = styleHeight || DEFAULT_TABBAR_HEIGHT
+        
   const insets = {
     top: safeAreaInsets?.top ?? defaultInsets.top,
     right: safeAreaInsets?.right ?? defaultInsets.right,
@@ -211,7 +214,7 @@ export default function BottomTabBar({
           position: isTabBarHidden ? 'absolute' : null,
         },
         {
-          height: DEFAULT_TABBAR_HEIGHT + insets.bottom,
+          height: height + insets.bottom,
           paddingBottom: insets.bottom,
           paddingHorizontal: Math.max(insets.left, insets.right),
         },


### PR DESCRIPTION
In my app the tab bar is slightly taller than the default. (`65` points)

So, setting the height works normally, unless there is a safe area inset, e.g. on more recent iOS devices, at which point my nav bar content is squashed.

I'm proposing to pluck the height from styles, falling back to the default and add the detected inset to that height.

Not sure if this is a good pattern, happy to alter.

Thanks for a great library - 5.0 took a day to add, but has been well worth it in terms of the performance/feature gains! :horse_racing: 