### PR TITLE
feat: Export `StackNavigator`, `StackNavigatorProps` and `TypedStackNavigator` type defs

### DIFF
--- a/packages/stack/src/index.tsx
+++ b/packages/stack/src/index.tsx
@@ -6,7 +6,11 @@ import * as TransitionPresets from './TransitionConfigs/TransitionPresets';
 /**
  * Navigators
  */
-export { default as createStackNavigator } from './navigators/createStackNavigator';
+export {
+  default as createStackNavigator,
+  StackNavigator,
+  Props as StackNavigatorProps
+} from './navigators/createStackNavigator';
 
 export const Assets = [
   // eslint-disable-next-line import/no-commonjs

--- a/packages/stack/src/navigators/createStackNavigator.tsx
+++ b/packages/stack/src/navigators/createStackNavigator.tsx
@@ -9,6 +9,8 @@ import {
   StackRouterOptions,
   StackNavigationState,
   StackActions,
+  ParamListBase,
+  TypedNavigator,
 } from '@react-navigation/native';
 import StackView from '../views/Stack/StackView';
 import {
@@ -17,11 +19,11 @@ import {
   StackNavigationEventMap,
 } from '../types';
 
-type Props = DefaultNavigatorOptions<StackNavigationOptions> &
+export type Props = DefaultNavigatorOptions<StackNavigationOptions> &
   StackRouterOptions &
   StackNavigationConfig;
 
-function StackNavigator({
+export function StackNavigator({
   initialRouteName,
   children,
   screenOptions,
@@ -94,3 +96,13 @@ export default createNavigatorFactory<
   StackNavigationEventMap,
   typeof StackNavigator
 >(StackNavigator);
+
+export type TypedStackNavigator<
+  ParamList extends ParamListBase
+> = TypedNavigator<
+  ParamList,
+  StackNavigationState,
+  StackNavigationOptions,
+  StackNavigationEventMap,
+  typeof StackNavigator
+>;


### PR DESCRIPTION
(Same as https://github.com/react-navigation/react-navigation/pull/8233 but rebased from master to main)

Thanks to this, you can easily import and construct a type of a value returned by `createStackNavigator<T>()` expression.

We would use this because our app is quite complex, and so we extract constructing routes/params/stacks to separate files. We could use this like that:

```tsx
import React from "react";
import { TypedStackNavigator } from "@react-navigation/stack";
import { RootStackNavigatorParamList, Screens } from "../navigation";
import { ChatScreen, ChatListScreen } from "./chat";

export const getChatStackScreens = (
  Stack: TypedStackNavigator<RootStackNavigatorParamList>
): React.ReactElement => {
  return (
    <>
      <Stack.Screen
        name={Screens.ChatList}
        component={ChatListScreen}
      />
      <Stack.Screen
        name={Screens.Chat}
        component={ChatScreen}
      />
    </>
  );
};

// and then in `Stack.Navigator` just use it like `{getMoreStackScreens(Stack)}`
```