### PR TITLE
Allow the `screenOptions` `header` to be a React component

### DIFF
--- a/packages/stack/src/views/Header/HeaderContainer.tsx
+++ b/packages/stack/src/views/Header/HeaderContainer.tsx
@@ -162,7 +162,7 @@ export default function HeaderContainer({
                     : null
                 }
               >
-                {header !== undefined ? header(props) : <Header {...props} />}
+                {header !== undefined ? React.createElement(header, props) : <Header {...props} />}
               </View>
             </NavigationRouteContext.Provider>
           </NavigationContext.Provider>


### PR DESCRIPTION
Fixes #8463

I've provided more information in the issue above.

In essence, the `header` in `screenOptions` is currently a "Function that given HeaderProps returns a React Element, to display as a header." according to the docs. A function that accepts props and returns a React Element is the signature of a React Function Component. Why not make the `header` officially a React Component in that case?

I stumbled upon this issue when trying to use a Hook inside a custom `header` component to see that I should instead write a function that returns a container component that then calls the hook inside of that... I think we can do better ✨ 