### PR TITLE
fix: fix screen disappearing on Android

### DIFF
--- a/packages/stack/src/views/Stack/Card.tsx
+++ b/packages/stack/src/views/Stack/Card.tsx
@@ -507,6 +507,7 @@ export default class Card extends React.Component<Props> {
               {overlay({ style: overlayStyle })}
             </View>
           ) : null}
+          {/* Make sure that this view isn't removed. If this view is removed, our style with animated value won't apply which will cause values to be incorrect */}
           <Animated.View
             style={[
               styles.container,
@@ -515,6 +516,7 @@ export default class Card extends React.Component<Props> {
               customContainerStyle,
             ]}
             pointerEvents="box-none"
+            collapsable={false}
           >
             <PanGestureHandler
               enabled={layout.width !== 0 && gestureEnabled}

--- a/packages/stack/src/views/Stack/Card.tsx
+++ b/packages/stack/src/views/Stack/Card.tsx
@@ -507,7 +507,6 @@ export default class Card extends React.Component<Props> {
               {overlay({ style: overlayStyle })}
             </View>
           ) : null}
-          {/* Make sure that this view isn't removed. If this view is removed, our style with animated value won't apply which will cause values to be incorrect */}
           <Animated.View
             style={[
               styles.container,
@@ -516,6 +515,7 @@ export default class Card extends React.Component<Props> {
               customContainerStyle,
             ]}
             pointerEvents="box-none"
+            // Make sure that this view isn't removed. If this view is removed, our style with animated value won't apply which will cause values to be incorrect
             collapsable={false}
           >
             <PanGestureHandler


### PR DESCRIPTION
Added `collapsable={false}` to the dummy View in order for the Android to render screens properly. This issue is most probably similar to https://github.com/react-navigation/react-navigation/commit/9c06a92d092af150d653c3a2f7fdccd28090bb14 but fixes it on Android since the View seems to be removed from a native view hierarchy due to not drawing anything. To see the bug go to https://github.com/software-mansion/react-native-screens/issues/544.