### PR TITLE
chore: inform users about @react-navigation/native

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "test": "jest",
     "prerelease": "yarn lerna run clean",
     "release": "yarn lerna publish",
-    "example": "yarn --cwd example"
+    "example": "yarn --cwd example",
+    "postinstall": "node -e \"try{require('./postinstall')}catch(e){}\""
   },
   "devDependencies": {
     "@babel/plugin-proposal-class-properties": "^7.8.3",

--- a/postinstall.js
+++ b/postinstall.js
@@ -1,5 +1,6 @@
-const banner = 'https://github.com/react-navigation/react-navigation \u001b[33mwas transformed into monorepo. ' +
+const banner =
+  'https://github.com/react-navigation/react-navigation \u001b[33mwas transformed into monorepo. ' +
   'If you want to use the latest version install @react-navigation/native. \n\n You can find more information in our ' +
   'getting started guide: https://reactnavigation.org/docs/getting-started';
 
-console.log(banner)
+console.log(banner);

--- a/postinstall.js
+++ b/postinstall.js
@@ -1,6 +1,6 @@
 const banner =
   'https://github.com/react-navigation/react-navigation \u001b[33mwas transformed into monorepo. ' +
   'If you want to use the latest version install @react-navigation/native. \n\n You can find more information in our ' +
-  'getting started guide: https://reactnavigation.org/docs/getting-started';
+  'getting started guide: https://reactnavigation.org/docs/getting-started\u001B[0m';
 
 console.log(banner);

--- a/postinstall.js
+++ b/postinstall.js
@@ -1,0 +1,5 @@
+const banner = 'https://github.com/react-navigation/react-navigation \u001b[33mwas transformed into monorepo. ' +
+  'If you want to use the latest version install @react-navigation/native. \n\n You can find more information in our ' +
+  'getting started guide: https://reactnavigation.org/docs/getting-started';
+
+console.log(banner)


### PR DESCRIPTION
I used `react-navigation` a couple of times in the past. I don't use StackOverflow too much during my day and I know the API for 4.x. Two weeks ago I started a new project. I installed `react-navigation` as usual and because I didn't check the documentation. It took me two weeks to realize that the latest version is actually `v5`.

It would be nice to inform users that `react-navigation` was transformed into a mono repository and that they should install `@react-navigation/native` instead.