### PR TITLE
chore: autofix eslint errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "husky": {
     "hooks": {
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
-      "pre-commit": "yarn lint && yarn typescript && yarn test"
+      "pre-commit": "yarn lint --fix && yarn typescript && yarn test"
     }
   },
   "jest": {


### PR DESCRIPTION
One of my PRs failed because of linting issues that could have been auto fixed. 🙂 

![image](https://user-images.githubusercontent.com/14946081/85237679-f6c4b700-b428-11ea-947d-a27ed6c25561.png)
