### PR TITLE
feat: add a `beforeRemove` event

### DIFF
--- a/example/src/Screens/PreventRemove.tsx
+++ b/example/src/Screens/PreventRemove.tsx
@@ -1,0 +1,168 @@
+import * as React from 'react';
+import {
+  Alert,
+  View,
+  TextInput,
+  ScrollView,
+  StyleSheet,
+  Platform,
+} from 'react-native';
+import { Button } from 'react-native-paper';
+import {
+  useTheme,
+  CommonActions,
+  ParamListBase,
+  NavigationAction,
+} from '@react-navigation/native';
+import {
+  createStackNavigator,
+  StackScreenProps,
+} from '@react-navigation/stack';
+import Article from '../Shared/Article';
+
+type PreventRemoveParams = {
+  Article: { author: string };
+  Input: undefined;
+};
+
+const scrollEnabled = Platform.select({ web: true, default: false });
+
+const ArticleScreen = ({
+  navigation,
+  route,
+}: StackScreenProps<PreventRemoveParams, 'Article'>) => {
+  return (
+    <ScrollView>
+      <View style={styles.buttons}>
+        <Button
+          mode="contained"
+          onPress={() => navigation.push('Input')}
+          style={styles.button}
+        >
+          Push Input
+        </Button>
+        <Button
+          mode="outlined"
+          onPress={() => navigation.popToTop()}
+          style={styles.button}
+        >
+          Pop to top
+        </Button>
+      </View>
+      <Article
+        author={{ name: route.params?.author ?? 'Unknown' }}
+        scrollEnabled={scrollEnabled}
+      />
+    </ScrollView>
+  );
+};
+
+const InputScreen = ({
+  navigation,
+}: StackScreenProps<PreventRemoveParams, 'Input'>) => {
+  const [text, setText] = React.useState('');
+  const { colors } = useTheme();
+
+  const hasUnsavedChanges = Boolean(text);
+
+  React.useEffect(
+    () =>
+      navigation.addListener('beforeRemove', (e) => {
+        const action: NavigationAction & { payload?: { confirmed?: boolean } } =
+          e.data.action;
+
+        if (!hasUnsavedChanges || action.payload?.confirmed) {
+          return;
+        }
+
+        e.preventDefault();
+
+        Alert.alert(
+          'Discard changes?',
+          'You have unsaved changes. Are you sure to discard them and leave the screen?',
+          [
+            { text: "Don't leave", style: 'cancel', onPress: () => {} },
+            {
+              text: 'Discard',
+              style: 'destructive',
+              onPress: () => navigation.dispatch(action),
+            },
+          ]
+        );
+      }),
+    [hasUnsavedChanges, navigation]
+  );
+
+  return (
+    <View style={styles.content}>
+      <TextInput
+        autoFocus
+        style={[
+          styles.input,
+          { backgroundColor: colors.card, color: colors.text },
+        ]}
+        value={text}
+        placeholder="Type something…"
+        onChangeText={setText}
+      />
+      <Button
+        mode="outlined"
+        color="tomato"
+        onPress={() =>
+          navigation.dispatch({
+            ...CommonActions.goBack(),
+            payload: { confirmed: true },
+          })
+        }
+        style={styles.button}
+      >
+        Discard and go back
+      </Button>
+      <Button
+        mode="outlined"
+        onPress={() => navigation.push('Article', { author: text })}
+        style={styles.button}
+      >
+        Push Article
+      </Button>
+    </View>
+  );
+};
+
+const SimpleStack = createStackNavigator<PreventRemoveParams>();
+
+type Props = StackScreenProps<ParamListBase>;
+
+export default function SimpleStackScreen({ navigation }: Props) {
+  navigation.setOptions({
+    headerShown: false,
+  });
+
+  return (
+    <SimpleStack.Navigator>
+      <SimpleStack.Screen name="Input" component={InputScreen} />
+      <SimpleStack.Screen name="Article" component={ArticleScreen} />
+    </SimpleStack.Navigator>
+  );
+}
+
+const styles = StyleSheet.create({
+  content: {
+    flex: 1,
+    padding: 16,
+  },
+  input: {
+    margin: 8,
+    padding: 10,
+    borderRadius: 3,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: 'rgba(0, 0, 0, 0.08)',
+  },
+  buttons: {
+    flexDirection: 'row',
+    padding: 8,
+  },
+  button: {
+    margin: 8,
+  },
+});

--- a/example/src/index.tsx
+++ b/example/src/index.tsx
@@ -53,9 +53,10 @@ import MaterialTopTabsScreen from './Screens/MaterialTopTabs';
 import MaterialBottomTabs from './Screens/MaterialBottomTabs';
 import NotFound from './Screens/NotFound';
 import DynamicTabs from './Screens/DynamicTabs';
-import AuthFlow from './Screens/AuthFlow';
-import CompatAPI from './Screens/CompatAPI';
 import MasterDetail from './Screens/MasterDetail';
+import AuthFlow from './Screens/AuthFlow';
+import PreventRemove from './Screens/PreventRemove';
+import CompatAPI from './Screens/CompatAPI';
 import LinkComponent from './Screens/LinkComponent';
 
 YellowBox.ignoreWarnings(['Require cycle:', 'Warning: Async Storage']);
@@ -108,6 +109,10 @@ const SCREENS = {
   AuthFlow: {
     title: 'Auth Flow',
     component: AuthFlow,
+  },
+  PreventRemove: {
+    title: 'Prevent removing screen',
+    component: PreventRemove,
   },
   CompatAPI: {
     title: 'Compat Layer',

--- a/packages/core/src/NavigationBuilderContext.tsx
+++ b/packages/core/src/NavigationBuilderContext.tsx
@@ -12,7 +12,8 @@ export type ListenerMap = {
 };
 
 export type KeyedListenerMap = {
-  getState: NavigatorStateGetter;
+  getState: GetStateListener;
+  beforeRemove: ChildBeforeRemoveListener;
 };
 
 export type AddListener = <T extends keyof ListenerMap>(
@@ -39,7 +40,9 @@ export type FocusedNavigationListener = <T>(
   callback: FocusedNavigationCallback<T>
 ) => { handled: boolean; result: T };
 
-export type NavigatorStateGetter = () => NavigationState;
+export type GetStateListener = () => NavigationState;
+
+export type ChildBeforeRemoveListener = (action: NavigationAction) => boolean;
 
 /**
  * Context which holds the required helpers needed to build nested navigators.

--- a/packages/core/src/__tests__/useOnAction.test.tsx
+++ b/packages/core/src/__tests__/useOnAction.test.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
-import { render } from 'react-native-testing-library';
-import type {
+import { act, render } from 'react-native-testing-library';
+import {
   Router,
   DefaultRouterOptions,
   NavigationState,
+  StackRouter,
 } from '@react-navigation/routers';
 import useNavigationBuilder from '../useNavigationBuilder';
 import BaseNavigationContainer from '../BaseNavigationContainer';
@@ -12,8 +13,19 @@ import MockRouter, {
   MockActions,
   MockRouterKey,
 } from './__fixtures__/MockRouter';
+import type { NavigationContainerRef } from '../types';
 
-beforeEach(() => (MockRouterKey.current = 0));
+jest.mock('nanoid/non-secure', () => {
+  const m = { nanoid: () => String(++m.__key), __key: 0 };
+
+  return m;
+});
+
+beforeEach(() => {
+  MockRouterKey.current = 0;
+
+  require('nanoid/non-secure').__key = 0;
+});
 
 it("lets parent handle the action if child didn't", () => {
   function CurrentRouter(options: DefaultRouterOptions) {
@@ -519,4 +531,650 @@ it('logs error if no navigator handled the action', () => {
   );
 
   spy.mockRestore();
+});
+
+it("prevents removing a screen with 'beforeRemove' event", () => {
+  const TestNavigator = (props: any) => {
+    const { state, descriptors } = useNavigationBuilder(StackRouter, props);
+
+    return (
+      <React.Fragment>
+        {state.routes.map((route) => descriptors[route.key].render())}
+      </React.Fragment>
+    );
+  };
+
+  const onBeforeRemove = jest.fn();
+
+  let shouldPrevent = true;
+  let shouldContinue = false;
+
+  const TestScreen = (props: any) => {
+    React.useEffect(
+      () =>
+        props.navigation.addListener('beforeRemove', (e: any) => {
+          onBeforeRemove();
+
+          if (shouldPrevent) {
+            e.preventDefault();
+
+            if (shouldContinue) {
+              props.navigation.dispatch(e.data.action);
+            }
+          }
+        }),
+      [props.navigation]
+    );
+
+    return null;
+  };
+
+  const onStateChange = jest.fn();
+
+  const ref = React.createRef<NavigationContainerRef>();
+
+  const element = (
+    <BaseNavigationContainer ref={ref} onStateChange={onStateChange}>
+      <TestNavigator>
+        <Screen name="foo">{() => null}</Screen>
+        <Screen name="bar" component={TestScreen} />
+        <Screen name="baz">{() => null}</Screen>
+      </TestNavigator>
+    </BaseNavigationContainer>
+  );
+
+  render(element);
+
+  act(() => ref.current?.navigate('bar'));
+
+  expect(onStateChange).toBeCalledTimes(1);
+  expect(onStateChange).toBeCalledWith({
+    index: 1,
+    key: 'stack-2',
+    routeNames: ['foo', 'bar', 'baz'],
+    routes: [
+      { key: 'foo-3', name: 'foo' },
+      { key: 'bar-4', name: 'bar' },
+    ],
+    stale: false,
+    type: 'stack',
+  });
+
+  act(() => ref.current?.navigate('baz'));
+
+  expect(onStateChange).toBeCalledTimes(2);
+  expect(onStateChange).toBeCalledWith({
+    index: 2,
+    key: 'stack-2',
+    routeNames: ['foo', 'bar', 'baz'],
+    routes: [
+      { key: 'foo-3', name: 'foo' },
+      { key: 'bar-4', name: 'bar' },
+      {
+        key: 'baz-5',
+        name: 'baz',
+      },
+    ],
+    stale: false,
+    type: 'stack',
+  });
+
+  act(() => ref.current?.navigate('foo'));
+
+  expect(onStateChange).toBeCalledTimes(2);
+  expect(onBeforeRemove).toBeCalledTimes(1);
+
+  expect(ref.current?.getRootState()).toEqual({
+    index: 2,
+    key: 'stack-2',
+    routeNames: ['foo', 'bar', 'baz'],
+    routes: [
+      { key: 'foo-3', name: 'foo' },
+      { key: 'bar-4', name: 'bar' },
+      { key: 'baz-5', name: 'baz' },
+    ],
+    stale: false,
+    type: 'stack',
+  });
+
+  shouldPrevent = false;
+
+  act(() => ref.current?.navigate('foo'));
+
+  expect(onStateChange).toBeCalledTimes(3);
+  expect(onStateChange).toBeCalledWith({
+    index: 0,
+    key: 'stack-2',
+    routeNames: ['foo', 'bar', 'baz'],
+    routes: [{ key: 'foo-3', name: 'foo' }],
+    stale: false,
+    type: 'stack',
+  });
+
+  shouldPrevent = true;
+  shouldContinue = true;
+
+  act(() => ref.current?.navigate('bar'));
+  act(() => ref.current?.navigate('foo'));
+
+  expect(onStateChange).toBeCalledTimes(5);
+  expect(onStateChange).toBeCalledWith({
+    index: 0,
+    key: 'stack-2',
+    routeNames: ['foo', 'bar', 'baz'],
+    routes: [{ key: 'foo-3', name: 'foo' }],
+    stale: false,
+    type: 'stack',
+  });
+});
+
+it("prevents removing a child screen with 'beforeRemove' event", () => {
+  const TestNavigator = (props: any) => {
+    const { state, descriptors } = useNavigationBuilder(StackRouter, props);
+
+    return (
+      <React.Fragment>
+        {state.routes.map((route) => descriptors[route.key].render())}
+      </React.Fragment>
+    );
+  };
+
+  const onBeforeRemove = jest.fn();
+
+  let shouldPrevent = true;
+  let shouldContinue = false;
+
+  const TestScreen = (props: any) => {
+    React.useEffect(
+      () =>
+        props.navigation.addListener('beforeRemove', (e: any) => {
+          onBeforeRemove();
+
+          if (shouldPrevent) {
+            e.preventDefault();
+
+            if (shouldContinue) {
+              props.navigation.dispatch(e.data.action);
+            }
+          }
+        }),
+      [props.navigation]
+    );
+
+    return null;
+  };
+
+  const onStateChange = jest.fn();
+
+  const ref = React.createRef<NavigationContainerRef>();
+
+  const element = (
+    <BaseNavigationContainer ref={ref} onStateChange={onStateChange}>
+      <TestNavigator>
+        <Screen name="foo">{() => null}</Screen>
+        <Screen name="bar">{() => null}</Screen>
+        <Screen name="baz">
+          {() => (
+            <TestNavigator>
+              <Screen name="qux" component={TestScreen} />
+              <Screen name="lex">{() => null}</Screen>
+            </TestNavigator>
+          )}
+        </Screen>
+      </TestNavigator>
+    </BaseNavigationContainer>
+  );
+
+  render(element);
+
+  act(() => ref.current?.navigate('bar'));
+
+  expect(onStateChange).toBeCalledTimes(1);
+  expect(onStateChange).toBeCalledWith({
+    index: 1,
+    key: 'stack-2',
+    routeNames: ['foo', 'bar', 'baz'],
+    routes: [
+      { key: 'foo-3', name: 'foo' },
+      { key: 'bar-4', name: 'bar' },
+    ],
+    stale: false,
+    type: 'stack',
+  });
+
+  act(() => ref.current?.navigate('baz'));
+
+  expect(onStateChange).toBeCalledTimes(2);
+  expect(onStateChange).toBeCalledWith({
+    index: 2,
+    key: 'stack-2',
+    routeNames: ['foo', 'bar', 'baz'],
+    routes: [
+      { key: 'foo-3', name: 'foo' },
+      { key: 'bar-4', name: 'bar' },
+      {
+        key: 'baz-5',
+        name: 'baz',
+        state: {
+          index: 0,
+          key: 'stack-7',
+          routeNames: ['qux', 'lex'],
+          routes: [{ key: 'qux-8', name: 'qux' }],
+          stale: false,
+          type: 'stack',
+        },
+      },
+    ],
+    stale: false,
+    type: 'stack',
+  });
+
+  act(() => ref.current?.navigate('foo'));
+
+  expect(onStateChange).toBeCalledTimes(2);
+  expect(onBeforeRemove).toBeCalledTimes(1);
+
+  expect(ref.current?.getRootState()).toEqual({
+    index: 2,
+    key: 'stack-2',
+    routeNames: ['foo', 'bar', 'baz'],
+    routes: [
+      { key: 'foo-3', name: 'foo' },
+      { key: 'bar-4', name: 'bar' },
+      {
+        key: 'baz-5',
+        name: 'baz',
+        state: {
+          index: 0,
+          key: 'stack-7',
+          routeNames: ['qux', 'lex'],
+          routes: [{ key: 'qux-8', name: 'qux' }],
+          stale: false,
+          type: 'stack',
+        },
+      },
+    ],
+    stale: false,
+    type: 'stack',
+  });
+
+  shouldPrevent = false;
+
+  act(() => ref.current?.navigate('foo'));
+
+  expect(onStateChange).toBeCalledTimes(3);
+  expect(onStateChange).toBeCalledWith({
+    index: 0,
+    key: 'stack-2',
+    routeNames: ['foo', 'bar', 'baz'],
+    routes: [{ key: 'foo-3', name: 'foo' }],
+    stale: false,
+    type: 'stack',
+  });
+
+  shouldPrevent = true;
+  shouldContinue = true;
+
+  act(() => ref.current?.navigate('bar'));
+  act(() => ref.current?.navigate('foo'));
+
+  expect(onStateChange).toBeCalledTimes(5);
+  expect(onStateChange).toBeCalledWith({
+    index: 0,
+    key: 'stack-2',
+    routeNames: ['foo', 'bar', 'baz'],
+    routes: [{ key: 'foo-3', name: 'foo' }],
+    stale: false,
+    type: 'stack',
+  });
+});
+
+it("prevents removing a grand child screen with 'beforeRemove' event", () => {
+  const TestNavigator = (props: any) => {
+    const { state, descriptors } = useNavigationBuilder(StackRouter, props);
+
+    return (
+      <React.Fragment>
+        {state.routes.map((route) => descriptors[route.key].render())}
+      </React.Fragment>
+    );
+  };
+
+  const onBeforeRemove = jest.fn();
+
+  let shouldPrevent = true;
+  let shouldContinue = false;
+
+  const TestScreen = (props: any) => {
+    React.useEffect(
+      () =>
+        props.navigation.addListener('beforeRemove', (e: any) => {
+          onBeforeRemove();
+
+          if (shouldPrevent) {
+            e.preventDefault();
+
+            if (shouldContinue) {
+              props.navigation.dispatch(e.data.action);
+            }
+          }
+        }),
+      [props.navigation]
+    );
+
+    return null;
+  };
+
+  const onStateChange = jest.fn();
+
+  const ref = React.createRef<NavigationContainerRef>();
+
+  const element = (
+    <BaseNavigationContainer ref={ref} onStateChange={onStateChange}>
+      <TestNavigator>
+        <Screen name="foo">{() => null}</Screen>
+        <Screen name="bar">{() => null}</Screen>
+        <Screen name="baz">
+          {() => (
+            <TestNavigator>
+              <Screen name="qux">
+                {() => (
+                  <TestNavigator>
+                    <Screen name="lex" component={TestScreen} />
+                  </TestNavigator>
+                )}
+              </Screen>
+            </TestNavigator>
+          )}
+        </Screen>
+      </TestNavigator>
+    </BaseNavigationContainer>
+  );
+
+  render(element);
+
+  act(() => ref.current?.navigate('bar'));
+
+  expect(onStateChange).toBeCalledTimes(1);
+  expect(onStateChange).toBeCalledWith({
+    index: 1,
+    key: 'stack-2',
+    routeNames: ['foo', 'bar', 'baz'],
+    routes: [
+      { key: 'foo-3', name: 'foo' },
+      { key: 'bar-4', name: 'bar' },
+    ],
+    stale: false,
+    type: 'stack',
+  });
+
+  act(() => ref.current?.navigate('baz'));
+
+  expect(onStateChange).toBeCalledTimes(2);
+  expect(onStateChange).toBeCalledWith({
+    index: 2,
+    key: 'stack-2',
+    routeNames: ['foo', 'bar', 'baz'],
+    routes: [
+      { key: 'foo-3', name: 'foo' },
+      { key: 'bar-4', name: 'bar' },
+      {
+        key: 'baz-5',
+        name: 'baz',
+        state: {
+          index: 0,
+          key: 'stack-7',
+          routeNames: ['qux'],
+          routes: [
+            {
+              key: 'qux-8',
+              name: 'qux',
+              state: {
+                index: 0,
+                key: 'stack-10',
+                routeNames: ['lex'],
+                routes: [{ key: 'lex-11', name: 'lex' }],
+                stale: false,
+                type: 'stack',
+              },
+            },
+          ],
+          stale: false,
+          type: 'stack',
+        },
+      },
+    ],
+    stale: false,
+    type: 'stack',
+  });
+
+  act(() => ref.current?.navigate('foo'));
+
+  expect(onStateChange).toBeCalledTimes(2);
+  expect(onBeforeRemove).toBeCalledTimes(1);
+
+  expect(ref.current?.getRootState()).toEqual({
+    index: 2,
+    key: 'stack-2',
+    routeNames: ['foo', 'bar', 'baz'],
+    routes: [
+      { key: 'foo-3', name: 'foo' },
+      { key: 'bar-4', name: 'bar' },
+      {
+        key: 'baz-5',
+        name: 'baz',
+        state: {
+          index: 0,
+          key: 'stack-7',
+          routeNames: ['qux'],
+          routes: [
+            {
+              key: 'qux-8',
+              name: 'qux',
+              state: {
+                index: 0,
+                key: 'stack-10',
+                routeNames: ['lex'],
+                routes: [{ key: 'lex-11', name: 'lex' }],
+                stale: false,
+                type: 'stack',
+              },
+            },
+          ],
+          stale: false,
+          type: 'stack',
+        },
+      },
+    ],
+    stale: false,
+    type: 'stack',
+  });
+
+  shouldPrevent = false;
+
+  act(() => ref.current?.navigate('foo'));
+
+  expect(onStateChange).toBeCalledTimes(3);
+  expect(onStateChange).toBeCalledWith({
+    index: 0,
+    key: 'stack-2',
+    routeNames: ['foo', 'bar', 'baz'],
+    routes: [{ key: 'foo-3', name: 'foo' }],
+    stale: false,
+    type: 'stack',
+  });
+
+  shouldPrevent = true;
+  shouldContinue = true;
+
+  act(() => ref.current?.navigate('bar'));
+  act(() => ref.current?.navigate('foo'));
+
+  expect(onStateChange).toBeCalledTimes(5);
+  expect(onStateChange).toBeCalledWith({
+    index: 0,
+    key: 'stack-2',
+    routeNames: ['foo', 'bar', 'baz'],
+    routes: [{ key: 'foo-3', name: 'foo' }],
+    stale: false,
+    type: 'stack',
+  });
+});
+
+it("prevents removing by multiple screens with 'beforeRemove' event", () => {
+  const TestNavigator = (props: any) => {
+    const { state, descriptors } = useNavigationBuilder(StackRouter, props);
+
+    return (
+      <React.Fragment>
+        {state.routes.map((route) => descriptors[route.key].render())}
+      </React.Fragment>
+    );
+  };
+
+  const onBeforeRemove = {
+    bar: jest.fn(),
+    baz: jest.fn(),
+    lex: jest.fn(),
+  };
+
+  const shouldPrevent = {
+    bar: true,
+    baz: true,
+    lex: true,
+  };
+
+  const TestScreen = (props: any) => {
+    React.useEffect(
+      () =>
+        props.navigation.addListener('beforeRemove', (e: any) => {
+          // @ts-expect-error: we should have the required mocks
+          onBeforeRemove[props.route.name]();
+          e.preventDefault();
+
+          // @ts-expect-error: we should have the required properties
+          if (!shouldPrevent[props.route.name]) {
+            props.navigation.dispatch(e.data.action);
+          }
+        }),
+      [props.navigation, props.route.name]
+    );
+
+    return null;
+  };
+
+  const onStateChange = jest.fn();
+
+  const ref = React.createRef<NavigationContainerRef>();
+
+  const element = (
+    <BaseNavigationContainer ref={ref} onStateChange={onStateChange}>
+      <TestNavigator>
+        <Screen name="foo">{() => null}</Screen>
+        <Screen name="bar" component={TestScreen} />
+        <Screen name="baz" component={TestScreen} />
+        <Screen name="bax">
+          {() => (
+            <TestNavigator>
+              <Screen name="qux">
+                {() => (
+                  <TestNavigator>
+                    <Screen name="lex" component={TestScreen} />
+                  </TestNavigator>
+                )}
+              </Screen>
+            </TestNavigator>
+          )}
+        </Screen>
+      </TestNavigator>
+    </BaseNavigationContainer>
+  );
+
+  render(element);
+
+  act(() => {
+    ref.current?.navigate('bar');
+    ref.current?.navigate('baz');
+    ref.current?.navigate('bax');
+  });
+
+  const preventedState = {
+    index: 3,
+    key: 'stack-2',
+    routeNames: ['foo', 'bar', 'baz', 'bax'],
+    routes: [
+      { key: 'foo-3', name: 'foo' },
+      { key: 'bar-4', name: 'bar' },
+      { key: 'baz-5', name: 'baz' },
+      {
+        key: 'bax-6',
+        name: 'bax',
+        state: {
+          index: 0,
+          key: 'stack-8',
+          routeNames: ['qux'],
+          routes: [
+            {
+              key: 'qux-9',
+              name: 'qux',
+              state: {
+                index: 0,
+                key: 'stack-11',
+                routeNames: ['lex'],
+                routes: [{ key: 'lex-12', name: 'lex' }],
+                stale: false,
+                type: 'stack',
+              },
+            },
+          ],
+          stale: false,
+          type: 'stack',
+        },
+      },
+    ],
+    stale: false,
+    type: 'stack',
+  };
+
+  expect(onStateChange).toBeCalledTimes(1);
+  expect(onStateChange).toBeCalledWith(preventedState);
+
+  act(() => ref.current?.navigate('foo'));
+
+  expect(onStateChange).toBeCalledTimes(1);
+  expect(onBeforeRemove.lex).toBeCalledTimes(1);
+
+  expect(ref.current?.getRootState()).toEqual(preventedState);
+
+  shouldPrevent.lex = false;
+
+  act(() => ref.current?.navigate('foo'));
+
+  expect(onStateChange).toBeCalledTimes(1);
+  expect(onBeforeRemove.baz).toBeCalledTimes(1);
+
+  expect(ref.current?.getRootState()).toEqual(preventedState);
+
+  shouldPrevent.baz = false;
+
+  act(() => ref.current?.navigate('foo'));
+
+  expect(onStateChange).toBeCalledTimes(1);
+  expect(onBeforeRemove.bar).toBeCalledTimes(1);
+
+  expect(ref.current?.getRootState()).toEqual(preventedState);
+
+  shouldPrevent.bar = false;
+
+  act(() => ref.current?.navigate('foo'));
+
+  expect(onStateChange).toBeCalledTimes(2);
+  expect(onStateChange).toBeCalledWith({
+    index: 0,
+    key: 'stack-2',
+    routeNames: ['foo', 'bar', 'baz', 'bax'],
+    routes: [{ key: 'foo-3', name: 'foo' }],
+    stale: false,
+    type: 'stack',
+  });
 });

--- a/packages/core/src/types.tsx
+++ b/packages/core/src/types.tsx
@@ -37,6 +37,7 @@ export type EventMapCore<State extends NavigationState> = {
   focus: { data: undefined };
   blur: { data: undefined };
   state: { data: { state: State } };
+  beforeRemove: { data: { action: NavigationAction }; canPreventDefault: true };
 };
 
 export type EventArg<

--- a/packages/core/src/useKeyedChildListeners.tsx
+++ b/packages/core/src/useKeyedChildListeners.tsx
@@ -15,6 +15,7 @@ export default function useKeyedChildListeners() {
     }
   >({
     getState: {},
+    beforeRemove: {},
   });
 
   const addKeyedListener = React.useCallback(

--- a/packages/core/src/useNavigationBuilder.tsx
+++ b/packages/core/src/useNavigationBuilder.tsx
@@ -438,11 +438,13 @@ export default function useNavigationBuilder<
     getState,
     setState,
     key: route?.key,
-    listeners: childListeners.action,
+    actionListeners: childListeners.action,
+    beforeRemoveListeners: keyedListeners.beforeRemove,
     routerConfigOptions: {
       routeNames,
       routeParamList,
     },
+    emitter,
   });
 
   const onRouteFocus = useOnRouteFocus({

--- a/packages/core/src/useOnGetState.tsx
+++ b/packages/core/src/useOnGetState.tsx
@@ -1,18 +1,20 @@
 import * as React from 'react';
 import type { NavigationState } from '@react-navigation/routers';
 import NavigationBuilderContext, {
-  NavigatorStateGetter,
+  GetStateListener,
 } from './NavigationBuilderContext';
 import NavigationRouteContext from './NavigationRouteContext';
 import isArrayEqual from './isArrayEqual';
 
+type Options = {
+  getState: () => NavigationState;
+  getStateListeners: Record<string, GetStateListener | undefined>;
+};
+
 export default function useOnGetState({
   getState,
   getStateListeners,
-}: {
-  getState: () => NavigationState;
-  getStateListeners: Record<string, NavigatorStateGetter | undefined>;
-}) {
+}: Options) {
   const { addKeyedListener } = React.useContext(NavigationBuilderContext);
   const route = React.useContext(NavigationRouteContext);
   const key = route ? route.key : 'root';

--- a/packages/core/src/useOnPreventRemove.tsx
+++ b/packages/core/src/useOnPreventRemove.tsx
@@ -1,0 +1,93 @@
+import * as React from 'react';
+import type {
+  NavigationState,
+  Route,
+  NavigationAction,
+} from '@react-navigation/routers';
+import NavigationBuilderContext, {
+  ChildBeforeRemoveListener,
+} from './NavigationBuilderContext';
+import NavigationRouteContext from './NavigationRouteContext';
+import type { NavigationEventEmitter } from './useEventEmitter';
+import type { EventMapCore } from './types';
+
+type Options = {
+  getState: () => NavigationState;
+  emitter: NavigationEventEmitter<EventMapCore<any>>;
+  beforeRemoveListeners: Record<string, ChildBeforeRemoveListener | undefined>;
+};
+
+const VISITED_ROUTE_KEYS = Symbol('VISITED_ROUTE_KEYS');
+
+export const shouldPreventRemove = (
+  emitter: NavigationEventEmitter<EventMapCore<any>>,
+  beforeRemoveListeners: Record<string, ChildBeforeRemoveListener | undefined>,
+  routes: Route<string>[],
+  action: NavigationAction
+) => {
+  // Call these in reverse order so last screens handle the event first
+  const reversedRoutes = [...routes].reverse();
+
+  const visitedRouteKeys: Set<string> =
+    // @ts-expect-error: add this property to mark that we've already emitted this action
+    action[VISITED_ROUTE_KEYS] ?? new Set<string>();
+
+  const beforeRemoveAction = {
+    ...action,
+    [VISITED_ROUTE_KEYS]: visitedRouteKeys,
+  };
+
+  for (const route of reversedRoutes) {
+    if (visitedRouteKeys.has(route.key)) {
+      // Skip if we've already emitted this action for this screen
+      continue;
+    }
+
+    // First, we need to check if any child screens want to prevent it
+    const isPrevented = beforeRemoveListeners[route.key]?.(beforeRemoveAction);
+
+    if (isPrevented) {
+      return true;
+    }
+
+    visitedRouteKeys.add(route.key);
+
+    const event = emitter.emit({
+      type: 'beforeRemove',
+      target: route.key,
+      data: { action: beforeRemoveAction },
+      canPreventDefault: true,
+    });
+
+    if (event.defaultPrevented) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
+export default function useOnPreventRemove({
+  getState,
+  emitter,
+  beforeRemoveListeners,
+}: Options) {
+  const { addKeyedListener } = React.useContext(NavigationBuilderContext);
+  const route = React.useContext(NavigationRouteContext);
+  const routeKey = route?.key;
+
+  React.useEffect(() => {
+    if (routeKey) {
+      return addKeyedListener?.('beforeRemove', routeKey, (action) => {
+        const state = getState();
+
+        return shouldPreventRemove(
+          emitter,
+          beforeRemoveListeners,
+          state.routes,
+          action
+        );
+      });
+    }
+  }, [addKeyedListener, beforeRemoveListeners, emitter, getState, routeKey]);
+}


### PR DESCRIPTION
A lot of times, we want to prompt before leaving a screen if we have unsaved changes. Currently, we need to handle multiple cases to prevent this:

- Disable swipe gestures
- Override the back button in header
- Override the hardware back button on Android

This PR adds a new event which is emitted before a screen gets removed, and the developer has a chance to ask the user before closing the screen.

Example:

```js
React.useEffect(
  () =>
    navigation.addListener('beforeRemove', (e) => {
      if (!hasUnsavedChanges) {
        return;
      }

      e.preventDefault();

      Alert.alert(
        'Discard changes?',
        'You have unsaved changes. Are you sure to discard them and leave the screen?',
        [
          { text: "Don't leave", style: 'cancel', onPress: () => {} },
          {
            text: 'Discard',
            style: 'destructive',
            onPress: () => navigation.dispatch(e.data.action),
          },
        ]
      );
    }),
  [navigation, hasUnsavedChanges]
);
```

![ezgif-2-09f96c4f63b5](https://user-images.githubusercontent.com/1174278/86263324-5e18fe80-bbc1-11ea-980f-50bb63fcb623.gif)


**TODO**

- [x] Make it work when the screen gets removed by a parent navigator as well
- [x] Investigate unhandled action if discard was pressed on first screen of navigator