### PR TITLE
fix: add accessibilityState property

### DIFF
--- a/packages/bottom-tabs/src/views/BottomTabItem.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabItem.tsx
@@ -247,6 +247,7 @@ export default function BottomTabBarItem({
     testID,
     accessibilityLabel,
     accessibilityRole: 'button',
+    accessibilityState: { selected: focused },
     accessibilityStates: focused ? ['selected'] : [],
     style: [
       styles.tab,

--- a/packages/drawer/src/views/DrawerItem.tsx
+++ b/packages/drawer/src/views/DrawerItem.tsx
@@ -156,6 +156,7 @@ export default function DrawerItem(props: Props) {
         accessibilityTraits={focused ? ['button', 'selected'] : 'button'}
         accessibilityComponentType="button"
         accessibilityRole="button"
+        accessibilityState={{ selected: focused }}
         accessibilityStates={focused ? ['selected'] : []}
         to={to}
       >


### PR DESCRIPTION
React Native 0.62 removes the deprecated `accessibilityStates` property and replaces it with an `accessibilityState` object instead. This PR adds the new property where needed, but leaves the old one in place for backwards compatibility. Without the change, the selected tab in BottomTabNavigator isn't announced properly in VoiceOver.