### PR TITLE
fix: make devtools global property configurable

### DIFF
--- a/packages/core/src/BaseNavigationContainer.tsx
+++ b/packages/core/src/BaseNavigationContainer.tsx
@@ -44,6 +44,7 @@ try {
           "Redux devtools extension integration can be enabled with the '@react-navigation/devtools' package. For more details, see https://reactnavigation.org/docs/devtools"
         );
       },
+      configurable: true,
     }
   );
 } catch (e) {


### PR DESCRIPTION
The recent addition of `Object.defineProperty(global, 'REACT_NAVIGATION_REDUX_DEVTOOLS_EXTENSION_INTEGRATION_ENABLED')` resulted in the following type error: `TypeError: Cannot redefine property: REACT_NAVIGATION_REDUX_DEVTOOLS_EXTENSION_INTEGRATION_ENABLED` when attempting to mock `@react-navigation/native` in jest test suite. 

The secondary import of a react-navigation package containing the core package dependency throws a type error due to the property being non configurable. Update property to configurable to avoid the type error for use cases like module mocking in jest.
