### PR TITLE
fix: pass label position flag to label rendering in BottomTabBar

### DIFF
--- a/packages/bottom-tabs/src/types.tsx
+++ b/packages/bottom-tabs/src/types.tsx
@@ -63,7 +63,7 @@ export type BottomTabNavigationOptions = {
 
   /**
    * Title string of a tab displayed in the tab bar
-   * or a function that given { focused: boolean, color: string, orientation: 'horizontal' | 'vertical' } returns a React.Node to display in tab bar.
+   * or a function that given { focused: boolean, color: string, position: 'below-icon' | 'beside-icon' } returns a React.Node to display in tab bar.
    * When undefined, scene title is used. To hide, see tabBarOptions.showLabel in the previous section.
    */
   tabBarLabel?:
@@ -182,7 +182,8 @@ export type BottomTabBarOptions = {
   tabStyle?: StyleProp<ViewStyle>;
   /**
    * Whether the label is rendered below the icon or beside the icon.
-   * By default, in `vertical` orientation, label is rendered below and in `horizontal` orientation, it's rendered beside.
+   * By default, the position is chosen automatically based on device width.
+   * In `below-icon` orientation (typical for iPhones), the label is rendered below and in `beside-icon` orientation, it's rendered beside (typical for iPad).
    */
   labelPosition?: LabelPosition;
   /**

--- a/packages/bottom-tabs/src/types.tsx
+++ b/packages/bottom-tabs/src/types.tsx
@@ -63,12 +63,16 @@ export type BottomTabNavigationOptions = {
 
   /**
    * Title string of a tab displayed in the tab bar
-   * or a function that given { focused: boolean, color: string } returns a React.Node to display in tab bar.
+   * or a function that given { focused: boolean, color: string, orientation: 'horizontal' | 'vertical' } returns a React.Node to display in tab bar.
    * When undefined, scene title is used. To hide, see tabBarOptions.showLabel in the previous section.
    */
   tabBarLabel?:
     | string
-    | ((props: { focused: boolean; color: string }) => React.ReactNode);
+    | ((props: {
+        focused: boolean;
+        color: string;
+        orientation: 'horizontal' | 'vertical';
+      }) => React.ReactNode);
 
   /**
    * A function that given { focused: boolean, color: string } returns a React.Node to display in the tab bar.

--- a/packages/bottom-tabs/src/types.tsx
+++ b/packages/bottom-tabs/src/types.tsx
@@ -71,7 +71,7 @@ export type BottomTabNavigationOptions = {
     | ((props: {
         focused: boolean;
         color: string;
-        orientation: 'horizontal' | 'vertical';
+        position: LabelPosition;
       }) => React.ReactNode);
 
   /**

--- a/packages/bottom-tabs/src/views/BottomTabItem.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabItem.tsx
@@ -30,7 +30,11 @@ type Props = {
    */
   label:
     | string
-    | ((props: { focused: boolean; color: string }) => React.ReactNode);
+    | ((props: {
+        focused: boolean;
+        color: string;
+        orientation: 'horizontal' | 'vertical';
+      }) => React.ReactNode);
   /**
    * Icon to display for the tab.
    */
@@ -206,7 +210,11 @@ export default function BottomTabBarItem({
       );
     }
 
-    return label({ focused, color });
+    return label({
+      focused,
+      color,
+      orientation: horizontal ? 'horizontal' : 'vertical',
+    });
   };
 
   const renderIcon = ({ focused }: { focused: boolean }) => {

--- a/packages/bottom-tabs/src/views/BottomTabItem.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabItem.tsx
@@ -14,7 +14,7 @@ import { Link, Route, useTheme } from '@react-navigation/native';
 import Color from 'color';
 
 import TabBarIcon from './TabBarIcon';
-import type { BottomTabBarButtonProps } from '../types';
+import type { BottomTabBarButtonProps, LabelPosition } from '../types';
 
 type Props = {
   /**
@@ -33,7 +33,7 @@ type Props = {
     | ((props: {
         focused: boolean;
         color: string;
-        orientation: 'horizontal' | 'vertical';
+        position: LabelPosition;
       }) => React.ReactNode);
   /**
    * Icon to display for the tab.
@@ -213,7 +213,7 @@ export default function BottomTabBarItem({
     return label({
       focused,
       color,
-      orientation: horizontal ? 'horizontal' : 'vertical',
+      position: horizontal ? 'beside-icon' : 'below-icon',
     });
   };
 


### PR DESCRIPTION
In the process of upgrading from v4, I noticed a regression. 
In the past, the function form of `tabBarLabel` did get an `orientation: 'landscape' | 'portrait'`, this is no longer the case.
However, when using a custom Text rendering, we need to apply a margin to the text in horizontal mode.

Since the orientation/horizontal state is decided based on internal heuristics, It is a huge pain with a high bug potential when reimplementing that detection myself.
