### PR TITLE
fix: replace url only when all the navigators are mounted

### DIFF
--- a/packages/native/src/__tests__/NavigationContainer.test.tsx
+++ b/packages/native/src/__tests__/NavigationContainer.test.tsx
@@ -99,6 +99,8 @@ it('integrates with the history API', () => {
     </NavigationContainer>
   );
 
+  jest.runAllTimers();
+
   expect(window.location.pathname).toBe('/feed');
 
   act(() => navigation.current?.navigate('Profile', { user: 'jane' }));

--- a/packages/native/src/useLinking.tsx
+++ b/packages/native/src/useLinking.tsx
@@ -376,18 +376,20 @@ export default function useLinking(
       return;
     }
 
-    if (ref.current) {
-      // We need to record the current metadata on the first render if they aren't set
-      // This will allow the initial state to be in the history entry
-      const state = ref.current.getRootState();
-      const path = getPathFromStateRef.current(state, configRef.current);
+    setTimeout(() => {
+      if (ref.current) {
+        // We need to record the current metadata on the first render if they aren't set
+        // This will allow the initial state to be in the history entry
+        const state = ref.current.getRootState();
+        const path = getPathFromStateRef.current(state, configRef.current);
 
-      if (previousStateRef.current === undefined) {
-        previousStateRef.current = state;
+        if (previousStateRef.current === undefined) {
+          previousStateRef.current = state;
+        }
+
+        history.replace({ path, state });
       }
-
-      history.replace({ path, state });
-    }
+    }, 0);
 
     const onStateChange = async () => {
       const navigation = ref.current;


### PR DESCRIPTION
I suspect that the `getRootState` is called before potential other nested navigators are mounted.
What this PR try to solve is an issue with the initial url of the page that is replaced incorrectly. If I hit refresh on a page provided by a nested navigator (`/rootPage/nestedPage`), the url of the page will be replaced with the root's screen (`/rootPage`).

By deferring for a bit that operation, getRootState will provide the correct state, and `path` will have the nested path instead of the root screen path. I'm not sure if https://github.com/react-navigation/react-navigation/blob/f4180295bf22e32c65f6a7ab7089523cb2de58fb/packages/core/src/useNavigationBuilder.tsx#L376-L379 is related.