### PR TITLE
feat: allow style overrides for HeaderBackButton

### DIFF
--- a/packages/stack/src/types.tsx
+++ b/packages/stack/src/types.tsx
@@ -406,6 +406,10 @@ export type StackHeaderLeftButtonProps = {
    * Accessibility label for the button for screen readers.
    */
   accessibilityLabel?: string;
+  /**
+   * Style object for the button.
+   */
+  style?: Animated.WithAnimatedValue<StyleProp<ViewStyle>>;
 };
 
 export type StackHeaderTitleProps = {

--- a/packages/stack/src/views/Header/HeaderBackButton.tsx
+++ b/packages/stack/src/views/Header/HeaderBackButton.tsx
@@ -30,7 +30,7 @@ export default function HeaderBackButton({
   titleLayout,
   truncatedLabel = 'Back',
   accessibilityLabel = label && label !== 'Back' ? `${label}, back` : 'Go back',
-  style
+  style,
 }: Props) {
   const { dark, colors } = useTheme();
 

--- a/packages/stack/src/views/Header/HeaderBackButton.tsx
+++ b/packages/stack/src/views/Header/HeaderBackButton.tsx
@@ -30,6 +30,7 @@ export default function HeaderBackButton({
   titleLayout,
   truncatedLabel = 'Back',
   accessibilityLabel = label && label !== 'Back' ? `${label}, back` : 'Go back',
+  style
 }: Props) {
   const { dark, colors } = useTheme();
 
@@ -160,7 +161,7 @@ export default function HeaderBackButton({
       delayPressIn={0}
       onPress={disabled ? undefined : handlePress}
       pressColor={pressColorAndroid}
-      style={[styles.container, disabled && styles.disabled]}
+      style={[styles.container, disabled && styles.disabled, style]}
       hitSlop={Platform.select({
         ios: undefined,
         default: { top: 16, right: 16, bottom: 16, left: 16 },


### PR DESCRIPTION
Currently, if you use HeaderBackButton with the react-native-screens, there is an extra margin added that is not needed. This can be solved via the style overrides