### PR TITLE
fix: parameter type in payload should use type in addListener’s param…

### DIFF
--- a/packages/core/src/views/NavigationFocusEvents.js
+++ b/packages/core/src/views/NavigationFocusEvents.js
@@ -284,7 +284,7 @@ export default class NavigationEventManager extends React.Component {
 
     onEvent(target, 'willFocus', {
       ...payload,
-      type: 'willFocus'
+      type: 'willFocus',
     });
 
     if (
@@ -316,7 +316,7 @@ export default class NavigationEventManager extends React.Component {
 
     onEvent(target, 'willBlur', {
       ...payload,
-      type: 'willBlur'
+      type: 'willBlur',
     });
 
     if (
@@ -343,7 +343,7 @@ export default class NavigationEventManager extends React.Component {
 
     onEvent(target, 'didFocus', {
       ...payload,
-      type: 'didFocus'
+      type: 'didFocus',
     });
   };
 
@@ -362,7 +362,7 @@ export default class NavigationEventManager extends React.Component {
 
     onEvent(target, 'didBlur', {
       ...payload,
-      type: 'didBlur'
+      type: 'didBlur',
     });
   };
 

--- a/packages/core/src/views/NavigationFocusEvents.js
+++ b/packages/core/src/views/NavigationFocusEvents.js
@@ -282,7 +282,10 @@ export default class NavigationEventManager extends React.Component {
 
     const { navigation, onEvent } = this.props;
 
-    onEvent(target, 'willFocus', payload);
+    onEvent(target, 'willFocus', {
+      ...payload,
+      type: 'willFocus'
+    });
 
     if (
       typeof navigation.state.isTransitioning !== 'boolean' ||
@@ -311,7 +314,10 @@ export default class NavigationEventManager extends React.Component {
 
     const { navigation, onEvent } = this.props;
 
-    onEvent(target, 'willBlur', payload);
+    onEvent(target, 'willBlur', {
+      ...payload,
+      type: 'willBlur'
+    });
 
     if (
       typeof navigation.state.isTransitioning !== 'boolean' ||
@@ -335,7 +341,10 @@ export default class NavigationEventManager extends React.Component {
 
     const { onEvent } = this.props;
 
-    onEvent(target, 'didFocus', payload);
+    onEvent(target, 'didFocus', {
+      ...payload,
+      type: 'didFocus'
+    });
   };
 
   /**
@@ -351,7 +360,10 @@ export default class NavigationEventManager extends React.Component {
 
     const { onEvent } = this.props;
 
-    onEvent(target, 'didBlur', payload);
+    onEvent(target, 'didBlur', {
+      ...payload,
+      type: 'didBlur'
+    });
   };
 
   render() {


### PR DESCRIPTION
when use navigation Events, like didFocus、didBlur, The payload type is always equal to action, like this.
```js
//current
this.props.navigation.addListener('didFocus', (payload) => {console.log(payload.type) // output action};
this.props.navigation.addListener('didBlur', (payload) => {console.log(payload.type) // output action};
this.props.navigation.addListener('willFocus', (payload) => {console.log(payload.type) // output action};
this.props.navigation.addListener('willBlur', (payload) => {console.log(payload.type) // output action};

//expect
this.props.navigation.addListener('didFocus', (payload) => {console.log(payload.type) // output didFocus};
this.props.navigation.addListener('didBlur', (payload) => {console.log(payload.type) // output didBlur};
this.props.navigation.addListener('willFocus', (payload) => {console.log(payload.type) // output willFocus};
this.props.navigation.addListener('willBlur', (payload) => {console.log(payload.type) // output willBlur};
```