### PR TITLE
feat: Adds options for offset for useScrollToTop

### DIFF
--- a/packages/native/src/useScrollToTop.tsx
+++ b/packages/native/src/useScrollToTop.tsx
@@ -14,6 +14,8 @@ type ScrollableWrapper =
   | { getNode(): ScrollableView }
   | ScrollableView;
 
+const defaultScrollOptions = { y: 0, animated: true };
+
 function getScrollableNode(ref: React.RefObject<ScrollableWrapper>) {
   if (ref.current == null) {
     return null;
@@ -43,7 +45,8 @@ function getScrollableNode(ref: React.RefObject<ScrollableWrapper>) {
 }
 
 export default function useScrollToTop(
-  ref: React.RefObject<ScrollableWrapper>
+  ref: React.RefObject<ScrollableWrapper>,
+  options?: ScrollOptions
 ) {
   const navigation = useNavigation();
   const route = useRoute();
@@ -80,16 +83,20 @@ export default function useScrollToTop(
         // This is necessary to know if preventDefault() has been called
         requestAnimationFrame(() => {
           const scrollable = getScrollableNode(ref) as ScrollableWrapper;
+          const actualOptions = { ...defaultScrollOptions, ...options };
 
           if (isFocused && isFirst && scrollable && !e.defaultPrevented) {
-            if ('scrollToTop' in scrollable) {
+            if ('scrollToTop' in scrollable && !options) {
               scrollable.scrollToTop();
             } else if ('scrollTo' in scrollable) {
-              scrollable.scrollTo({ y: 0, animated: true });
+              scrollable.scrollTo(actualOptions);
             } else if ('scrollToOffset' in scrollable) {
-              scrollable.scrollToOffset({ offset: 0, animated: true });
+              scrollable.scrollToOffset({
+                offset: actualOptions.y,
+                animated: actualOptions.animated,
+              });
             } else if ('scrollResponderScrollTo' in scrollable) {
-              scrollable.scrollResponderScrollTo({ y: 0, animated: true });
+              scrollable.scrollResponderScrollTo(actualOptions);
             }
           }
         });


### PR DESCRIPTION
Hi! Thanks for an awesome package. Just found the `useScrollToTop` hook which made my life much simpler.

There are some cases when scrolling to the top doesn't mean setting Y-axis to 0. There can be instances where you do some offset on the top due to animations, headers, or other content. I don't know how you feel about this feature, but thought I'd suggest it as a PR.

This introduces an optional options parameter to the custom hook for handling scroll to top. All it does is exposing the inner `ScrollOptions` and maps from differences for the different scrollable views.

I've set the options parameter as an optional without providing a default value to be able to check in the `scrollToTop` conditional wether or not options were provided. I'm not sure if this is necessary and if this causes some cases where you aren't able to scroll to top. Might be that we need to be more sophisticated with type signature?