### PR TITLE
feat: expose `BottomTabBarButtonProps` type

### DIFF
--- a/packages/bottom-tabs/src/index.tsx
+++ b/packages/bottom-tabs/src/index.tsx
@@ -18,4 +18,5 @@ export type {
   BottomTabScreenProps,
   BottomTabBarProps,
   BottomTabBarOptions,
+  BottomTabBarButtonProps,
 } from './types';


### PR DESCRIPTION
Exposed `BottomTabBarButtonProps` type is needed when providing a custom component to `tabBarButton` property.