### PR TITLE
Remove the now deprecated `useSafeArea` hook

### DIFF
--- a/packages/bottom-tabs/package.json
+++ b/packages/bottom-tabs/package.json
@@ -43,15 +43,15 @@
     "@react-native-community/bob": "^0.15.1",
     "@react-navigation/native": "^5.7.2",
     "@types/color": "^3.0.1",
-    "@types/react": "^16.9.36",
-    "@types/react-native": "^0.62.7",
+    "@types/react": "^16.9.44",
+    "@types/react-native": "^0.63.2",
     "del-cli": "^3.0.1",
     "react": "~16.9.0",
     "react-native": "~0.62.2",
     "react-native-safe-area-context": "~3.0.0",
     "react-native-screens": "^2.7.0",
     "react-native-testing-library": "^2.1.0",
-    "typescript": "^3.9.5"
+    "typescript": "^3.9.7"
   },
   "peerDependencies": {
     "@react-navigation/native": "^5.0.5",

--- a/packages/bottom-tabs/package.json
+++ b/packages/bottom-tabs/package.json
@@ -48,7 +48,7 @@
     "del-cli": "^3.0.1",
     "react": "~16.9.0",
     "react-native": "~0.62.2",
-    "react-native-safe-area-context": "~3.0.0",
+    "react-native-safe-area-context": "~3.1.1",
     "react-native-screens": "^2.7.0",
     "react-native-testing-library": "^2.1.0",
     "typescript": "^3.9.7"

--- a/packages/bottom-tabs/src/views/BottomTabBar.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabBar.tsx
@@ -13,7 +13,7 @@ import {
   StyleSheet,
   View,
 } from 'react-native';
-import { useSafeArea } from 'react-native-safe-area-context';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import type { BottomTabBarProps } from '../types';
 import useIsKeyboardShown from '../utils/useIsKeyboardShown';
 import useWindowDimensions from '../utils/useWindowDimensions';
@@ -165,7 +165,7 @@ export default function BottomTabBar({
     }
   };
 
-  const defaultInsets = useSafeArea();
+  const defaultInsets = useSafeAreaInsets();
 
   const insets = {
     top: safeAreaInsets?.top ?? defaultInsets.top,

--- a/packages/bottom-tabs/src/views/BottomTabBar.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabBar.tsx
@@ -1,24 +1,23 @@
-import React from 'react';
 import {
-  View,
-  Animated,
-  StyleSheet,
-  Platform,
-  LayoutChangeEvent,
-} from 'react-native';
-import {
+  CommonActions,
   NavigationContext,
   NavigationRouteContext,
-  CommonActions,
-  useTheme,
   useLinkBuilder,
+  useTheme,
 } from '@react-navigation/native';
+import React from 'react';
+import {
+  Animated,
+  LayoutChangeEvent,
+  Platform,
+  StyleSheet,
+  View,
+} from 'react-native';
 import { useSafeArea } from 'react-native-safe-area-context';
-
-import BottomTabItem from './BottomTabItem';
-import useWindowDimensions from '../utils/useWindowDimensions';
-import useIsKeyboardShown from '../utils/useIsKeyboardShown';
 import type { BottomTabBarProps } from '../types';
+import useIsKeyboardShown from '../utils/useIsKeyboardShown';
+import useWindowDimensions from '../utils/useWindowDimensions';
+import BottomTabItem from './BottomTabItem';
 
 type Props = BottomTabBarProps & {
   activeTintColor?: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -16834,6 +16834,11 @@ react-native-safe-area-context@~3.0.0, react-native-safe-area-context@~3.0.7:
   resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-3.0.7.tgz#0f53de7a30d626d82936000f3f6db374ecc4b800"
   integrity sha512-dqhRTlIFe5+P1yxitj0C9XVUxLqOmjomeqzUSSY8sNOWVjtIhEY/fl4ZKYpAVnktd8dt3zl13XmJTmRmy3d0uA==
 
+react-native-safe-area-context@~3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-3.1.1.tgz#9b04d1154766e6c1132030aca8f4b0336f561ccd"
+  integrity sha512-Iqb41OT5+QxFn0tpTbbHgz8+3VU/F9OH2fTeeoU7oZCzojOXQbC6sp6mN7BlsAoTKhngWoJLMcSosL58uRaLWQ==
+
 react-native-safe-area-view@^0.14.9:
   version "0.14.9"
   resolved "https://registry.yarnpkg.com/react-native-safe-area-view/-/react-native-safe-area-view-0.14.9.tgz#90ee8383037010d9a5055a97cf97e4c1da1f0c3d"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4845,6 +4845,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-native@^0.63.2":
+  version "0.63.2"
+  resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.63.2.tgz#428a4d71351ccbc31ab170b5f32477c7ce78dfd7"
+  integrity sha512-oxbp084lUsZvwfdWmWxKjJAuqEraQDRf+cE/JgwmrHQMguSrmgIHZ3xkeoQ5FYnW5NHIPpHudB3BbjL1Zn3vnA==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-native@~0.62.13":
   version "0.62.18"
   resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.62.18.tgz#ad63691e7c44edef2beeb6af52b2eb942c3ed8a1"
@@ -4867,6 +4874,14 @@
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"
+
+"@types/react@^16.9.44":
+  version "16.9.44"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.44.tgz#da84b179c031aef67dc92c33bd3401f1da2fa3bc"
+  integrity sha512-BtLoJrXdW8DVZauKP+bY4Kmiq7ubcJq+H/aCpRfvPF7RAT3RwR73Sg8szdc2YasbAlWBDrQ6Q+AFM0KwtQY+WQ==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^3.0.2"
 
 "@types/react@~16.9.41":
   version "16.9.43"
@@ -8033,6 +8048,11 @@ csstype@^2.2.0:
   version "2.6.10"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.10.tgz#e63af50e66d7c266edb6b32909cfd0aabe03928b"
   integrity sha512-D34BqZU4cIlMCY93rZHbrq9pjTAQJ3U8S8rfBqjwHxkGPThWFjzZDQpgMJY0QViLxth6ZKYiwFBo14RdN44U/w==
+
+csstype@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.2.tgz#ee5ff8f208c8cd613b389f7b222c9801ca62b3f7"
+  integrity sha512-ofovWglpqoqbfLNOTBNZLSbMuGrblAf1efvvArGKOZMBrIoJeu5UsAipQolkijtyQx5MtAzT/J9IHj/CEY1mJw==
 
 currently-unhandled@^0.4.1:
   version "0.4.1"
@@ -19403,7 +19423,7 @@ typescript@^3.9.5:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.5.tgz#586f0dba300cde8be52dd1ac4f7e1009c1b13f36"
   integrity sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==
 
-typescript@~3.9.5:
+typescript@^3.9.7, typescript@~3.9.5:
   version "3.9.7"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
   integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==


### PR DESCRIPTION
react-native-safe-area-context has deprecated the `useSafeArea` hook that sets the default insets in the bottom tabs component. `useSafeAreaInsets` is what is now in place and this PR updates the bottom-tabs package to accomodate that change.

This change will also update the react types packages as well as bumping the typescript version used with bottom tabs to 3.9.7

For reference: https://github.com/th3rdwave/react-native-safe-area-context/blob/master/src/SafeAreaContext.tsx#L134