### PR TITLE
fix: Depricate scrollWithoutAnimationTo to support react-native 0.63.0 and later

### DIFF
--- a/packages/native/src/createNavigationAwareScrollable.js
+++ b/packages/native/src/createNavigationAwareScrollable.js
@@ -95,8 +95,10 @@ export default function createNavigationAwareScrollable(Component) {
     };
 
     scrollWithoutAnimationTo = (...args) => {
-      console.warn('`scrollWithoutAnimationTo` is deprecated. Use `scrollTo` instead');
-      return this._innerRef.getNode().scrollTo({...args, animated: false});
+      console.warn(
+        '`scrollWithoutAnimationTo` is deprecated. Use `scrollTo` instead'
+      );
+      return this._innerRef.getNode().scrollTo({ ...args, animated: false });
     };
 
     flashScrollIndicators = (...args) => {

--- a/packages/native/src/createNavigationAwareScrollable.js
+++ b/packages/native/src/createNavigationAwareScrollable.js
@@ -95,7 +95,8 @@ export default function createNavigationAwareScrollable(Component) {
     };
 
     scrollWithoutAnimationTo = (...args) => {
-      return this._innerRef.getNode().scrollWithoutAnimationTo(...args);
+      console.warn('`scrollWithoutAnimationTo` is deprecated. Use `scrollTo` instead');
+      return this._innerRef.getNode().scrollTo({...args, animated: false});
     };
 
     flashScrollIndicators = (...args) => {


### PR DESCRIPTION
Remove usage of depricated API and add deprication warning.