### PR TITLE
fix: don't use deprecated currentlyFocusedField

### DIFF
--- a/packages/native/src/createKeyboardAwareNavigator.js
+++ b/packages/native/src/createKeyboardAwareNavigator.js
@@ -9,8 +9,8 @@ export default (Navigator, navigatorConfig) =>
 
     _handleGestureBegin = () => {
       this._previouslyFocusedTextInput = TextInput.State.currentlyFocusedInput
-      ? TextInput.State.currentlyFocusedInput()
-      : TextInput.State.currentlyFocusedField();
+        ? TextInput.State.currentlyFocusedInput()
+        : TextInput.State.currentlyFocusedField();
       if (this._previouslyFocusedTextInput) {
         TextInput.State.blurTextInput(this._previouslyFocusedTextInput);
       }
@@ -35,8 +35,8 @@ export default (Navigator, navigatorConfig) =>
       // should revisit this after 2.0 release.
       if (transitionProps.index !== prevTransitionProps.index) {
         const currentField = TextInput.State.currentlyFocusedInput
-        ? TextInput.State.currentlyFocusedInput()
-        : TextInput.State.currentlyFocusedField();
+          ? TextInput.State.currentlyFocusedInput()
+          : TextInput.State.currentlyFocusedField();
         if (currentField) {
           TextInput.State.blurTextInput(currentField);
         }

--- a/packages/native/src/createKeyboardAwareNavigator.js
+++ b/packages/native/src/createKeyboardAwareNavigator.js
@@ -8,7 +8,9 @@ export default (Navigator, navigatorConfig) =>
     _previouslyFocusedTextInput = null;
 
     _handleGestureBegin = () => {
-      this._previouslyFocusedTextInput = TextInput.State.currentlyFocusedField();
+      this._previouslyFocusedTextInput = TextInput.State.currentlyFocusedInput
+      ? TextInput.State.currentlyFocusedInput()
+      : TextInput.State.currentlyFocusedField();
       if (this._previouslyFocusedTextInput) {
         TextInput.State.blurTextInput(this._previouslyFocusedTextInput);
       }
@@ -32,7 +34,9 @@ export default (Navigator, navigatorConfig) =>
       // in the case where the index did not change, I believe. We
       // should revisit this after 2.0 release.
       if (transitionProps.index !== prevTransitionProps.index) {
-        const currentField = TextInput.State.currentlyFocusedField();
+        const currentField = TextInput.State.currentlyFocusedInput
+        ? TextInput.State.currentlyFocusedInput()
+        : TextInput.State.currentlyFocusedField();
         if (currentField) {
           TextInput.State.blurTextInput(currentField);
         }


### PR DESCRIPTION
currentlyFocusedField => currentlyFocusedInput

Fixes #8457 for 4.x because `createKeyboardAwareNavigator.js` is not inside the `main` branch.

Fixed in main here: https://github.com/react-navigation/react-navigation/commit/35d6b9e3a4a28a59b3b11a67acbf7753d41705ae