### PR TITLE
fix: add aria-level to HeaderTitle

### DIFF
--- a/packages/stack/src/views/Header/HeaderTitle.tsx
+++ b/packages/stack/src/views/Header/HeaderTitle.tsx
@@ -21,6 +21,7 @@ export default function HeaderTitle({ tintColor, style, ...rest }: Props) {
   return (
     <Animated.Text
       accessibilityRole="header"
+      aria-level="1"
       numberOfLines={1}
       {...rest}
       style={[


### PR DESCRIPTION
We use `cypress-axe` to ensure accessibility compliance for the web version of our app (WCAG level A and AA) and it showed that the `HeaderTitle` is not compliant.

The rule that fails is `aria-required-attr` and it complains about the `h1` missing the `aria-level` attribute:
https://dequeuniversity.com/rules/axe/3.4/aria-required-attr?application=axeAPI

![2020-08-10_17-23](https://user-images.githubusercontent.com/418787/89800120-9e5b8d00-db2e-11ea-9b56-9ae62f632f53.png)


The solution is documented in `react-native-web`:
https://github.com/necolas/react-native-web/blob/master/packages/docs/src/guides/accessibility.stories.mdx#accessibilityrole-string

If you're interested, I could also add basic accessibility tests on `react-navigation` for the web using `cypress` and `cypress-axe`.