### PR TITLE
test: move assertions into their own tests

### DIFF
--- a/packages/core/src/__tests__/NavigationStateUtils.test.js
+++ b/packages/core/src/__tests__/NavigationStateUtils.test.js
@@ -3,48 +3,51 @@ import NavigationStateUtils from '../StateUtils';
 const routeName = 'Anything';
 
 describe('StateUtils', () => {
-  // Getters
-  it('gets route', () => {
-    const state = {
-      index: 0,
-      routes: [{ key: 'a', routeName }],
-      isTransitioning: false,
-    };
-    expect(NavigationStateUtils.get(state, 'a')).toEqual({
-      key: 'a',
-      routeName,
+  describe('get', () => {
+    it('gets route', () => {
+      const state = {
+        index: 0,
+        routes: [{ key: 'a', routeName }],
+        isTransitioning: false,
+      };
+      expect(NavigationStateUtils.get(state, 'a')).toEqual({
+        key: 'a',
+        routeName,
+      });
+    });
+
+    it('returns null when getting an unknown route', () => {
+      const state = {
+        index: 0,
+        routes: [{ key: 'a', routeName }],
+        isTransitioning: false,
+      };
+      expect(NavigationStateUtils.get(state, 'b')).toBe(null);
     });
   });
 
-  it('returns null when getting an unknown route', () => {
-    const state = {
-      index: 0,
-      routes: [{ key: 'a', routeName }],
-      isTransitioning: false,
-    };
-    expect(NavigationStateUtils.get(state, 'b')).toBe(null);
-  });
+  describe('indexOf', () => {
+    it('gets route index', () => {
+      const state = {
+        index: 1,
+        routes: [
+          { key: 'a', routeName },
+          { key: 'b', routeName },
+        ],
+        isTransitioning: false,
+      };
+      expect(NavigationStateUtils.indexOf(state, 'a')).toBe(0);
+      expect(NavigationStateUtils.indexOf(state, 'b')).toBe(1);
+    });
 
-  it('gets route index', () => {
-    const state = {
-      index: 1,
-      routes: [
-        { key: 'a', routeName },
-        { key: 'b', routeName },
-      ],
-      isTransitioning: false,
-    };
-    expect(NavigationStateUtils.indexOf(state, 'a')).toBe(0);
-    expect(NavigationStateUtils.indexOf(state, 'b')).toBe(1);
-  });
-
-  it('returns -1 when getting an unknown route index', () => {
-    const state = {
-      index: 1,
-      routes: [{ key: 'a', routeName }],
-      isTransitioning: false,
-    };
-    expect(NavigationStateUtils.indexOf(state, 'b')).toBe(-1);
+    it('returns -1 when getting an unknown route index', () => {
+      const state = {
+        index: 1,
+        routes: [{ key: 'a', routeName }],
+        isTransitioning: false,
+      };
+      expect(NavigationStateUtils.indexOf(state, 'b')).toBe(-1);
+    });
   });
 
   it('has a route', () => {
@@ -60,379 +63,390 @@ describe('StateUtils', () => {
     expect(NavigationStateUtils.has(state, 'c')).toBe(false);
   });
 
-  // Push
-  it('pushes a route', () => {
-    const state = {
-      index: 0,
-      routes: [{ key: 'a', routeName }],
-      isTransitioning: false,
-    };
-    const newState = {
-      index: 1,
-      isTransitioning: false,
-      routes: [
-        { key: 'a', routeName },
-        { key: 'b', routeName },
-      ],
-    };
-    expect(NavigationStateUtils.push(state, { key: 'b', routeName })).toEqual(
-      newState
-    );
-  });
-
-  it('does not push duplicated route', () => {
-    const state = {
-      index: 0,
-      routes: [{ key: 'a', routeName }],
-      isTransitioning: false,
-    };
-    expect(() =>
-      NavigationStateUtils.push(state, { key: 'a', routeName })
-    ).toThrow('should not push route with duplicated key a');
-  });
-
-  // Pop
-  it('pops route', () => {
-    const state = {
-      index: 1,
-      routes: [
-        { key: 'a', routeName },
-        { key: 'b', routeName },
-      ],
-      isTransitioning: false,
-    };
-    const newState = {
-      index: 0,
-      routes: [{ key: 'a', routeName }],
-      isTransitioning: false,
-    };
-    expect(NavigationStateUtils.pop(state)).toEqual(newState);
-  });
-
-  it('does not pop route if not applicable with single route config', () => {
-    const state = {
-      index: 0,
-      routes: [{ key: 'a', routeName }],
-      isTransitioning: false,
-    };
-    expect(NavigationStateUtils.pop(state)).toBe(state);
-  });
-
-  it('does not pop route if not applicable with multiple route config', () => {
-    const state = {
-      index: 0,
-      routes: [
-        { key: 'a', routeName },
-        { key: 'b', routeName },
-      ],
-      isTransitioning: false,
-    };
-    expect(NavigationStateUtils.pop(state)).toBe(state);
-  });
-
-  // Jump
-  it('jumps to new index', () => {
-    const state = {
-      index: 0,
-      routes: [
-        { key: 'a', routeName },
-        { key: 'b', routeName },
-      ],
-      isTransitioning: false,
-    };
-    const newState = {
-      index: 1,
-      routes: [
-        { key: 'a', routeName },
-        { key: 'b', routeName },
-      ],
-      isTransitioning: false,
-    };
-    expect(NavigationStateUtils.jumpToIndex(state, 0)).toBe(state);
-    expect(NavigationStateUtils.jumpToIndex(state, 1)).toEqual(newState);
-  });
-
-  it('throws if jumps to invalid index', () => {
-    const state = {
-      index: 0,
-      routes: [
-        { key: 'a', routeName },
-        { key: 'b', routeName },
-      ],
-      isTransitioning: false,
-    };
-    expect(() => NavigationStateUtils.jumpToIndex(state, 2)).toThrow(
-      'invalid index 2 to jump to'
-    );
-  });
-
-  it('jumps to the current key', () => {
-    const state = {
-      index: 0,
-      routes: [
-        { key: 'a', routeName },
-        { key: 'b', routeName },
-      ],
-      isTransitioning: false,
-    };
-    expect(NavigationStateUtils.jumpTo(state, 'a')).toBe(state);
-  });
-
-  it('jumps to new key', () => {
-    const state = {
-      index: 0,
-      routes: [
-        { key: 'a', routeName },
-        { key: 'b', routeName },
-      ],
-      isTransitioning: false,
-    };
-    const newState = {
-      index: 1,
-      routes: [
-        { key: 'a', routeName },
-        { key: 'b', routeName },
-      ],
-      isTransitioning: false,
-    };
-    expect(NavigationStateUtils.jumpTo(state, 'b')).toEqual(newState);
-  });
-
-  it('throws if jumps to invalid key', () => {
-    const state = {
-      index: 0,
-      routes: [
-        { key: 'a', routeName },
-        { key: 'b', routeName },
-      ],
-      isTransitioning: false,
-    };
-    expect(() => NavigationStateUtils.jumpTo(state, 'c')).toThrow(
-      'invalid index -1 to jump to'
-    );
-  });
-
-  it('move backwards', () => {
-    const state = {
-      index: 1,
-      routes: [
-        { key: 'a', routeName },
-        { key: 'b', routeName },
-      ],
-      isTransitioning: false,
-    };
-    const newState = {
-      index: 0,
-      routes: [
-        { key: 'a', routeName },
-        { key: 'b', routeName },
-      ],
-      isTransitioning: false,
-    };
-    expect(NavigationStateUtils.back(state)).toEqual(newState);
-  });
-
-  it('does not move backwards when the active route is the first', () => {
-    const state = {
-      index: 0,
-      routes: [
-        { key: 'a', routeName },
-        { key: 'b', routeName },
-      ],
-      isTransitioning: false,
-    };
-    expect(NavigationStateUtils.back(state)).toBe(state);
-  });
-
-  it('move forwards', () => {
-    const state = {
-      index: 0,
-      routes: [
-        { key: 'a', routeName },
-        { key: 'b', routeName },
-      ],
-      isTransitioning: false,
-    };
-    const newState = {
-      index: 1,
-      routes: [
-        { key: 'a', routeName },
-        { key: 'b', routeName },
-      ],
-      isTransitioning: false,
-    };
-    expect(NavigationStateUtils.forward(state)).toEqual(newState);
-  });
-
-  it('does not move forward when active route is already the top-most', () => {
-    const state = {
-      index: 1,
-      routes: [
-        { key: 'a', routeName },
-        { key: 'b', routeName },
-      ],
-      isTransitioning: false,
-    };
-    expect(NavigationStateUtils.forward(state)).toEqual(state);
-  });
-
-  // Replace
-  it('Replaces by key', () => {
-    const state = {
-      index: 0,
-      routes: [
-        { key: 'a', routeName },
-        { key: 'b', routeName },
-      ],
-      isTransitioning: false,
-    };
-    const newState = {
-      index: 1,
-      routes: [
-        { key: 'a', routeName },
-        { key: 'c', routeName },
-      ],
-      isTransitioning: false,
-    };
-    expect(
-      NavigationStateUtils.replaceAt(state, 'b', { key: 'c', routeName })
-    ).toEqual(newState);
-  });
-
-  it('Replaces by index', () => {
-    const state = {
-      index: 0,
-      routes: [
-        { key: 'a', routeName },
-        { key: 'b', routeName },
-      ],
-      isTransitioning: false,
-    };
-    const newState = {
-      index: 1,
-      routes: [
-        { key: 'a', routeName },
-        { key: 'c', routeName },
-      ],
-      isTransitioning: false,
-    };
-    expect(
-      NavigationStateUtils.replaceAtIndex(state, 1, { key: 'c', routeName })
-    ).toEqual(newState);
-  });
-
-  it('Returns the state with updated index if route is unchanged but index changes', () => {
-    const state = {
-      index: 0,
-      routes: [
-        { key: 'a', routeName },
-        { key: 'b', routeName },
-      ],
-      isTransitioning: false,
-    };
-    expect(
-      NavigationStateUtils.replaceAtIndex(state, 1, state.routes[1])
-    ).toEqual({ ...state, index: 1 });
-  });
-
-  // Reset
-  it('Resets routes', () => {
-    const state = {
-      index: 0,
-      routes: [
-        { key: 'a', routeName },
-        { key: 'b', routeName },
-      ],
-      isTransitioning: false,
-    };
-    const newState = {
-      index: 1,
-      routes: [
-        { key: 'x', routeName },
-        { key: 'y', routeName },
-      ],
-      isTransitioning: false,
-    };
-    expect(
-      NavigationStateUtils.reset(state, [
-        { key: 'x', routeName },
-        { key: 'y', routeName },
-      ])
-    ).toEqual(newState);
-  });
-
-  it('throws when attempting to set empty state', () => {
-    const state = {
-      index: 0,
-      routes: [
-        { key: 'a', routeName },
-        { key: 'b', routeName },
-      ],
-      isTransitioning: false,
-    };
-    expect(() => {
-      NavigationStateUtils.reset(state, []);
-    }).toThrow('invalid routes to replace');
-  });
-
-  it('Resets routes with index', () => {
-    const state = {
-      index: 0,
-      routes: [
-        { key: 'a', routeName },
-        { key: 'b', routeName },
-      ],
-      isTransitioning: false,
-    };
-    const newState = {
-      index: 0,
-      routes: [
-        { key: 'x', routeName },
-        { key: 'y', routeName },
-      ],
-      isTransitioning: false,
-    };
-    expect(
-      NavigationStateUtils.reset(
-        state,
-        [
-          { key: 'x', routeName },
-          { key: 'y', routeName },
+  describe('push', () => {
+    it('pushes a route', () => {
+      const state = {
+        index: 0,
+        routes: [{ key: 'a', routeName }],
+        isTransitioning: false,
+      };
+      const newState = {
+        index: 1,
+        isTransitioning: false,
+        routes: [
+          { key: 'a', routeName },
+          { key: 'b', routeName },
         ],
-        0
-      )
-    ).toEqual(newState);
-
-    expect(() => {
-      NavigationStateUtils.reset(
-        state,
-        [
-          { key: 'x', routeName },
-          { key: 'y', routeName },
-        ],
-        100
+      };
+      expect(NavigationStateUtils.push(state, { key: 'b', routeName })).toEqual(
+        newState
       );
-    }).toThrow('invalid index 100 to reset');
+    });
+
+    it('does not push duplicated route', () => {
+      const state = {
+        index: 0,
+        routes: [{ key: 'a', routeName }],
+        isTransitioning: false,
+      };
+      expect(() =>
+        NavigationStateUtils.push(state, { key: 'a', routeName })
+      ).toThrow('should not push route with duplicated key a');
+    });
   });
 
-  it('throws when attempting to set an out of range route index', () => {
-    const state = {
-      index: 0,
-      routes: [
-        { key: 'a', routeName },
-        { key: 'b', routeName },
-      ],
-      isTransitioning: false,
-    };
-    expect(() => {
-      NavigationStateUtils.reset(
-        state,
-        [
+  describe('pop', () => {
+    it('pops route', () => {
+      const state = {
+        index: 1,
+        routes: [
+          { key: 'a', routeName },
+          { key: 'b', routeName },
+        ],
+        isTransitioning: false,
+      };
+      const newState = {
+        index: 0,
+        routes: [{ key: 'a', routeName }],
+        isTransitioning: false,
+      };
+      expect(NavigationStateUtils.pop(state)).toEqual(newState);
+    });
+
+    it('does not pop route if not applicable with single route config', () => {
+      const state = {
+        index: 0,
+        routes: [{ key: 'a', routeName }],
+        isTransitioning: false,
+      };
+      expect(NavigationStateUtils.pop(state)).toBe(state);
+    });
+
+    it('does not pop route if not applicable with multiple route config', () => {
+      const state = {
+        index: 0,
+        routes: [
+          { key: 'a', routeName },
+          { key: 'b', routeName },
+        ],
+        isTransitioning: false,
+      };
+      expect(NavigationStateUtils.pop(state)).toBe(state);
+    });
+  });
+
+  describe('jumpToIndex', () => {
+    it('jumps to new index', () => {
+      const state = {
+        index: 0,
+        routes: [
+          { key: 'a', routeName },
+          { key: 'b', routeName },
+        ],
+        isTransitioning: false,
+      };
+      const newState = {
+        index: 1,
+        routes: [
+          { key: 'a', routeName },
+          { key: 'b', routeName },
+        ],
+        isTransitioning: false,
+      };
+      expect(NavigationStateUtils.jumpToIndex(state, 0)).toBe(state);
+      expect(NavigationStateUtils.jumpToIndex(state, 1)).toEqual(newState);
+    });
+
+    it('throws if jumps to invalid index', () => {
+      const state = {
+        index: 0,
+        routes: [
+          { key: 'a', routeName },
+          { key: 'b', routeName },
+        ],
+        isTransitioning: false,
+      };
+      expect(() => NavigationStateUtils.jumpToIndex(state, 2)).toThrow(
+        'invalid index 2 to jump to'
+      );
+    });
+  });
+
+  describe('jumpTo', () => {
+    it('jumps to the current key', () => {
+      const state = {
+        index: 0,
+        routes: [
+          { key: 'a', routeName },
+          { key: 'b', routeName },
+        ],
+        isTransitioning: false,
+      };
+      expect(NavigationStateUtils.jumpTo(state, 'a')).toBe(state);
+    });
+
+    it('jumps to new key', () => {
+      const state = {
+        index: 0,
+        routes: [
+          { key: 'a', routeName },
+          { key: 'b', routeName },
+        ],
+        isTransitioning: false,
+      };
+      const newState = {
+        index: 1,
+        routes: [
+          { key: 'a', routeName },
+          { key: 'b', routeName },
+        ],
+        isTransitioning: false,
+      };
+      expect(NavigationStateUtils.jumpTo(state, 'b')).toEqual(newState);
+    });
+
+    it('throws if jumps to invalid key', () => {
+      const state = {
+        index: 0,
+        routes: [
+          { key: 'a', routeName },
+          { key: 'b', routeName },
+        ],
+        isTransitioning: false,
+      };
+      expect(() => NavigationStateUtils.jumpTo(state, 'c')).toThrow(
+        'invalid index -1 to jump to'
+      );
+    });
+  });
+
+  describe('back', () => {
+    it('move backwards', () => {
+      const state = {
+        index: 1,
+        routes: [
+          { key: 'a', routeName },
+          { key: 'b', routeName },
+        ],
+        isTransitioning: false,
+      };
+      const newState = {
+        index: 0,
+        routes: [
+          { key: 'a', routeName },
+          { key: 'b', routeName },
+        ],
+        isTransitioning: false,
+      };
+      expect(NavigationStateUtils.back(state)).toEqual(newState);
+    });
+
+    it('does not move backwards when the active route is the first', () => {
+      const state = {
+        index: 0,
+        routes: [
+          { key: 'a', routeName },
+          { key: 'b', routeName },
+        ],
+        isTransitioning: false,
+      };
+      expect(NavigationStateUtils.back(state)).toBe(state);
+    });
+  });
+
+  describe('forward', () => {
+    it('move forwards', () => {
+      const state = {
+        index: 0,
+        routes: [
+          { key: 'a', routeName },
+          { key: 'b', routeName },
+        ],
+        isTransitioning: false,
+      };
+      const newState = {
+        index: 1,
+        routes: [
+          { key: 'a', routeName },
+          { key: 'b', routeName },
+        ],
+        isTransitioning: false,
+      };
+      expect(NavigationStateUtils.forward(state)).toEqual(newState);
+    });
+
+    it('does not move forward when active route is already the top-most', () => {
+      const state = {
+        index: 1,
+        routes: [
+          { key: 'a', routeName },
+          { key: 'b', routeName },
+        ],
+        isTransitioning: false,
+      };
+      expect(NavigationStateUtils.forward(state)).toEqual(state);
+    });
+  });
+
+  describe('replace', () => {
+    it('Replaces by key', () => {
+      const state = {
+        index: 0,
+        routes: [
+          { key: 'a', routeName },
+          { key: 'b', routeName },
+        ],
+        isTransitioning: false,
+      };
+      const newState = {
+        index: 1,
+        routes: [
+          { key: 'a', routeName },
+          { key: 'c', routeName },
+        ],
+        isTransitioning: false,
+      };
+      expect(
+        NavigationStateUtils.replaceAt(state, 'b', { key: 'c', routeName })
+      ).toEqual(newState);
+    });
+
+    it('Replaces by index', () => {
+      const state = {
+        index: 0,
+        routes: [
+          { key: 'a', routeName },
+          { key: 'b', routeName },
+        ],
+        isTransitioning: false,
+      };
+      const newState = {
+        index: 1,
+        routes: [
+          { key: 'a', routeName },
+          { key: 'c', routeName },
+        ],
+        isTransitioning: false,
+      };
+      expect(
+        NavigationStateUtils.replaceAtIndex(state, 1, { key: 'c', routeName })
+      ).toEqual(newState);
+    });
+
+    it('Returns the state with updated index if route is unchanged but index changes', () => {
+      const state = {
+        index: 0,
+        routes: [
+          { key: 'a', routeName },
+          { key: 'b', routeName },
+        ],
+        isTransitioning: false,
+      };
+      expect(
+        NavigationStateUtils.replaceAtIndex(state, 1, state.routes[1])
+      ).toEqual({ ...state, index: 1 });
+    });
+  });
+
+  describe('reset', () => {
+    it('Resets routes', () => {
+      const state = {
+        index: 0,
+        routes: [
+          { key: 'a', routeName },
+          { key: 'b', routeName },
+        ],
+        isTransitioning: false,
+      };
+      const newState = {
+        index: 1,
+        routes: [
           { key: 'x', routeName },
           { key: 'y', routeName },
         ],
-        100
-      );
-    }).toThrow('invalid index 100 to reset');
+        isTransitioning: false,
+      };
+      expect(
+        NavigationStateUtils.reset(state, [
+          { key: 'x', routeName },
+          { key: 'y', routeName },
+        ])
+      ).toEqual(newState);
+    });
+
+    it('throws when attempting to set empty state', () => {
+      const state = {
+        index: 0,
+        routes: [
+          { key: 'a', routeName },
+          { key: 'b', routeName },
+        ],
+        isTransitioning: false,
+      };
+      expect(() => {
+        NavigationStateUtils.reset(state, []);
+      }).toThrow('invalid routes to replace');
+    });
+
+    it('Resets routes with index', () => {
+      const state = {
+        index: 0,
+        routes: [
+          { key: 'a', routeName },
+          { key: 'b', routeName },
+        ],
+        isTransitioning: false,
+      };
+      const newState = {
+        index: 0,
+        routes: [
+          { key: 'x', routeName },
+          { key: 'y', routeName },
+        ],
+        isTransitioning: false,
+      };
+      expect(
+        NavigationStateUtils.reset(
+          state,
+          [
+            { key: 'x', routeName },
+            { key: 'y', routeName },
+          ],
+          0
+        )
+      ).toEqual(newState);
+
+      expect(() => {
+        NavigationStateUtils.reset(
+          state,
+          [
+            { key: 'x', routeName },
+            { key: 'y', routeName },
+          ],
+          100
+        );
+      }).toThrow('invalid index 100 to reset');
+    });
+
+    it('throws when attempting to set an out of range route index', () => {
+      const state = {
+        index: 0,
+        routes: [
+          { key: 'a', routeName },
+          { key: 'b', routeName },
+        ],
+        isTransitioning: false,
+      };
+      expect(() => {
+        NavigationStateUtils.reset(
+          state,
+          [
+            { key: 'x', routeName },
+            { key: 'y', routeName },
+          ],
+          100
+        );
+      }).toThrow('invalid index 100 to reset');
+    });
   });
 });

--- a/packages/core/src/__tests__/NavigationStateUtils.test.js
+++ b/packages/core/src/__tests__/NavigationStateUtils.test.js
@@ -14,6 +14,14 @@ describe('StateUtils', () => {
       key: 'a',
       routeName,
     });
+  });
+
+  it('returns null when getting an unknown route', () => {
+    const state = {
+      index: 0,
+      routes: [{ key: 'a', routeName }],
+      isTransitioning: false,
+    };
     expect(NavigationStateUtils.get(state, 'b')).toBe(null);
   });
 
@@ -28,7 +36,15 @@ describe('StateUtils', () => {
     };
     expect(NavigationStateUtils.indexOf(state, 'a')).toBe(0);
     expect(NavigationStateUtils.indexOf(state, 'b')).toBe(1);
-    expect(NavigationStateUtils.indexOf(state, 'c')).toBe(-1);
+  });
+
+  it('returns -1 when getting an unknown route index', () => {
+    const state = {
+      index: 1,
+      routes: [{ key: 'a', routeName }],
+      isTransitioning: false,
+    };
+    expect(NavigationStateUtils.indexOf(state, 'b')).toBe(-1);
   });
 
   it('has a route', () => {
@@ -150,6 +166,18 @@ describe('StateUtils', () => {
     );
   });
 
+  it('jumps to the current key', () => {
+    const state = {
+      index: 0,
+      routes: [
+        { key: 'a', routeName },
+        { key: 'b', routeName },
+      ],
+      isTransitioning: false,
+    };
+    expect(NavigationStateUtils.jumpTo(state, 'a')).toBe(state);
+  });
+
   it('jumps to new key', () => {
     const state = {
       index: 0,
@@ -167,7 +195,6 @@ describe('StateUtils', () => {
       ],
       isTransitioning: false,
     };
-    expect(NavigationStateUtils.jumpTo(state, 'a')).toBe(state);
     expect(NavigationStateUtils.jumpTo(state, 'b')).toEqual(newState);
   });
 
@@ -203,7 +230,18 @@ describe('StateUtils', () => {
       isTransitioning: false,
     };
     expect(NavigationStateUtils.back(state)).toEqual(newState);
-    expect(NavigationStateUtils.back(newState)).toBe(newState);
+  });
+
+  it('does not move backwards when the active route is the first', () => {
+    const state = {
+      index: 0,
+      routes: [
+        { key: 'a', routeName },
+        { key: 'b', routeName },
+      ],
+      isTransitioning: false,
+    };
+    expect(NavigationStateUtils.back(state)).toBe(state);
   });
 
   it('move forwards', () => {
@@ -224,7 +262,18 @@ describe('StateUtils', () => {
       isTransitioning: false,
     };
     expect(NavigationStateUtils.forward(state)).toEqual(newState);
-    expect(NavigationStateUtils.forward(newState)).toBe(newState);
+  });
+
+  it('does not move forward when active route is already the top-most', () => {
+    const state = {
+      index: 1,
+      routes: [
+        { key: 'a', routeName },
+        { key: 'b', routeName },
+      ],
+      isTransitioning: false,
+    };
+    expect(NavigationStateUtils.forward(state)).toEqual(state);
   });
 
   // Replace
@@ -310,7 +359,17 @@ describe('StateUtils', () => {
         { key: 'y', routeName },
       ])
     ).toEqual(newState);
+  });
 
+  it('throws when attempting to set empty state', () => {
+    const state = {
+      index: 0,
+      routes: [
+        { key: 'a', routeName },
+        { key: 'b', routeName },
+      ],
+      isTransitioning: false,
+    };
     expect(() => {
       NavigationStateUtils.reset(state, []);
     }).toThrow('invalid routes to replace');
@@ -344,6 +403,27 @@ describe('StateUtils', () => {
       )
     ).toEqual(newState);
 
+    expect(() => {
+      NavigationStateUtils.reset(
+        state,
+        [
+          { key: 'x', routeName },
+          { key: 'y', routeName },
+        ],
+        100
+      );
+    }).toThrow('invalid index 100 to reset');
+  });
+
+  it('throws when attempting to set an out of range route index', () => {
+    const state = {
+      index: 0,
+      routes: [
+        { key: 'a', routeName },
+        { key: 'b', routeName },
+      ],
+      isTransitioning: false,
+    };
     expect(() => {
       NavigationStateUtils.reset(
         state,


### PR DESCRIPTION
This change makes the tests in NavigationStateUtils more specific by splitting tests with multiple assertions.

I also grouped the tests into describe blocks by the function they test. Let me know if that's something you want or not, I can revert it if needed.

This is my first contribution, but I plan to make more of these which would mostly consists on improving tests.