### PR TITLE
refactor: Use NavigateParams in CommonActions.navigate function signatures

### DIFF
--- a/packages/core/src/getActionFromState.tsx
+++ b/packages/core/src/getActionFromState.tsx
@@ -1,10 +1,8 @@
-import type { PartialState, NavigationState } from '@react-navigation/routers';
-
-type NavigateParams = {
-  screen?: string;
-  params?: NavigateParams;
-  initial?: boolean;
-};
+import type {
+  PartialState,
+  NavigationState,
+  NavigateParams,
+} from '@react-navigation/routers';
 
 type NavigateAction = {
   type: 'NAVIGATE';

--- a/packages/routers/src/CommonActions.tsx
+++ b/packages/routers/src/CommonActions.tsx
@@ -1,4 +1,9 @@
-import type { NavigationState, PartialState, Route } from './types';
+import type {
+  NavigationState,
+  NavigateParams,
+  PartialState,
+  Route,
+} from './types';
 
 type ResetState =
   | PartialState<NavigationState>
@@ -16,8 +21,8 @@ export type Action =
   | {
       type: 'NAVIGATE';
       payload:
-        | { key: string; name?: undefined; params?: object }
-        | { name: string; key?: string; params?: object };
+        | { key: string; name?: undefined; params?: NavigateParams }
+        | { name: string; key?: string; params?: NavigateParams };
       source?: string;
       target?: string;
     }
@@ -40,10 +45,10 @@ export function goBack(): Action {
 
 export function navigate(
   route:
-    | { key: string; params?: object }
-    | { name: string; key?: string; params?: object }
+    | { key: string; params?: NavigateParams }
+    | { name: string; key?: string; params?: NavigateParams }
 ): Action;
-export function navigate(name: string, params?: object): Action;
+export function navigate(name: string, params?: NavigateParams): Action;
 export function navigate(...args: any): Action {
   if (typeof args[0] === 'string') {
     return { type: 'NAVIGATE', payload: { name: args[0], params: args[1] } };

--- a/packages/routers/src/types.tsx
+++ b/packages/routers/src/types.tsx
@@ -2,6 +2,12 @@ import type * as CommonActions from './CommonActions';
 
 export type CommonNavigationAction = CommonActions.Action;
 
+export type NavigateParams = {
+  screen?: string;
+  params?: NavigateParams;
+  initial?: boolean;
+};
+
 export type NavigationState = Readonly<{
   /**
    * Unique key for the navigation state.


### PR DESCRIPTION
This PR improves the type of the `params` argument when using `CommonActions.navigate`.

Formerly it was just `object`, but the type `NavigateParams` type already existed, but just as a local type in  [core/src/getActionFromState.tsx](https://github.com/react-navigation/react-navigation/blob/1aadc79fb89177a2fff2dcd791d67a3c880009d0/packages/core/src/getActionFromState.tsx). It is now exported and used for the signature of the `CommonActions.navigate` action.

I opened a PR in the docs repo which describes this alternative function signature: https://github.com/react-navigation/react-navigation.github.io/pull/852