### PR TITLE
chore: enable faster bundling on preview builds

### DIFF
--- a/.github/workflows/expo-preview.yml
+++ b/.github/workflows/expo-preview.yml
@@ -37,6 +37,8 @@ jobs:
       - name: Publish Expo app
         working-directory: ./example
         run: expo publish --release-channel=pr-${{ github.event.number }}
+        env:
+          EXPO_USE_DEV_SERVER: true
 
       - name: Get expo link
         id: expo


### PR DESCRIPTION
This enables a new interface with Metro, [outlined in this tweet](https://twitter.com/expo/status/1293613036482121728). It's still in a sort-of beta and that's why it's opt-in. We would love to see how this improves bundling on the React Navigation example app, and/or if you encounter anything special.

Feel free to close this as well if you don't want to do this right now!