### PR TITLE
feat: add compact size for bottom tabs

### DIFF
--- a/packages/bottom-tabs/src/views/BottomTabBar.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabBar.tsx
@@ -26,6 +26,7 @@ type Props = BottomTabBarProps & {
 };
 
 const DEFAULT_TABBAR_HEIGHT = 49;
+const COMPACT_TABBAR_HEIGHT = 32;
 const DEFAULT_MAX_TAB_ITEM_WIDTH = 125;
 
 const useNativeDriver = Platform.OS !== 'web';
@@ -119,6 +120,8 @@ export default function BottomTabBar({
     width: dimensions.width,
   });
 
+  const isLandscape = () => dimensions.width > dimensions.height;
+
   const handleLayout = (e: LayoutChangeEvent) => {
     const { height, width } = e.nativeEvent.layout;
 
@@ -160,9 +163,7 @@ export default function BottomTabBar({
 
       return routes.length * maxTabItemWidth <= layout.width;
     } else {
-      const isLandscape = dimensions.width > dimensions.height;
-
-      return isLandscape;
+      return isLandscape();
     }
   };
 
@@ -179,6 +180,18 @@ export default function BottomTabBar({
     insets.bottom - Platform.select({ ios: 4, default: 0 }),
     0
   );
+
+  const getDefaultTabBarHeight = () => {
+    if (
+      Platform.OS === 'ios' &&
+      !Platform.isPad &&
+      isLandscape() &&
+      shouldUseHorizontalLabels()
+    ) {
+      return COMPACT_TABBAR_HEIGHT;
+    }
+    return DEFAULT_TABBAR_HEIGHT;
+  };
 
   return (
     <Animated.View
@@ -202,7 +215,7 @@ export default function BottomTabBar({
           position: isTabBarHidden ? 'absolute' : (null as any),
         },
         {
-          height: DEFAULT_TABBAR_HEIGHT + paddingBottom,
+          height: getDefaultTabBarHeight() + paddingBottom,
           paddingBottom,
           paddingHorizontal: Math.max(insets.left, insets.right),
         },


### PR DESCRIPTION
This adds a compact height mode for iOS devices that are in a compact vertical class (phones in landscape). This is similar to the size change that happens to the header when in landscape mode. Finding a size reference was challenging since most apps lock phones to portrait, but [this answer](https://stackoverflow.com/a/25550871) on Stack Overflow states that it should be 32 pts.

I asked yesterday in the Discord chat if there would be interest in this and some other enhancements here, but no on replied, so I thought I would go ahead and open this to at least start a discussion.