### PR TITLE
test: add test case for StateUtils.pop

### DIFF
--- a/packages/core/src/__tests__/NavigationStateUtils.test.js
+++ b/packages/core/src/__tests__/NavigationStateUtils.test.js
@@ -93,10 +93,22 @@ describe('StateUtils', () => {
     expect(NavigationStateUtils.pop(state)).toEqual(newState);
   });
 
-  it('does not pop route if not applicable', () => {
+  it('does not pop route if not applicable with single route config', () => {
     const state = {
       index: 0,
       routes: [{ key: 'a', routeName }],
+      isTransitioning: false,
+    };
+    expect(NavigationStateUtils.pop(state)).toBe(state);
+  });
+
+  it('does not pop route if not applicable with multiple route config', () => {
+    const state = {
+      index: 0,
+      routes: [
+        { key: 'a', routeName },
+        { key: 'b', routeName },
+      ],
       isTransitioning: false,
     };
     expect(NavigationStateUtils.pop(state)).toBe(state);


### PR DESCRIPTION
From the current implementation of `NavigationStateUtils.pop`, a new
test case was added to document the behavior when popping when the index
is at the first route and there are multiple routes.

Question: what is the reason why the top route does not get removed in that specific case? I'm not that familiar with react-navigation, but my basic intuition would probably have told me that popping in that situation would have removed the top-most route.

Thanks in advance for your feedback :) 