### PR TITLE
fix: export type error on typescript/babel projects

### DIFF
--- a/packages/stack/src/index.tsx
+++ b/packages/stack/src/index.tsx
@@ -48,7 +48,7 @@ export { default as useGestureHandlerRef } from './utils/useGestureHandlerRef';
 /**
  * Types
  */
-export type {
+export {
   StackNavigationOptions,
   StackNavigationProp,
   StackScreenProps,


### PR DESCRIPTION
I found out that the #8399 is due to a bug with babel. You can read more about here: https://github.com/vercel/next.js/issues/7882. 
But actually we can fix this import error by just deleting the keyword `type` when exporting. Or using `export *` instead of declaring every specific type.
I must add that this issue is still happening even in a fresh new project, but this little change has fixed it.