### PR TITLE
fix: useThenable doesn't always resolve

### DIFF
--- a/packages/native/src/useThenable.tsx
+++ b/packages/native/src/useThenable.tsx
@@ -34,6 +34,10 @@ export default function useThenable<T>(create: () => PromiseLike<T>) {
 
     if (!resolved) {
       resolve();
+    } else {
+      if (!cancelled) {
+        setState([true, value]);
+      }
     }
 
     return () => {


### PR DESCRIPTION
When  app is run in debug mode and has deeplinks enabled, it's stuck at the fallback ui.  Noticed this when app runs in debug mode with chrome debugger, not an issue when safari inspector is connected.
Upon digging a little, found the following as the reason, I could be off:
`useThenable` doesn't resolve if the **input promise resolves after**
 ```js
 const [state, setState] = React.useState<[boolean, T | undefined]>([
    resolved,
    value,
  ]);
```
but **before the following  inner effect**  has run 
```js
React.useEffect(() => {
    let cancelled = false;
    const resolve = async () => {
      let result;
      try {
        result = await promise;
      } finally {
        if (!cancelled) {
          setState([true, result]);
        }
      }
    };
    if (!resolved) {
      resolve();
    }   
    
    return () => {
      cancelled = true;
    };
  }, [promise, resolved]);

```

