### PR TITLE
chore: update docs website URLs to avoid the redirect

### DIFF
--- a/packages/bottom-tabs/README.md
+++ b/packages/bottom-tabs/README.md
@@ -2,4 +2,4 @@
 
 Bottom tab navigator for React Navigation following iOS design guidelines.
 
-Installation instructions and documentation can be found on the [React Navigation website](https://reactnavigation.org/docs/bottom-tab-navigator.html).
+Installation instructions and documentation can be found on the [React Navigation website](https://reactnavigation.org/docs/bottom-tab-navigator/).

--- a/packages/compat/README.md
+++ b/packages/compat/README.md
@@ -2,4 +2,4 @@
 
 Compatibility layer to write navigator definitions in static configuration format.
 
-Installation instructions and documentation can be found on the [React Navigation website](https://reactnavigation.org/docs/compatibility.html).
+Installation instructions and documentation can be found on the [React Navigation website](https://reactnavigation.org/docs/compatibility/).

--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -11,7 +11,7 @@
   "bugs": {
     "url": "https://github.com/react-navigation/react-navigation/issues"
   },
-  "homepage": "https://reactnavigation.org/docs/compatibility.html",
+  "homepage": "https://reactnavigation.org/docs/compatibility/",
   "main": "lib/commonjs/index.js",
   "react-native": "src/index.tsx",
   "source": "src/index.tsx",

--- a/packages/drawer/README.md
+++ b/packages/drawer/README.md
@@ -2,4 +2,4 @@
 
 Drawer navigator for React Navigation following Material Design guidelines. 
 
-Installation instructions and documentation can be found on the [React Navigation website](https://reactnavigation.org/docs/drawer-navigator.html).
+Installation instructions and documentation can be found on the [React Navigation website](https://reactnavigation.org/docs/drawer-navigator/).

--- a/packages/drawer/package.json
+++ b/packages/drawer/package.json
@@ -21,7 +21,7 @@
   "bugs": {
     "url": "https://github.com/react-navigation/react-navigation/issues"
   },
-  "homepage": "https://reactnavigation.org/docs/drawer-navigator.html",
+  "homepage": "https://reactnavigation.org/docs/drawer-navigator/",
   "main": "lib/commonjs/index.js",
   "react-native": "src/index.tsx",
   "source": "src/index.tsx",

--- a/packages/drawer/src/views/DrawerView.tsx
+++ b/packages/drawer/src/views/DrawerView.tsx
@@ -46,7 +46,7 @@ const getDefaultDrawerWidth = ({
   /*
    * Default drawer width is screen width - header height
    * with a max width of 280 on mobile and 320 on tablet
-   * https://material.io/guidelines/patterns/navigation-drawer/
+   * https://material.io/components/navigation-drawer
    */
   const smallerAxisSize = Math.min(height, width);
   const isLandscape = width > height;

--- a/packages/drawer/src/views/DrawerView.tsx
+++ b/packages/drawer/src/views/DrawerView.tsx
@@ -46,7 +46,7 @@ const getDefaultDrawerWidth = ({
   /*
    * Default drawer width is screen width - header height
    * with a max width of 280 on mobile and 320 on tablet
-   * https://material.io/guidelines/patterns/navigation-drawer.html
+   * https://material.io/guidelines/patterns/navigation-drawer/
    */
   const smallerAxisSize = Math.min(height, width);
   const isLandscape = width > height;

--- a/packages/material-bottom-tabs/README.md
+++ b/packages/material-bottom-tabs/README.md
@@ -1,5 +1,5 @@
 # `@react-navigation/material-bottom-tabs`
 
-React Navigation integration for [bottom navigation](https://material.io/design/components/bottom-navigation.html) component from [`react-native-paper`](https://callstack.github.io/react-native-paper/bottom-navigation.html).
+React Navigation integration for [bottom navigation](https://material.io/components/bottom-navigation) component from [`react-native-paper`](https://callstack.github.io/react-native-paper/bottom-navigation.html).
 
-Installation instructions and documentation can be found on the [React Navigation website](https://reactnavigation.org/docs/material-bottom-tab-navigator.html).
+Installation instructions and documentation can be found on the [React Navigation website](https://reactnavigation.org/docs/material-bottom-tab-navigator/).

--- a/packages/material-bottom-tabs/package.json
+++ b/packages/material-bottom-tabs/package.json
@@ -21,7 +21,7 @@
   "bugs": {
     "url": "https://github.com/react-navigation/react-navigation/issues"
   },
-  "homepage": "https://reactnavigation.org/docs/material-bottom-tab-navigator.html",
+  "homepage": "https://reactnavigation.org/docs/material-bottom-tab-navigator/",
   "main": "lib/commonjs/index.js",
   "react-native": "src/index.tsx",
   "source": "src/index.tsx",

--- a/packages/material-top-tabs/README.md
+++ b/packages/material-top-tabs/README.md
@@ -2,4 +2,4 @@
 
 React Navigation integration for animated tab view component from [`react-native-tab-view`](https://github.com/react-native-community/react-native-tab-view).
 
-Installation instructions and documentation can be found on the [React Navigation website](https://reactnavigation.org/docs/material-top-tab-navigator.html).
+Installation instructions and documentation can be found on the [React Navigation website](https://reactnavigation.org/docs/material-top-tab-navigator/).

--- a/packages/material-top-tabs/package.json
+++ b/packages/material-top-tabs/package.json
@@ -21,7 +21,7 @@
   "bugs": {
     "url": "https://github.com/react-navigation/react-navigation/issues"
   },
-  "homepage": "https://reactnavigation.org/docs/material-top-tab-navigator.html",
+  "homepage": "https://reactnavigation.org/docs/material-top-tab-navigator/",
   "main": "lib/commonjs/index.js",
   "react-native": "src/index.tsx",
   "source": "src/index.tsx",

--- a/packages/native/README.md
+++ b/packages/native/README.md
@@ -2,4 +2,4 @@
 
 React Native integration for React Navigation.
 
-Installation instructions and documentation can be found on the [React Navigation website](https://reactnavigation.org/docs/getting-started.html).
+Installation instructions and documentation can be found on the [React Navigation website](https://reactnavigation.org/docs/getting-started/).

--- a/packages/routers/README.md
+++ b/packages/routers/README.md
@@ -14,4 +14,4 @@ yarn add @react-navigation/routers
 
 ## Usage
 
-Documentation can be found on the [React Navigation website](https://reactnavigation.org/docs/custom-routers.html).
+Documentation can be found on the [React Navigation website](https://reactnavigation.org/docs/custom-routers/).

--- a/packages/routers/package.json
+++ b/packages/routers/package.json
@@ -16,7 +16,7 @@
   "bugs": {
     "url": "https://github.com/react-navigation/react-navigation/issues"
   },
-  "homepage": "https://reactnavigation.org/docs/custom-routers.html",
+  "homepage": "https://reactnavigation.org/docs/custom-routers/",
   "main": "lib/commonjs/index.js",
   "react-native": "src/index.tsx",
   "source": "src/index.tsx",

--- a/packages/stack/README.md
+++ b/packages/stack/README.md
@@ -2,4 +2,4 @@
 
 Stack navigator for React Navigation.
 
-Installation instructions and documentation can be found on the [React Navigation website](https://reactnavigation.org/docs/stack-navigator.html).
+Installation instructions and documentation can be found on the [React Navigation website](https://reactnavigation.org/docs/stack-navigator/).

--- a/packages/stack/package.json
+++ b/packages/stack/package.json
@@ -20,7 +20,7 @@
   "bugs": {
     "url": "https://github.com/react-navigation/react-navigation/issues"
   },
-  "homepage": "https://reactnavigation.org/docs/stack-navigator.html",
+  "homepage": "https://reactnavigation.org/docs/stack-navigator/",
   "main": "lib/commonjs/index.js",
   "react-native": "src/index.tsx",
   "source": "src/index.tsx",


### PR DESCRIPTION
After the docs website migration to the Docusaurus V2 the URL format have changed. Using the old URLs format results in redirect, which can be avoided by updating the docs website links. This PR updates all outdated URLs that I was able to find.

Additionally I have updated the Material Design website link which was changed too.