### PR TITLE
fix: catch error if unable to access setNativeProps

### DIFF
--- a/packages/stack/src/views/Stack/Card.tsx
+++ b/packages/stack/src/views/Stack/Card.tsx
@@ -235,7 +235,8 @@ export default class Card extends React.Component<Props> {
   private setPointerEventsEnabled = (enabled: boolean) => {
     const pointerEvents = enabled ? 'box-none' : 'none';
 
-    this.contentRef.current?.setNativeProps({ pointerEvents });
+    this.contentRef.current?.setNativeProps && 
+      this.contentRef.current?.setNativeProps({ pointerEvents });
   };
 
   private handleStartInteraction = () => {


### PR DESCRIPTION
Prevents this error: 

<img width="369" alt="Screen Shot 2020-09-09 at 7 30 13 PM" src="https://user-images.githubusercontent.com/2933593/92675934-6b471d80-f2d5-11ea-9d23-a5a50a1840fd.png">
