### PR TITLE
refactor: improve error message of StateUtils.jumpTo

### DIFF
--- a/packages/core/src/StateUtils.js
+++ b/packages/core/src/StateUtils.js
@@ -93,6 +93,7 @@ const StateUtils = {
    */
   jumpTo(state, key) {
     const index = StateUtils.indexOf(state, key);
+    invariant(index !== -1, 'attempt to jump to unknown key "%s"', key);
     return StateUtils.jumpToIndex(state, index);
   },
 

--- a/packages/core/src/__tests__/NavigationStateUtils.test.js
+++ b/packages/core/src/__tests__/NavigationStateUtils.test.js
@@ -215,7 +215,7 @@ describe('StateUtils', () => {
         isTransitioning: false,
       };
       expect(() => NavigationStateUtils.jumpTo(state, 'c')).toThrow(
-        'invalid index -1 to jump to'
+        'attempt to jump to unknown key "c"'
       );
     });
   });


### PR DESCRIPTION
I think this improves the error message a little, let me know if you have a better suggestion :)