### PR TITLE
feat: add pressColor and pressOpacity props to drawerItem

### DIFF
--- a/packages/drawer/src/views/DrawerItem.tsx
+++ b/packages/drawer/src/views/DrawerItem.tsx
@@ -64,6 +64,10 @@ type Props = {
    * Style object for the wrapper element.
    */
   style?: StyleProp<ViewStyle>;
+  /**
+   * Color of the touchable effect created on press.
+   */
+  pressColor?: string;
 };
 
 const Touchable = ({
@@ -132,6 +136,7 @@ export default function DrawerItem(props: Props) {
     inactiveBackgroundColor = 'transparent',
     style,
     onPress,
+    pressColor,
     ...rest
   } = props;
 
@@ -160,6 +165,7 @@ export default function DrawerItem(props: Props) {
         // @ts-expect-error: keep for compatibility with older React Native versions
         accessibilityStates={focused ? ['selected'] : []}
         to={to}
+        pressColor={pressColor}
       >
         <React.Fragment>
           {iconNode}

--- a/packages/drawer/src/views/DrawerItem.tsx
+++ b/packages/drawer/src/views/DrawerItem.tsx
@@ -57,6 +57,20 @@ type Props = {
    */
   inactiveBackgroundColor?: string;
   /**
+   * Color of the touchable effect on press.
+   * Only supported on Android.
+   *
+   * @platform android
+   */
+  pressColor?: string;
+  /**
+   * Opacity of the touchable effect on press.
+   * Only supported on iOS.
+   *
+   * @platform ios
+   */
+  pressOpacity?: string;
+  /**
    * Style object for the label element.
    */
   labelStyle?: StyleProp<TextStyle>;
@@ -64,10 +78,6 @@ type Props = {
    * Style object for the wrapper element.
    */
   style?: StyleProp<ViewStyle>;
-  /**
-   * Color of the touchable effect created on press.
-   */
-  pressColor?: string;
 };
 
 const Touchable = ({
@@ -137,6 +147,7 @@ export default function DrawerItem(props: Props) {
     style,
     onPress,
     pressColor,
+    pressOpacity,
     ...rest
   } = props;
 
@@ -164,8 +175,9 @@ export default function DrawerItem(props: Props) {
         accessibilityState={{ selected: focused }}
         // @ts-expect-error: keep for compatibility with older React Native versions
         accessibilityStates={focused ? ['selected'] : []}
-        to={to}
         pressColor={pressColor}
+        pressOpacity={pressOpacity}
+        to={to}
       >
         <React.Fragment>
           {iconNode}

--- a/packages/drawer/src/views/TouchableItem.ios.tsx
+++ b/packages/drawer/src/views/TouchableItem.ios.tsx
@@ -5,14 +5,14 @@ import { BaseButton } from 'react-native-gesture-handler';
 const AnimatedBaseButton = Animated.createAnimatedComponent(BaseButton);
 
 type Props = React.ComponentProps<typeof BaseButton> & {
-  activeOpacity: number;
+  pressOpacity: number;
 };
 
 const useNativeDriver = Platform.OS !== 'web';
 
 export default class TouchableItem extends React.Component<Props> {
   static defaultProps = {
-    activeOpacity: 0.3,
+    pressOpacity: 0.3,
     borderless: true,
     enabled: true,
   };
@@ -27,7 +27,7 @@ export default class TouchableItem extends React.Component<Props> {
       overshootClamping: true,
       restDisplacementThreshold: 0.01,
       restSpeedThreshold: 0.01,
-      toValue: active ? this.props.activeOpacity : 1,
+      toValue: active ? this.props.pressOpacity : 1,
       useNativeDriver,
     }).start();
 

--- a/packages/stack/src/views/BorderlessButton.tsx
+++ b/packages/stack/src/views/BorderlessButton.tsx
@@ -5,7 +5,7 @@ import { BaseButton } from 'react-native-gesture-handler';
 const AnimatedBaseButton = Animated.createAnimatedComponent(BaseButton);
 
 type Props = React.ComponentProps<typeof BaseButton> & {
-  activeOpacity: number;
+  pressOpacity: number;
 };
 
 const useNativeDriver = Platform.OS !== 'web';
@@ -27,7 +27,7 @@ export default class BorderlessButton extends React.Component<Props> {
         overshootClamping: true,
         restDisplacementThreshold: 0.01,
         restSpeedThreshold: 0.01,
-        toValue: active ? this.props.activeOpacity : 1,
+        toValue: active ? this.props.pressOpacity : 1,
         useNativeDriver,
       }).start();
     }

--- a/packages/stack/src/views/TouchableItem.ios.tsx
+++ b/packages/stack/src/views/TouchableItem.ios.tsx
@@ -5,7 +5,7 @@ import { BaseButton } from 'react-native-gesture-handler';
 const AnimatedBaseButton = Animated.createAnimatedComponent(BaseButton);
 
 type Props = React.ComponentProps<typeof BaseButton> & {
-  activeOpacity: number;
+  pressOpacity: number;
 };
 
 const useNativeDriver = Platform.OS !== 'web';
@@ -27,7 +27,7 @@ export default class TouchableItem extends React.Component<Props> {
       overshootClamping: true,
       restDisplacementThreshold: 0.01,
       restSpeedThreshold: 0.01,
-      toValue: active ? this.props.activeOpacity : 1,
+      toValue: active ? this.props.pressOpacity : 1,
       useNativeDriver,
     }).start();
 


### PR DESCRIPTION
- Include pressColor property that could override the default grey value presented in TouchableItem