### PR TITLE
test: fix usage of routerTestHelper back action

### DIFF
--- a/packages/core/src/routers/__tests__/SwitchRouter.test.js
+++ b/packages/core/src/routers/__tests__/SwitchRouter.test.js
@@ -158,7 +158,7 @@ describe('SwitchRouter', () => {
     expect(getSubState(1).routeName).toEqual('A');
 
     // The back action should not switch to B. It should stay on A
-    back({ key: null });
+    back(null);
     expect(getSubState(1).routeName).toEqual('A');
   });
 


### PR DESCRIPTION
Found this case were the key gets set to `{ key: null }` instead of just being `null`. Should I just call `back()` at this point? Because I don't think there is a difference between a `null` vs `undefined` key