### PR TITLE
fix: add missing types to drawer export

### DIFF
--- a/packages/drawer/src/index.tsx
+++ b/packages/drawer/src/index.tsx
@@ -23,6 +23,8 @@ export { default as useIsDrawerOpen } from './utils/useIsDrawerOpen';
  * Types
  */
 export type {
+  DrawerNavigationConfig,
+   DrawerNavigationEventMap,
   DrawerNavigationOptions,
   DrawerNavigationProp,
   DrawerScreenProps,

--- a/packages/drawer/src/index.tsx
+++ b/packages/drawer/src/index.tsx
@@ -24,7 +24,7 @@ export { default as useIsDrawerOpen } from './utils/useIsDrawerOpen';
  */
 export type {
   DrawerNavigationConfig,
-   DrawerNavigationEventMap,
+  DrawerNavigationEventMap,
   DrawerNavigationOptions,
   DrawerNavigationProp,
   DrawerScreenProps,


### PR DESCRIPTION
these are useful when making a custom navigator that you want to share the config and events of the current drawer.