### PR TITLE
Fix: blink issue for floatingHeader (Android)

### DIFF
--- a/packages/stack/src/views/Stack/CardStack.tsx
+++ b/packages/stack/src/views/Stack/CardStack.tsx
@@ -420,7 +420,7 @@ export default class CardStack extends React.Component<Props, State> {
                     headerShown = isParentHeaderShown === false,
                   } = options;
 
-                  if (headerTransparent || headerShown === false) {
+                  if (!headerTransparent || headerShown === false) {
                     return true;
                   }
 


### PR DESCRIPTION
Solves the blink issue when you are using a custom header (`headerMode="float"`), if could you please take a look 🙏  @Ashoat 

### Before: 
![before](https://user-images.githubusercontent.com/11186639/93402149-8b348f00-f849-11ea-8116-942c2451277a.gif)

### After:
![after](https://user-images.githubusercontent.com/11186639/93402155-912a7000-f849-11ea-875b-a7993faccc81.gif)
