### PR TITLE
fix: cleanly removing event listeners in useWindowDimensions

### DIFF
--- a/packages/bottom-tabs/src/utils/useWindowDimensions.tsx
+++ b/packages/bottom-tabs/src/utils/useWindowDimensions.tsx
@@ -30,7 +30,7 @@ export default function useWindowDimensions() {
 
     Dimensions.addEventListener('change', onChange);
 
-    return () => Dimensions.addEventListener('change', onChange);
+    return () => Dimensions.removeEventListener('change', onChange);
   }, []);
 
   return dimensions;

--- a/packages/drawer/src/utils/useWindowDimensions.tsx
+++ b/packages/drawer/src/utils/useWindowDimensions.tsx
@@ -30,7 +30,7 @@ export default function useWindowDimensions() {
 
     Dimensions.addEventListener('change', onChange);
 
-    return () => Dimensions.addEventListener('change', onChange);
+    return () => Dimensions.removeEventListener('change', onChange);
   }, []);
 
   return dimensions;


### PR DESCRIPTION
This PR fixes the `useWindowDimensions` hook by making sure that the event listener is properly removed.