### PR TITLE
fix: typo in logic of getStateFromPath

### DIFF
--- a/packages/core/src/getStateFromPath.tsx
+++ b/packages/core/src/getStateFromPath.tsx
@@ -122,7 +122,7 @@ export default function getStateFromPath(
       // If one of the patterns starts with the other, it's more exhaustive
       // So move it up
       if (a.pattern.startsWith(b.pattern)) {
-        return 1;
+        return -1;
       }
 
       if (b.pattern.startsWith(a.pattern)) {


### PR DESCRIPTION
What just randomly reading, but I think there's a typo
```
['ab', 'aba'].sort((a, b) => {
      if (a.startsWith(b)) {
        return -1;
      }

      if (b.startsWith(a)) {
        return 1;
      }
});
(2) ["aba", "ab"]
['ab', 'a'].sort((a, b) => {
      if (a.startsWith(b)) {
        return -1;
      }

      if (b.startsWith(a)) {
        return 1;
      }
});
(2) ["ab", "a"]
```