### PR TITLE
feat: specify badge color

### DIFF
--- a/packages/bottom-tabs/src/views/Badge.tsx
+++ b/packages/bottom-tabs/src/views/Badge.tsx
@@ -61,7 +61,11 @@ export default function Badge({
   // @ts-expect-error: backgroundColor definitely exists
   const { backgroundColor = theme.colors.notification, ...restStyle } =
     StyleSheet.flatten(style) || {};
-  const textColor = color(backgroundColor).isLight() ? 'black' : 'white';
+  const textColor = theme.colors.notificationText
+    ? theme.colors.notificationText
+    : color(backgroundColor).isLight()
+    ? 'black'
+    : 'white';
 
   const borderRadius = size / 2;
   const fontSize = Math.floor((size * 3) / 4);

--- a/packages/native/src/types.tsx
+++ b/packages/native/src/types.tsx
@@ -14,6 +14,7 @@ export type Theme = {
     text: string;
     border: string;
     notification: string;
+    notificationText?: string;
   };
 };
 


### PR DESCRIPTION
Optionally specify badge text color. We use a green color for badge that resulted in black text, but we want white text. 