### PR TITLE
Always set isOpen when the drawer is toggled

### DIFF
--- a/packages/drawer/src/views/Drawer.tsx
+++ b/packages/drawer/src/views/Drawer.tsx
@@ -542,6 +542,8 @@ export default class DrawerView extends React.Component<Props> {
   };
 
   private toggleDrawer = (open: boolean) => {
+    this.isOpen.setValue(open ? TRUE : FALSE)
+    
     if (this.currentOpenValue !== open) {
       this.nextIsOpen.setValue(open ? TRUE : FALSE);
 


### PR DESCRIPTION
This fixes an issue for us in our app for multi-tasking on iPad. When we were on iPad, if we closed the drawer and went narrow (to mobile size) the drawer was still open and would never close. I am not sure why isOpen was always true when we called `toggleDrawer(false)`. This might not be a good/valid fix but we didn't have issues after testing this.

An issue that was very similar was https://github.com/react-navigation/react-navigation/issues/8892 but seemed like that one may be for web