### PR TITLE
fix: NavigationEvents subscribe events on new nav state

### DIFF
--- a/packages/core/src/views/NavigationEvents.js
+++ b/packages/core/src/views/NavigationEvents.js
@@ -12,11 +12,28 @@ const EventNames = Object.keys(EventNameToPropName);
 
 class NavigationEvents extends React.Component {
   componentDidMount() {
-    this.subscriptions = {};
-
     // We register all navigation listeners on mount to ensure listener stability across re-render
     // A former implementation was replacing (removing/adding) listeners on all update (if prop provided)
     // but there were issues (see https://github.com/react-navigation/react-navigation/issues/5058)
+    this.subscribeAll();
+  }
+
+  componentDidUpdate(prevProps) {
+    if (this.props.navigation !== prevProps.navigation) {
+      this.removeAll();
+      this.subscribeAll();
+    }
+  }
+
+  componentWillUnmount() {
+    this.removeAll();
+  }
+
+  getPropListener = (eventName) => this.props[EventNameToPropName[eventName]];
+
+  subscribeAll() {
+    this.subscriptions = {};
+
     EventNames.forEach((eventName) => {
       this.subscriptions[eventName] = this.props.navigation.addListener(
         eventName,
@@ -28,13 +45,11 @@ class NavigationEvents extends React.Component {
     });
   }
 
-  componentWillUnmount() {
+  removeAll() {
     EventNames.forEach((eventName) => {
       this.subscriptions[eventName].remove();
     });
   }
-
-  getPropListener = (eventName) => this.props[EventNameToPropName[eventName]];
 
   render() {
     return null;


### PR DESCRIPTION
If the navigation prop changes, the NavigationEvents component was not
subscribing to the new navigation value. These changes fix this problem and add a
test to verify that behavior.

Let me know if that is something you would need in 5.x, I can submit a fix for that version too.