### PR TITLE
feat: support wildcard string prefixes

### DIFF
--- a/packages/native/package.json
+++ b/packages/native/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "@react-navigation/core": "^5.12.5",
+    "escape-string-regexp": "^4.0.0",
     "nanoid": "^3.1.12"
   },
   "devDependencies": {

--- a/packages/native/src/types.tsx
+++ b/packages/native/src/types.tsx
@@ -27,8 +27,16 @@ export type LinkingOptions = {
    * The prefixes are stripped from the URL before parsing them.
    * Usually they are the `scheme` + `host` (e.g. `myapp://chat?user=jane`)
    * Only applicable on Android and iOS.
+   *
+   * @example
+   *  {
+   *    prefixes: [
+   *      "https://example.com", // Exact
+   *      /^[^.s]+.example.com/g // Match with all subdomain and scheme,
+   *    ],
+   *  }
    */
-  prefixes: string[];
+  prefixes: (string | RegExp)[];
   /**
    * Config to fine-tune how to parse the path.
    *

--- a/packages/native/src/types.tsx
+++ b/packages/native/src/types.tsx
@@ -29,14 +29,12 @@ export type LinkingOptions = {
    * Only applicable on Android and iOS.
    *
    * @example
-   *  {
    *    prefixes: [
    *      "https://example.com", // Exact
-   *      /^[^.s]+.example.com/g // Match with all subdomain and scheme,
-   *    ],
-   *  }
+   *      "https://*.example.com" // Match with any subdomain
+   *    ]
    */
-  prefixes: (string | RegExp)[];
+  prefixes: string[];
   /**
    * Config to fine-tune how to parse the path.
    *

--- a/packages/native/src/useLinking.native.tsx
+++ b/packages/native/src/useLinking.native.tsx
@@ -60,10 +60,7 @@ export default function useLinking(
   const extractPathFromURL = React.useCallback((url: string) => {
     for (const prefix of prefixesRef.current) {
       /**
-       * https is default schema, as mentioned in android documentation
-       * User can add prefixes like this `example.com`
-       */
-      const protocol = prefix.match(/^[^:]+:\/\//)?.[0] || 'https://';
+      const protocol = prefix.match(/^[^:]+:\/\//)?.[0] ?? '';
       const host = prefix.replace(protocol, '');
       const prefixRegex = new RegExp(
         `^${escapeStringRegexp(protocol)}${host

--- a/packages/native/src/useLinking.native.tsx
+++ b/packages/native/src/useLinking.native.tsx
@@ -58,8 +58,9 @@ export default function useLinking(
 
   const extractPathFromURL = React.useCallback((url: string) => {
     for (const prefix of prefixesRef.current) {
-      if (checkIsPrefixMatch(url, prefix)) {
-        return url.replace(prefix, '');
+      const prefixRegex = new RegExp(`^${prefix.replace(/\*/g, '[^/]+')}`);
+      if (url.match(prefixRegex)) {
+        return url.replace(prefixRegex, '');
       }
     }
 
@@ -121,19 +122,4 @@ export default function useLinking(
   return {
     getInitialState,
   };
-}
-
-function checkIsPrefixMatch(
-  url: string,
-  prefix: string | RegExp
-): string | RegExp | false {
-  if (typeof prefix === 'string') {
-    if (url.startsWith(prefix)) {
-      return prefix;
-    }
-  } else if (url.match(prefix)) {
-    return prefix;
-  }
-
-  return false;
 }

--- a/packages/native/src/useLinking.native.tsx
+++ b/packages/native/src/useLinking.native.tsx
@@ -131,7 +131,7 @@ function checkIsPrefixMatch(
     if (url.startsWith(prefix)) {
       return prefix;
     }
-  } else if (prefix.test(url)) {
+  } else if (url.match(prefix)) {
     return prefix;
   }
 

--- a/packages/native/src/useLinking.native.tsx
+++ b/packages/native/src/useLinking.native.tsx
@@ -59,7 +59,7 @@ export default function useLinking(
   const extractPathFromURL = React.useCallback((url: string) => {
     for (const prefix of prefixesRef.current) {
       const prefixRegex = new RegExp(`^${prefix.replace(/\*/g, '[^/]+')}`);
-      if (url.match(prefixRegex)) {
+      if (prefixRegex.test(url)) {
         return url.replace(prefixRegex, '');
       }
     }

--- a/packages/native/src/useLinking.native.tsx
+++ b/packages/native/src/useLinking.native.tsx
@@ -58,7 +58,7 @@ export default function useLinking(
 
   const extractPathFromURL = React.useCallback((url: string) => {
     for (const prefix of prefixesRef.current) {
-      if (url.startsWith(prefix)) {
+      if (checkIsPrefixMatch(url, prefix)) {
         return url.replace(prefix, '');
       }
     }
@@ -121,4 +121,19 @@ export default function useLinking(
   return {
     getInitialState,
   };
+}
+
+function checkIsPrefixMatch(
+  url: string,
+  prefix: string | RegExp
+): string | RegExp | false {
+  if (typeof prefix === 'string') {
+    if (url.startsWith(prefix)) {
+      return prefix;
+    }
+  } else if (prefix.test(url)) {
+    return prefix;
+  }
+
+  return false;
 }

--- a/packages/native/src/useLinking.native.tsx
+++ b/packages/native/src/useLinking.native.tsx
@@ -59,7 +59,6 @@ export default function useLinking(
 
   const extractPathFromURL = React.useCallback((url: string) => {
     for (const prefix of prefixesRef.current) {
-      /**
       const protocol = prefix.match(/^[^:]+:\/\//)?.[0] ?? '';
       const host = prefix.replace(protocol, '');
       const prefixRegex = new RegExp(


### PR DESCRIPTION
https://github.com/react-navigation/react-navigation/issues/8941
Prefixes should be more flexible for situations like wild card subdomain. On android and IOS we can define wild cards by * but react-navigation does not work, In this PR I added support for RegExp Prefixes.

For Example
```js
{
  prefixes: [
    /^[^.s]+.example.com/g
 ],
}
```
I tested this work well.