### PR TITLE
feat: add sceneContainerStyle prop to bottom-tabs navigator

### DIFF
--- a/example/src/Screens/BottomTabs.tsx
+++ b/example/src/Screens/BottomTabs.tsx
@@ -76,6 +76,9 @@ export default function BottomTabsScreen({
 
   return (
     <BottomTabs.Navigator
+      sceneContainerStyle={{
+        backgroundColor: 'lightblue',
+      }}
       screenOptions={{
         tabBarButton:
           Platform.OS === 'web'

--- a/example/src/Screens/BottomTabs.tsx
+++ b/example/src/Screens/BottomTabs.tsx
@@ -76,9 +76,6 @@ export default function BottomTabsScreen({
 
   return (
     <BottomTabs.Navigator
-      sceneContainerStyle={{
-        backgroundColor: 'lightblue',
-      }}
       screenOptions={{
         tabBarButton:
           Platform.OS === 'web'

--- a/packages/bottom-tabs/src/navigators/createBottomTabNavigator.tsx
+++ b/packages/bottom-tabs/src/navigators/createBottomTabNavigator.tsx
@@ -23,6 +23,7 @@ function BottomTabNavigator({
   backBehavior,
   children,
   screenOptions,
+  sceneContainerStyle,
   ...rest
 }: Props) {
   const { state, descriptors, navigation } = useNavigationBuilder<
@@ -43,6 +44,7 @@ function BottomTabNavigator({
       state={state}
       navigation={navigation}
       descriptors={descriptors}
+      sceneContainerStyle={sceneContainerStyle}
     />
   );
 }

--- a/packages/bottom-tabs/src/types.tsx
+++ b/packages/bottom-tabs/src/types.tsx
@@ -170,6 +170,10 @@ export type BottomTabNavigationConfig<T = BottomTabBarOptions> = {
    * Options for the tab bar which will be passed as props to the tab bar component.
    */
   tabBarOptions?: T;
+  /**
+   * Style object for the component wrapping the screen content.
+   */
+  sceneContainerStyle?: StyleProp<ViewStyle>;
 };
 
 export type BottomTabBarOptions = {

--- a/packages/bottom-tabs/src/views/BottomTabView.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabView.tsx
@@ -43,11 +43,7 @@ function SceneContent({
     <View
       accessibilityElementsHidden={!isFocused}
       importantForAccessibility={isFocused ? 'auto' : 'no-hide-descendants'}
-      style={[
-        styles.content,
-        { backgroundColor: colors.background },
-        style,
-      ]}
+      style={[styles.content, { backgroundColor: colors.background }, style]}
     >
       {children}
     </View>

--- a/packages/bottom-tabs/src/views/BottomTabView.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabView.tsx
@@ -22,7 +22,6 @@ type Props = BottomTabNavigationConfig & {
   state: TabNavigationState;
   navigation: BottomTabNavigationHelpers;
   descriptors: BottomTabDescriptorMap;
-  sceneContainerStyle?: StyleProp<ViewStyle>;
 };
 
 type State = {
@@ -32,11 +31,11 @@ type State = {
 function SceneContent({
   isFocused,
   children,
-  sceneContainerStyle,
+  style,
 }: {
   isFocused: boolean;
   children: React.ReactNode;
-  sceneContainerStyle?: StyleProp<ViewStyle>;
+  style?: StyleProp<ViewStyle>;
 }) {
   const { colors } = useTheme();
 
@@ -47,7 +46,7 @@ function SceneContent({
       style={[
         styles.content,
         { backgroundColor: colors.background },
-        sceneContainerStyle,
+        style,
       ]}
     >
       {children}
@@ -58,7 +57,6 @@ function SceneContent({
 export default class BottomTabView extends React.Component<Props, State> {
   static defaultProps = {
     lazy: true,
-    sceneContainerStyle: {},
   };
 
   static getDerivedStateFromProps(nextProps: Props, prevState: State) {
@@ -130,7 +128,7 @@ export default class BottomTabView extends React.Component<Props, State> {
                   >
                     <SceneContent
                       isFocused={isFocused}
-                      sceneContainerStyle={sceneContainerStyle}
+                      style={sceneContainerStyle}
                     >
                       {descriptor.render()}
                     </SceneContent>

--- a/packages/bottom-tabs/src/views/BottomTabView.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabView.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { View, StyleSheet } from 'react-native';
+import { View, StyleSheet, StyleProp, ViewStyle } from 'react-native';
 
 import {
   NavigationHelpersContext,
@@ -22,6 +22,7 @@ type Props = BottomTabNavigationConfig & {
   state: TabNavigationState;
   navigation: BottomTabNavigationHelpers;
   descriptors: BottomTabDescriptorMap;
+  sceneContainerStyle?: StyleProp<ViewStyle>;
 };
 
 type State = {
@@ -31,9 +32,11 @@ type State = {
 function SceneContent({
   isFocused,
   children,
+  sceneContainerStyle,
 }: {
   isFocused: boolean;
   children: React.ReactNode;
+  sceneContainerStyle?: StyleProp<ViewStyle>;
 }) {
   const { colors } = useTheme();
 
@@ -41,7 +44,11 @@ function SceneContent({
     <View
       accessibilityElementsHidden={!isFocused}
       importantForAccessibility={isFocused ? 'auto' : 'no-hide-descendants'}
-      style={[styles.content, { backgroundColor: colors.background }]}
+      style={[
+        styles.content,
+        { backgroundColor: colors.background },
+        sceneContainerStyle,
+      ]}
     >
       {children}
     </View>
@@ -51,6 +58,7 @@ function SceneContent({
 export default class BottomTabView extends React.Component<Props, State> {
   static defaultProps = {
     lazy: true,
+    sceneContainerStyle: {},
   };
 
   static getDerivedStateFromProps(nextProps: Props, prevState: State) {
@@ -85,7 +93,13 @@ export default class BottomTabView extends React.Component<Props, State> {
   };
 
   render() {
-    const { state, descriptors, navigation, lazy } = this.props;
+    const {
+      state,
+      descriptors,
+      navigation,
+      lazy,
+      sceneContainerStyle,
+    } = this.props;
     const { routes } = state;
     const { loaded } = this.state;
 
@@ -114,7 +128,10 @@ export default class BottomTabView extends React.Component<Props, State> {
                     style={StyleSheet.absoluteFill}
                     isVisible={isFocused}
                   >
-                    <SceneContent isFocused={isFocused}>
+                    <SceneContent
+                      isFocused={isFocused}
+                      sceneContainerStyle={sceneContainerStyle}
+                    >
                       {descriptor.render()}
                     </SceneContent>
                   </ResourceSavingScene>


### PR DESCRIPTION
This feature adds the sceneContainerStyle prop to the bottom-tabs navigator, to allow setting styles on the container's view. It's already implemented in the material-top-tabs and drawer navigators, I've simply ported it into the bottom-tabs navigator.

It also fixes this issue:

https://github.com/react-navigation/react-navigation/issues/8076