### PR TITLE
fix(prefixes): add http or https for default protocol

### DIFF
--- a/packages/native/src/useLinking.native.tsx
+++ b/packages/native/src/useLinking.native.tsx
@@ -61,8 +61,12 @@ export default function useLinking(
     for (const prefix of prefixesRef.current) {
       const protocol = prefix.match(/^[^:]+:\/\//)?.[0] ?? '';
       const host = prefix.replace(protocol, '');
+      const schema = protocol
+        ? escapeStringRegexp(protocol)
+        : '(http|https)://';
+
       const prefixRegex = new RegExp(
-        `^${escapeStringRegexp(protocol)}${host
+        `^${schema}${host
           .split('.')
           .map((it) => (it === '*' ? '[^/]+' : escapeStringRegexp(it)))
           .join('\\.')}`


### PR DESCRIPTION
Prefixes without a scheme are assumed as either http or https. For example, www.google.com matches both http://www.google.com and https://www.google.com.

https://developer.android.com/guide/navigation/navigation-deep-link