### PR TITLE
feat: improve types for navigation state

### DIFF
--- a/packages/bottom-tabs/src/navigators/createBottomTabNavigator.tsx
+++ b/packages/bottom-tabs/src/navigators/createBottomTabNavigator.tsx
@@ -6,6 +6,7 @@ import {
   TabRouter,
   TabRouterOptions,
   TabNavigationState,
+  ParamListBase,
 } from '@react-navigation/native';
 import BottomTabView from '../views/BottomTabView';
 import type {
@@ -27,7 +28,7 @@ function BottomTabNavigator({
   ...rest
 }: Props) {
   const { state, descriptors, navigation } = useNavigationBuilder<
-    TabNavigationState,
+    TabNavigationState<ParamListBase>,
     TabRouterOptions,
     BottomTabNavigationOptions,
     BottomTabNavigationEventMap
@@ -50,7 +51,7 @@ function BottomTabNavigator({
 }
 
 export default createNavigatorFactory<
-  TabNavigationState,
+  TabNavigationState<ParamListBase>,
   BottomTabNavigationOptions,
   BottomTabNavigationEventMap,
   typeof BottomTabNavigator

--- a/packages/bottom-tabs/src/types.tsx
+++ b/packages/bottom-tabs/src/types.tsx
@@ -41,7 +41,7 @@ export type BottomTabNavigationProp<
 > = NavigationProp<
   ParamList,
   RouteName,
-  TabNavigationState,
+  TabNavigationState<ParamList>,
   BottomTabNavigationOptions,
   BottomTabNavigationEventMap
 > &
@@ -148,7 +148,7 @@ export type BottomTabNavigationOptions = {
 export type BottomTabDescriptor = Descriptor<
   ParamListBase,
   string,
-  TabNavigationState,
+  TabNavigationState<ParamListBase>,
   BottomTabNavigationOptions
 >;
 
@@ -244,7 +244,7 @@ export type BottomTabBarOptions = {
 };
 
 export type BottomTabBarProps<T = BottomTabBarOptions> = T & {
-  state: TabNavigationState;
+  state: TabNavigationState<ParamListBase>;
   descriptors: BottomTabDescriptorMap;
   navigation: NavigationHelpers<ParamListBase, BottomTabNavigationEventMap>;
 };

--- a/packages/bottom-tabs/src/views/BottomTabView.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabView.tsx
@@ -3,6 +3,7 @@ import { View, StyleSheet, StyleProp, ViewStyle } from 'react-native';
 
 import {
   NavigationHelpersContext,
+  ParamListBase,
   TabNavigationState,
   useTheme,
 } from '@react-navigation/native';
@@ -19,7 +20,7 @@ import type {
 } from '../types';
 
 type Props = BottomTabNavigationConfig & {
-  state: TabNavigationState;
+  state: TabNavigationState<ParamListBase>;
   navigation: BottomTabNavigationHelpers;
   descriptors: BottomTabDescriptorMap;
 };

--- a/packages/compat/src/createSwitchNavigator.tsx
+++ b/packages/compat/src/createSwitchNavigator.tsx
@@ -5,6 +5,7 @@ import {
   TabRouter,
   TabRouterOptions,
   TabNavigationState,
+  ParamListBase,
 } from '@react-navigation/native';
 import createCompatNavigatorFactory from './createCompatNavigatorFactory';
 
@@ -12,7 +13,7 @@ type Props = DefaultNavigatorOptions<{}> & TabRouterOptions;
 
 function SwitchNavigator(props: Props) {
   const { state, descriptors } = useNavigationBuilder<
-    TabNavigationState,
+    TabNavigationState<ParamListBase>,
     TabRouterOptions,
     {},
     {}
@@ -22,7 +23,10 @@ function SwitchNavigator(props: Props) {
 }
 
 export default createCompatNavigatorFactory(
-  createNavigatorFactory<TabNavigationState, {}, {}, typeof SwitchNavigator>(
-    SwitchNavigator
-  )
+  createNavigatorFactory<
+    TabNavigationState<ParamListBase>,
+    {},
+    {},
+    typeof SwitchNavigator
+  >(SwitchNavigator)
 );

--- a/packages/core/src/types.tsx
+++ b/packages/core/src/types.tsx
@@ -256,7 +256,7 @@ export type NavigationContainerProps = {
 export type NavigationProp<
   ParamList extends ParamListBase,
   RouteName extends keyof ParamList = string,
-  State extends NavigationState = NavigationState,
+  State extends NavigationState = NavigationState<ParamList>,
   ScreenOptions extends {} = {},
   EventMap extends EventMapBase = {}
 > = NavigationHelpersCommon<ParamList, State> & {
@@ -281,20 +281,7 @@ export type NavigationProp<
 export type RouteProp<
   ParamList extends ParamListBase,
   RouteName extends keyof ParamList
-> = Omit<Route<Extract<RouteName, string>>, 'params'> &
-  (undefined extends ParamList[RouteName]
-    ? Readonly<{
-        /**
-         * Params for this route
-         */
-        params?: Readonly<ParamList[RouteName]>;
-      }>
-    : Readonly<{
-        /**
-         * Params for this route
-         */
-        params: Readonly<ParamList[RouteName]>;
-      }>);
+> = Route<Extract<RouteName, string>, ParamList[RouteName]>;
 
 export type CompositeNavigationProp<
   A extends NavigationProp<ParamListBase, string, any, any>,

--- a/packages/drawer/src/navigators/createDrawerNavigator.tsx
+++ b/packages/drawer/src/navigators/createDrawerNavigator.tsx
@@ -6,6 +6,7 @@ import {
   DrawerNavigationState,
   DrawerRouterOptions,
   DrawerRouter,
+  ParamListBase,
 } from '@react-navigation/native';
 
 import DrawerView from '../views/DrawerView';
@@ -28,7 +29,7 @@ function DrawerNavigator({
   ...rest
 }: Props) {
   const { state, descriptors, navigation } = useNavigationBuilder<
-    DrawerNavigationState,
+    DrawerNavigationState<ParamListBase>,
     DrawerRouterOptions,
     DrawerNavigationOptions,
     DrawerNavigationEventMap
@@ -51,7 +52,7 @@ function DrawerNavigator({
 }
 
 export default createNavigatorFactory<
-  DrawerNavigationState,
+  DrawerNavigationState<ParamListBase>,
   DrawerNavigationOptions,
   DrawerNavigationEventMap,
   typeof DrawerNavigator

--- a/packages/drawer/src/types.tsx
+++ b/packages/drawer/src/types.tsx
@@ -136,7 +136,7 @@ export type DrawerNavigationOptions = {
 };
 
 export type DrawerContentComponentProps<T = DrawerContentOptions> = T & {
-  state: DrawerNavigationState;
+  state: DrawerNavigationState<ParamListBase>;
   navigation: DrawerNavigationHelpers;
   descriptors: DrawerDescriptorMap;
   /**
@@ -203,7 +203,7 @@ export type DrawerNavigationProp<
 > = NavigationProp<
   ParamList,
   RouteName,
-  DrawerNavigationState,
+  DrawerNavigationState<ParamList>,
   DrawerNavigationOptions,
   DrawerNavigationEventMap
 > &
@@ -220,7 +220,7 @@ export type DrawerScreenProps<
 export type DrawerDescriptor = Descriptor<
   ParamListBase,
   string,
-  DrawerNavigationState,
+  DrawerNavigationState<ParamListBase>,
   DrawerNavigationOptions
 >;
 

--- a/packages/drawer/src/views/DrawerItemList.tsx
+++ b/packages/drawer/src/views/DrawerItemList.tsx
@@ -3,6 +3,7 @@ import {
   CommonActions,
   DrawerActions,
   DrawerNavigationState,
+  ParamListBase,
   useLinkBuilder,
 } from '@react-navigation/native';
 import DrawerItem from './DrawerItem';
@@ -13,7 +14,7 @@ import type {
 } from '../types';
 
 type Props = Omit<DrawerContentOptions, 'contentContainerStyle' | 'style'> & {
-  state: DrawerNavigationState;
+  state: DrawerNavigationState<ParamListBase>;
   navigation: DrawerNavigationHelpers;
   descriptors: DrawerDescriptorMap;
 };

--- a/packages/drawer/src/views/DrawerView.tsx
+++ b/packages/drawer/src/views/DrawerView.tsx
@@ -13,6 +13,7 @@ import {
   DrawerNavigationState,
   DrawerActions,
   useTheme,
+  ParamListBase,
 } from '@react-navigation/native';
 
 import { GestureHandlerRootView } from './GestureHandler';
@@ -31,7 +32,7 @@ import type {
 } from '../types';
 
 type Props = DrawerNavigationConfig & {
-  state: DrawerNavigationState;
+  state: DrawerNavigationState<ParamListBase>;
   navigation: DrawerNavigationHelpers;
   descriptors: DrawerDescriptorMap;
 };

--- a/packages/material-bottom-tabs/src/navigators/createMaterialBottomTabNavigator.tsx
+++ b/packages/material-bottom-tabs/src/navigators/createMaterialBottomTabNavigator.tsx
@@ -6,6 +6,7 @@ import {
   TabRouter,
   TabRouterOptions,
   TabNavigationState,
+  ParamListBase,
 } from '@react-navigation/native';
 
 import MaterialBottomTabView from '../views/MaterialBottomTabView';
@@ -27,7 +28,7 @@ function MaterialBottomTabNavigator({
   ...rest
 }: Props) {
   const { state, descriptors, navigation } = useNavigationBuilder<
-    TabNavigationState,
+    TabNavigationState<ParamListBase>,
     TabRouterOptions,
     MaterialBottomTabNavigationOptions,
     MaterialBottomTabNavigationEventMap
@@ -49,7 +50,7 @@ function MaterialBottomTabNavigator({
 }
 
 export default createNavigatorFactory<
-  TabNavigationState,
+  TabNavigationState<ParamListBase>,
   MaterialBottomTabNavigationOptions,
   MaterialBottomTabNavigationEventMap,
   typeof MaterialBottomTabNavigator

--- a/packages/material-bottom-tabs/src/types.tsx
+++ b/packages/material-bottom-tabs/src/types.tsx
@@ -27,7 +27,7 @@ export type MaterialBottomTabNavigationProp<
 > = NavigationProp<
   ParamList,
   RouteName,
-  TabNavigationState,
+  TabNavigationState<ParamList>,
   MaterialBottomTabNavigationOptions,
   MaterialBottomTabNavigationEventMap
 > &
@@ -84,7 +84,7 @@ export type MaterialBottomTabNavigationOptions = {
 export type MaterialBottomTabDescriptor = Descriptor<
   ParamListBase,
   string,
-  TabNavigationState,
+  TabNavigationState<ParamListBase>,
   MaterialBottomTabNavigationOptions
 >;
 

--- a/packages/material-bottom-tabs/src/views/MaterialBottomTabView.tsx
+++ b/packages/material-bottom-tabs/src/views/MaterialBottomTabView.tsx
@@ -9,6 +9,7 @@ import {
   useTheme,
   useLinkBuilder,
   Link,
+  ParamListBase,
 } from '@react-navigation/native';
 
 import type {
@@ -18,7 +19,7 @@ import type {
 } from '../types';
 
 type Props = MaterialBottomTabNavigationConfig & {
-  state: TabNavigationState;
+  state: TabNavigationState<ParamListBase>;
   navigation: MaterialBottomTabNavigationHelpers;
   descriptors: MaterialBottomTabDescriptorMap;
 };

--- a/packages/material-top-tabs/src/navigators/createMaterialTopTabNavigator.tsx
+++ b/packages/material-top-tabs/src/navigators/createMaterialTopTabNavigator.tsx
@@ -6,6 +6,7 @@ import {
   TabRouter,
   TabRouterOptions,
   TabNavigationState,
+  ParamListBase,
 } from '@react-navigation/native';
 import MaterialTopTabView from '../views/MaterialTopTabView';
 import type {
@@ -26,7 +27,7 @@ function MaterialTopTabNavigator({
   ...rest
 }: Props) {
   const { state, descriptors, navigation } = useNavigationBuilder<
-    TabNavigationState,
+    TabNavigationState<ParamListBase>,
     TabRouterOptions,
     MaterialTopTabNavigationOptions,
     MaterialTopTabNavigationEventMap
@@ -48,7 +49,7 @@ function MaterialTopTabNavigator({
 }
 
 export default createNavigatorFactory<
-  TabNavigationState,
+  TabNavigationState<ParamListBase>,
   MaterialTopTabNavigationOptions,
   MaterialTopTabNavigationEventMap,
   typeof MaterialTopTabNavigator

--- a/packages/material-top-tabs/src/types.tsx
+++ b/packages/material-top-tabs/src/types.tsx
@@ -45,7 +45,7 @@ export type MaterialTopTabNavigationProp<
 > = NavigationProp<
   ParamList,
   RouteName,
-  TabNavigationState,
+  TabNavigationState<ParamList>,
   MaterialTopTabNavigationOptions,
   MaterialTopTabNavigationEventMap
 > &
@@ -94,7 +94,7 @@ export type MaterialTopTabNavigationOptions = {
 export type MaterialTopTabDescriptor = Descriptor<
   ParamListBase,
   string,
-  TabNavigationState,
+  TabNavigationState<ParamListBase>,
   MaterialTopTabNavigationOptions
 >;
 
@@ -192,7 +192,7 @@ export type MaterialTopTabBarOptions = Partial<
 
 export type MaterialTopTabBarProps = MaterialTopTabBarOptions &
   SceneRendererProps & {
-    state: TabNavigationState;
+    state: TabNavigationState<ParamListBase>;
     navigation: NavigationHelpers<
       ParamListBase,
       MaterialTopTabNavigationEventMap

--- a/packages/material-top-tabs/src/views/MaterialTopTabView.tsx
+++ b/packages/material-top-tabs/src/views/MaterialTopTabView.tsx
@@ -4,6 +4,7 @@ import {
   NavigationHelpersContext,
   TabNavigationState,
   TabActions,
+  ParamListBase,
   useTheme,
 } from '@react-navigation/native';
 
@@ -16,7 +17,7 @@ import type {
 } from '../types';
 
 type Props = MaterialTopTabNavigationConfig & {
-  state: TabNavigationState;
+  state: TabNavigationState<ParamListBase>;
   navigation: MaterialTopTabNavigationHelpers;
   descriptors: MaterialTopTabDescriptorMap;
   tabBarPosition?: 'top' | 'bottom';

--- a/packages/routers/src/DrawerRouter.tsx
+++ b/packages/routers/src/DrawerRouter.tsx
@@ -25,8 +25,8 @@ export type DrawerRouterOptions = TabRouterOptions & {
   openByDefault?: boolean;
 };
 
-export type DrawerNavigationState = Omit<
-  TabNavigationState,
+export type DrawerNavigationState<ParamList extends ParamListBase> = Omit<
+  TabNavigationState<ParamList>,
   'type' | 'history'
 > & {
   /**
@@ -72,10 +72,14 @@ export const DrawerActions = {
 };
 
 const isDrawerOpen = (
-  state: DrawerNavigationState | PartialState<DrawerNavigationState>
+  state:
+    | DrawerNavigationState<ParamListBase>
+    | PartialState<DrawerNavigationState<ParamListBase>>
 ) => Boolean(state.history?.find((it) => it.type === 'drawer'));
 
-const openDrawer = (state: DrawerNavigationState): DrawerNavigationState => {
+const openDrawer = (
+  state: DrawerNavigationState<ParamListBase>
+): DrawerNavigationState<ParamListBase> => {
   if (isDrawerOpen(state)) {
     return state;
   }
@@ -86,7 +90,9 @@ const openDrawer = (state: DrawerNavigationState): DrawerNavigationState => {
   };
 };
 
-const closeDrawer = (state: DrawerNavigationState): DrawerNavigationState => {
+const closeDrawer = (
+  state: DrawerNavigationState<ParamListBase>
+): DrawerNavigationState<ParamListBase> => {
   if (!isDrawerOpen(state)) {
     return state;
   }
@@ -101,11 +107,11 @@ export default function DrawerRouter({
   openByDefault,
   ...rest
 }: DrawerRouterOptions): Router<
-  DrawerNavigationState,
+  DrawerNavigationState<ParamListBase>,
   DrawerActionType | CommonNavigationAction
 > {
   const router = (TabRouter(rest) as unknown) as Router<
-    DrawerNavigationState,
+    DrawerNavigationState<ParamListBase>,
     TabActionType | CommonNavigationAction
   >;
 

--- a/packages/routers/src/StackRouter.tsx
+++ b/packages/routers/src/StackRouter.tsx
@@ -36,7 +36,9 @@ export type StackActionType =
 
 export type StackRouterOptions = DefaultRouterOptions;
 
-export type StackNavigationState = NavigationState & {
+export type StackNavigationState<
+  ParamList extends ParamListBase
+> = NavigationState<ParamList> & {
   /**
    * Type of the router, in this case, it's stack.
    */
@@ -96,7 +98,7 @@ export const StackActions = {
 
 export default function StackRouter(options: StackRouterOptions) {
   const router: Router<
-    StackNavigationState,
+    StackNavigationState<ParamListBase>,
     CommonNavigationAction | StackActionType
   > = {
     ...BaseRouter,

--- a/packages/routers/src/TabRouter.tsx
+++ b/packages/routers/src/TabRouter.tsx
@@ -23,7 +23,10 @@ export type TabRouterOptions = DefaultRouterOptions & {
   backBehavior?: BackBehavior;
 };
 
-export type TabNavigationState = Omit<NavigationState, 'history'> & {
+export type TabNavigationState<ParamList extends ParamListBase> = Omit<
+  NavigationState<ParamList>,
+  'history'
+> & {
   /**
    * Type of the router, in this case, it's tab.
    */
@@ -93,7 +96,7 @@ const getRouteHistory = (
 };
 
 const changeIndex = (
-  state: TabNavigationState,
+  state: TabNavigationState<ParamListBase>,
   index: number,
   backBehavior: BackBehavior,
   initialRouteName: string | undefined
@@ -127,7 +130,7 @@ export default function TabRouter({
   backBehavior = 'history',
 }: TabRouterOptions) {
   const router: Router<
-    TabNavigationState,
+    TabNavigationState<ParamListBase>,
     TabActionType | CommonNavigationAction
   > = {
     ...BaseRouter,
@@ -172,9 +175,9 @@ export default function TabRouter({
       }
 
       const routes = routeNames.map((name) => {
-        const route = (state as PartialState<TabNavigationState>).routes.find(
-          (r) => r.name === name
-        );
+        const route = (state as PartialState<
+          TabNavigationState<ParamListBase>
+        >).routes.find((r) => r.name === name);
 
         return {
           ...route,

--- a/packages/routers/src/__tests__/DrawerRouter.test.tsx
+++ b/packages/routers/src/__tests__/DrawerRouter.test.tsx
@@ -3,6 +3,7 @@ import {
   DrawerRouter,
   DrawerActions,
   DrawerNavigationState,
+  ParamListBase,
 } from '..';
 
 jest.mock('nanoid/non-secure', () => ({ nanoid: () => 'test' }));
@@ -199,7 +200,7 @@ it('gets rehydrated state from partial state', () => {
 it("doesn't rehydrate state if it's not stale", () => {
   const router = DrawerRouter({});
 
-  const state: DrawerNavigationState = {
+  const state: DrawerNavigationState<ParamListBase> = {
     index: 0,
     key: 'drawer-test',
     routeNames: ['bar', 'baz', 'qux'],
@@ -340,7 +341,7 @@ it('handles open drawer action', () => {
     history: [{ type: 'route', key: 'bar' }, { type: 'drawer' }],
   });
 
-  const state: DrawerNavigationState = {
+  const state: DrawerNavigationState<ParamListBase> = {
     stale: false as const,
     type: 'drawer' as const,
     key: 'root',
@@ -395,7 +396,7 @@ it('handles close drawer action', () => {
     history: [{ type: 'route', key: 'bar' }],
   });
 
-  const state: DrawerNavigationState = {
+  const state: DrawerNavigationState<ParamListBase> = {
     stale: false as const,
     type: 'drawer' as const,
     key: 'root',
@@ -487,7 +488,7 @@ it('handles toggle drawer action', () => {
 it('updates history on focus change', () => {
   const router = DrawerRouter({ backBehavior: 'history' });
 
-  const state: DrawerNavigationState = {
+  const state: DrawerNavigationState<ParamListBase> = {
     index: 0,
     key: 'drawer-test',
     routeNames: ['baz', 'bar'],

--- a/packages/routers/src/__tests__/TabRouter.test.tsx
+++ b/packages/routers/src/__tests__/TabRouter.test.tsx
@@ -1,4 +1,10 @@
-import { CommonActions, TabRouter, TabActions, TabNavigationState } from '..';
+import {
+  CommonActions,
+  TabRouter,
+  TabActions,
+  TabNavigationState,
+  ParamListBase,
+} from '..';
 
 jest.mock('nanoid/non-secure', () => ({ nanoid: () => 'test' }));
 
@@ -217,7 +223,7 @@ it('gets rehydrated state from partial state', () => {
 it("doesn't rehydrate state if it's not stale", () => {
   const router = TabRouter({});
 
-  const state: TabNavigationState = {
+  const state: TabNavigationState<ParamListBase> = {
     index: 0,
     key: 'tab-test',
     routeNames: ['bar', 'baz', 'qux'],
@@ -699,7 +705,7 @@ it('handles back action with backBehavior: history', () => {
     state,
     TabActions.jumpTo('qux'),
     options
-  ) as TabNavigationState;
+  ) as TabNavigationState<ParamListBase>;
 
   expect(
     router.getStateForAction(state, CommonActions.goBack(), options)
@@ -721,7 +727,7 @@ it('handles back action with backBehavior: history', () => {
     state,
     TabActions.jumpTo('baz'),
     options
-  ) as TabNavigationState;
+  ) as TabNavigationState<ParamListBase>;
 
   expect(
     router.getStateForAction(state, CommonActions.goBack(), options)
@@ -746,7 +752,7 @@ it('handles back action with backBehavior: history', () => {
     state,
     TabActions.jumpTo('bar'),
     options
-  ) as TabNavigationState;
+  ) as TabNavigationState<ParamListBase>;
 
   expect(
     router.getStateForAction(state, CommonActions.goBack(), options)
@@ -785,7 +791,7 @@ it('handles back action with backBehavior: order', () => {
     state,
     TabActions.jumpTo('qux'),
     options
-  ) as TabNavigationState;
+  ) as TabNavigationState<ParamListBase>;
 
   expect(
     router.getStateForAction(state, CommonActions.goBack(), options)
@@ -810,7 +816,7 @@ it('handles back action with backBehavior: order', () => {
     state,
     TabActions.jumpTo('baz'),
     options
-  ) as TabNavigationState;
+  ) as TabNavigationState<ParamListBase>;
 
   expect(
     router.getStateForAction(state, CommonActions.goBack(), options)
@@ -832,7 +838,7 @@ it('handles back action with backBehavior: order', () => {
     state,
     TabActions.jumpTo('bar'),
     options
-  ) as TabNavigationState;
+  ) as TabNavigationState<ParamListBase>;
 
   expect(
     router.getStateForAction(state, CommonActions.goBack(), options)
@@ -856,7 +862,7 @@ it('handles back action with backBehavior: initialRoute', () => {
     state,
     TabActions.jumpTo('qux'),
     options
-  ) as TabNavigationState;
+  ) as TabNavigationState<ParamListBase>;
 
   expect(
     router.getStateForAction(state, CommonActions.goBack(), options)
@@ -878,7 +884,7 @@ it('handles back action with backBehavior: initialRoute', () => {
     state,
     TabActions.jumpTo('baz'),
     options
-  ) as TabNavigationState;
+  ) as TabNavigationState<ParamListBase>;
 
   expect(
     router.getStateForAction(state, CommonActions.goBack(), options)
@@ -900,7 +906,7 @@ it('handles back action with backBehavior: initialRoute', () => {
     state,
     TabActions.jumpTo('bar'),
     options
-  ) as TabNavigationState;
+  ) as TabNavigationState<ParamListBase>;
 
   expect(
     router.getStateForAction(state, CommonActions.goBack(), options)
@@ -928,7 +934,7 @@ it('handles back action with backBehavior: initialRoute and initialRouteName', (
     state,
     TabActions.jumpTo('qux'),
     options
-  ) as TabNavigationState;
+  ) as TabNavigationState<ParamListBase>;
 
   expect(
     router.getStateForAction(state, CommonActions.goBack(), options)
@@ -950,7 +956,7 @@ it('handles back action with backBehavior: initialRoute and initialRouteName', (
     state,
     TabActions.jumpTo('bar'),
     options
-  ) as TabNavigationState;
+  ) as TabNavigationState<ParamListBase>;
 
   expect(
     router.getStateForAction(state, CommonActions.goBack(), options)
@@ -972,7 +978,7 @@ it('handles back action with backBehavior: initialRoute and initialRouteName', (
     state,
     TabActions.jumpTo('baz'),
     options
-  ) as TabNavigationState;
+  ) as TabNavigationState<ParamListBase>;
 
   expect(
     router.getStateForAction(state, CommonActions.goBack(), options)
@@ -992,7 +998,7 @@ it('handles back action with backBehavior: none', () => {
     state,
     TabActions.jumpTo('baz'),
     options
-  ) as TabNavigationState;
+  ) as TabNavigationState<ParamListBase>;
 
   expect(
     router.getStateForAction(state, CommonActions.goBack(), options)
@@ -1006,7 +1012,7 @@ it('updates route key history on navigate and jump to', () => {
     routeParamList: {},
   };
 
-  let state: TabNavigationState = {
+  let state: TabNavigationState<ParamListBase> = {
     index: 1,
     key: 'tab-test',
     routeNames: ['bar', 'baz', 'qux'],
@@ -1024,7 +1030,7 @@ it('updates route key history on navigate and jump to', () => {
     state,
     TabActions.jumpTo('qux'),
     options
-  ) as TabNavigationState;
+  ) as TabNavigationState<ParamListBase>;
 
   expect(state.history).toEqual([
     { type: 'route', key: 'baz-0' },
@@ -1035,7 +1041,7 @@ it('updates route key history on navigate and jump to', () => {
     state,
     CommonActions.navigate('bar'),
     options
-  ) as TabNavigationState;
+  ) as TabNavigationState<ParamListBase>;
 
   expect(state.history).toEqual([
     { type: 'route', key: 'baz-0' },
@@ -1047,7 +1053,7 @@ it('updates route key history on navigate and jump to', () => {
     state,
     TabActions.jumpTo('baz'),
     options
-  ) as TabNavigationState;
+  ) as TabNavigationState<ParamListBase>;
 
   expect(state.history).toEqual([
     { type: 'route', key: 'qux-0' },
@@ -1059,7 +1065,7 @@ it('updates route key history on navigate and jump to', () => {
     state,
     CommonActions.goBack(),
     options
-  ) as TabNavigationState;
+  ) as TabNavigationState<ParamListBase>;
 
   expect(state.history).toEqual([
     { type: 'route', key: 'qux-0' },
@@ -1070,7 +1076,7 @@ it('updates route key history on navigate and jump to', () => {
     state,
     CommonActions.goBack(),
     options
-  ) as TabNavigationState;
+  ) as TabNavigationState<ParamListBase>;
 
   expect(state.history).toEqual([{ type: 'route', key: 'qux-0' }]);
 });

--- a/packages/routers/src/types.tsx
+++ b/packages/routers/src/types.tsx
@@ -2,7 +2,16 @@ import type * as CommonActions from './CommonActions';
 
 export type CommonNavigationAction = CommonActions.Action;
 
-export type NavigationState = Readonly<{
+type NavigationRoute<
+  ParamList extends ParamListBase,
+  RouteName extends keyof ParamList
+> = Route<Extract<RouteName, string>, ParamList[RouteName]> & {
+  state?: NavigationState | PartialState<NavigationState>;
+};
+
+export type NavigationState<
+  ParamList extends ParamListBase = ParamListBase
+> = Readonly<{
   /**
    * Unique key for the navigation state.
    */
@@ -14,7 +23,7 @@ export type NavigationState = Readonly<{
   /**
    * List of valid route names as defined in the screen components.
    */
-  routeNames: string[];
+  routeNames: Extract<keyof ParamList, string>[];
   /**
    * Alternative entries for history.
    */
@@ -22,9 +31,7 @@ export type NavigationState = Readonly<{
   /**
    * List of rendered routes.
    */
-  routes: (Route<string> & {
-    state?: NavigationState | PartialState<NavigationState>;
-  })[];
+  routes: NavigationRoute<ParamList, keyof ParamList>[];
   /**
    * Custom type for the state, whether it's for tab, stack, drawer etc.
    * During rehydration, the state will be discarded if type doesn't match with router type.
@@ -55,7 +62,10 @@ export type PartialState<State extends NavigationState> = Partial<
     })[];
   }>;
 
-export type Route<RouteName extends string> = Readonly<{
+export type Route<
+  RouteName extends string,
+  Params extends object | undefined = object | undefined
+> = Readonly<{
   /**
    * Unique key for the route.
    */
@@ -64,11 +74,20 @@ export type Route<RouteName extends string> = Readonly<{
    * User-provided name for the route.
    */
   name: RouteName;
-  /**
-   * Params for the route.
-   */
-  params?: object;
-}>;
+}> &
+  (undefined extends Params
+    ? Readonly<{
+        /**
+         * Params for this route
+         */
+        params?: Readonly<Params>;
+      }>
+    : Readonly<{
+        /**
+         * Params for this route
+         */
+        params: Readonly<Params>;
+      }>);
 
 export type ParamListBase = Record<string, object | undefined>;
 

--- a/packages/stack/src/navigators/createStackNavigator.tsx
+++ b/packages/stack/src/navigators/createStackNavigator.tsx
@@ -9,6 +9,7 @@ import {
   StackRouterOptions,
   StackNavigationState,
   StackActions,
+  ParamListBase,
 } from '@react-navigation/native';
 import StackView from '../views/Stack/StackView';
 import type {
@@ -36,7 +37,7 @@ function StackNavigator({
   };
 
   const { state, descriptors, navigation } = useNavigationBuilder<
-    StackNavigationState,
+    StackNavigationState<ParamListBase>,
     StackRouterOptions,
     StackNavigationOptions,
     StackNavigationEventMap
@@ -91,7 +92,7 @@ function StackNavigator({
 }
 
 export default createNavigatorFactory<
-  StackNavigationState,
+  StackNavigationState<ParamListBase>,
   StackNavigationOptions,
   StackNavigationEventMap,
   typeof StackNavigator

--- a/packages/stack/src/types.tsx
+++ b/packages/stack/src/types.tsx
@@ -52,7 +52,7 @@ export type StackNavigationProp<
 > = NavigationProp<
   ParamList,
   RouteName,
-  StackNavigationState,
+  StackNavigationState<ParamList>,
   StackNavigationOptions,
   StackNavigationEventMap
 > &
@@ -250,7 +250,7 @@ export type StackHeaderProps = {
 export type StackDescriptor = Descriptor<
   ParamListBase,
   string,
-  StackNavigationState,
+  StackNavigationState<ParamListBase>,
   StackNavigationOptions
 >;
 

--- a/packages/stack/src/views/Stack/CardStack.tsx
+++ b/packages/stack/src/views/Stack/CardStack.tsx
@@ -7,7 +7,11 @@ import {
   Platform,
 } from 'react-native';
 import type { EdgeInsets } from 'react-native-safe-area-context';
-import type { Route, StackNavigationState } from '@react-navigation/native';
+import type {
+  ParamListBase,
+  Route,
+  StackNavigationState,
+} from '@react-navigation/native';
 
 import { MaybeScreenContainer, MaybeScreen } from '../Screens';
 import { getDefaultHeaderHeight } from '../Header/HeaderSegment';
@@ -37,7 +41,7 @@ type GestureValues = {
 type Props = {
   mode: StackCardMode;
   insets: EdgeInsets;
-  state: StackNavigationState;
+  state: StackNavigationState<ParamListBase>;
   descriptors: StackDescriptorMap;
   routes: Route<string>[];
   openingRouteKeys: string[];

--- a/packages/stack/src/views/Stack/StackView.tsx
+++ b/packages/stack/src/views/Stack/StackView.tsx
@@ -6,6 +6,7 @@ import {
   StackActions,
   StackNavigationState,
   Route,
+  ParamListBase,
 } from '@react-navigation/native';
 
 import { GestureHandlerRootView } from '../GestureHandler';
@@ -23,7 +24,7 @@ import type {
 import HeaderShownContext from '../../utils/HeaderShownContext';
 
 type Props = StackNavigationConfig & {
-  state: StackNavigationState;
+  state: StackNavigationState<ParamListBase>;
   navigation: StackNavigationHelpers;
   descriptors: StackDescriptorMap;
 };


### PR DESCRIPTION
The commit improves the navigation state object to have more specific types.
e.g. The `routeNames` array will now have proper type instead of `string[]`

<img width="737" alt="Screen Shot 2020-10-23 at 16 55 59" src="https://user-images.githubusercontent.com/1174278/97019531-b731e700-1550-11eb-8145-946ef96d4473.png">
