### PR TITLE
feat: add `getInitialURL` and `subscribe` options to linking config

### DIFF
--- a/packages/native/src/types.tsx
+++ b/packages/native/src/types.tsx
@@ -50,6 +50,20 @@ export type LinkingOptions = {
    */
   config?: { initialRouteName?: string; screens: PathConfigMap };
   /**
+   * Custom function to get the initial URL used for linking.
+   * Uses `Linking.getInitialURL()` by default.
+   * Not supported on the web.
+   */
+  getInitialURL?: () => Promise<string | null | undefined>;
+  /**
+   * Custom function to get subscribe to URL updates.
+   * Uses `Linking.addEventListener('url', callback)` by default.
+   * Not supported on the web.
+   */
+  subscribe?: (
+    listener: (url: string) => void
+  ) => undefined | void | (() => void);
+  /**
    * Custom function to parse the URL to a valid navigation state (advanced).
    * Only applicable on Web.
    */


### PR DESCRIPTION
For apps with push notifications linking to screens inside the app, currently we need to handle them separately (e.g. [instructions for firebase](https://rnfirebase.io/messaging/notifications#handling-interaction), [instructions for expo notifications](https://docs.expo.io/push-notifications/receiving-notifications/)). But if we add a link in the notification to use for deep linking, we can instead reuse the same deep linking logic instead.

This commit adds the `getInitialURL` and `subscribe` options which internally used `Linking` API to allow more advanced implementations by combining it with other sources such as push notifications.

Example usage with Firebase notifications could look like this:

```js
const linking = {
  prefixes: ['myapp://', 'https://myapp.com'],
  async getInitialURL() {
    // Check if app was opened from a deep link
    const url = await Linking.getInitialURL();

    if (url != null) {
      return url;
    }

    // Check if there is an initial firebase notification
    const message = await messaging().getInitialNotification();

    // Get the `url` property from the notification which corresponds to a screen
    // This property needs to be set on the notification payload when sending it
    return message?.notification.url;
  },
  subscribe(listener) {
    const onReceiveURL = ({ url }: { url: string }) => listener(url);

    // Listen to incoming links from deep linking
    Linking.addEventListener('url', onReceiveURL);

    // Listen to firebase push notifications
    const unsubscribeNotification = messaging().onNotificationOpenedApp(
      (message) => {
        const url = message.notification.url;

        if (url) {
          // If the notification has a `url` property, use it for linking
          listener(url);
        }
      }
    );

    return () => {
      // Clean up the event listeners
      Linking.removeEventListener('url', onReceiveURL);
      unsubscribeNotification();
    };
  },
  config,
};
```