### PR TITLE
test: add tests to getEventManager

### DIFF
--- a/packages/core/src/__tests__/getEventManager.test.js
+++ b/packages/core/src/__tests__/getEventManager.test.js
@@ -1,0 +1,48 @@
+import getEventManager from '../getEventManager';
+
+const TARGET = 'target';
+
+it('calls listeners to emitted event', () => {
+  const eventManager = getEventManager(TARGET);
+  const callback = jest.fn();
+  eventManager.addListener('didFocus', callback);
+
+  eventManager.emit('didFocus');
+
+  expect(callback).toHaveBeenCalledTimes(1);
+});
+
+it('does not call listeners connected to a different event', () => {
+  const eventManager = getEventManager(TARGET);
+  const callback = jest.fn();
+  eventManager.addListener('didFocus', callback);
+
+  eventManager.emit('didBlur');
+
+  expect(callback).not.toHaveBeenCalled();
+});
+
+it('does not call removed listeners', () => {
+  const eventManager = getEventManager(TARGET);
+  const callback = jest.fn();
+  const { remove } = eventManager.addListener('didFocus', callback);
+
+  eventManager.emit('didFocus');
+  expect(callback).toHaveBeenCalled();
+
+  remove();
+
+  eventManager.emit('didFocus');
+  expect(callback).toHaveBeenCalledTimes(1);
+});
+
+it('calls the listeners with the given payload', () => {
+  const eventManager = getEventManager(TARGET);
+  const callback = jest.fn();
+  eventManager.addListener('didFocus', callback);
+
+  const payload = { foo: 0 };
+  eventManager.emit('didFocus', payload);
+
+  expect(callback).toHaveBeenCalledWith(payload);
+});


### PR DESCRIPTION
Decided to contribute back some tests I've written when porting over the implementation of getEventManager. Let me know if I can improve anything :)