### PR TITLE
fix: let Bottom Tabs accessibility labels generated by the OS

### DIFF
--- a/packages/bottom-tabs/src/views/BottomTabBar.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabBar.tsx
@@ -260,13 +260,6 @@ export default function BottomTabBar({
               ? options.title
               : route.name;
 
-          const accessibilityLabel =
-            options.tabBarAccessibilityLabel !== undefined
-              ? options.tabBarAccessibilityLabel
-              : typeof label === 'string'
-              ? `${label}, tab, ${index + 1} of ${routes.length}`
-              : undefined;
-
           return (
             <NavigationContext.Provider
               key={route.key}
@@ -279,7 +272,7 @@ export default function BottomTabBar({
                   horizontal={shouldUseHorizontalLabels()}
                   onPress={onPress}
                   onLongPress={onLongPress}
-                  accessibilityLabel={accessibilityLabel}
+                  accessibilityLabel={options.tabBarAccessibilityLabel}
                   to={buildLink(route.name, route.params)}
                   testID={options.tabBarTestID}
                   allowFontScaling={allowFontScaling}

--- a/packages/bottom-tabs/src/views/BottomTabBar.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabBar.tsx
@@ -226,7 +226,11 @@ export default function BottomTabBar({
       ]}
       pointerEvents={isTabBarHidden ? 'none' : 'auto'}
     >
-      <View style={styles.content} onLayout={handleLayout}>
+      <View
+        accessibilityRole="tablist"
+        style={styles.content}
+        onLayout={handleLayout}
+      >
         {routes.map((route, index) => {
           const focused = index === state.index;
           const { options } = descriptors[route.key];

--- a/packages/bottom-tabs/src/views/BottomTabItem.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabItem.tsx
@@ -257,7 +257,7 @@ export default function BottomTabBarItem({
     onLongPress,
     testID,
     accessibilityLabel,
-    accessibilityRole: 'button',
+    accessibilityRole: 'tab',
     accessibilityState: { selected: focused },
     // @ts-expect-error: keep for compatibility with older React Native versions
     accessibilityStates: focused ? ['selected'] : [],


### PR DESCRIPTION
The accessibility label "tab X of Y" is generated by the os, with the proper language. In order to do so, we need the OS to detect tab inside a tablist. This PR should handle this.
It can be tested on iOS via VoiceOver. Pressing a tab should say "{label}, tab X on Y".