### PR TITLE
fix: android textinput gets blurred after navigating back

### DIFF
--- a/packages/stack/src/views/KeyboardManager.tsx
+++ b/packages/stack/src/views/KeyboardManager.tsx
@@ -58,10 +58,12 @@ export default class KeyboardManager extends React.Component<Props> {
 
     const input = this.previouslyFocusedTextInput;
 
-    if (Platform.OS === 'android') {
-      Keyboard.dismiss();
-    } else if (input) {
-      TextInput.State.blurTextInput(input);
+    if (input) {
+      if (Platform.OS === 'android') {
+        Keyboard.dismiss();
+      } else {
+        TextInput.State.blurTextInput(input);
+      }
     }
 
     // Cleanup the ID on successful page change


### PR DESCRIPTION
When navigating from ScreenA to ScreenB and then back to ScreenA,
react-navigation unconditionally calls `Keyboard.dismiss()`.
If the user is fast enough and taps on a `TextInput` after coming
back from ScreenB, the keyboard opens, just to be dismissed again.
This would also happen if some logic automatically focuses the
`TextInput` in ScreenA. This behaviour can be observed in
https://snack.expo.io/lTDZhVNhV.