### PR TITLE
chore: replace community maskedview

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@expo/vector-icons": "^10.0.0",
     "@react-native-async-storage/async-storage": "^1.13.1",
-    "@react-native-community/masked-view": "0.1.10",
+    "@react-native-masked-view/masked-view": "0.2.0",
     "color": "^3.1.3",
     "expo": "^39.0.0",
     "expo-asset": "~8.2.0",

--- a/packages/stack/package.json
+++ b/packages/stack/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@react-native-community/bob": "^0.16.2",
-    "@react-native-community/masked-view": "^0.1.10",
+    "@react-native-masked-view/masked-view": "^0.2.0",
     "@react-navigation/native": "^5.8.9",
     "@testing-library/react-native": "^7.1.0",
     "@types/color": "^3.0.1",
@@ -60,7 +60,7 @@
     "typescript": "^4.0.3"
   },
   "peerDependencies": {
-    "@react-native-community/masked-view": ">= 0.1.0",
+    "@react-native-masked-view/masked-view": ">= 0.2.0",
     "@react-navigation/native": "^5.0.5",
     "react": "*",
     "react-native": "*",

--- a/packages/stack/src/views/MaskedViewNative.tsx
+++ b/packages/stack/src/views/MaskedViewNative.tsx
@@ -4,7 +4,7 @@
 import * as React from 'react';
 import { UIManager } from 'react-native';
 
-type MaskedViewType = typeof import('@react-native-community/masked-view').default;
+type MaskedViewType = typeof import('@react-native-masked-view/masked-view').default;
 
 type Props = React.ComponentProps<MaskedViewType> & {
   children: React.ReactElement;
@@ -15,7 +15,7 @@ let RNCMaskedView: MaskedViewType | undefined;
 try {
   // Add try/catch to support usage even if it's not installed, since it's optional.
   // Newer versions of Metro will handle it properly.
-  RNCMaskedView = require('@react-native-community/masked-view').default;
+  RNCMaskedView = require('@react-native-masked-view/masked-view').default;
 } catch (e) {
   // Ignore
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3494,10 +3494,10 @@
     sudo-prompt "^9.0.0"
     wcwidth "^1.0.1"
 
-"@react-native-community/masked-view@0.1.10", "@react-native-community/masked-view@^0.1.10":
-  version "0.1.10"
-  resolved "https://registry.yarnpkg.com/@react-native-community/masked-view/-/masked-view-0.1.10.tgz#5dda643e19e587793bc2034dd9bf7398ad43d401"
-  integrity sha512-rk4sWFsmtOw8oyx8SD3KSvawwaK7gRBSEIy2TAwURyGt+3TizssXP1r8nx3zY+R7v2vYYHXZ+k2/GULAT/bcaQ==
+"@react-native-masked-view/masked-view@0.2.0", "@react-native-masked-view/masked-view@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@react-native-masked-view/masked-view/-/masked-view-0.2.0.tgz#3309ada28dafd7ac1fead4eb99286acd43180b2a"
+  integrity sha512-OXYHN8lRvqLHPM2qB4wagcV1thCzR/PmFaJPOIsq+KU7PBmB0CY5DaC5WCPbyzGP8X9ehVmmK/yWlew3GJIgnQ==
 
 "@segment/loosely-validate-event@^2.0.0":
   version "2.0.0"


### PR DESCRIPTION
replaced `@react-native-community/masked-view` with `@react-native-masked-view/masked-view` due to namespace change.