### PR TITLE
fix: consider openByDefault prop when rehydrating drawer state

### DIFF
--- a/packages/routers/src/DrawerRouter.tsx
+++ b/packages/routers/src/DrawerRouter.tsx
@@ -145,7 +145,7 @@ export default function DrawerRouter({
         routeParamList,
       });
 
-      if (isDrawerOpen(partialState) || openByDefault) {
+      if (partialState.history ? isDrawerOpen(partialState) : openByDefault) {
         state = openDrawer(state);
       }
 

--- a/packages/routers/src/DrawerRouter.tsx
+++ b/packages/routers/src/DrawerRouter.tsx
@@ -145,7 +145,7 @@ export default function DrawerRouter({
         routeParamList,
       });
 
-      if (isDrawerOpen(partialState)) {
+      if (isDrawerOpen(partialState) || openByDefault) {
         state = openDrawer(state);
       }
 


### PR DESCRIPTION
openByDefault in connection with expo-links only works for `getInitialState()`. When a page of the application is refreshed, `getRehydratedState()` is called and the drawer stays closed. This should fix the issue.