### PR TITLE
fix: warnings printing to console for un-exported members of react-native-screens

### DIFF
--- a/packages/bottom-tabs/src/views/ResourceSavingScene.tsx
+++ b/packages/bottom-tabs/src/views/ResourceSavingScene.tsx
@@ -1,11 +1,9 @@
 import * as React from 'react';
 import { Platform, StyleSheet, View } from 'react-native';
-import {
-  Screen,
-  screensEnabled,
-  // @ts-ignore
-  shouldUseActivityState,
-} from 'react-native-screens';
+import { Screen, screensEnabled } from 'react-native-screens';
+
+// eslint-disable-next-line import/no-commonjs
+const ReactNativeScreens = require('react-native-screens');
 
 type Props = {
   isVisible: boolean;
@@ -22,7 +20,8 @@ export default class ResourceSavingScene extends React.Component<Props> {
     if (screensEnabled?.() && Platform.OS !== 'web') {
       const { isVisible, ...rest } = this.props;
 
-      if (shouldUseActivityState) {
+      // @ts-ignore
+      if (ReactNativeScreens.shouldUseActivityState) {
         return (
           // @ts-expect-error: there was an `active` prop and no `activityState` in older version and stackPresentation was required
           <Screen activityState={isVisible ? 2 : 0} {...rest} />

--- a/packages/drawer/src/views/ResourceSavingScene.tsx
+++ b/packages/drawer/src/views/ResourceSavingScene.tsx
@@ -1,11 +1,9 @@
 import * as React from 'react';
 import { Platform, StyleSheet, View } from 'react-native';
-import {
-  Screen,
-  screensEnabled,
-  // @ts-ignore
-  shouldUseActivityState,
-} from 'react-native-screens';
+import { Screen, screensEnabled } from 'react-native-screens';
+
+// eslint-disable-next-line import/no-commonjs
+const ReactNativeScreens = require('react-native-screens');
 
 type Props = {
   isVisible: boolean;
@@ -22,7 +20,8 @@ export default class ResourceSavingScene extends React.Component<Props> {
     if (screensEnabled?.() && Platform.OS !== 'web') {
       const { isVisible, ...rest } = this.props;
 
-      if (shouldUseActivityState) {
+      // @ts-ignore
+      if (ReactNativeScreens.shouldUseActivityState) {
         return (
           // @ts-expect-error: there was an `active` prop and no `activityState` in older version and stackPresentation was required
           <Screen activityState={isVisible ? 2 : 0} {...rest} />

--- a/packages/material-bottom-tabs/src/views/MaterialBottomTabView.tsx
+++ b/packages/material-bottom-tabs/src/views/MaterialBottomTabView.tsx
@@ -28,11 +28,9 @@ type Scene = { route: { key: string } };
 
 // Optionally require vector-icons referenced from react-native-paper:
 // https://github.com/callstack/react-native-paper/blob/4b26429c49053eaa4c3e0fae208639e01093fa87/src/components/MaterialCommunityIcon.tsx#L14
-let MaterialCommunityIcons: React.ComponentType<
-  React.ComponentProps<
-    typeof import('react-native-vector-icons/MaterialCommunityIcons').default
-  >
->;
+let MaterialCommunityIcons: React.ComponentType<React.ComponentProps<
+  typeof import('react-native-vector-icons/MaterialCommunityIcons').default
+>>;
 
 try {
   // Optionally require vector-icons


### PR DESCRIPTION
- Fixes #8993
- Fixes failing lint

Will rebase from master if lint error is fixed before this is merged