### PR TITLE
chore: set displayName for ThemeContext

### DIFF
--- a/packages/native/src/theming/ThemeContext.tsx
+++ b/packages/native/src/theming/ThemeContext.tsx
@@ -3,6 +3,7 @@ import DefaultTheme from './DefaultTheme';
 import type { Theme } from '../types';
 
 const ThemeContext = React.createContext<Theme>(DefaultTheme);
+
 ThemeContext.displayName = 'ThemeContext';
 
 export default ThemeContext;

--- a/packages/native/src/theming/ThemeContext.tsx
+++ b/packages/native/src/theming/ThemeContext.tsx
@@ -3,5 +3,6 @@ import DefaultTheme from './DefaultTheme';
 import type { Theme } from '../types';
 
 const ThemeContext = React.createContext<Theme>(DefaultTheme);
+ThemeContext.displayName = 'ThemeContext';
 
 export default ThemeContext;


### PR DESCRIPTION
Set displayName for ThemeContext, so that it'll show ThemeContext.Provider instead of mere Context.Provider in React Devtools.