### PR TITLE
Fix NavigationContainer ref prop

### DIFF
--- a/packages/core/src/BaseNavigationContainer.tsx
+++ b/packages/core/src/BaseNavigationContainer.tsx
@@ -219,7 +219,12 @@ const BaseNavigationContainer = React.forwardRef(
       dangerouslyGetParent: () => undefined,
       getCurrentRoute,
       getCurrentOptions,
-    }), [ref]);
+    }), [
+		resetRoot, 
+		getRootState,
+		getCurrentRoute,
+		getCurrentOptions,
+	]);
 
     const onDispatchAction = React.useCallback(
       (action: NavigationAction, noop: boolean) => {

--- a/packages/core/src/BaseNavigationContainer.tsx
+++ b/packages/core/src/BaseNavigationContainer.tsx
@@ -219,7 +219,7 @@ const BaseNavigationContainer = React.forwardRef(
       dangerouslyGetParent: () => undefined,
       getCurrentRoute,
       getCurrentOptions,
-    }));
+    }), [ref]);
 
     const onDispatchAction = React.useCallback(
       (action: NavigationAction, noop: boolean) => {

--- a/packages/native/src/NavigationContainer.tsx
+++ b/packages/native/src/NavigationContainer.tsx
@@ -61,7 +61,7 @@ const NavigationContainer = React.forwardRef(function NavigationContainer(
 
   const [isResolved, initialState] = useThenable(getInitialState);
 
-  React.useImperativeHandle(ref, () => refContainer.current);
+  React.useImperativeHandle(ref, () => refContainer.current, [ref]);
 
   const linkingContext = React.useMemo(() => ({ options: linking }), [linking]);
 

--- a/packages/native/src/NavigationContainer.tsx
+++ b/packages/native/src/NavigationContainer.tsx
@@ -61,7 +61,7 @@ const NavigationContainer = React.forwardRef(function NavigationContainer(
 
   const [isResolved, initialState] = useThenable(getInitialState);
 
-  React.useImperativeHandle(ref, () => refContainer.current, [ref]);
+  React.useImperativeHandle(ref, () => refContainer.current, [refContainer.current]);
 
   const linkingContext = React.useMemo(() => ({ options: linking }), [linking]);
 


### PR DESCRIPTION
Fix for issue #9213.

The `ref` prop is added as dependency at the call of `React.useImperativeHandle()`.