### PR TITLE
fix: correct typings for tabPress event

### DIFF
--- a/packages/core/src/types.tsx
+++ b/packages/core/src/types.tsx
@@ -39,6 +39,7 @@ export type EventMapCore<State extends NavigationState> = {
   blur: { data: undefined };
   state: { data: { state: State } };
   beforeRemove: { data: { action: NavigationAction }; canPreventDefault: true };
+  tabPress: { data: undefined };
 };
 
 export type EventArg<


### PR DESCRIPTION
## Context
https://reactnavigation.org/docs/material-bottom-tab-navigator/#events

## Before
<img width="1066" alt="Screen Shot 2021-01-23 at 3 19 33 PM" src="https://user-images.githubusercontent.com/2933593/105616882-c5311700-5d8e-11eb-8225-cbecba3bbebb.png">


## After
<img width="967" alt="Screen Shot 2021-01-23 at 3 21 42 PM" src="https://user-images.githubusercontent.com/2933593/105616881-c19d9000-5d8e-11eb-9e67-611dc39b3a29.png">
