### PR TITLE
fix: upgrade masked view dependency so users can use latest version

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@expo/vector-icons": "^10.0.0",
     "@react-native-async-storage/async-storage": "^1.13.1",
-    "@react-native-community/masked-view": "0.1.10",
+    "@react-native-masked-view/masked-view": "^0.2.1",
     "color": "^3.1.3",
     "expo": "^39.0.0",
     "expo-asset": "~8.2.0",

--- a/packages/stack/package.json
+++ b/packages/stack/package.json
@@ -44,7 +44,7 @@
     "react-native-iphone-x-helper": "^1.3.0"
   },
   "devDependencies": {
-    "@react-native-community/masked-view": "^0.1.10",
+    "@react-native-masked-view/masked-view": "^0.2.1",
     "@react-navigation/native": "^5.9.2",
     "@testing-library/react-native": "^7.1.0",
     "@types/color": "^3.0.1",
@@ -60,7 +60,7 @@
     "typescript": "^4.0.3"
   },
   "peerDependencies": {
-    "@react-native-community/masked-view": ">= 0.1.0",
+    "@react-native-masked-view/masked-view": "^0.2.1",
     "@react-navigation/native": "^5.0.5",
     "react": "*",
     "react-native": "*",

--- a/packages/stack/src/views/MaskedViewNative.tsx
+++ b/packages/stack/src/views/MaskedViewNative.tsx
@@ -4,7 +4,7 @@
 import * as React from 'react';
 import { UIManager } from 'react-native';
 
-type MaskedViewType = typeof import('@react-native-community/masked-view').default;
+type MaskedViewType = typeof import('@react-native-masked-view/masked-view').default;
 
 type Props = React.ComponentProps<MaskedViewType> & {
   children: React.ReactElement;
@@ -15,7 +15,7 @@ let RNCMaskedView: MaskedViewType | undefined;
 try {
   // Add try/catch to support usage even if it's not installed, since it's optional.
   // Newer versions of Metro will handle it properly.
-  RNCMaskedView = require('@react-native-community/masked-view').default;
+  RNCMaskedView = require('@react-native-masked-view/masked-view').default;
 } catch (e) {
   // Ignore
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3716,10 +3716,10 @@
     sudo-prompt "^9.0.0"
     wcwidth "^1.0.1"
 
-"@react-native-community/masked-view@0.1.10", "@react-native-community/masked-view@^0.1.10":
-  version "0.1.10"
-  resolved "https://registry.yarnpkg.com/@react-native-community/masked-view/-/masked-view-0.1.10.tgz#5dda643e19e587793bc2034dd9bf7398ad43d401"
-  integrity sha512-rk4sWFsmtOw8oyx8SD3KSvawwaK7gRBSEIy2TAwURyGt+3TizssXP1r8nx3zY+R7v2vYYHXZ+k2/GULAT/bcaQ==
+"@react-native-masked-view/masked-view@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@react-native-masked-view/masked-view/-/masked-view-0.2.1.tgz#35fec941ebcac7f94d837fc0aa27ad91ffcc0a5c"
+  integrity sha512-NY856RX98v8q6RFW+8cUq/QAzsvg5H4vAW0/Jk//XE7Fspmvd1qR15y9GZAUACPkwHg+8taEPiozn/wY5OyMYA==
 
 "@segment/loosely-validate-event@^2.0.0":
   version "2.0.0"


### PR DESCRIPTION
# Problem:
React Navigation has a dependency on an old release of masked-view, and all updates are now being made in a different namespace (@react-native-community -> @react-native-masked-view). In my project I need the latest version of masked-view because the older version causes a bug with Detox. Since the masked-view library has changed to a new namespace I can't simply use a newer version of the package than specified in the package.json, and they can't exist side by side because the native modules have the same name.

# Solution:
Update by switching to the dependency from the new namespace