### PR TITLE
V5: add peerDependencies to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,13 @@
     "release": "lerna publish",
     "example": "yarn --cwd example"
   },
+  "peerDependencies": {
+    "react-native-reanimated": "~1.13.2",
+    "react-native-gesture-handler": "~1.9.0",
+    "react-native-screens": "~2.17.1",
+    "react-native-safe-area-context": "~3.1.9",
+    "@react-native-community/masked-view": "~0.1.10"
+  },
   "devDependencies": {
     "@commitlint/config-conventional": "^11.0.0",
     "@types/jest": "^26.0.15",


### PR DESCRIPTION
## Why
Required dependencies are not listed in peerDependencies package.json

## How
Create "peerDependencies" json object and add require peerDependencies listed in the documentation for the `@react-navigation/native` base lib.

## TODOs
- [ ] verify that those dependency ranges are acceptable.