### PR TITLE
feat: associate path with the route it opens when deep linking

### DIFF
--- a/example/src/Screens/NotFound.tsx
+++ b/example/src/Screens/NotFound.tsx
@@ -4,11 +4,12 @@ import { Button } from 'react-native-paper';
 import type { StackScreenProps } from '@react-navigation/stack';
 
 const NotFoundScreen = ({
+  route,
   navigation,
 }: StackScreenProps<{ Home: undefined }>) => {
   return (
     <View style={styles.container}>
-      <Text style={styles.title}>404 Not Found</Text>
+      <Text style={styles.title}>404 Not Found ({route.path})</Text>
       <Button
         mode="contained"
         onPress={() => navigation.navigate('Home')}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -47,6 +47,7 @@
     "@types/react": "^16.9.53",
     "@types/react-is": "^16.7.1",
     "del-cli": "^3.0.1",
+    "immer": "^8.0.1",
     "react": "~16.13.1",
     "react-native-builder-bob": "^0.17.1",
     "react-test-renderer": "~16.13.1",

--- a/packages/core/src/BaseNavigationContainer.tsx
+++ b/packages/core/src/BaseNavigationContainer.tsx
@@ -21,6 +21,7 @@ import useEventEmitter from './useEventEmitter';
 import useSyncState from './useSyncState';
 import checkSerializable from './checkSerializable';
 import checkDuplicateRouteNames from './checkDuplicateRouteNames';
+import findFocusedRoute from './findFocusedRoute';
 import type {
   NavigationContainerEventMap,
   NavigationContainerRef,
@@ -185,14 +186,15 @@ const BaseNavigationContainer = React.forwardRef(
     }, [keyedListeners.getState]);
 
     const getCurrentRoute = React.useCallback(() => {
-      let state = getRootState();
-      if (state === undefined) {
+      const state = getRootState();
+
+      if (state == null) {
         return undefined;
       }
-      while (state.routes[state.index].state !== undefined) {
-        state = state.routes[state.index].state as NavigationState;
-      }
-      return state.routes[state.index];
+
+      const route = findFocusedRoute(state);
+
+      return route as Route<string> | undefined;
     }, [getRootState]);
 
     const emitter = useEventEmitter<NavigationContainerEventMap>();

--- a/packages/core/src/__tests__/getActionFromState.test.tsx
+++ b/packages/core/src/__tests__/getActionFromState.test.tsx
@@ -15,6 +15,7 @@ it('gets navigate action from state', () => {
                   {
                     name: 'qux',
                     params: { author: 'jane' },
+                    path: '/foo/bar',
                   },
                 ],
               },
@@ -35,6 +36,7 @@ it('gets navigate action from state', () => {
             author: 'jane',
           },
           screen: 'qux',
+          path: '/foo/bar',
           initial: true,
         },
         screen: 'bar',
@@ -51,6 +53,7 @@ it('gets navigate action from state for top-level screen', () => {
       {
         name: 'foo',
         params: { answer: 42 },
+        path: '/foo/bar',
       },
     ],
   };
@@ -59,6 +62,7 @@ it('gets navigate action from state for top-level screen', () => {
     payload: {
       name: 'foo',
       params: { answer: 42 },
+      path: '/foo/bar',
     },
     type: 'NAVIGATE',
   });
@@ -80,6 +84,7 @@ it('gets reset action from state with 1 route with key at root', () => {
                     key: 'test',
                     name: 'qux',
                     params: { author: 'jane' },
+                    path: '/foo/bar',
                   },
                 ],
               },
@@ -102,7 +107,12 @@ it('gets reset action from state with 1 route with key at root', () => {
                 name: 'bar',
                 state: {
                   routes: [
-                    { key: 'test', name: 'qux', params: { author: 'jane' } },
+                    {
+                      key: 'test',
+                      name: 'qux',
+                      params: { author: 'jane' },
+                      path: '/foo/bar',
+                    },
                   ],
                 },
               },
@@ -125,6 +135,7 @@ it('gets reset action from state for top-level screen with 2 screens', () => {
       {
         name: 'bar',
         params: { author: 'jane' },
+        path: '/foo/bar',
       },
     ],
   };
@@ -139,6 +150,7 @@ it('gets reset action from state for top-level screen with 2 screens', () => {
         {
           name: 'bar',
           params: { author: 'jane' },
+          path: '/foo/bar',
         },
       ],
     },
@@ -197,6 +209,7 @@ it('gets reset action from state for top-level screen with 2 screens with config
         name: 'bar',
         key: 'test',
         params: { author: 'jane' },
+        path: '/foo/bar',
       },
     ],
   };
@@ -219,6 +232,7 @@ it('gets reset action from state for top-level screen with 2 screens with config
           name: 'bar',
           key: 'test',
           params: { author: 'jane' },
+          path: '/foo/bar',
         },
       ],
     },
@@ -236,6 +250,7 @@ it('gets navigate action from state for top-level screen with 2 screens with con
       {
         name: 'bar',
         params: { author: 'jane' },
+        path: '/foo/bar',
       },
     ],
   };
@@ -251,6 +266,7 @@ it('gets navigate action from state for top-level screen with 2 screens with con
     payload: {
       name: 'bar',
       params: { author: 'jane' },
+      path: '/foo/bar',
     },
     type: 'NAVIGATE',
   });
@@ -267,6 +283,7 @@ it('gets navigate action from state for top-level screen with more than 2 screen
       {
         name: 'bar',
         params: { author: 'jane' },
+        path: '/foo/bar',
       },
       { name: 'baz' },
     ],
@@ -283,6 +300,7 @@ it('gets navigate action from state for top-level screen with more than 2 screen
     payload: {
       name: 'bar',
       params: { author: 'jane' },
+      path: '/foo/bar',
     },
     type: 'NAVIGATE',
   });
@@ -303,7 +321,7 @@ it('gets navigate action from state with 2 screens', () => {
                     name: 'qux',
                     params: { author: 'jane' },
                   },
-                  { name: 'quz' },
+                  { name: 'quz', path: '/foo/bar' },
                 ],
               },
             },
@@ -328,7 +346,7 @@ it('gets navigate action from state with 2 screens', () => {
                   author: 'jane',
                 },
               },
-              { name: 'quz' },
+              { name: 'quz', path: '/foo/bar' },
             ],
           },
         },
@@ -353,6 +371,7 @@ it('gets navigate action from state with 2 screens with lower index', () => {
                   {
                     name: 'qux',
                     params: { author: 'jane' },
+                    path: '/foo/bar',
                   },
                   { name: 'quz' },
                 ],
@@ -376,6 +395,7 @@ it('gets navigate action from state with 2 screens with lower index', () => {
           params: {
             author: 'jane',
           },
+          path: '/foo/bar',
         },
       },
     },
@@ -450,6 +470,7 @@ it('gets navigate action from state with config', () => {
                   {
                     name: 'qux',
                     params: { author: 'jane' },
+                    path: '/foo/bar',
                   },
                 ],
               },
@@ -483,6 +504,7 @@ it('gets navigate action from state with config', () => {
             author: 'jane',
           },
           screen: 'qux',
+          path: '/foo/bar',
           initial: true,
         },
         screen: 'bar',
@@ -499,6 +521,7 @@ it('gets navigate action from state for top-level screen with config', () => {
       {
         name: 'foo',
         params: { answer: 42 },
+        path: '/foo/bar',
       },
     ],
   };
@@ -519,6 +542,7 @@ it('gets navigate action from state for top-level screen with config', () => {
     payload: {
       name: 'foo',
       params: { answer: 42 },
+      path: '/foo/bar',
     },
     type: 'NAVIGATE',
   });
@@ -539,7 +563,7 @@ it('gets navigate action from state with 2 screens including initial route and w
                     name: 'qux',
                     params: { author: 'jane' },
                   },
-                  { name: 'quz' },
+                  { name: 'quz', path: '/foo/bar' },
                 ],
               },
             },
@@ -571,6 +595,7 @@ it('gets navigate action from state with 2 screens including initial route and w
         params: {
           screen: 'quz',
           initial: false,
+          path: '/foo/bar',
         },
       },
     },
@@ -593,7 +618,7 @@ it('gets navigate action from state with 2 screens without initial route and wit
                     name: 'qux',
                     params: { author: 'jane' },
                   },
-                  { name: 'quz' },
+                  { name: 'quz', path: '/foo/bar' },
                 ],
               },
             },
@@ -631,7 +656,7 @@ it('gets navigate action from state with 2 screens without initial route and wit
                   author: 'jane',
                 },
               },
-              { name: 'quz' },
+              { name: 'quz', path: '/foo/bar' },
             ],
           },
         },
@@ -856,6 +881,7 @@ it('gets navigate action from state with more than 2 screens with lower index', 
                   {
                     name: 'qux',
                     params: { author: 'jane' },
+                    path: '/foo/bar',
                   },
                   { name: 'quz' },
                 ],
@@ -889,6 +915,7 @@ it('gets navigate action from state with more than 2 screens with lower index', 
         params: {
           screen: 'qux',
           initial: false,
+          path: '/foo/bar',
           params: {
             author: 'jane',
           },

--- a/packages/core/src/__tests__/getPathFromState.test.tsx
+++ b/packages/core/src/__tests__/getPathFromState.test.tsx
@@ -82,7 +82,11 @@ it('converts state to path string with config', () => {
                 routes: [
                   {
                     name: 'Baz',
-                    params: { author: 'Jane', valid: true, id: 10 },
+                    params: {
+                      author: 'Jane',
+                      id: 10,
+                      valid: true,
+                    },
                   },
                 ],
               },
@@ -186,9 +190,9 @@ it('handles state with config with nested screens', () => {
                         {
                           name: 'Baz',
                           params: {
+                            answer: '42',
                             author: 'Jane',
                             count: '10',
-                            answer: '42',
                             valid: true,
                           },
                         },
@@ -265,9 +269,9 @@ it('handles state with config with nested screens and exact', () => {
                         {
                           name: 'Baz',
                           params: {
+                            answer: '42',
                             author: 'Jane',
                             count: '10',
-                            answer: '42',
                             valid: true,
                           },
                         },
@@ -333,9 +337,9 @@ it('handles state with config with nested screens and unused configs', () => {
                   {
                     name: 'Baz',
                     params: {
+                      answer: '42',
                       author: 'Jane',
                       count: 10,
-                      answer: '42',
                       valid: true,
                     },
                   },
@@ -399,9 +403,9 @@ it('handles state with config with nested screens and unused configs with exact'
                   {
                     name: 'Baz',
                     params: {
+                      answer: '42',
                       author: 'Jane',
                       count: 10,
-                      answer: '42',
                       valid: true,
                     },
                   },
@@ -476,9 +480,9 @@ it('handles nested object with stringify in it', () => {
                         {
                           name: 'Bis',
                           params: {
+                            answer: '42',
                             author: 'Jane',
                             count: 10,
-                            answer: '42',
                             valid: true,
                           },
                         },
@@ -558,9 +562,9 @@ it('handles nested object with stringify in it with exact', () => {
                         {
                           name: 'Bis',
                           params: {
+                            answer: '42',
                             author: 'Jane',
                             count: 10,
-                            answer: '42',
                             valid: true,
                           },
                         },

--- a/packages/core/src/findFocusedRoute.tsx
+++ b/packages/core/src/findFocusedRoute.tsx
@@ -1,0 +1,13 @@
+import type { InitialState } from '@react-navigation/routers';
+
+export default function findFocusedRoute(state: InitialState) {
+  let current: InitialState | undefined = state;
+
+  while (current?.routes[current.index ?? 0].state != null) {
+    current = current.routes[current.index ?? 0].state;
+  }
+
+  const route = current?.routes[current?.index ?? 0];
+
+  return route;
+}

--- a/packages/core/src/getActionFromState.tsx
+++ b/packages/core/src/getActionFromState.tsx
@@ -20,6 +20,7 @@ type NavigateAction<State extends NavigationState> = {
   payload: {
     name: string;
     params?: NavigatorScreenParams<State>;
+    path?: string;
   };
 };
 
@@ -61,7 +62,9 @@ export default function getActionFromState(
     NavigationState
   >;
 
-  let payload = route ? { name: route.name, params } : undefined;
+  let payload = route
+    ? { name: route.name, path: route.path, params }
+    : undefined;
 
   while (current) {
     if (current.routes.length === 0) {
@@ -107,6 +110,7 @@ export default function getActionFromState(
         NavigationState
       >;
     } else {
+      params.path = route.path;
       params.params = route.params;
     }
 

--- a/packages/core/src/getPathFromState.tsx
+++ b/packages/core/src/getPathFromState.tsx
@@ -211,7 +211,7 @@ export default function getPathFromState(
         }
       }
 
-      const query = queryString.stringify(focusedParams);
+      const query = queryString.stringify(focusedParams, { sort: false });
 
       if (query) {
         path += `?${query}`;

--- a/packages/core/src/index.tsx
+++ b/packages/core/src/index.tsx
@@ -20,6 +20,8 @@ export { default as getStateFromPath } from './getStateFromPath';
 export { default as getPathFromState } from './getPathFromState';
 export { default as getActionFromState } from './getActionFromState';
 
+export { default as findFocusedRoute } from './findFocusedRoute';
+
 export { default as getFocusedRouteNameFromRoute } from './getFocusedRouteNameFromRoute';
 
 export * from './types';

--- a/packages/core/src/types.tsx
+++ b/packages/core/src/types.tsx
@@ -525,6 +525,7 @@ export type NavigatorScreenParams<
       screen?: never;
       params?: never;
       initial?: never;
+      path?: string;
       state: PartialState<State> | State | undefined;
     }
   | {
@@ -533,12 +534,14 @@ export type NavigatorScreenParams<
             screen: RouteName;
             params?: ParamList[RouteName];
             initial?: boolean;
+            path?: string;
             state?: never;
           }
         : {
             screen: RouteName;
             params: ParamList[RouteName];
             initial?: boolean;
+            path?: string;
             state?: never;
           };
     }[keyof ParamList];

--- a/packages/core/src/useNavigationBuilder.tsx
+++ b/packages/core/src/useNavigationBuilder.tsx
@@ -376,7 +376,11 @@ export default function useNavigationBuilder<
         route.params !== previousParams)
     ) {
       // If the route was updated with new screen name and/or params, we should navigate there
-      action = CommonActions.navigate(route.params.screen, route.params.params);
+      action = CommonActions.navigate({
+        name: route.params.screen,
+        params: route.params.params,
+        path: route.params.path,
+      });
     }
 
     // The update should be limited to current navigator only, so we call the router manually

--- a/packages/native/src/useLinking.tsx
+++ b/packages/native/src/useLinking.tsx
@@ -5,6 +5,7 @@ import {
   NavigationContainerRef,
   NavigationState,
   getActionFromState,
+  findFocusedRoute,
 } from '@react-navigation/core';
 import { nanoid } from 'nanoid/non-secure';
 import ServerContext from './ServerContext';
@@ -447,7 +448,9 @@ export default function useLinking(
       const state = ref.current.getRootState();
 
       if (state) {
-        const path = getPathFromStateRef.current(state, configRef.current);
+        const route = findFocusedRoute(state);
+        const path =
+          route?.path ?? getPathFromStateRef.current(state, configRef.current);
 
         if (previousStateRef.current === undefined) {
           previousStateRef.current = state;
@@ -468,7 +471,9 @@ export default function useLinking(
       const state = navigation.getRootState();
 
       const pendingPath = pendingPopStatePathRef.current;
-      const path = getPathFromStateRef.current(state, configRef.current);
+      const route = findFocusedRoute(state);
+      const path =
+        route?.path ?? getPathFromStateRef.current(state, configRef.current);
 
       previousStateRef.current = state;
       pendingPopStatePathRef.current = undefined;

--- a/packages/routers/src/CommonActions.tsx
+++ b/packages/routers/src/CommonActions.tsx
@@ -16,8 +16,20 @@ export type Action =
   | {
       type: 'NAVIGATE';
       payload:
-        | { key: string; name?: undefined; params?: object; merge?: boolean }
-        | { name: string; key?: string; params?: object; merge?: boolean };
+        | {
+            key: string;
+            name?: undefined;
+            params?: object;
+            path?: string;
+            merge?: boolean;
+          }
+        | {
+            name: string;
+            key?: string;
+            params?: object;
+            path?: string;
+            merge?: boolean;
+          };
       source?: string;
       target?: string;
     }
@@ -40,8 +52,14 @@ export function goBack(): Action {
 
 export function navigate(
   options:
-    | { key: string; params?: object; merge?: boolean }
-    | { name: string; key?: string; params?: object; merge?: boolean }
+    | { key: string; params?: object; path?: string; merge?: boolean }
+    | {
+        name: string;
+        key?: string;
+        params?: object;
+        path?: string;
+        merge?: boolean;
+      }
 ): Action;
 // eslint-disable-next-line no-redeclare
 export function navigate(name: string, params?: object): Action;

--- a/packages/routers/src/StackRouter.tsx
+++ b/packages/routers/src/StackRouter.tsx
@@ -401,6 +401,7 @@ export default function StackRouter(options: StackRouterOptions) {
                   key:
                     action.payload.key ?? `${action.payload.name}-${nanoid()}`,
                   name: action.payload.name,
+                  path: action.payload.path,
                   params:
                     routeParamList[action.payload.name] !== undefined
                       ? {
@@ -447,8 +448,13 @@ export default function StackRouter(options: StackRouterOptions) {
               index,
               routes: [
                 ...state.routes.slice(0, index),
-                params !== route.params
-                  ? { ...route, params }
+                params !== route.params ||
+                (action.payload.path && action.payload.path !== route.path)
+                  ? {
+                      ...route,
+                      path: action.payload.path ?? route.path,
+                      params,
+                    }
                   : state.routes[index],
               ],
             };

--- a/packages/routers/src/TabRouter.tsx
+++ b/packages/routers/src/TabRouter.tsx
@@ -334,7 +334,14 @@ export default function TabRouter({
                       : action.payload.params;
                 }
 
-                return params !== route.params ? { ...route, params } : route;
+                const path =
+                  action.type === 'NAVIGATE' && action.payload.path != null
+                    ? action.payload.path
+                    : route.path;
+
+                return params !== route.params || path !== route.path
+                  ? { ...route, path, params }
+                  : route;
               }),
             },
             index,

--- a/packages/routers/src/__tests__/StackRouter.test.tsx
+++ b/packages/routers/src/__tests__/StackRouter.test.tsx
@@ -1299,6 +1299,159 @@ it('ensure unique ID is only per route name for push', () => {
   });
 });
 
+it('adds path on navigate if provided', () => {
+  const router = StackRouter({});
+  const options: RouterConfigOptions = {
+    routeNames: ['baz', 'bar', 'qux'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+
+  expect(
+    router.getStateForAction(
+      {
+        stale: false,
+        type: 'stack',
+        key: 'root',
+        index: 2,
+        routeNames: ['baz', 'bar', 'qux'],
+        routes: [
+          { key: 'baz', name: 'baz' },
+          { key: 'bar', name: 'bar', params: { answer: 42 } },
+          { key: 'qux', name: 'qux' },
+        ],
+      },
+
+      CommonActions.navigate({
+        name: 'bar',
+        path: '/foo/bar',
+      }),
+      options
+    )
+  ).toEqual({
+    stale: false,
+    type: 'stack',
+    key: 'root',
+    index: 1,
+    routeNames: ['baz', 'bar', 'qux'],
+    routes: [
+      { key: 'baz', name: 'baz' },
+      { key: 'bar', name: 'bar', path: '/foo/bar' },
+    ],
+  });
+
+  expect(
+    router.getStateForAction(
+      {
+        stale: false,
+        type: 'stack',
+        key: 'root',
+        index: 1,
+        routeNames: ['baz', 'bar', 'qux'],
+        routes: [
+          { key: 'baz', name: 'baz' },
+          { key: 'bar', name: 'bar', params: { answer: 42 }, path: '/foo/bar' },
+        ],
+      },
+      CommonActions.navigate({
+        name: 'bar',
+        params: { fruit: 'orange' },
+        path: '/foo/baz',
+      }),
+      options
+    )
+  ).toEqual({
+    stale: false,
+    type: 'stack',
+    key: 'root',
+    index: 1,
+    routeNames: ['baz', 'bar', 'qux'],
+    routes: [
+      { key: 'baz', name: 'baz' },
+      {
+        key: 'bar',
+        name: 'bar',
+        params: { fruit: 'orange' },
+        path: '/foo/baz',
+      },
+    ],
+  });
+
+  expect(
+    router.getStateForAction(
+      {
+        stale: false,
+        type: 'stack',
+        key: 'root',
+        index: 0,
+        routeNames: ['baz', 'bar', 'qux'],
+        routes: [{ key: 'bar', name: 'bar', params: { answer: 42 } }],
+      },
+      CommonActions.navigate({
+        name: 'baz',
+        path: '/foo/bar',
+      }),
+      options
+    )
+  ).toEqual({
+    stale: false,
+    type: 'stack',
+    key: 'root',
+    index: 1,
+    routeNames: ['baz', 'bar', 'qux'],
+    routes: [
+      { key: 'bar', name: 'bar', params: { answer: 42 } },
+      {
+        key: 'baz-test',
+        name: 'baz',
+        path: '/foo/bar',
+      },
+    ],
+  });
+});
+
+it("doesn't remove existing path on navigate if not provided", () => {
+  const router = StackRouter({});
+  const options: RouterConfigOptions = {
+    routeNames: ['baz', 'bar', 'qux'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+
+  expect(
+    router.getStateForAction(
+      {
+        stale: false,
+        type: 'stack',
+        key: 'root',
+        index: 2,
+        routeNames: ['baz', 'bar', 'qux'],
+        routes: [
+          { key: 'baz', name: 'baz' },
+          { key: 'bar', name: 'bar', path: '/foo/bar' },
+          { key: 'qux', name: 'qux' },
+        ],
+      },
+
+      CommonActions.navigate({
+        name: 'bar',
+        params: { answer: 42 },
+      }),
+      options
+    )
+  ).toEqual({
+    stale: false,
+    type: 'stack',
+    key: 'root',
+    index: 1,
+    routeNames: ['baz', 'bar', 'qux'],
+    routes: [
+      { key: 'baz', name: 'baz' },
+      { key: 'bar', name: 'bar', params: { answer: 42 }, path: '/foo/bar' },
+    ],
+  });
+});
+
 it("doesn't merge params on navigate to an existing screen", () => {
   const router = StackRouter({});
   const options: RouterConfigOptions = {

--- a/packages/routers/src/__tests__/TabRouter.test.tsx
+++ b/packages/routers/src/__tests__/TabRouter.test.tsx
@@ -1264,6 +1264,145 @@ it('updates route key history on focus change', () => {
   ]);
 });
 
+it('adds path on navigate if provided', () => {
+  const router = TabRouter({});
+  const options: RouterConfigOptions = {
+    routeNames: ['baz', 'bar', 'qux'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+
+  expect(
+    router.getStateForAction(
+      {
+        stale: false,
+        type: 'tab',
+        key: 'root',
+        index: 1,
+        routeNames: ['baz', 'bar', 'qux'],
+        routes: [
+          { key: 'baz', name: 'baz' },
+          { key: 'bar', name: 'bar' },
+          { key: 'qux', name: 'qux' },
+        ],
+        history: [{ type: 'route', key: 'baz' }],
+      },
+      CommonActions.navigate({
+        name: 'bar',
+        path: '/foo/bar',
+      }),
+      options
+    )
+  ).toEqual({
+    stale: false,
+    type: 'tab',
+    key: 'root',
+    index: 1,
+    routeNames: ['baz', 'bar', 'qux'],
+    routes: [
+      { key: 'baz', name: 'baz' },
+      { key: 'bar', name: 'bar', path: '/foo/bar' },
+      { key: 'qux', name: 'qux' },
+    ],
+    history: [
+      { type: 'route', key: 'baz' },
+      { type: 'route', key: 'bar' },
+    ],
+  });
+
+  expect(
+    router.getStateForAction(
+      {
+        stale: false,
+        type: 'tab',
+        key: 'root',
+        index: 1,
+        routeNames: ['baz', 'bar', 'qux'],
+        routes: [
+          { key: 'baz', name: 'baz' },
+          {
+            key: 'bar',
+            name: 'bar',
+            path: '/foo/bar',
+          },
+          { key: 'qux', name: 'qux' },
+        ],
+        history: [{ type: 'route', key: 'baz' }],
+      },
+      CommonActions.navigate({
+        name: 'bar',
+        params: { fruit: 'orange' },
+        path: '/foo/baz',
+      }),
+      options
+    )
+  ).toEqual({
+    stale: false,
+    type: 'tab',
+    key: 'root',
+    index: 1,
+    routeNames: ['baz', 'bar', 'qux'],
+    routes: [
+      { key: 'baz', name: 'baz' },
+      {
+        key: 'bar',
+        name: 'bar',
+        params: { fruit: 'orange' },
+        path: '/foo/baz',
+      },
+      { key: 'qux', name: 'qux' },
+    ],
+    history: [
+      { type: 'route', key: 'baz' },
+      { type: 'route', key: 'bar' },
+    ],
+  });
+});
+
+it("doesn't remove existing path on navigate if not provided", () => {
+  const router = TabRouter({});
+  const options: RouterConfigOptions = {
+    routeNames: ['baz', 'bar', 'qux'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+
+  expect(
+    router.getStateForAction(
+      {
+        stale: false,
+        type: 'tab',
+        key: 'root',
+        index: 1,
+        routeNames: ['baz', 'bar', 'qux'],
+        routes: [
+          { key: 'baz', name: 'baz' },
+          { key: 'bar', name: 'bar', path: '/foo/bar' },
+          { key: 'qux', name: 'qux' },
+        ],
+        history: [{ type: 'route', key: 'baz' }],
+      },
+      CommonActions.navigate({ name: 'bar' }),
+      options
+    )
+  ).toEqual({
+    stale: false,
+    type: 'tab',
+    key: 'root',
+    index: 1,
+    routeNames: ['baz', 'bar', 'qux'],
+    routes: [
+      { key: 'baz', name: 'baz' },
+      { key: 'bar', name: 'bar', path: '/foo/bar' },
+      { key: 'qux', name: 'qux' },
+    ],
+    history: [
+      { type: 'route', key: 'baz' },
+      { type: 'route', key: 'bar' },
+    ],
+  });
+});
+
 it("doesn't merge params on navigate to an existing screen", () => {
   const router = TabRouter({});
   const options: RouterConfigOptions = {

--- a/packages/routers/src/types.tsx
+++ b/packages/routers/src/types.tsx
@@ -75,6 +75,11 @@ export type Route<
    * User-provided name for the route.
    */
   name: RouteName;
+  /**
+   * Path associated with the route.
+   * Usually present when the screen was opened from a deep link.
+   */
+  path?: string;
 }> &
   (undefined extends Params
     ? Readonly<{

--- a/yarn.lock
+++ b/yarn.lock
@@ -10886,6 +10886,11 @@ immer@7.0.9:
   resolved "https://registry.yarnpkg.com/immer/-/immer-7.0.9.tgz#28e7552c21d39dd76feccd2b800b7bc86ee4a62e"
   integrity sha512-Vs/gxoM4DqNAYR7pugIxi0Xc8XAun/uy7AQu4fLLqaTBHxjOP9pJ266Q9MWA/ly4z6rAFZbvViOtihxUZ7O28A==
 
+immer@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-8.0.1.tgz#9c73db683e2b3975c424fb0572af5889877ae656"
+  integrity sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA==
+
 import-fresh@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-2.0.0.tgz#d81355c15612d386c61f9ddd3922d4304822a546"


### PR DESCRIPTION
This commit adds a new optional property on the `route` object called `path`.
This property will be added if the screen was opened from a deep link.

Having this property helps with few things:

- Preserve the URL when the path was unmatched, e.g. 404 routes
- Expose the path to the user so they could handle it manually if needed, e.g. open in a webview
- Avoid changing URL if state to path doesn't match current path, e.g. if orders of params change

Fixes #9102


https://user-images.githubusercontent.com/1174278/110035095-81d9a900-7d3b-11eb-8c94-856f5fecfc00.mp4

