### PR TITLE
fix: respect headerStatusBarHeight option in Stack

### DIFF
--- a/packages/stack/src/views/Header/Header.tsx
+++ b/packages/stack/src/views/Header/Header.tsx
@@ -46,7 +46,6 @@ export default React.memo(function Header({
     (state) => state.routes[0].key === route.key
   );
 
-
   const statusBarHeight =
     options.headerStatusBarHeight !== undefined
       ? options.headerStatusBarHeight

--- a/packages/stack/src/views/Header/Header.tsx
+++ b/packages/stack/src/views/Header/Header.tsx
@@ -46,8 +46,13 @@ export default React.memo(function Header({
     (state) => state.routes[0].key === route.key
   );
 
+
   const statusBarHeight =
-    (isModal && !isFirstRouteInParent) || isParentHeaderShown ? 0 : insets.top;
+    options.headerStatusBarHeight !== undefined
+    ? options.headerStatusBarHeight
+    : ((isModal && !isFirstRouteInParent) || isParentHeaderShown
+      ? 0
+      : insets.top);
 
   return (
     <HeaderSegment

--- a/packages/stack/src/views/Header/Header.tsx
+++ b/packages/stack/src/views/Header/Header.tsx
@@ -49,10 +49,10 @@ export default React.memo(function Header({
 
   const statusBarHeight =
     options.headerStatusBarHeight !== undefined
-    ? options.headerStatusBarHeight
-    : ((isModal && !isFirstRouteInParent) || isParentHeaderShown
+      ? options.headerStatusBarHeight
+      : (isModal && !isFirstRouteInParent) || isParentHeaderShown
       ? 0
-      : insets.top);
+      : insets.top;
 
   return (
     <HeaderSegment


### PR DESCRIPTION
Use `headerStatusBarHeight` that was passed in `options`