### PR TITLE
fix: remove calls to removed Keyboard.removeListener in useIsKeyboardShown

### DIFF
--- a/packages/bottom-tabs/src/utils/useIsKeyboardShown.tsx
+++ b/packages/bottom-tabs/src/utils/useIsKeyboardShown.tsx
@@ -9,6 +9,7 @@ export default function useIsKeyboardShown() {
     const handleKeyboardHide = () => setIsKeyboardShown(false);
 
     let subscriptions: EmitterSubscription[];
+
     if (Platform.OS === 'ios') {
       subscriptions = [
         Keyboard.addListener('keyboardWillShow', handleKeyboardShow),

--- a/packages/bottom-tabs/src/utils/useIsKeyboardShown.tsx
+++ b/packages/bottom-tabs/src/utils/useIsKeyboardShown.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Keyboard, Platform } from 'react-native';
+import { Keyboard, Platform, EmitterSubscription } from 'react-native';
 
 export default function useIsKeyboardShown() {
   const [isKeyboardShown, setIsKeyboardShown] = React.useState(false);
@@ -8,22 +8,21 @@ export default function useIsKeyboardShown() {
     const handleKeyboardShow = () => setIsKeyboardShown(true);
     const handleKeyboardHide = () => setIsKeyboardShown(false);
 
+    let subscriptions: EmitterSubscription[];
     if (Platform.OS === 'ios') {
-      Keyboard.addListener('keyboardWillShow', handleKeyboardShow);
-      Keyboard.addListener('keyboardWillHide', handleKeyboardHide);
+      subscriptions = [
+        Keyboard.addListener('keyboardWillShow', handleKeyboardShow),
+        Keyboard.addListener('keyboardWillHide', handleKeyboardHide),
+      ];
     } else {
-      Keyboard.addListener('keyboardDidShow', handleKeyboardShow);
-      Keyboard.addListener('keyboardDidHide', handleKeyboardHide);
+      subscriptions = [
+        Keyboard.addListener('keyboardDidShow', handleKeyboardShow),
+        Keyboard.addListener('keyboardDidHide', handleKeyboardHide),
+      ];
     }
 
     return () => {
-      if (Platform.OS === 'ios') {
-        Keyboard.removeListener('keyboardWillShow', handleKeyboardShow);
-        Keyboard.removeListener('keyboardWillHide', handleKeyboardHide);
-      } else {
-        Keyboard.removeListener('keyboardDidShow', handleKeyboardShow);
-        Keyboard.removeListener('keyboardDidHide', handleKeyboardHide);
-      }
+      subscriptions.forEach((s) => s.remove());
     };
   }, []);
 


### PR DESCRIPTION
Keyboard.removeEventListener was restored in https://github.com/facebook/react-native/commit/035718ba97bb44c68f2a4ccdd95e537e3d28690c but not Keyboard.removeListener. In this case we can use the subscription object returned from addListener. The addListener method always returned a subscription object so no need to check if the return value is an object (like in other cases of addEventListener methods).