### PR TITLE
fix: check for screens enabled in ScreenContainer

### DIFF
--- a/packages/drawer/src/views/DrawerView.tsx
+++ b/packages/drawer/src/views/DrawerView.tsx
@@ -6,7 +6,7 @@ import {
   ThemeContext,
   NavigationScreenProp,
 } from 'react-navigation';
-import { ScreenContainer } from 'react-native-screens';
+import { ScreenContainer, screensEnabled } from 'react-native-screens';
 
 import * as DrawerActions from '../routers/DrawerActions';
 import DrawerSidebar from './DrawerSidebar';
@@ -183,9 +183,11 @@ export default class DrawerView extends React.PureComponent<Props, State> {
         />
       );
     } else {
+      const enabled = screensEnabled?.() && detachInactiveScreens;
+
       return (
         // @ts-ignore
-        <ScreenContainer enabled={detachInactiveScreens} style={styles.content}>
+        <ScreenContainer enabled={enabled} style={styles.content}>
           {routes.map((route, index) => {
             if (lazy && !loaded.includes(index)) {
               // Don't render a screen if we've never navigated to it

--- a/packages/tabs/src/navigators/createBottomTabNavigator.tsx
+++ b/packages/tabs/src/navigators/createBottomTabNavigator.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { View, StyleSheet, AccessibilityRole } from 'react-native';
 import { NavigationRoute } from 'react-navigation';
 
-import { ScreenContainer } from 'react-native-screens';
+import { ScreenContainer, screensEnabled } from 'react-native-screens';
 
 import createTabNavigator, {
   NavigationViewProps,
@@ -141,10 +141,12 @@ class TabNavigationView extends React.PureComponent<Props, State> {
     const { routes } = navigation.state;
     const { loaded } = this.state;
 
+    const enabled = screensEnabled?.() && detachInactiveScreens;
+
     return (
       <View style={styles.container}>
         {/* @ts-ignore */}
-        <ScreenContainer enabled={detachInactiveScreens} style={styles.pages}>
+        <ScreenContainer enabled={enabled} style={styles.pages}>
           {routes.map((route, index) => {
             if (lazy && !loaded.includes(index)) {
               // Don't render a screen if we've never navigated to it


### PR DESCRIPTION
Added a check for `screensEnabled` in `ScreenContainer` to make it behave the same as `Screen` in `ResourceSavingScreen.tsx`. Should resolve https://github.com/expo/expo/issues/12374.