### PR TITLE
fix default `pressOpacity` for `TouchableItem.ios.tsx`

### DIFF
--- a/packages/stack/src/views/TouchableItem.ios.tsx
+++ b/packages/stack/src/views/TouchableItem.ios.tsx
@@ -12,7 +12,7 @@ const useNativeDriver = Platform.OS !== 'web';
 
 export default class TouchableItem extends React.Component<Props> {
   static defaultProps = {
-    activeOpacity: 0.3,
+    pressOpacity: 0.3,
     borderless: true,
     enabled: true,
   };


### PR DESCRIPTION
fixes https://github.com/react-navigation/react-navigation/issues/9496

`this.props.pressOpacity` is used for the opacity animation. HeaderBackButton does not pass an explicit value for this prop so the default should be used. But the default does not exist because the name `activeOpacity` is invalid.