### PR TITLE
Improve params type

### DIFF
--- a/packages/routers/src/types.tsx
+++ b/packages/routers/src/types.tsx
@@ -65,7 +65,7 @@ export type PartialState<State extends NavigationState> = Partial<
 
 export type Route<
   RouteName extends string,
-  Params extends object | undefined = object | undefined
+  Params extends {[title: string]: string} | undefined = {} | undefined
 > = Readonly<{
   /**
    * Unique key for the route.


### PR DESCRIPTION
Prevent type check error when use useRoute().params using typescript.
If I using ```const { params } = useRouter()``` there is alwas error if I put params data like ```params.id```, the error is like ```Property 'id' does  not exist on type 'object'```.