### PR TITLE
Change react-native-community to react-native-masked-view

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@expo/vector-icons": "^10.0.0",
     "@react-native-async-storage/async-storage": "^1.13.1",
-    "@react-native-community/masked-view": "0.1.10",
+    "@react-native-masked-view/masked-view": "^0.2.4",
     "color": "^3.1.3",
     "expo": "^39.0.0",
     "expo-asset": "~8.2.0",

--- a/packages/stack/package.json
+++ b/packages/stack/package.json
@@ -44,7 +44,7 @@
     "react-native-iphone-x-helper": "^1.3.0"
   },
   "devDependencies": {
-    "@react-native-community/masked-view": "^0.1.10",
+    "@react-native-masked-view/masked-view": "^0.2.4",
     "@react-navigation/native": "^5.9.4",
     "@testing-library/react-native": "^7.1.0",
     "@types/color": "^3.0.1",
@@ -60,7 +60,7 @@
     "typescript": "^4.0.3"
   },
   "peerDependencies": {
-    "@react-native-community/masked-view": ">= 0.1.0",
+    "@react-native-masked-view/masked-view": ">= 0.2.4",
     "@react-navigation/native": "^5.0.5",
     "react": "*",
     "react-native": "*",

--- a/packages/stack/src/views/MaskedViewNative.tsx
+++ b/packages/stack/src/views/MaskedViewNative.tsx
@@ -4,7 +4,7 @@
 import * as React from 'react';
 import { UIManager } from 'react-native';
 
-type MaskedViewType = typeof import('@react-native-community/masked-view').default;
+type MaskedViewType = typeof import('@react-native-masked-view/masked-view').default;
 
 type Props = React.ComponentProps<MaskedViewType> & {
   children: React.ReactElement;
@@ -15,7 +15,7 @@ let RNCMaskedView: MaskedViewType | undefined;
 try {
   // Add try/catch to support usage even if it's not installed, since it's optional.
   // Newer versions of Metro will handle it properly.
-  RNCMaskedView = require('@react-native-community/masked-view').default;
+  RNCMaskedView = require('@react-native-masked-view/masked-view').default;
 } catch (e) {
   // Ignore
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3716,10 +3716,10 @@
     sudo-prompt "^9.0.0"
     wcwidth "^1.0.1"
 
-"@react-native-community/masked-view@0.1.10", "@react-native-community/masked-view@^0.1.10":
-  version "0.1.10"
-  resolved "https://registry.yarnpkg.com/@react-native-community/masked-view/-/masked-view-0.1.10.tgz#5dda643e19e587793bc2034dd9bf7398ad43d401"
-  integrity sha512-rk4sWFsmtOw8oyx8SD3KSvawwaK7gRBSEIy2TAwURyGt+3TizssXP1r8nx3zY+R7v2vYYHXZ+k2/GULAT/bcaQ==
+"@react-native-masked-view/masked-view@^0.2.4":
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/@react-native-masked-view/masked-view/-/masked-view-0.2.4.tgz#305a548abd47dee494a38f90016432d3a6e4164c"
+  integrity sha512-2Y9OXWHRutYmdyW+bNMaFTW8uTBpaaK20xdIFoVtqahEOO9++B+ut3CAWKPZcdRtb9ikG0LUKChGqMeocg0PGA==
 
 "@segment/loosely-validate-event@^2.0.0":
   version "2.0.0"


### PR DESCRIPTION
From React Native 64 can't use @react-navigation/stack correctly due to having dependency on the old masked-view version.
https://github.com/react-native-masked-view/masked-view/issues/111

This PR will fix that problem. Thanks.