### PR TITLE
Feat: Linking context

### DIFF
--- a/packages/native/src/index.tsx
+++ b/packages/native/src/index.tsx
@@ -17,4 +17,5 @@ export { default as useLinkBuilder } from './useLinkBuilder';
 
 export { default as ServerContainer } from './ServerContainer';
 
+export { default as LinkingContext } from './LinkingContext';
 export * from './types';


### PR DESCRIPTION
Allow to export linking context so module for react navigation can access the linking configuration. It's a must.