### PR TITLE
fix: sort wildcard and :params 

### DIFF
--- a/packages/core/src/__tests__/getStateFromPath.test.tsx
+++ b/packages/core/src/__tests__/getStateFromPath.test.tsx
@@ -2196,7 +2196,7 @@ it('tries to match wildcard patterns at the end', () => {
             path: '/bar/:id/',
             screens: {
               404: '*',
-              matches: ':params',
+              UserProfile: ':userSlug',
               Test: 'test',
             },
           },

--- a/packages/core/src/__tests__/getStateFromPath.test.tsx
+++ b/packages/core/src/__tests__/getStateFromPath.test.tsx
@@ -2196,6 +2196,7 @@ it('tries to match wildcard patterns at the end', () => {
             path: '/bar/:id/',
             screens: {
               404: '*',
+              matches: ':params',
               Test: 'test',
             },
           },

--- a/packages/core/src/getStateFromPath.tsx
+++ b/packages/core/src/getStateFromPath.tsx
@@ -144,20 +144,25 @@ export default function getStateFromPath<ParamList extends {}>(
       const bParts = b.pattern.split('/');
 
       for (let i = 0; i < Math.max(aParts.length, bParts.length); i++) {
+        // if b is longer, b get higher priority
         if (aParts[i] == null) {
           return 1;
         }
+        // if a is longer, a get higher priority
         if (bParts[i] == null) {
           return -1;
         }
         const aWildCard = aParts[i] === '*' || aParts[i].startsWith(':');
         const bWildCard = bParts[i] === '*' || bParts[i].startsWith(':');
+        // if both are wildcard we compare next component
         if (aWildCard && bWildCard) {
           continue;
         }
+        // if only a is wild card, b get higher priority
         if (aWildCard) {
           return 1;
         }
+        // if only b is wild card, a get higher priority
         if (bWildCard) {
           return -1;
         }

--- a/packages/core/src/getStateFromPath.tsx
+++ b/packages/core/src/getStateFromPath.tsx
@@ -143,27 +143,26 @@ export default function getStateFromPath<ParamList extends {}>(
       const aParts = a.pattern.split('/');
       const bParts = b.pattern.split('/');
 
-      const aWildcardIndex = aParts.indexOf('*');
-      const bWildcardIndex = bParts.indexOf('*');
-
-      // If only one of the patterns has a wildcard, move it down in the list
-      if (aWildcardIndex === -1 && bWildcardIndex !== -1) {
-        return -1;
+      for (let i = 0; i < Math.max(aParts.length, bParts.length); i++) {
+        if (aParts[i] == null) {
+          return 1;
+        }
+        if (bParts[i] == null) {
+          return -1;
+        }
+        const aWildCard = aParts[i] === '*' || aParts[i].startsWith(':');
+        const bWildCard = bParts[i] === '*' || bParts[i].startsWith(':');
+        if (aWildCard && bWildCard) {
+          continue;
+        }
+        if (aWildCard) {
+          return 1;
+        }
+        if (bWildCard) {
+          return -1;
+        }
       }
-
-      if (aWildcardIndex !== -1 && bWildcardIndex === -1) {
-        return 1;
-      }
-
-      if (aWildcardIndex === bWildcardIndex) {
-        // If `b` has more `/`, it's more exhaustive
-        // So we move it up in the list
-        return bParts.length - aParts.length;
-      }
-
-      // If the wildcard appears later in the pattern (has higher index), it's more specific
-      // So we move it up in the list
-      return bWildcardIndex - aWildcardIndex;
+      return bParts.length - aParts.length;
     });
 
   // Check for duplicate patterns in the config


### PR DESCRIPTION
We want to server user profile like https://github.com/zhigang1992 or https://twitter.com/zhigang1992 along side with screens in the app.

```typescript
const configs = {
  screens: {
    debugPanel: 'debugPanel',
    user: ':userSlug',
  },
}
getStateFromPath('/debugPanel', configs)
```

and

```typescript
const configs = {
  screens: {
    debugPanel: 'debugPanel',
    user: '*',
  },
}
getStateFromPath('/debugPanel', configs)
```

have different behaviors under Hermes engine, because we are only sorting '*'.

IMHO `:urlCode` is also a form of wildCard.