### PR TITLE
chore: upgrade to expo-github-actions v6

### DIFF
--- a/.github/workflows/expo-preview.yml
+++ b/.github/workflows/expo-preview.yml
@@ -16,10 +16,9 @@ jobs:
           node-version: 14.x
 
       - name: Setup Expo
-        uses: expo/expo-github-action@v5
+        uses: expo/expo-github-action@v6
         with:
-          expo-token: ${{ secrets.EXPO_TOKEN }}
-          expo-cache: true
+          token: ${{ secrets.EXPO_TOKEN }}
 
       - name: Restore yarn cache
         id: yarn-cache

--- a/.github/workflows/expo.yml
+++ b/.github/workflows/expo.yml
@@ -19,10 +19,9 @@ jobs:
           node-version: 14.x
 
       - name: Setup Expo
-        uses: expo/expo-github-action@v5
+        uses: expo/expo-github-action@v6
         with:
-          expo-token: ${{ secrets.EXPO_TOKEN }}
-          expo-cache: true
+          token: ${{ secrets.EXPO_TOKEN }}
 
       - name: Restore yarn cache
         id: yarn-cache


### PR DESCRIPTION
This version allows you to skip installing `expo-cli`. If you want to use EAS, this also got you covered! Having no CLI installed prevents the GH action from validating the `EXPO_TOKEN`, the [GH action handles this case](https://github.com/expo/expo-github-action/blob/main/src/tools.ts#L54) and I'm pretty confident this is set up properly 😄 