### PR TITLE
feat: use forwardRef with DrawerContent and DrawerContentScrollView

### DIFF
--- a/packages/drawer/src/views/DrawerContent.tsx
+++ b/packages/drawer/src/views/DrawerContent.tsx
@@ -1,24 +1,25 @@
 import * as React from 'react';
+import type { ScrollView } from 'react-native';
 
 import type { DrawerContentComponentProps } from '../types';
 import DrawerContentScrollView from './DrawerContentScrollView';
 import DrawerItemList from './DrawerItemList';
 
-export default function DrawerContent({
-  descriptors,
-  state,
-  ...rest
-}: DrawerContentComponentProps) {
+export default React.forwardRef(function DrawerContent(
+  { descriptors, state, ...rest }: DrawerContentComponentProps,
+  ref?: React.Ref<ScrollView>
+) {
   const { drawerContentStyle, drawerContentContainerStyle } =
     descriptors[state.routes[state.index].key].options;
 
   return (
     <DrawerContentScrollView
       {...rest}
+      ref={ref}
       contentContainerStyle={drawerContentContainerStyle}
       style={drawerContentStyle}
     >
       <DrawerItemList descriptors={descriptors} state={state} {...rest} />
     </DrawerContentScrollView>
   );
-}
+});

--- a/packages/drawer/src/views/DrawerContent.tsx
+++ b/packages/drawer/src/views/DrawerContent.tsx
@@ -5,7 +5,7 @@ import type { DrawerContentComponentProps } from '../types';
 import DrawerContentScrollView from './DrawerContentScrollView';
 import DrawerItemList from './DrawerItemList';
 
-export default React.forwardRef(function DrawerContent(
+function DrawerContent(
   { descriptors, state, ...rest }: DrawerContentComponentProps,
   ref?: React.Ref<ScrollView>
 ) {
@@ -22,4 +22,6 @@ export default React.forwardRef(function DrawerContent(
       <DrawerItemList descriptors={descriptors} state={state} {...rest} />
     </DrawerContentScrollView>
   );
-});
+}
+
+export default React.forwardRef(DrawerContent);

--- a/packages/drawer/src/views/DrawerContent.tsx
+++ b/packages/drawer/src/views/DrawerContent.tsx
@@ -1,21 +1,20 @@
 import * as React from 'react';
-import type { ScrollView } from 'react-native';
 
 import type { DrawerContentComponentProps } from '../types';
 import DrawerContentScrollView from './DrawerContentScrollView';
 import DrawerItemList from './DrawerItemList';
 
-function DrawerContent(
-  { descriptors, state, ...rest }: DrawerContentComponentProps,
-  ref?: React.Ref<ScrollView>
-) {
+export default function DrawerContent({
+  descriptors,
+  state,
+  ...rest
+}: DrawerContentComponentProps) {
   const { drawerContentStyle, drawerContentContainerStyle } =
     descriptors[state.routes[state.index].key].options;
 
   return (
     <DrawerContentScrollView
       {...rest}
-      ref={ref}
       contentContainerStyle={drawerContentContainerStyle}
       style={drawerContentStyle}
     >
@@ -23,5 +22,3 @@ function DrawerContent(
     </DrawerContentScrollView>
   );
 }
-
-export default React.forwardRef(DrawerContent);

--- a/packages/drawer/src/views/DrawerContentScrollView.tsx
+++ b/packages/drawer/src/views/DrawerContentScrollView.tsx
@@ -13,12 +13,10 @@ type Props = ScrollViewProps & {
   children: React.ReactNode;
 };
 
-export default function DrawerContentScrollView({
-  contentContainerStyle,
-  style,
-  children,
-  ...rest
-}: Props) {
+export default React.forwardRef(function DrawerContentScrollView(
+  { contentContainerStyle, style, children, ...rest }: Props,
+  ref?: React.Ref<ScrollView>
+) {
   const drawerPosition = React.useContext(DrawerPositionContext);
   const insets = useSafeAreaInsets();
 
@@ -29,6 +27,7 @@ export default function DrawerContentScrollView({
   return (
     <ScrollView
       {...rest}
+      ref={ref}
       contentContainerStyle={[
         {
           paddingTop: insets.top + 4,
@@ -42,7 +41,7 @@ export default function DrawerContentScrollView({
       {children}
     </ScrollView>
   );
-}
+});
 
 const styles = StyleSheet.create({
   container: {

--- a/packages/drawer/src/views/DrawerContentScrollView.tsx
+++ b/packages/drawer/src/views/DrawerContentScrollView.tsx
@@ -13,7 +13,7 @@ type Props = ScrollViewProps & {
   children: React.ReactNode;
 };
 
-export default React.forwardRef(function DrawerContentScrollView(
+function DrawerContentScrollView(
   { contentContainerStyle, style, children, ...rest }: Props,
   ref?: React.Ref<ScrollView>
 ) {
@@ -41,7 +41,9 @@ export default React.forwardRef(function DrawerContentScrollView(
       {children}
     </ScrollView>
   );
-});
+}
+
+export default React.forwardRef(DrawerContentScrollView);
 
 const styles = StyleSheet.create({
   container: {


### PR DESCRIPTION
Closes #9350 

Fixed to use ref in DrawerContent and DrawerContentScrollView.
Please review.
