### PR TITLE
fix: blink while switching screens

### DIFF
--- a/packages/drawer/src/views/DrawerView.tsx
+++ b/packages/drawer/src/views/DrawerView.tsx
@@ -225,7 +225,7 @@ function DrawerViewBase({
           return (
             <MaybeScreen
               key={route.key}
-              style={[StyleSheet.absoluteFill, { opacity: isFocused ? 1 : 0 }]}
+              style={[StyleSheet.absoluteFill, { zIndex: isFocused ? 0 : -1 }]}
               visible={isFocused}
               enabled={detachInactiveScreens}
             >


### PR DESCRIPTION
Fix to prevent showing blank screen while screens switching process.
Currently we can see it using dark background color in screens.
This fix also makes clear work with eager loading of screens (`detachInactiveScreens={false}` `lazy={false}`).