### PR TITLE
fix: update isClosing in Stack Card

### DIFF
--- a/packages/stack/src/views/Stack/Card.tsx
+++ b/packages/stack/src/views/Stack/Card.tsx
@@ -184,6 +184,8 @@ export default class Card extends React.Component<Props> {
 
     this.lastToValue = toValue;
 
+    this.isClosing.setValue(closing ? TRUE : FALSE);
+
     const spec = closing ? transitionSpec.close : transitionSpec.open;
 
     const animation =


### PR DESCRIPTION
I noticed that accessing `closing` through `cardStyleInterpolator` would always return an Animated node with value 0. It looks like it isn't being updated anywhere, so I added it to the `animate` method.

I am using this functionality to allow screens to have different in and out transitions.

On a side note, I feel like this would be more useful as a boolean, instead of an Animated value.