### PR TITLE
feat: add prop for new container

### DIFF
--- a/packages/bottom-tabs/src/views/BottomTabView.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabView.tsx
@@ -92,7 +92,7 @@ export default function BottomTabView(props: Props) {
     <SafeAreaProviderCompat>
       <MaybeScreenContainer
         enabled={detachInactiveScreens}
-        tabsOrDrawer
+        hasTwoStates
         style={styles.container}
       >
         {routes.map((route, index) => {

--- a/packages/bottom-tabs/src/views/BottomTabView.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabView.tsx
@@ -92,6 +92,7 @@ export default function BottomTabView(props: Props) {
     <SafeAreaProviderCompat>
       <MaybeScreenContainer
         enabled={detachInactiveScreens}
+        tabsOrDrawer
         style={styles.container}
       >
         {routes.map((route, index) => {

--- a/packages/bottom-tabs/src/views/ScreenFallback.tsx
+++ b/packages/bottom-tabs/src/views/ScreenFallback.tsx
@@ -22,7 +22,7 @@ export const MaybeScreenContainer = ({
   ...rest
 }: ViewProps & {
   enabled: boolean;
-  tabsOrDrawer: boolean;
+  hasTwoStates: boolean;
   children: React.ReactNode;
 }) => {
   if (Screens?.screensEnabled?.()) {

--- a/packages/bottom-tabs/src/views/ScreenFallback.tsx
+++ b/packages/bottom-tabs/src/views/ScreenFallback.tsx
@@ -22,6 +22,7 @@ export const MaybeScreenContainer = ({
   ...rest
 }: ViewProps & {
   enabled: boolean;
+  tabsOrDrawer: boolean;
   children: React.ReactNode;
 }) => {
   if (Screens?.screensEnabled?.()) {

--- a/packages/drawer/src/views/DrawerView.tsx
+++ b/packages/drawer/src/views/DrawerView.tsx
@@ -191,6 +191,7 @@ function DrawerViewBase({
     return (
       <MaybeScreenContainer
         enabled={detachInactiveScreens}
+        tabsOrDrawer
         style={styles.content}
       >
         {state.routes.map((route, index) => {

--- a/packages/drawer/src/views/DrawerView.tsx
+++ b/packages/drawer/src/views/DrawerView.tsx
@@ -191,7 +191,7 @@ function DrawerViewBase({
     return (
       <MaybeScreenContainer
         enabled={detachInactiveScreens}
-        tabsOrDrawer
+        hasTwoStates
         style={styles.content}
       >
         {state.routes.map((route, index) => {

--- a/packages/drawer/src/views/ScreenFallback.tsx
+++ b/packages/drawer/src/views/ScreenFallback.tsx
@@ -22,7 +22,7 @@ export const MaybeScreenContainer = ({
   ...rest
 }: ViewProps & {
   enabled: boolean;
-  tabsOrDrawer: boolean;
+  hasTwoStates: boolean;
   children: React.ReactNode;
 }) => {
   if (Screens?.screensEnabled?.()) {

--- a/packages/drawer/src/views/ScreenFallback.tsx
+++ b/packages/drawer/src/views/ScreenFallback.tsx
@@ -22,6 +22,7 @@ export const MaybeScreenContainer = ({
   ...rest
 }: ViewProps & {
   enabled: boolean;
+  tabsOrDrawer: boolean;
   children: React.ReactNode;
 }) => {
   if (Screens?.screensEnabled?.()) {


### PR DESCRIPTION
Added new prop `tabsOrDrawer` for `ScreenContainer` which makes `react-native-screens` on `iOS` use new component if it is available. See https://github.com/software-mansion/react-native-screens/pull/1029 for context.