### PR TITLE
fix: check current route in its children before checking all of them to handle navigation action

### DIFF
--- a/packages/core/src/BaseNavigationContainer.tsx
+++ b/packages/core/src/BaseNavigationContainer.tsx
@@ -120,23 +120,23 @@ const BaseNavigationContainer = React.forwardRef(
           | NavigationAction
           | ((state: NavigationState) => NavigationAction)
       ) => {
-        if (listeners.focus[0] == null) {
+        const focus = Object.values(listeners.focus)[0];
+        if (focus == null) {
           console.error(NOT_INITIALIZED_ERROR);
         } else {
-          listeners.focus[0]((navigation) => navigation.dispatch(action));
+          focus((navigation) => navigation.dispatch(action));
         }
       },
       [listeners.focus]
     );
 
     const canGoBack = React.useCallback(() => {
-      if (listeners.focus[0] == null) {
+      const focus = Object.values(listeners.focus)[0];
+      if (focus == null) {
         return false;
       }
 
-      const { result, handled } = listeners.focus[0]((navigation) =>
-        navigation.canGoBack()
-      );
+      const { result, handled } = focus((navigation) => navigation.canGoBack());
 
       if (handled) {
         return result;
@@ -152,7 +152,7 @@ const BaseNavigationContainer = React.forwardRef(
         if (target == null) {
           console.error(NOT_INITIALIZED_ERROR);
         } else {
-          listeners.focus[0]((navigation) =>
+          Object.values(listeners.focus)[0]((navigation) =>
             navigation.dispatch({
               ...CommonActions.reset(state),
               target,
@@ -200,7 +200,7 @@ const BaseNavigationContainer = React.forwardRef(
         getParent: () => undefined,
         getCurrentRoute,
         getCurrentOptions,
-        isReady: () => listeners.focus[0] != null,
+        isReady: () => Object.values(listeners.focus)[0] != null,
       }),
       [
         canGoBack,

--- a/packages/core/src/NavigationBuilderContext.tsx
+++ b/packages/core/src/NavigationBuilderContext.tsx
@@ -19,6 +19,7 @@ export type KeyedListenerMap = {
 
 export type AddListener = <T extends keyof ListenerMap>(
   type: T,
+  key: string,
   listener: ListenerMap[T]
 ) => void;
 

--- a/packages/core/src/useChildListeners.tsx
+++ b/packages/core/src/useChildListeners.tsx
@@ -8,23 +8,24 @@ import type { ListenerMap } from './NavigationBuilderContext';
 export default function useChildListeners() {
   const { current: listeners } = React.useRef<
     {
-      [K in keyof ListenerMap]: ListenerMap[K][];
+      [K in keyof ListenerMap]: Record<string, ListenerMap[K]>;
     }
   >({
-    action: [],
-    focus: [],
+    action: {},
+    focus: {},
   });
 
   const addListener = React.useCallback(
-    <T extends keyof ListenerMap>(type: T, listener: ListenerMap[T]) => {
-      // @ts-expect-error: listener should be correct type according to `type`
-      listeners[type].push(listener);
+    <T extends keyof ListenerMap>(
+      type: T,
+      key: string,
+      listener: ListenerMap[T]
+    ) => {
+      listeners[type][key] = listener;
 
       return () => {
-        // @ts-expect-error: listener should be correct type according to `type`
-        const index = listeners[type].indexOf(listener);
-
-        listeners[type].splice(index, 1);
+        // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+        delete listeners[type][key];
       };
     },
     [listeners]

--- a/packages/core/src/useFocusedListenersChildrenAdapter.tsx
+++ b/packages/core/src/useFocusedListenersChildrenAdapter.tsx
@@ -8,14 +8,16 @@ import NavigationBuilderContext, {
 import type { NavigationHelpers } from './types';
 
 type Options = {
+  key?: string;
   navigation: NavigationHelpers<ParamListBase>;
-  focusedListeners: FocusedNavigationListener[];
+  focusedListeners: Record<string, FocusedNavigationListener>;
 };
 
 /**
  * Hook for passing focus callback to children
  */
 export default function useFocusedListenersChildrenAdapter({
+  key,
   navigation,
   focusedListeners,
 }: Options) {
@@ -24,7 +26,7 @@ export default function useFocusedListenersChildrenAdapter({
   const listener = React.useCallback(
     (callback: FocusedNavigationCallback<any>) => {
       if (navigation.isFocused()) {
-        for (const listener of focusedListeners) {
+        for (const listener of Object.values(focusedListeners)) {
           const { handled, result } = listener(callback);
 
           if (handled) {
@@ -41,7 +43,7 @@ export default function useFocusedListenersChildrenAdapter({
   );
 
   React.useEffect(
-    () => addListener?.('focus', listener),
-    [addListener, listener]
+    () => addListener?.('focus', key ?? 'root', listener),
+    [addListener, listener, key]
   );
 }

--- a/packages/core/src/useNavigationBuilder.tsx
+++ b/packages/core/src/useNavigationBuilder.tsx
@@ -590,6 +590,7 @@ export default function useNavigationBuilder<
   });
 
   useFocusedListenersChildrenAdapter({
+    key: route?.key,
     navigation,
     focusedListeners: childListeners.focus,
   });


### PR DESCRIPTION
Currently React Navigation checks if it can handle navigation action in following order as noted in `useOnAction`:

1. check if current router can handle
2. if not, check if parent can handle
3. if not, check if children can handle

In step 3, it checks the listeners from the newest order.
However this might be a problem especially in Tab navigator where it lazily initialize its children, so it always checks if the latest initialized tab index can handle the action first.

For example, if we made the navigator to be following (sorry if the drawing is not clear 😅 ), and wanted to go to `NoteDetail` from `AddNote`, it goes to the second tab regardless of the current selected tab once we open the second tab.

![Group](https://user-images.githubusercontent.com/2619092/127396249-d41657db-a3d1-4b2d-98d1-7cc920dc0f02.jpg)

To solve this, this PR makes handlers to be stored as objects, not arrays, and look up the handler using the current route key first. There were some places I was not too sure, so leaving comments by myself.