### PR TITLE
chore: bump react-native-screens to v3.5.0

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -370,7 +370,7 @@ PODS:
     - React-RCTVibration
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNScreens (3.3.0):
+  - RNScreens (3.5.0):
     - React-Core
     - React-RCTImage
   - RNVectorIcons (8.1.0):
@@ -681,7 +681,7 @@ SPEC CHECKSUMS:
   RNCMaskedView: fc29d354a40316a990e8fb46391f08aea829c3aa
   RNGestureHandler: a479ebd5ed4221a810967000735517df0d2db211
   RNReanimated: d9da990fc90123f4ffbfdda93d00fc15174863a8
-  RNScreens: bf59f17fbf001f1025243eeed5f19419d3c11ef2
+  RNScreens: 01ab149b5dd5c27f5ff26741b1d2bdf2cee1af35
   RNVectorIcons: 31cebfcf94e8cf8686eb5303ae0357da64d7a5a4
   UMAppLoader: fe2708bb0ac5cd70052bc207d06aa3b7e72b9e97
   UMBarCodeScannerInterface: 79f92bea5f7af39b381a4c82298105ceb537408a

--- a/example/package.json
+++ b/example/package.json
@@ -35,7 +35,7 @@
     "react-native-paper": "^4.9.1",
     "react-native-reanimated": "~2.2.0",
     "react-native-safe-area-context": "~3.2.0",
-    "react-native-screens": "~3.3.0",
+    "react-native-screens": "~3.5.0",
     "react-native-tab-view": "^3.1.1",
     "react-native-unimodules": "~0.13.3",
     "react-native-vector-icons": "^8.1.0",

--- a/packages/bottom-tabs/package.json
+++ b/packages/bottom-tabs/package.json
@@ -51,7 +51,7 @@
     "react-native": "~0.63.4",
     "react-native-builder-bob": "^0.18.1",
     "react-native-safe-area-context": "~3.2.0",
-    "react-native-screens": "~3.3.0",
+    "react-native-screens": "~3.5.0",
     "typescript": "^4.3.2"
   },
   "peerDependencies": {

--- a/packages/drawer/package.json
+++ b/packages/drawer/package.json
@@ -57,7 +57,7 @@
     "react-native-gesture-handler": "~1.10.2",
     "react-native-reanimated": "~2.2.0",
     "react-native-safe-area-context": "~3.2.0",
-    "react-native-screens": "~3.3.0",
+    "react-native-screens": "~3.5.0",
     "typescript": "^4.3.2"
   },
   "peerDependencies": {

--- a/packages/native-stack/package.json
+++ b/packages/native-stack/package.json
@@ -52,7 +52,7 @@
     "react": "~16.13.1",
     "react-native": "~0.63.4",
     "react-native-builder-bob": "^0.18.1",
-    "react-native-screens": "^3.3.0",
+    "react-native-screens": "^3.5.0",
     "typescript": "^4.3.2"
   },
   "peerDependencies": {

--- a/packages/stack/package.json
+++ b/packages/stack/package.json
@@ -56,7 +56,7 @@
     "react-native-builder-bob": "^0.18.1",
     "react-native-gesture-handler": "~1.10.2",
     "react-native-safe-area-context": "~3.2.0",
-    "react-native-screens": "~3.3.0",
+    "react-native-screens": "~3.5.0",
     "typescript": "^4.3.2"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -17778,10 +17778,12 @@ react-native-safe-area-context@3.2.0, react-native-safe-area-context@~3.2.0:
   resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-3.2.0.tgz#06113c6b208f982d68ab5c3cebd199ca93db6941"
   integrity sha512-k2Nty4PwSnrg9HwrYeeE+EYqViYJoOFwEy9LxL5RIRfoqxAq/uQXNGwpUg2/u4gnKpBbEPa9eRh15KKMe/VHkA==
 
-react-native-screens@^3.3.0, react-native-screens@~3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-3.3.0.tgz#d4464a96620b85d09e46bd6865b5f48456c244f0"
-  integrity sha512-ni11jC6I9cFVXdLIDwkgafDHw/STXUNzkR5Fx3w8Wikdzi8gfTEan2kiOm7aS42d2F/LXddZ6i74Z2em0L6LPQ==
+react-native-screens@^3.5.0, react-native-screens@~3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-3.5.0.tgz#c40be78dff8e2dff1b00ba8fa670b2e429e632d2"
+  integrity sha512-xew4x0YX0RaDduNYM4gZXkphPwGZIbbu9fTU85xOtT1tOUPm3OU4pFMiN6PF54haMCsaMQRvdOXvLicUVRiptA==
+  dependencies:
+    warn-once "^0.1.0"
 
 react-native-tab-view@^3.1.1:
   version "3.1.1"


### PR DESCRIPTION
Besides bug fixes in RNS v3.5.0 two new animations were added - `fade_from_bottom` and `slide_from_bottom`.  Bump in devDependencies assures up-to-date types for animations for native-stack.