### PR TITLE
feat(elements): add style to SafeAreaProviderCompat props

### DIFF
--- a/packages/elements/src/SafeAreaProviderCompat.tsx
+++ b/packages/elements/src/SafeAreaProviderCompat.tsx
@@ -1,5 +1,12 @@
 import * as React from 'react';
-import { Dimensions, Platform, StyleProp, View, ViewStyle } from 'react-native';
+import {
+  Dimensions,
+  Platform,
+  StyleProp,
+  StyleSheet,
+  View,
+  ViewStyle,
+} from 'react-native';
 import {
   initialWindowMetrics,
   SafeAreaInsetsContext,
@@ -32,11 +39,7 @@ export default function SafeAreaProviderCompat({ children, style }: Props) {
           // If we already have insets, don't wrap the stack in another safe area provider
           // This avoids an issue with updates at the cost of potentially incorrect values
           // https://github.com/react-navigation/react-navigation/issues/174
-          return style == null ? (
-            children
-          ) : (
-            <View style={style}>{children}</View>
-          );
+          return <View style={[styles.container, style]}>{children}</View>;
         }
 
         return (
@@ -50,3 +53,9 @@ export default function SafeAreaProviderCompat({ children, style }: Props) {
 }
 
 SafeAreaProviderCompat.initialMetrics = initialMetrics;
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+});

--- a/packages/elements/src/SafeAreaProviderCompat.tsx
+++ b/packages/elements/src/SafeAreaProviderCompat.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Dimensions, Platform } from 'react-native';
+import { Dimensions, Platform, StyleProp, View, ViewStyle } from 'react-native';
 import {
   initialWindowMetrics,
   SafeAreaInsetsContext,
@@ -8,6 +8,7 @@ import {
 
 type Props = {
   children: React.ReactNode;
+  style?: StyleProp<ViewStyle>;
 };
 
 const { width = 0, height = 0 } = Dimensions.get('window');
@@ -23,7 +24,7 @@ const initialMetrics =
       }
     : initialWindowMetrics;
 
-export default function SafeAreaProviderCompat({ children }: Props) {
+export default function SafeAreaProviderCompat({ children, style }: Props) {
   return (
     <SafeAreaInsetsContext.Consumer>
       {(insets) => {
@@ -31,11 +32,15 @@ export default function SafeAreaProviderCompat({ children }: Props) {
           // If we already have insets, don't wrap the stack in another safe area provider
           // This avoids an issue with updates at the cost of potentially incorrect values
           // https://github.com/react-navigation/react-navigation/issues/174
-          return children;
+          return style == null ? (
+            children
+          ) : (
+            <View style={style}>{children}</View>
+          );
         }
 
         return (
-          <SafeAreaProvider initialMetrics={initialMetrics}>
+          <SafeAreaProvider initialMetrics={initialMetrics} style={style}>
             {children}
           </SafeAreaProvider>
         );


### PR DESCRIPTION
When using SafeAreaProvider I can pass style directly and when I decide to SafeAreaProviderCompat I discover that style props is missing.