### PR TITLE
fix: fix useLinkTo crash when an object is passed as a parameter

### DIFF
--- a/packages/native/src/useLinkTo.tsx
+++ b/packages/native/src/useLinkTo.tsx
@@ -38,7 +38,7 @@ export default function useLinkTo<
 
       if (typeof to !== 'string') {
         // @ts-expect-error: This is fine
-        root.navigate(to.screen, to.params);
+        navigation.navigate(to.screen, to.params);
         return;
       }
 


### PR DESCRIPTION
When an object was passed to the `to` parameter in `useLinkTo`, an error message would be thrown (*Cannot find property 'root'*). Apparently, this was introduced in commit 1d40279, where the `root` variable was removed.