### PR TITLE
fix: pass all props to custom headerLeft

### DIFF
--- a/packages/stack/src/views/Header/HeaderSegment.tsx
+++ b/packages/stack/src/views/Header/HeaderSegment.tsx
@@ -2,6 +2,7 @@ import {
   getDefaultHeaderHeight,
   Header,
   HeaderBackButton,
+  HeaderBackButtonProps,
   HeaderShownContext,
   HeaderTitle,
 } from '@react-navigation/elements';
@@ -103,7 +104,9 @@ export default function HeaderSegment(props: Props) {
     modal,
     onGoBack,
     headerTitle: title,
-    headerLeft: left,
+    headerLeft: left = onGoBack
+      ? (props: HeaderBackButtonProps) => <HeaderBackButton {...props} />
+      : undefined,
     headerBackImage,
     headerBackTitle,
     headerBackTitleVisible,
@@ -149,26 +152,23 @@ export default function HeaderSegment(props: Props) {
   );
 
   const headerLeft: StackHeaderOptions['headerLeft'] = left
-    ? left
-    : onGoBack
-    ? (props) => (
-        <HeaderBackButton
-          {...props}
-          backImage={headerBackImage}
-          accessibilityLabel={headerBackAccessibilityLabel}
-          testID={headerBackTestID}
-          allowFontScaling={headerBackAllowFontScaling}
-          onPress={onGoBack}
-          labelVisible={headerBackTitleVisible}
-          label={headerBackTitle}
-          truncatedLabel={headerTruncatedBackTitle}
-          labelStyle={[leftLabelStyle, headerBackTitleStyle]}
-          onLabelLayout={handleLeftLabelLayout}
-          screenLayout={layout}
-          titleLayout={titleLayout}
-          canGoBack={Boolean(onGoBack)}
-        />
-      )
+    ? (props) =>
+        left({
+          ...props,
+          backImage: headerBackImage,
+          accessibilityLabel: headerBackAccessibilityLabel,
+          testID: headerBackTestID,
+          allowFontScaling: headerBackAllowFontScaling,
+          onPress: onGoBack,
+          labelVisible: headerBackTitleVisible,
+          label: headerBackTitle,
+          truncatedLabel: headerTruncatedBackTitle,
+          labelStyle: [leftLabelStyle, headerBackTitleStyle],
+          onLabelLayout: handleLeftLabelLayout,
+          screenLayout: layout,
+          titleLayout,
+          canGoBack: Boolean(onGoBack),
+        })
     : undefined;
 
   const headerTitle: StackHeaderOptions['headerTitle'] =


### PR DESCRIPTION
I'm having an issue with a custom back button in v6: I'm passing a react component as headerLeft and I'm expecting it to receive some props such as onPress (see v5. https://github.com/react-navigation/react-navigation/blob/89d3365efb48c48e879c05ece2423f42c20f26cb/packages/stack/src/views/Header/HeaderSegment.tsx#L296) but in v6, these props are no longer passed, they are only passed to the default back button (https://github.com/react-navigation/react-navigation/blob/b0130570be938268bcd40e1552a64cc14545cea4/packages/stack/src/views/Header/HeaderSegment.tsx#L161). 
This PR fixes it.


test plan: use the following diff in the example app. Currently, the button does not react to presses. With the fix, it works as expected (takes user to previous screen).

```diff
diff --git a/example/src/Screens/SimpleStack.tsx b/example/src/Screens/SimpleStack.tsx
index d0f98122..ea858796 100644
--- a/example/src/Screens/SimpleStack.tsx
+++ b/example/src/Screens/SimpleStack.tsx
@@ -1,3 +1,4 @@
+import { HeaderBackButton } from '@react-navigation/elements';
 import type { ParamListBase } from '@react-navigation/native';
 import {
   createStackNavigator,
@@ -118,7 +119,12 @@ export default function SimpleStackScreen({
   }, [navigation]);

   return (
-    <SimpleStack.Navigator screenOptions={screenOptions}>
+    <SimpleStack.Navigator
+      screenOptions={{
+        ...screenOptions,
+        headerLeft: (props) => <HeaderBackButton {...props} />,
+      }}
+    >
       <SimpleStack.Screen
         name="Article"
         component={ArticleScreen}

```
