### PR TITLE
fix: pass onlayout to header title

### DIFF
--- a/packages/elements/src/Header/Header.tsx
+++ b/packages/elements/src/Header/Header.tsx
@@ -191,11 +191,7 @@ export default function Header(props: Props) {
     : null;
 
   const headerTitle =
-    typeof customTitle !== 'function'
-      ? (props: React.ComponentProps<typeof HeaderTitle>) => (
-          <HeaderTitle {...props} />
-        )
-      : customTitle;
+    typeof customTitle === 'function' ? customTitle : HeaderTitle;
 
   return (
     <React.Fragment>

--- a/packages/elements/src/Header/getHeaderTitle.tsx
+++ b/packages/elements/src/Header/getHeaderTitle.tsx
@@ -1,7 +1,7 @@
-import type { HeaderOptions } from '../types';
+import type { StackHeaderOptions } from '@react-navigation/stack/src/types';
 
 export default function getHeaderTitle(
-  options: { title?: string; headerTitle?: HeaderOptions['headerTitle'] },
+  options: { title?: string; headerTitle?: StackHeaderOptions['headerTitle'] },
   fallback: string
 ): string {
   return typeof options.headerTitle === 'string'

--- a/packages/elements/src/types.tsx
+++ b/packages/elements/src/types.tsx
@@ -8,6 +8,25 @@ import type {
 
 export type Layout = { width: number; height: number };
 
+export type HeaderTitleProps = {
+  /**
+   * The title text of the header.
+   */
+  children: string;
+  /**
+   * Whether title font should scale to respect Text Size accessibility settings.
+   */
+  allowFontScaling?: boolean;
+  /**
+   * Tint color for the header.
+   */
+  tintColor?: string;
+  /**
+   * Style object for the title element.
+   */
+  style?: Animated.WithAnimatedValue<StyleProp<TextStyle>>;
+};
+
 export type HeaderOptions = {
   /**
    * String or a function that returns a React Element to be used by the header.
@@ -16,26 +35,7 @@ export type HeaderOptions = {
    * It receives `allowFontScaling`, `tintColor`, `style` and `children` in the options object as an argument.
    * The title string is passed in `children`.
    */
-  headerTitle?:
-    | string
-    | ((props: {
-        /**
-         * The title text of the header.
-         */
-        children: string;
-        /**
-         * Whether title font should scale to respect Text Size accessibility settings.
-         */
-        allowFontScaling?: boolean;
-        /**
-         * Tint color for the header.
-         */
-        tintColor?: string;
-        /**
-         * Style object for the title element.
-         */
-        style?: Animated.WithAnimatedValue<StyleProp<TextStyle>>;
-      }) => React.ReactNode);
+  headerTitle?: string | ((props: HeaderTitleProps) => React.ReactNode);
   /**
    * How to align the the header title.
    * Defaults to `center` on iOS and `left` on Android.

--- a/packages/stack/src/types.tsx
+++ b/packages/stack/src/types.tsx
@@ -1,6 +1,7 @@
 import type {
   HeaderBackButton,
   HeaderOptions,
+  HeaderTitleProps,
 } from '@react-navigation/elements';
 import type {
   Descriptor,
@@ -13,7 +14,13 @@ import type {
   StackNavigationState,
 } from '@react-navigation/native';
 import type * as React from 'react';
-import type { Animated, StyleProp, TextStyle, ViewStyle } from 'react-native';
+import type {
+  Animated,
+  StyleProp,
+  TextStyle,
+  ViewProps,
+  ViewStyle,
+} from 'react-native';
 
 export type StackNavigationEventMap = {
   /**
@@ -118,7 +125,12 @@ export type StackHeaderMode = 'float' | 'screen';
 
 export type StackPresentationMode = 'card' | 'modal';
 
-export type StackHeaderOptions = HeaderOptions & {
+export type StackHeaderOptions = Omit<HeaderOptions, 'headerTitle'> & {
+  headerTitle?:
+    | string
+    | ((
+        props: HeaderTitleProps & { onLayout: ViewProps['onLayout'] }
+      ) => React.ReactNode);
   /**
    * Whether back button title font should scale to respect Text Size accessibility settings. Defaults to `false`.
    */

--- a/packages/stack/src/views/Header/HeaderSegment.tsx
+++ b/packages/stack/src/views/Header/HeaderSegment.tsx
@@ -2,8 +2,10 @@ import {
   getDefaultHeaderHeight,
   Header,
   HeaderBackButton,
+  HeaderOptions,
   HeaderShownContext,
   HeaderTitle,
+  HeaderTitleProps,
 } from '@react-navigation/elements';
 import * as React from 'react';
 import {
@@ -171,10 +173,14 @@ export default function HeaderSegment(props: Props) {
       )
     : undefined;
 
-  const headerTitle: StackHeaderOptions['headerTitle'] =
-    typeof title !== 'function'
-      ? (props) => <HeaderTitle {...props} onLayout={handleTitleLayout} />
-      : title;
+  const headerTitle: HeaderOptions['headerTitle'] =
+    typeof title === 'function'
+      ? (props: HeaderTitleProps) => {
+          return title({ ...props, onLayout: handleTitleLayout });
+        }
+      : (props: HeaderTitleProps) => (
+          <HeaderTitle {...props} onLayout={handleTitleLayout} />
+        );
 
   return (
     <Header


### PR DESCRIPTION
to be discussed. This makes @react-navigation/elements depend on @react-navigation/stack, which is obviously wrong, but I opened regardless to see if this makes sense at all :)

feel free to close and / or rework yourself.