### PR TITLE
Fixing nullpointer exception

### DIFF
--- a/packages/stack/src/views/Stack/CardStack.tsx
+++ b/packages/stack/src/views/Stack/CardStack.tsx
@@ -326,7 +326,7 @@ export default class CardStack extends React.Component<Props, State> {
           ),
           next:
             nextGesture &&
-            nextDescriptor.options.presentation !== 'transparentModal'
+            nextDescriptor?.options.presentation !== 'transparentModal'
               ? getProgressFromGesture(
                   nextGesture,
                   state.layout,


### PR DESCRIPTION
We were encountering an error on this piece of code.

I don't have clear reproduction paths with an Expo snack, but if you look at the TypeScript types, you see that `nextDescriptor` can be undefined, causing the error on this line of code.