### PR TITLE
fix: content container in native web stack should fill parent

### DIFF
--- a/packages/native-stack/src/views/NativeStackView.tsx
+++ b/packages/native-stack/src/views/NativeStackView.tsx
@@ -138,7 +138,9 @@ export default function NativeStackView({ state, descriptors }: Props) {
                 { display: isFocused ? 'flex' : 'none' },
               ]}
             >
-              <View style={contentStyle}>{render()}</View>
+              <View style={[styles.contentContainer, contentStyle]}>
+                {render()}
+              </View>
             </Screen>
           );
         })}
@@ -149,6 +151,9 @@ export default function NativeStackView({ state, descriptors }: Props) {
 
 const styles = StyleSheet.create({
   container: {
+    flex: 1,
+  },
+  contentContainer: {
     flex: 1,
   },
   backImage: {


### PR DESCRIPTION
`flex: 1` needs to be set on the `View` container sits between the `Screen` component and screen contents in `NativeStackView` otherwise content on tabs nested inside native stack will not be visible, along with other similar types of bugs.

Reproducible example: https://gist.github.com/brentvatne/273d34be0c937237eb353e4100c49949

Apply the fix from this diff to see it resolves the issue.