### PR TITLE
fix: remove React Native Keyboard method deprecated in 0.65

### DIFF
--- a/packages/tabs/src/views/BottomTabBar.tsx
+++ b/packages/tabs/src/views/BottomTabBar.tsx
@@ -7,6 +7,7 @@ import {
   Keyboard,
   Platform,
   LayoutChangeEvent,
+  EmitterSubscription,
 } from 'react-native';
 import {
   getStatusBarHeight,
@@ -121,23 +122,37 @@ class TabBarBottom extends React.Component<BottomTabBarProps, State> {
     visible: new Animated.Value(1),
   };
 
+  keyboardDidShowSubscription: EmitterSubscription | null = null;
+  keyboardDidHideSubscription: EmitterSubscription | null = null;
+
   componentDidMount() {
     if (Platform.OS === 'ios') {
-      Keyboard.addListener('keyboardWillShow', this._handleKeyboardShow);
-      Keyboard.addListener('keyboardWillHide', this._handleKeyboardHide);
+      this.keyboardDidShowSubscription = Keyboard.addListener(
+        'keyboardWillShow',
+        this._handleKeyboardShow
+      );
+      this.keyboardDidHideSubscription = Keyboard.addListener(
+        'keyboardWillHide',
+        this._handleKeyboardHide
+      );
     } else {
-      Keyboard.addListener('keyboardDidShow', this._handleKeyboardShow);
-      Keyboard.addListener('keyboardDidHide', this._handleKeyboardHide);
+      this.keyboardDidShowSubscription = Keyboard.addListener(
+        'keyboardDidShow',
+        this._handleKeyboardShow
+      );
+      this.keyboardDidHideSubscription = Keyboard.addListener(
+        'keyboardDidHide',
+        this._handleKeyboardHide
+      );
     }
   }
 
   componentWillUnmount() {
-    if (Platform.OS === 'ios') {
-      Keyboard.removeListener('keyboardWillShow', this._handleKeyboardShow);
-      Keyboard.removeListener('keyboardWillHide', this._handleKeyboardHide);
-    } else {
-      Keyboard.removeListener('keyboardDidShow', this._handleKeyboardShow);
-      Keyboard.removeListener('keyboardDidHide', this._handleKeyboardHide);
+    if (this.keyboardDidShowSubscription) {
+      this.keyboardDidShowSubscription.remove();
+    }
+    if (this.keyboardDidHideSubscription) {
+      this.keyboardDidHideSubscription.remove();
     }
   }
 

--- a/packages/tabs/src/views/BottomTabBar.tsx
+++ b/packages/tabs/src/views/BottomTabBar.tsx
@@ -148,12 +148,8 @@ class TabBarBottom extends React.Component<BottomTabBarProps, State> {
   }
 
   componentWillUnmount() {
-    if (this.keyboardDidShowSubscription) {
-      this.keyboardDidShowSubscription.remove();
-    }
-    if (this.keyboardDidHideSubscription) {
-      this.keyboardDidHideSubscription.remove();
-    }
+    this.keyboardDidShowSubscription?.remove();
+    this.keyboardDidHideSubscription?.remove();
   }
 
   // @ts-ignore


### PR DESCRIPTION
Fixes https://github.com/react-navigation/react-navigation/issues/9803

In React Native 0.65 [`Keyboard.removeListener`](https://github.com/react-navigation/react-navigation/issues/9803) has been deprecated, therefore unmounting the `BottomTabBar` component in a RN 0.65 app causes a crash.

This change replaces that method with the `.remove()` method returned by `Keyboard.addListener`.