### PR TITLE
feat: add headerBackButtonMenuEnabled prop

### DIFF
--- a/packages/native-stack/src/types.tsx
+++ b/packages/native-stack/src/types.tsx
@@ -285,6 +285,15 @@ export type NativeStackNavigationOptions = {
    */
   headerSearchBarOptions?: SearchBarProps;
   /**
+   * Boolean indicating whether to show the menu on longPress of iOS >= 14 back button. Defaults to `true`.
+   * Requires `react-native-screens` version >=3.3.0.
+   *
+   * Only supported on iOS.
+   *
+   * @platform ios
+   */
+  headerBackButtonMenuEnabled?: boolean;
+  /**
    * Sets the status bar animation (similar to the `StatusBar` component).
    * Requires setting `View controller-based status bar appearance -> YES` (or removing the config) in your `Info.plist` file.
    *
@@ -317,6 +326,7 @@ export type NativeStackNavigationOptions = {
   contentStyle?: StyleProp<ViewStyle>;
   /**
    * Whether you can use gestures to dismiss this screen. Defaults to `true`.
+   *
    * Only supported on iOS.
    *
    * @platform ios

--- a/packages/native-stack/src/views/HeaderConfig.tsx
+++ b/packages/native-stack/src/views/HeaderConfig.tsx
@@ -22,6 +22,7 @@ type Props = NativeStackNavigationOptions & {
 
 export default function HeaderConfig({
   headerBackImageSource,
+  headerBackButtonMenuEnabled,
   headerBackTitle,
   headerBackTitleStyle,
   headerBackTitleVisible = true,
@@ -110,6 +111,7 @@ export default function HeaderConfig({
       blurEffect={headerBlurEffect}
       color={tintColor}
       direction={I18nManager.isRTL ? 'rtl' : 'ltr'}
+      disableBackButtonMenu={headerBackButtonMenuEnabled === false}
       hidden={headerShown === false}
       hideBackButton={headerBackVisible === false}
       hideShadow={headerShadowVisible === false}


### PR DESCRIPTION
Thanks to https://github.com/software-mansion/react-native-screens/discussions/1071#discussioncomment-1227326.

PR exposing `disableBackButtonMenu` from react-native-screens to `@react-navigation/native-stack` under new name - `headerBackButtonMenuEnabled`.