### PR TITLE
chore: add type definition for contentOptions

### DIFF
--- a/packages/drawer/src/types.tsx
+++ b/packages/drawer/src/types.tsx
@@ -77,9 +77,67 @@ export type NavigationDrawerRouterConfig = {
   resetOnBlur?: boolean;
   initialRouteName?: string;
   contentComponent?: React.ComponentType<DrawerContentComponentProps>;
-  contentOptions?: object;
+  contentOptions?: {
+    /**
+     * the array of routes, can be modified or overridden
+     */
+    items?: NavigationRoute[];
+    /**
+     * key identifying the active route
+     */
+    activeItemKey?: string;
+    /**
+     * label and icon color of the active label
+     */
+    activeTintColor?: string;
+    /**
+     * background color of the active label
+     */
+    activeBackgroundColor?: string;
+    /**
+     * label and icon color of the inactive label
+     */
+    inactiveTintColor?: string;
+    /**
+     * background color of the inactive label
+     */
+    inactiveBackgroundColor?: string;
+    /**
+     * function to be invoked when an item is pressed
+     */
+    onItemPress?: (info: DrawerItem) => void;
+    /**
+     * style object for the content section
+     */
+    itemsContainerStyle?: StyleProp<ViewStyle>;
+    /**
+     * style object for the single item, which can contain an Icon and/or a Label
+     */
+    itemStyle?: StyleProp<ViewStyle>;
+    /**
+     * style object to overwrite Text style inside content section, when your label is a string
+     */
+    labelStyle?: StyleProp<TextStyle>;
+    /**
+     * style object to overwrite Text style of the active label, when your label is a string (merged with labelStyle)
+     */
+    activeLabelStyle?: StyleProp<TextStyle>;
+    /**
+     * style object to overwrite Text style of the inactive label, when your label is a string (merged with labelStyle)
+     */
+    inactiveLabelStyle?: StyleProp<TextStyle>;
+    /**
+     * style object to overwrite View icon container styles
+     */
+    iconContainerStyle?: StyleProp<ViewStyle>;
+  };
   backBehavior?: 'none' | 'initialRoute' | 'history';
 };
+
+export interface DrawerItem {
+  route: NavigationRoute;
+  focused: boolean;
+}
 
 export type ThemedColor =
   | string


### PR DESCRIPTION
Added type definition  and documentation for contentOptions


Resources:
[react-navigation.d.ts#L999](https://github.com/react-navigation/react-navigation/blob/3.x/typescript/react-navigation.d.ts#L999)
[react-navigation.d.ts#L1004](https://github.com/react-navigation/react-navigation/blob/3.x/typescript/react-navigation.d.ts#L1024)
[Official docs](https://reactnavigation.org/docs/4.x/drawer-navigator/#contentoptions-for-draweritems)