### PR TITLE
fix: resized view never re-appears on macos #9889

### DIFF
--- a/packages/elements/src/ResourceSavingView.tsx
+++ b/packages/elements/src/ResourceSavingView.tsx
@@ -42,9 +42,9 @@ export default function ResourceSavingScene({
       <View
         collapsable={false}
         removeClippedSubviews={
-          // On iOS, set removeClippedSubviews to true only when not focused
+          // On iOS & macOS, set removeClippedSubviews to true only when not focused
           // This is an workaround for a bug where the clipped view never re-appears
-          Platform.OS === 'ios' ? !visible : true
+          Platform.OS === 'ios' || Platform.OS === 'macos' ? !visible : true
         }
         pointerEvents={visible ? 'auto' : 'none'}
         style={visible ? styles.attached : styles.detached}


### PR DESCRIPTION
I created the original issue, found the root cause and was able to fix it.

Original issue: https://github.com/react-navigation/react-navigation/issues/9889