### PR TITLE
feat: add specific type for merging on navigation

### DIFF
--- a/packages/core/src/types.tsx
+++ b/packages/core/src/types.tsx
@@ -205,7 +205,13 @@ type NavigationHelpersCommon<
           name: RouteName;
           key?: string;
           params: ParamList[RouteName];
-          merge?: boolean;
+          merge?: false;
+        }
+      | {
+          name: RouteName;
+          key?: string;
+          params: Partial<ParamList[RouteName]>;
+          merge: true;
         }
   ): void;
 


### PR DESCRIPTION
When navigating to existing screen we should be able to send partial params. That's what merging params expects on navigate options. Therefore this pull request add this type when merge is true.