### PR TITLE
feat: Add inner-container style object prop for tabbar

### DIFF
--- a/packages/bottom-tabs/src/types.tsx
+++ b/packages/bottom-tabs/src/types.tsx
@@ -211,6 +211,11 @@ export type BottomTabNavigationOptions = HeaderOptions & {
   tabBarStyle?: Animated.WithAnimatedValue<StyleProp<ViewStyle>>;
 
   /**
+   * Style object for the tab bar's inner container.
+   */
+  tabBarInnerContainerStyle?: Animated.WithAnimatedValue<StyleProp<ViewStyle>>;
+
+  /**
    * Function which returns a React Element to use as background for the tab bar.
    * You could render an image, a gradient, blur view etc.
    *

--- a/packages/bottom-tabs/src/views/BottomTabBar.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabBar.tsx
@@ -144,6 +144,7 @@ export default function BottomTabBar({
     tabBarHideOnKeyboard = false,
     tabBarVisibilityAnimationConfig,
     tabBarStyle,
+    tabBarInnerContainerStyle,
     tabBarBackground,
     tabBarActiveTintColor,
     tabBarInactiveTintColor,
@@ -253,6 +254,11 @@ export default function BottomTabBar({
 
   const tabBarBackgroundElement = tabBarBackground?.();
 
+  const innerContainerStyles = StyleSheet.flatten([
+    styles.content,
+    tabBarInnerContainerStyle,
+  ]) as StyleProp<ViewStyle>;
+
   return (
     <Animated.View
       style={[
@@ -291,7 +297,7 @@ export default function BottomTabBar({
       <View pointerEvents="none" style={StyleSheet.absoluteFill}>
         {tabBarBackgroundElement}
       </View>
-      <View accessibilityRole="tablist" style={styles.content}>
+      <View accessibilityRole="tablist" style={innerContainerStyles}>
         {routes.map((route, index) => {
           const focused = index === state.index;
           const { options } = descriptors[route.key];


### PR DESCRIPTION
**Motivation**
4 tabs on a iPad Pro in landscape mode looked bad. Was trying to make the tab bar items containerized on large screens. Using the prop, I could set `maxWidth` to do that. 

Using the screenOptions:
```
tabBarStyle: {
  display: 'flex',
  justifyContent: 'center',
  alignItems: 'center'
},
tabBarInnerContainerStyle: {
  maxWidth: 640
}
```
I changed this:
<img width="773" alt="Screenshot 2021-09-11 at 1 54 04 PM" src="https://user-images.githubusercontent.com/10547529/132941606-78cf72ca-3f84-4b9d-b792-4ae73fd7ac42.png">

to look like this:
<img width="506" alt="Screenshot 2021-09-11 at 1 50 59 PM" src="https://user-images.githubusercontent.com/10547529/132941516-15bfbb8d-afae-4833-a245-e9a1c1510846.png">
