### PR TITLE
feat: enhance native-stack header left props

### DIFF
--- a/packages/native-stack/src/types.tsx
+++ b/packages/native-stack/src/types.tsx
@@ -85,6 +85,27 @@ export type NativeStackHeaderProps = {
   navigation: NativeStackNavigationProp<ParamListBase>;
 };
 
+export type HeaderLeftProps = {
+  /**
+   * Tint color for the header.
+   */
+  tintColor?: string;
+  /**
+   * Label text for the button. Usually the title of the previous screen.
+   * By default, this is only shown on iOS.
+   */
+  headerBackTitle?: string;
+  /**
+   * Whether it's possible to navigate back in stack.
+   */
+  canGoBack: boolean;
+  /**
+   * Whether header is in modal or not
+   * It's common to show different styled button on the modals, so this would convenient
+   */
+  isInModal: boolean;
+};
+
 export type NativeStackNavigationOptions = {
   /**
    * String that can be displayed in the header as a fallback for `headerTitle`.
@@ -233,7 +254,7 @@ export type NativeStackNavigationOptions = {
    * Function which returns a React Element to display on the left side of the header.
    * This replaces the back button. See `headerBackVisible` to show the back button along side left element.
    */
-  headerLeft?: (props: { tintColor?: string }) => React.ReactNode;
+  headerLeft?: (props: HeaderLeftProps) => React.ReactNode;
   /**
    * Function which returns a React Element to display on the right side of the header.
    */

--- a/packages/native-stack/src/views/HeaderConfig.tsx
+++ b/packages/native-stack/src/views/HeaderConfig.tsx
@@ -18,6 +18,8 @@ import { processFonts } from './FontProcessor';
 
 type Props = NativeStackNavigationOptions & {
   route: Route<string>;
+  canGoBack: boolean;
+  isInModal: boolean;
 };
 
 export default function HeaderConfig({
@@ -44,6 +46,8 @@ export default function HeaderConfig({
   route,
   headerSearchBarOptions,
   title,
+  canGoBack,
+  isInModal,
 }: Props): JSX.Element {
   const insets = useSafeAreaInsets();
   const { colors } = useTheme();
@@ -73,7 +77,12 @@ export default function HeaderConfig({
   const titleColor =
     headerTitleStyleFlattened.color ?? headerTintColor ?? colors.text;
 
-  const headerLeftElement = headerLeft?.({ tintColor });
+  const headerLeftElement = headerLeft?.({
+    tintColor,
+    headerBackTitle,
+    canGoBack,
+    isInModal,
+  });
   const headerRightElement = headerRight?.({ tintColor });
   const headerTitleElement =
     typeof headerTitle === 'function'

--- a/packages/native-stack/src/views/NativeStackView.native.tsx
+++ b/packages/native-stack/src/views/NativeStackView.native.tsx
@@ -106,7 +106,7 @@ const MaybeNestedStack = ({
         <Screen enabled style={StyleSheet.absoluteFill}>
           <HeaderShownContext.Provider value>
             <HeaderHeightContext.Provider value={headerHeight}>
-              <HeaderConfig {...options} route={route} />
+              <HeaderConfig {...options} route={route} canGoBack isInModal />
               {content}
             </HeaderHeightContext.Provider>
           </HeaderShownContext.Provider>
@@ -223,6 +223,8 @@ const SceneView = ({
               {...options}
               route={route}
               headerShown={isHeaderInPush}
+              canGoBack={index !== 0}
+              isInModal={false}
             />
           )}
           <MaybeNestedStack

--- a/packages/native-stack/src/views/NativeStackView.tsx
+++ b/packages/native-stack/src/views/NativeStackView.tsx
@@ -52,6 +52,7 @@ export default function NativeStackView({ state, descriptors }: Props) {
             headerShadowVisible,
             headerTransparent,
             contentStyle,
+            headerBackTitle,
           } = options;
 
           return (
@@ -83,7 +84,13 @@ export default function NativeStackView({ state, descriptors }: Props) {
                     headerTintColor={headerTintColor}
                     headerLeft={
                       typeof headerLeft === 'function'
-                        ? ({ tintColor }) => headerLeft({ tintColor })
+                        ? ({ tintColor }) =>
+                            headerLeft({
+                              tintColor,
+                              canGoBack,
+                              isInModal: false,
+                              headerBackTitle,
+                            })
                         : headerLeft === undefined && canGoBack
                         ? ({ tintColor }) => (
                             <HeaderBackButton


### PR DESCRIPTION
## Motivation 
I needed to implement a custom back button for our project that uses `native stack` of the react-navigation. The thing is, the only way seems to implement it with `headerLeft` prop but the native stack does not provide some basic props to make a custom back button implementation possible. What those `basic` props would be you might ask;

* **canGoBack**: To determine if we should show a back button
* **isInModal**: To determine the style of the back button. It's common to show a "X" button on modals instead of the regular left arrowed back button.
* **headerBackTitle**: To support iOS styled back button with a title

I checked the regular stack version and [there are plenty of props passing to the `headerLeft`](https://github.com/react-navigation/react-navigation/blob/main/packages/stack/src/views/Header/HeaderSegment.tsx#L150) so we can implement a custom back button easily.

I added the most crucial props to be able to implement a custom back button. We should probably enhance this more but I feel like this is a good start.

Waiting for your valuable feedback!