### PR TITLE
fix: typings: when merge is true in navigate, allow partial params

### DIFF
--- a/packages/core/src/types.tsx
+++ b/packages/core/src/types.tsx
@@ -205,7 +205,13 @@ type NavigationHelpersCommon<
           name: RouteName;
           key?: string;
           params: ParamList[RouteName];
-          merge?: boolean;
+          merge?: false;
+        }
+      | {
+          name: RouteName;
+          key?: string;
+          params: Partial<ParamList[RouteName]>;
+          merge: true;
         }
   ): void;
 

--- a/packages/core/src/types.tsx
+++ b/packages/core/src/types.tsx
@@ -210,7 +210,7 @@ type NavigationHelpersCommon<
       | {
           name: RouteName;
           key?: string;
-          params: Partial<ParamList[RouteName]>;
+          params?: Partial<ParamList[RouteName]>;
           merge: true;
         }
   ): void;


### PR DESCRIPTION
Allows to pass only part of parameters when navigate is used with merge: true