### PR TITLE
fix: flipper react navigation plugin ui rows text not showing in dark theme (Fix issue #10000)

### DIFF
--- a/packages/flipper-plugin-react-navigation/src/Logs.tsx
+++ b/packages/flipper-plugin-react-navigation/src/Logs.tsx
@@ -72,14 +72,13 @@ const Row = styled.button<{ selected: boolean; faded: boolean }>((props) => ({
   'fontSize': theme.monospace.fontSize,
   'textAlign': 'left',
   'padding': `${theme.space.medium}px ${theme.space.large}px`,
-  'color': props.selected ? '#fff' : '#000',
+  'color': props.selected ? '#fff' : '',
   'backgroundColor': props.selected ? theme.primaryColor : 'transparent',
   'opacity': props.faded ? 0.5 : 1,
   'border': 0,
   'boxShadow': `inset 0 -1px 0 0 ${theme.dividerColor}`,
   'width': '100%',
   'cursor': 'pointer',
-
   '&:hover': {
     backgroundColor: props.selected
       ? theme.primaryColor
@@ -97,7 +96,6 @@ const JumpButton = styled.button({
   'cursor': 'pointer',
   'fontSize': theme.fontSize.small,
   'borderRadius': theme.borderRadius,
-
   '&:hover': {
     backgroundColor: 'rgba(0, 0, 0, 0.2)',
   },
@@ -125,7 +123,6 @@ const EmptyIcon = styled(CompassOutlined)({
 });
 
 const BlankslateText = styled.h5({
-  color: 'rgba(0, 0, 0, 0.85)',
   fontWeight: 600,
   fontSize: 16,
   lineHeight: 1.5,


### PR DESCRIPTION
Fix for issue: https://github.com/react-navigation/react-navigation/issues/10000+

In [line 75](https://github.com/react-navigation/react-navigation/blob/main/packages/flipper-plugin-react-navigation/src/Logs.tsx#L75) 

We made the change to

```tsx
'color': props.selected && '#fff'
```

Because when the color property is not set (falsy value). flipper-plugin by default provide the right colors to the dark and light themes each. ( it get white in dark theme and black in light theme by default in such case ).<br>
So we set it to white only if selected (element with background highlight color). Otherwise leave it to the default.

In [line 128](https://github.com/react-navigation/react-navigation/blob/main/packages/flipper-plugin-react-navigation/src/Logs.tsx#L128) the color value is always black ('rgba(0, 0, 0, 0.85)'), so in Dark Mode the element "BlankslateText" would be unreadable, so leaving the default element color is the solution.
