### PR TITLE
fix: fix type checking in linking config #9897

### DIFF
--- a/packages/core/src/getActionFromState.tsx
+++ b/packages/core/src/getActionFromState.tsx
@@ -23,7 +23,7 @@ type NavigateAction<State extends NavigationState> = {
   type: 'NAVIGATE';
   payload: {
     name: string;
-    params?: NavigatorScreenParams<State>;
+    params?: NavigatorScreenParams<ParamListBase, State>;
     path?: string;
   };
 };

--- a/packages/core/src/types.tsx
+++ b/packages/core/src/types.tsx
@@ -599,7 +599,7 @@ export type TypedNavigator<
 };
 
 export type NavigatorScreenParams<
-  ParamList,
+  ParamList extends ParamListBase,
   State extends NavigationState = NavigationState
 > =
   | {


### PR DESCRIPTION

This PR update `NavigatorScreenParams` type to fix type checking in linking config

```
export type PathConfigMap<ParamList extends {}> = {
  [RouteName in keyof ParamList]?: NonNullable<
    ParamList[RouteName]
  > extends NavigatorScreenParams<infer T, any>
    ? string | PathConfig<T>
    : string | Omit<PathConfig<{}>, 'screens' | 'initialRouteName'>;
};
```

The check in `PathConfigMap` always return false, so whatever `ParamList[RouteName]` is, its type will be `string | Omit<PathConfig<{}>, 'screens' | 'initialRouteName'>` 

Please check #9897 for the issue description.
