### PR TITLE
fix: example CocoaPodsError invalid Podfile

### DIFF
--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -17,7 +17,7 @@ target 'ReactNavigation' do
   #
   # Note that if you have use_frameworks! enabled, Flipper will not work.
   #
-  use_flipper!('Flipper' => '0.75.1', 'Flipper-Folly' => '2.5.3', 'Flipper-RSocket' => '1.3.1')
+  use_flipper!({ 'Flipper' => '0.75.1', 'Flipper-Folly' => '2.5.3', 'Flipper-RSocket' => '1.3.1' })
   post_install do |installer|
     flipper_post_install(installer)
   end


### PR DESCRIPTION
Causing pod install to abort.

Match [correct syntax](https://github.com/facebook/flipper/blob/main/react-native/ReactNativeFlipperExample/ios/Podfile).

Before

![Screenshot 2021-10-11 at 14 17 49](https://user-images.githubusercontent.com/1881059/136800181-328878f6-f15b-450f-9984-e34ece87142b.png)

After

![Screenshot 2021-10-11 at 14 30 59](https://user-images.githubusercontent.com/1881059/136800292-16061526-f580-4522-af3d-aba8ab845bf1.png)
