### PR TITLE
feat(drawer): add `drawerAllowFontScaling` option

### DIFF
--- a/packages/drawer/src/types.tsx
+++ b/packages/drawer/src/types.tsx
@@ -111,6 +111,11 @@ export type DrawerNavigationOptions = HeaderOptions & {
   drawerInactiveBackgroundColor?: string;
 
   /**
+   * Whether label font should scale to respect Text Size accessibility settings.
+   */
+  drawerAllowFontScaling?: boolean;
+
+  /**
    * Style object for the single item, which can contain an icon and/or a label.
    */
   drawerItemStyle?: StyleProp<ViewStyle>;

--- a/packages/drawer/src/views/DrawerItem.tsx
+++ b/packages/drawer/src/views/DrawerItem.tsx
@@ -77,6 +77,10 @@ type Props = {
    * Style object for the wrapper element.
    */
   style?: StyleProp<ViewStyle>;
+  /**
+   * Whether label font should scale to respect Text Size accessibility settings.
+   */
+  allowFontScaling?: boolean;
 };
 
 const LinkPressable = ({
@@ -141,6 +145,7 @@ export default function DrawerItem(props: Props) {
     labelStyle,
     to,
     focused = false,
+    allowFontScaling,
     activeTintColor = colors.primary,
     inactiveTintColor = Color(colors.text).alpha(0.68).rgb().string(),
     activeBackgroundColor = Color(activeTintColor).alpha(0.12).rgb().string(),
@@ -186,6 +191,7 @@ export default function DrawerItem(props: Props) {
             {typeof label === 'string' ? (
               <Text
                 numberOfLines={1}
+                allowFontScaling={allowFontScaling}
                 style={[
                   {
                     color,

--- a/packages/drawer/src/views/DrawerItemList.tsx
+++ b/packages/drawer/src/views/DrawerItemList.tsx
@@ -45,6 +45,7 @@ export default function DrawerItemList({
       drawerIcon,
       drawerLabelStyle,
       drawerItemStyle,
+      drawerAllowFontScaling,
     } = descriptors[route.key].options;
 
     return (
@@ -63,6 +64,7 @@ export default function DrawerItemList({
         inactiveTintColor={drawerInactiveTintColor}
         activeBackgroundColor={drawerActiveBackgroundColor}
         inactiveBackgroundColor={drawerInactiveBackgroundColor}
+        allowFontScaling={drawerAllowFontScaling}
         labelStyle={drawerLabelStyle}
         style={drawerItemStyle}
         to={buildLink(route.name, route.params)}


### PR DESCRIPTION
Add `drawerAllowFontScaling` to the drawer options, so consumers can enable or disable font scaling for drawer labels to respect Text Size accessibility settings. The option functions similarly to [`tabBarAllowFontScaling`](tabBarAllowFontScaling).