### PR TITLE
fix(core): removal of non-existing listener should not break updating navigation container ref

### DIFF
--- a/packages/core/src/__tests__/createNavigationContainerRef.test.tsx
+++ b/packages/core/src/__tests__/createNavigationContainerRef.test.tsx
@@ -45,3 +45,11 @@ it('adds the listener even if container is mounted later', () => {
 
   expect(listener).toHaveBeenCalledTimes(1);
 });
+
+it('removal of non-existing listener should not break updating ref', () => {
+  const ref = createNavigationContainerRef<ParamListBase>();
+  ref.removeListener('state', jest.fn());
+  expect(() => {
+    ref.current = createNavigationContainerRef<ParamListBase>();
+  }).not.toThrow();
+});

--- a/packages/core/src/createNavigationContainerRef.tsx
+++ b/packages/core/src/createNavigationContainerRef.tsx
@@ -33,7 +33,9 @@ export default function createNavigationContainerRef<
     event: string,
     callback: (...args: any[]) => void
   ) => {
-    listeners[event] = listeners[event]?.filter((cb) => cb !== callback);
+    if (listeners[event]) {
+      listeners[event] = listeners[event].filter((cb) => cb !== callback);
+    }
   };
 
   let current: NavigationContainerRef<ParamList> | null = null;


### PR DESCRIPTION
Calling `removeListener` on event that doesn't have any listeners will add new key for that event to listeners with value `undefined`. After that attempts to set `ref.current` will fail with "Cannot read property 'forEach' of undefined" error. Fix is quite simple. Just needed to add check if there is listeners for the given event.

FYI @satya164. This is related to your recent change https://github.com/react-navigation/react-navigation/commit/acdde18d8938741fd27d8ff8c8249977e0cb03e7