### PR TITLE
fix(core): remove unsupported type annotation

### DIFF
--- a/packages/core/src/types.tsx
+++ b/packages/core/src/types.tsx
@@ -189,8 +189,8 @@ type NavigationHelpersCommon<
    */
   navigate<RouteName extends keyof ParamList>(
     ...args: undefined extends ParamList[RouteName]
-      ? [screen: RouteName] | [screen: RouteName, params: ParamList[RouteName]]
-      : [screen: RouteName, params: ParamList[RouteName]]
+      ? [RouteName] | [RouteName, params: ParamList[RouteName]]
+      : [RouteName, params: ParamList[RouteName]]
   ): void;
 
   /**


### PR DESCRIPTION
Remove unsupported type annotation in tsc version 3.9.10. In this version of tsc such annotation will produce a type error like this:
![image](https://user-images.githubusercontent.com/15797507/142797252-f6b380fb-3f43-4b79-a94b-93f68e43cbf4.png)

