### PR TITLE
feat(native-stack): add export for NativeStackView

### DIFF
--- a/packages/native-stack/src/index.tsx
+++ b/packages/native-stack/src/index.tsx
@@ -3,7 +3,6 @@
  */
 export { default as createNativeStackNavigator } from './navigators/createNativeStackNavigator';
 
-
 /**
  * Views
  */

--- a/packages/native-stack/src/index.tsx
+++ b/packages/native-stack/src/index.tsx
@@ -3,6 +3,13 @@
  */
 export { default as createNativeStackNavigator } from './navigators/createNativeStackNavigator';
 
+
+/**
+ * Views
+ */
+
+export { default as NativeStackView } from './views/NativeStackView';
+
 /**
  * Types
  */

--- a/packages/native-stack/src/index.tsx
+++ b/packages/native-stack/src/index.tsx
@@ -7,7 +7,6 @@ export { default as createNativeStackNavigator } from './navigators/createNative
 /**
  * Views
  */
-
 export { default as NativeStackView } from './views/NativeStackView';
 
 /**


### PR DESCRIPTION
Adds export for `NativeStackView` component. 
Will be useful for creating a custom navigator that [extends](https://reactnavigation.org/docs/custom-navigators/#extending-navigators) the native stack navigator.