### PR TITLE
fix(web): avoid passing undefined root state in web

### DIFF
--- a/packages/native/src/useLinking.tsx
+++ b/packages/native/src/useLinking.tsx
@@ -510,6 +510,11 @@ export default function useLinking(
       const previousState = previousStateRef.current;
       const state = navigation.getRootState();
 
+      // root state may not available, for example when root navigators switch inside the container
+      if (!state) {
+        return;
+      }
+
       const pendingPath = pendingPopStatePathRef.current;
       const route = findFocusedRoute(state);
       const path =


### PR DESCRIPTION
this avoids an uncaught exception from getPathFromState
it appears root state is undefined during full root navigation switch
(for example during a login event and going from unprotected to protected nav)
This is tested and works in my app, including the linking URL behavior as expected
Fixes #10185

Here's the patch-package patch I'm using

[@react-navigation+native+6.0.6.patch.txt](https://github.com/react-navigation/react-navigation/files/7672638/%40react-navigation%2Bnative%2B6.0.6.patch.txt)


