### PR TITLE
docs: correct typos on line 75

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,7 +72,7 @@ We follow the [conventional commits specification](https://www.conventionalcommi
 - `fix`: bug fixes, e.g. fix crash due to deprecated method.
 - `feat`: new features, e.g. add new method to the module.
 - `refactor`: code refactor, e.g. migrate from class components to hooks.
-- `docs`: changes into documentation, e.g. add usage example for the module..
+- `docs`: changes to documentation, e.g. add usage example for the module.
 - `test`: adding or updating tests, eg add integration tests using detox.
 - `chore`: tooling changes, e.g. change CI config.
 


### PR DESCRIPTION
Oddly enough the CONTRIBUTING.md file had two documentation typos on the commit guide for docs :)
Very meta