### PR TITLE
feat(native-stack): Add Android header search bar

### DIFF
--- a/packages/native-stack/package.json
+++ b/packages/native-stack/package.json
@@ -52,7 +52,7 @@
     "react": "~16.13.1",
     "react-native": "~0.63.4",
     "react-native-builder-bob": "^0.18.1",
-    "react-native-screens": "^3.3.0",
+    "react-native-screens": "^3.10.1",
     "typescript": "^4.3.2"
   },
   "peerDependencies": {

--- a/packages/native-stack/src/views/HeaderConfig.tsx
+++ b/packages/native-stack/src/views/HeaderConfig.tsx
@@ -10,6 +10,7 @@ import {
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
+  isSearchBarAvailableForCurrentPlatform,
   ScreenStackHeaderBackButtonImage,
   ScreenStackHeaderCenterView,
   ScreenStackHeaderConfig,
@@ -109,7 +110,7 @@ export default function HeaderConfig({
       : null;
 
   if (
-    Platform.OS === 'ios' &&
+    isSearchBarAvailableForCurrentPlatform &&
     headerSearchBarOptions != null &&
     SearchBar == null
   ) {
@@ -220,7 +221,8 @@ export default function HeaderConfig({
           {headerRightElement}
         </ScreenStackHeaderRightView>
       ) : null}
-      {Platform.OS === 'ios' && headerSearchBarOptions != null ? (
+      {isSearchBarAvailableForCurrentPlatform &&
+      headerSearchBarOptions != null ? (
         <ScreenStackHeaderSearchBarView>
           <SearchBar {...headerSearchBarOptions} />
         </ScreenStackHeaderSearchBarView>

--- a/yarn.lock
+++ b/yarn.lock
@@ -17475,6 +17475,11 @@ react-fast-compare@^3.0.1:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
   integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
 
+react-freeze@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/react-freeze/-/react-freeze-1.0.0.tgz#b21c65fe1783743007c8c9a2952b1c8879a77354"
+  integrity sha512-yQaiOqDmoKqks56LN9MTgY06O0qQHgV4FUrikH357DydArSZHQhl0BJFqGKIZoTqi8JizF9Dxhuk1FIZD6qCaw==
+
 react-inspector@^5.1.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/react-inspector/-/react-inspector-5.1.1.tgz#58476c78fde05d5055646ed8ec02030af42953c8"
@@ -17599,10 +17604,13 @@ react-native-safe-area-context@3.2.0, react-native-safe-area-context@~3.2.0:
   resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-3.2.0.tgz#06113c6b208f982d68ab5c3cebd199ca93db6941"
   integrity sha512-k2Nty4PwSnrg9HwrYeeE+EYqViYJoOFwEy9LxL5RIRfoqxAq/uQXNGwpUg2/u4gnKpBbEPa9eRh15KKMe/VHkA==
 
-react-native-screens@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-3.3.0.tgz#d4464a96620b85d09e46bd6865b5f48456c244f0"
-  integrity sha512-ni11jC6I9cFVXdLIDwkgafDHw/STXUNzkR5Fx3w8Wikdzi8gfTEan2kiOm7aS42d2F/LXddZ6i74Z2em0L6LPQ==
+react-native-screens@^3.10.1:
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-3.10.1.tgz#2634a1a17380c559a06de391e4969ae72c4365ff"
+  integrity sha512-ZF/XHnRsuinvDY1XiCWLXxoUoSf+NgsAes2SZfX9rFQQcv128zmh/+19SSavGrSf6rQNzqytEMdRGI6yr4Gbjw==
+  dependencies:
+    react-freeze "^1.0.0"
+    warn-once "^0.1.0"
 
 react-native-screens@~3.8.0:
   version "3.8.0"


### PR DESCRIPTION
In `react-native-screens` [3.10.0](https://github.com/software-mansion/react-native-screens/releases/tag/3.10.0), the header search bar was added to Android (PR [here](https://github.com/software-mansion/react-native-screens/pull/1166)).

The docs for `react-navigation` also need updating - but I'm unsure of the order of operations for this.

p.s. Merry Christmas 🎄 