### PR TITLE
feat(native-stack): export NativeStackView to support custom routers on native-stack

### DIFF
--- a/packages/bottom-tabs/src/index.tsx
+++ b/packages/bottom-tabs/src/index.tsx
@@ -22,6 +22,7 @@ export type {
   BottomTabBarButtonProps,
   BottomTabBarProps,
   BottomTabHeaderProps,
+  BottomTabNavigationEventMap,
   BottomTabNavigationOptions,
   BottomTabNavigationProp,
   BottomTabScreenProps,

--- a/packages/drawer/src/index.tsx
+++ b/packages/drawer/src/index.tsx
@@ -28,6 +28,7 @@ export { default as useDrawerStatus } from './utils/useDrawerStatus';
 export type {
   DrawerContentComponentProps,
   DrawerHeaderProps,
+  DrawerNavigationEventMap,
   DrawerNavigationOptions,
   DrawerNavigationProp,
   DrawerScreenProps,

--- a/packages/material-bottom-tabs/src/index.tsx
+++ b/packages/material-bottom-tabs/src/index.tsx
@@ -12,6 +12,7 @@ export { default as MaterialBottomTabView } from './views/MaterialBottomTabView'
  * Types
  */
 export type {
+  MaterialBottomTabNavigationEventMap,
   MaterialBottomTabNavigationOptions,
   MaterialBottomTabNavigationProp,
   MaterialBottomTabScreenProps,

--- a/packages/material-top-tabs/src/index.tsx
+++ b/packages/material-top-tabs/src/index.tsx
@@ -14,6 +14,7 @@ export { default as MaterialTopTabView } from './views/MaterialTopTabView';
  */
 export type {
   MaterialTopTabBarProps,
+  MaterialTopTabNavigationEventMap,
   MaterialTopTabNavigationOptions,
   MaterialTopTabNavigationProp,
   MaterialTopTabScreenProps,

--- a/packages/native-stack/src/index.tsx
+++ b/packages/native-stack/src/index.tsx
@@ -2,6 +2,7 @@
  * Navigators
  */
 export { default as createNativeStackNavigator } from './navigators/createNativeStackNavigator';
+export { default as NativeStackView } from './views/NativeStackView';
 
 /**
  * Types
@@ -11,4 +12,6 @@ export type {
   NativeStackNavigationOptions,
   NativeStackNavigationProp,
   NativeStackScreenProps,
+  NativeStackNavigationEventMap,
+  NativeStackNavigatorProps,
 } from './types';

--- a/packages/native-stack/src/index.tsx
+++ b/packages/native-stack/src/index.tsx
@@ -9,9 +9,9 @@ export { default as NativeStackView } from './views/NativeStackView';
  */
 export type {
   NativeStackHeaderProps,
+  NativeStackNavigationEventMap,
   NativeStackNavigationOptions,
   NativeStackNavigationProp,
-  NativeStackScreenProps,
-  NativeStackNavigationEventMap,
   NativeStackNavigatorProps,
+  NativeStackScreenProps,
 } from './types';

--- a/packages/native-stack/src/index.tsx
+++ b/packages/native-stack/src/index.tsx
@@ -12,6 +12,5 @@ export type {
   NativeStackNavigationEventMap,
   NativeStackNavigationOptions,
   NativeStackNavigationProp,
-  NativeStackNavigatorProps,
   NativeStackScreenProps,
 } from './types';

--- a/packages/native-stack/src/index.tsx
+++ b/packages/native-stack/src/index.tsx
@@ -6,7 +6,7 @@ export { default as createNativeStackNavigator } from './navigators/createNative
 /**
  * Views
  */
- export { default as NativeStackView } from './views/NativeStackView';
+export { default as NativeStackView } from './views/NativeStackView';
 
 /**
  * Types

--- a/packages/native-stack/src/index.tsx
+++ b/packages/native-stack/src/index.tsx
@@ -2,7 +2,11 @@
  * Navigators
  */
 export { default as createNativeStackNavigator } from './navigators/createNativeStackNavigator';
-export { default as NativeStackView } from './views/NativeStackView';
+
+/**
+ * Views
+ */
+ export { default as NativeStackView } from './views/NativeStackView';
 
 /**
  * Types

--- a/packages/stack/src/index.tsx
+++ b/packages/stack/src/index.tsx
@@ -43,6 +43,7 @@ export type {
   StackHeaderInterpolationProps,
   StackHeaderProps,
   StackHeaderStyleInterpolator,
+  StackNavigationEventMap,
   StackNavigationOptions,
   StackNavigationProp,
   StackScreenProps,


### PR DESCRIPTION
Currently, there is no way to create a custom navigator and router on top of **Native-Stack**

So by exporting **NativeStackView** along with its types from native-stack, we can use it along with **useNavigationBuilder** to create custom navigators​ with some additional functionality built on top of it.

We can also use **StackRouter** from **@react-navigation/native** to create customised routers and use it with the navigator we created on top of **NativeStackView**.

We can follow the same doc to extend NativeStackView with our own router or build additional functionality on top of it.
https://reactnavigation.org/docs/custom-navigators#extending-navigators.

