### PR TITLE
fix: useLinking crash

### DIFF
--- a/packages/native/src/useLinking.tsx
+++ b/packages/native/src/useLinking.tsx
@@ -125,14 +125,10 @@ const createMemoryHistory = () => {
         return;
       }
 
-      if (n < 0) {
-        // We shouldn't go back more than the 0 index
-        // Otherwise we'll exit the page
-        n = index + n < 0 ? -index : n;
-      }
-
-      // We shouldn't go forward more than available index
-      index = Math.min(index + n, items.length - 1);
+      // We shouldn't go back more than the 0 index (otherwise we'll exit the page)
+      // Or forward more than the available index (or the app will crash)
+      index =
+        n < 0 ? Math.max(index - n, 0) : Math.min(index + n, items.length - 1);
 
       // When we call `history.go`, `popstate` will fire when there's history to go back to
       // So we need to somehow handle following cases:

--- a/packages/native/src/useLinking.tsx
+++ b/packages/native/src/useLinking.tsx
@@ -121,20 +121,18 @@ const createMemoryHistory = () => {
     go(n: number) {
       interrupt();
 
-      if (n > 0) {
-        // We shouldn't go forward more than available index
-        n = Math.min(n, items.length - 1);
-      } else if (n < 0) {
+      if (n === 0) {
+        return;
+      }
+
+      if (n < 0) {
         // We shouldn't go back more than the 0 index
         // Otherwise we'll exit the page
         n = index + n < 0 ? -index : n;
       }
 
-      if (n === 0) {
-        return;
-      }
-
-      index += n;
+      // We shouldn't go forward more than available index
+      index = Math.min(index + n, items.length - 1);
 
       // When we call `history.go`, `popstate` will fire when there's history to go back to
       // So we need to somehow handle following cases:


### PR DESCRIPTION
Hello 👋 

We've been seeing [this crash](https://github.com/react-navigation/react-navigation/pull/9970#issuecomment-941908688) (shown in the following screenshot) happening in our production code. I unfortunately don't know how to consistently reproduce this problem, but I believe this PR is very safe and will fix the issue.

![image](https://user-images.githubusercontent.com/47436092/149445563-ab5dbece-d3eb-4ca8-afac-fc2793d243c7.png)

As explained in [this comment](https://github.com/react-navigation/react-navigation/pull/9970/files#r784475821), `TypeError: Cannot read property 'id' of undefined` tells us that somehow the `items` array is actually getting in a state where it contains `undefined`.

Now, there's only four places the `items` array is written to: [line 84](https://github.com/react-navigation/react-navigation/blob/fb84805c889bbb7059e7e95592c004aea2a510d6/packages/native/src/useLinking.tsx#L84), [line 86](https://github.com/react-navigation/react-navigation/blob/fb84805c889bbb7059e7e95592c004aea2a510d6/packages/native/src/useLinking.tsx#L86), [line 108](https://github.com/react-navigation/react-navigation/blob/fb84805c889bbb7059e7e95592c004aea2a510d6/packages/native/src/useLinking.tsx#L108), and [line 110](https://github.com/react-navigation/react-navigation/blob/fb84805c889bbb7059e7e95592c004aea2a510d6/packages/native/src/useLinking.tsx#L110).

Reviewing these one-by-one:

#### Line 84
`items = items.slice(0, index - 1)` -> I don't see any way this can add an `undefined` value to the array ❌ 

#### Line 86
`items.push({ path, state, id })` -> At worst, this could append an object like: `{path: undefined, state: undefined, id: undefined}`, but we wouldn't end up with `undefined` itself in the `items` array. So not here either ❌ 

#### Line 108
`items = [{ path, state, id }];` -> Similar to line 86, this can't cause `undefined` to be in the `items` array ❌ 

#### Line 110
`items[index] = { path, state, id };` -> This _can_ cause `undefined` to be in the `items` array if `index` is greater than the length of the array, like so:

```js
> let items = [];
undefined
> items[1] = 'Hello';
'Hello'
> items[0];
undefined
```

It seems this is our problem line, and tells us that the `index` is becoming greater than the length of the items array. I believe I found the only location in this component where that could happen, and fix it in this PR.

Let me know if you have questions or concerns! If anyone from the community wants to help out with providing testing or consistent reproduction steps, that would be great!