### PR TITLE
Change state at which swipe back gesture starts to `ACTIVE`

### DIFF
--- a/packages/stack/src/views/Stack/Card.tsx
+++ b/packages/stack/src/views/Stack/Card.tsx
@@ -272,7 +272,7 @@ export default class Card extends React.Component<Props> {
     } = this.props;
 
     switch (nativeEvent.state) {
-      case GestureState.BEGAN:
+      case GestureState.ACTIVE:
         this.isSwiping.setValue(TRUE);
         this.handleStartInteraction();
         onGestureBegin?.();


### PR DESCRIPTION
With the release of Gesture Handler 2 some gesture handlers have been updated to follow state-flow more consistently across the platforms. Among them was the Pan gesture which was changed to transition to the `BEGAN` state as soon as finger touches the screen opposed to just before transitioning to the `ACTIVE` state.
`@react-navigation/stack` is relying on the old behavior which may be causing some unexpected issues in apps, for example: https://github.com/software-mansion/react-native-gesture-handler/issues/1801.

This PR changes the swipe-back gesture to start when the Pan transitions to the`ACTIVE` state. Since previously Pan gesture was transitioning to the `BEGAN` state just before transitioning to the `ACTIVE` state this change would be compatible with older versions of Gesture Handler.