### PR TITLE
fix: back and forward does not work correctly, items might have empty indexes

### DIFF
--- a/packages/native/src/useLinking.tsx
+++ b/packages/native/src/useLinking.tsx
@@ -50,7 +50,7 @@ const createMemoryHistory = () => {
       const id = window.history.state?.id;
 
       if (id) {
-        const index = items.findIndex((item) => item.id === id);
+        const index = items.findIndex((item) =>item && item.id === id);
 
         return index > -1 ? index : 0;
       }
@@ -99,7 +99,7 @@ const createMemoryHistory = () => {
 
       const id = window.history.state?.id ?? nanoid();
 
-      if (!items.length || items.findIndex((item) => item.id === id) < 0) {
+      if (!items.length || items.findIndex((item) =>item && item.id === id) < 0) {
         // There are two scenarios for creating an array with only one history record:
         // - When loaded id not found in the items array, this function by default will replace
         //   the first item. We need to keep only the new updated object, otherwise it will break
@@ -179,7 +179,7 @@ const createMemoryHistory = () => {
 
         const onPopState = () => {
           const id = window.history.state?.id;
-          const currentIndex = items.findIndex((item) => item.id === id);
+          const currentIndex = items.findIndex((item) =>item && item.id === id);
 
           // Fix createMemoryHistory.index variable's value
           // as it may go out of sync when navigating in the browser.

--- a/packages/native/src/useLinking.tsx
+++ b/packages/native/src/useLinking.tsx
@@ -50,7 +50,7 @@ const createMemoryHistory = () => {
       const id = window.history.state?.id;
 
       if (id) {
-        const index = items.findIndex((item) =>item && item.id === id);
+        const index = items.findIndex((item) => item && item.id === id);
 
         return index > -1 ? index : 0;
       }
@@ -99,7 +99,7 @@ const createMemoryHistory = () => {
 
       const id = window.history.state?.id ?? nanoid();
 
-      if (!items.length || items.findIndex((item) =>item && item.id === id) < 0) {
+      if (!items.length || items.findIndex((item) => item && item.id === id) < 0) {
         // There are two scenarios for creating an array with only one history record:
         // - When loaded id not found in the items array, this function by default will replace
         //   the first item. We need to keep only the new updated object, otherwise it will break
@@ -179,7 +179,7 @@ const createMemoryHistory = () => {
 
         const onPopState = () => {
           const id = window.history.state?.id;
-          const currentIndex = items.findIndex((item) =>item && item.id === id);
+          const currentIndex = items.findIndex((item) => item && item.id === id);
 
           // Fix createMemoryHistory.index variable's value
           // as it may go out of sync when navigating in the browser.


### PR DESCRIPTION

items array sometimes has empty indexes. This fixes the findixes functions to work correctly , when items array has an empty element.

<img width="539" alt="Screen Shot 2022-01-28 at 22 48 18" src="https://user-images.githubusercontent.com/5358438/151621478-51a45113-0c4b-4935-89d9-a0805a668ec5.png">
