### PR TITLE
fix: back and forward does not work correctly, items should not have empty indexes

### DIFF
--- a/packages/native/src/useLinking.tsx
+++ b/packages/native/src/useLinking.tsx
@@ -179,7 +179,7 @@ const createMemoryHistory = () => {
 
         const onPopState = () => {
           const id = window.history.state?.id;
-          const currentIndex = items.findIndex((item) => item && item.id === id);
+          const currentIndex = items.findIndex((item) => item?.id === id);
 
           // Fix createMemoryHistory.index variable's value
           // as it may go out of sync when navigating in the browser.

--- a/packages/native/src/useLinking.tsx
+++ b/packages/native/src/useLinking.tsx
@@ -99,7 +99,7 @@ const createMemoryHistory = () => {
 
       const id = window.history.state?.id ?? nanoid();
 
-      if (!items.length || items.findIndex((item) => item && item.id === id) < 0) {
+      if (!items.length || items.findIndex((item) => item?.id === id) < 0) {
         // There are two scenarios for creating an array with only one history record:
         // - When loaded id not found in the items array, this function by default will replace
         //   the first item. We need to keep only the new updated object, otherwise it will break

--- a/packages/native/src/useLinking.tsx
+++ b/packages/native/src/useLinking.tsx
@@ -50,7 +50,7 @@ const createMemoryHistory = () => {
       const id = window.history.state?.id;
 
       if (id) {
-        const index = items.findIndex((item) => item.id === id);
+        const index = items.findIndex((item) => item && item.id === id);
 
         return index > -1 ? index : 0;
       }
@@ -99,7 +99,7 @@ const createMemoryHistory = () => {
 
       const id = window.history.state?.id ?? nanoid();
 
-      if (!items.length || items.findIndex((item) => item.id === id) < 0) {
+      if (!items.length || items.findIndex((item) => item && item.id === id) < 0) {
         // There are two scenarios for creating an array with only one history record:
         // - When loaded id not found in the items array, this function by default will replace
         //   the first item. We need to keep only the new updated object, otherwise it will break
@@ -108,7 +108,7 @@ const createMemoryHistory = () => {
         //   So we need to push the entry as there's nothing to replace
         items = [{ path, state, id }];
       } else {
-        items[index] = { path, state, id };
+        items[0] = { path, state, id };
       }
 
       window.history.replaceState({ id }, '', path);
@@ -179,7 +179,7 @@ const createMemoryHistory = () => {
 
         const onPopState = () => {
           const id = window.history.state?.id;
-          const currentIndex = items.findIndex((item) => item.id === id);
+          const currentIndex = items.findIndex((item) => item && item.id === id);
 
           // Fix createMemoryHistory.index variable's value
           // as it may go out of sync when navigating in the browser.

--- a/packages/native/src/useLinking.tsx
+++ b/packages/native/src/useLinking.tsx
@@ -50,7 +50,7 @@ const createMemoryHistory = () => {
       const id = window.history.state?.id;
 
       if (id) {
-        const index = items.findIndex((item) => item && item.id === id);
+        const index = items.findIndex((item) => item?.id === id);
 
         return index > -1 ? index : 0;
       }


### PR DESCRIPTION
In findindexes function , there's no need to

`item?.`

as the indexes are now being managed properly , I left them just because further testing might be essential and if there's still a mistake in the commit , not to make it crash.

It is possibly safe not to 

`item?.`.