### PR TITLE
fix: broken history items index when items reset

### DIFF
--- a/packages/native/src/useLinking.tsx
+++ b/packages/native/src/useLinking.tsx
@@ -107,6 +107,7 @@ const createMemoryHistory = () => {
         // - This is the first time any state modifications are done
         //   So we need to push the entry as there's nothing to replace
         items = [{ path, state, id }];
+        index = 0;
       } else {
         items[index] = { path, state, id };
       }


### PR DESCRIPTION
This PR aims to fix a crash when quickly navigating back and forward in browser (same as [#10306](https://github.com/react-navigation/react-navigation/pull/10306) but in a different way).

I'm not sure either it's by design to allow _empty_ elements in [items](https://github.com/react-navigation/react-navigation/blob/c864c9ecfe825d293f0fe354f21a161f934d4f56/packages/native/src/useLinking.tsx#L30) array (then type definition should be also changed [here](https://github.com/react-navigation/react-navigation/pull/10306) to reflect the runtime, or it's safe to also reset the index when [items is reset](https://github.com/react-navigation/react-navigation/blob/c864c9ecfe825d293f0fe354f21a161f934d4f56/packages/native/src/useLinking.tsx#L109) (this PR).


