### PR TITLE
feat: add customAnimationOnGesture & fullScreenSwipeEnabled props to native-stack

### DIFF
--- a/example/src/Screens/NativeStack.tsx
+++ b/example/src/Screens/NativeStack.tsx
@@ -145,7 +145,10 @@ export default function NativeStackScreen({
       <NativeStack.Screen
         name="NewsFeed"
         component={NewsFeedScreen}
-        options={{ title: 'Feed' }}
+        options={{
+          title: 'Feed',
+          fullScreenGestureEnabled: true,
+        }}
       />
       <NativeStack.Screen
         name="Albums"

--- a/packages/native-stack/src/types.tsx
+++ b/packages/native-stack/src/types.tsx
@@ -356,9 +356,9 @@ export type NativeStackNavigationOptions = {
    */
   customAnimationOnGesture?: boolean;
   /**
-   * Whether the gesture to dismiss should work on the whole screen. Swiping with this option results in the same transition animation as `simple_push` by default.
-   * It can be changed to other custom animations with `customAnimationOnSwipe` prop, but default iOS swipe animation is not achievable due to usage of custom recognizer.
-   * Defaults to `false`.
+   * Whether the gesture to dismiss should work on the whole screen. Using gesture to dismiss with this option results in the same
+   * transition animation as `simple_push`. This behavior can be changed by setting `customAnimationOnGesture` prop. Achieving the
+   * default iOS animation isn't possible due to platform limitations. Defaults to `false`.
    *
    * @platform ios
    */

--- a/packages/native-stack/src/types.tsx
+++ b/packages/native-stack/src/types.tsx
@@ -352,6 +352,8 @@ export type NativeStackNavigationOptions = {
   /**
    * Whether the gesture to dismiss should use animation provided to `animation` prop. Defaults to `false`.
    *
+   * Doesn't affect the behavior of screens presented modally.
+   *
    * @platform ios
    */
   customAnimationOnGesture?: boolean;
@@ -359,6 +361,8 @@ export type NativeStackNavigationOptions = {
    * Whether the gesture to dismiss should work on the whole screen. Using gesture to dismiss with this option results in the same
    * transition animation as `simple_push`. This behavior can be changed by setting `customAnimationOnGesture` prop. Achieving the
    * default iOS animation isn't possible due to platform limitations. Defaults to `false`.
+   *
+   * Doesn't affect the behavior of screens presented modally.
    *
    * @platform ios
    */
@@ -387,7 +391,7 @@ export type NativeStackNavigationOptions = {
    * Supported values:
    * - "default": use the platform default animation
    * - "fade": fade screen in or out
-   * - "flip": flip the screen, requires stackPresentation: "modal" (iOS only)
+   * - "flip": flip the screen, requires presentation: "modal" (iOS only)
    * - "simple_push": use the platform default animation, but without shadow and native header transition (iOS only)
    * - "slide_from_bottom": slide in the new screen from bottom
    * - "slide_from_right": slide in the new screen from right (Android only, uses default animation on iOS)

--- a/packages/native-stack/src/types.tsx
+++ b/packages/native-stack/src/types.tsx
@@ -350,6 +350,20 @@ export type NativeStackNavigationOptions = {
    */
   contentStyle?: StyleProp<ViewStyle>;
   /**
+   * Whether the gesture to dismiss should use animation provided to `animation` prop. Defaults to `false`.
+   *
+   * @platform ios
+   */
+  customAnimationOnGesture?: boolean;
+  /**
+   * Whether the gesture to dismiss should work on the whole screen. Swiping with this option results in the same transition animation as `simple_push` by default.
+   * It can be changed to other custom animations with `customAnimationOnSwipe` prop, but default iOS swipe animation is not achievable due to usage of custom recognizer.
+   * Defaults to `false`.
+   *
+   * @platform ios
+   */
+  fullScreenGestureEnabled?: boolean;
+  /**
    * Whether you can use gestures to dismiss this screen. Defaults to `true`.
    *
    * Only supported on iOS.
@@ -374,6 +388,8 @@ export type NativeStackNavigationOptions = {
    * - "default": use the platform default animation
    * - "fade": fade screen in or out
    * - "flip": flip the screen, requires stackPresentation: "modal" (iOS only)
+   * - "simple_push": use the platform default animation, but without shadow and native header transition (iOS only)
+   * - "slide_from_bottom": slide in the new screen from bottom
    * - "slide_from_right": slide in the new screen from right (Android only, uses default animation on iOS)
    * - "slide_from_left": slide in the new screen from left (Android only, uses default animation on iOS)
    * - "none": don't animate the screen

--- a/packages/native-stack/src/views/NativeStackView.native.tsx
+++ b/packages/native-stack/src/views/NativeStackView.native.tsx
@@ -127,11 +127,13 @@ const SceneView = ({
 }: SceneViewProps) => {
   const { route, navigation, options, render } = descriptor;
   const {
+    animation,
+    animationTypeForReplace = 'push',
+    customAnimationOnGesture,
+    fullScreenGestureEnabled,
     gestureEnabled,
     header,
     headerShown,
-    animationTypeForReplace = 'push',
-    animation,
     orientation,
     statusBarAnimation,
     statusBarHidden,
@@ -178,6 +180,8 @@ const SceneView = ({
       key={route.key}
       enabled
       style={StyleSheet.absoluteFill}
+      customAnimationOnSwipe={customAnimationOnGesture}
+      fullScreenSwipeEnabled={fullScreenGestureEnabled}
       gestureEnabled={
         isAndroid
           ? // This prop enables handling of system back gestures on Android
@@ -196,6 +200,7 @@ const SceneView = ({
       onAppear={onAppear}
       onDisappear={onDisappear}
       onDismissed={onDismissed}
+      isNativeStack
     >
       <HeaderShownContext.Provider
         value={isParentHeaderShown || isHeaderInPush !== false}


### PR DESCRIPTION


**Motivation**

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

This PR adds two missing props from `react-native-screens` - `customAnimationOnGesture` (renamed from `customAnimationOnSwipe`) and `fullScreenGestureEnabled` (renamed from `fullScreenSwipeEnabled `).

Also, the `isNativeStack` prop is set in order to make transition progress work correctly.

PR to docs to accommodate the changes: https://github.com/react-navigation/react-navigation.github.io/pull/1112

**Test plan**

<!--
Demonstrate the code is solid. Example: the exact commands you ran and their output, screenshots / videos if the pull request changes UI.

Make sure you test on both platforms if your change affects both platforms.
-->
`fullScreenGestureEnabled` in action:

https://user-images.githubusercontent.com/39658211/152153496-a844d034-78f4-4f19-9722-ad04f1baddf7.mov

`fullScreenGestureEnabled` & `customAnimationOnGesture` & animation: `fade`:


https://user-images.githubusercontent.com/39658211/152153654-5e9f1dd5-dc2f-4897-b975-76591ff7dbe3.mov



- [x] The code must pass tests.

**Code formatting**

- [x] Look around. Match the style of the rest of the codebase. Run `yarn lint --fix` before committing.