### PR TITLE
feat: add nativeBackButtonDismissalEnabled prop to native-stack

### DIFF
--- a/packages/native-stack/src/types.tsx
+++ b/packages/native-stack/src/types.tsx
@@ -379,6 +379,16 @@ export type NativeStackNavigationOptions = {
    */
   gestureEnabled?: boolean;
   /**
+   * Boolean indicating whether, when the Android default back button is clicked, the `pop` action should be performed on the native
+   * side or on the JS side to be able to prevent it. Unfortunately the same behavior is not available on iOS since the behavior of
+   * native back button cannot be changed there. Defaults to `false`.
+   *
+   * Only supported on Android.
+   *
+   * @platform android
+   */
+  nativeBackButtonDismissalEnabled?: boolean;
+  /**
    * The type of animation to use when this screen replaces another screen. Defaults to `pop`.
    *
    * Supported values:

--- a/packages/native-stack/src/types.tsx
+++ b/packages/native-stack/src/types.tsx
@@ -379,9 +379,8 @@ export type NativeStackNavigationOptions = {
    */
   gestureEnabled?: boolean;
   /**
-   * Boolean indicating whether, when the Android default back button is clicked, the `pop` action should be performed on the native
-   * side or on the JS side to be able to prevent it. Unfortunately the same behavior is not available on iOS since the behavior of
-   * native back button cannot be changed there. Defaults to `false`.
+   * Whether the dismissal of the screen on tap of the header back button on Android should be performed by the native or the
+   * navigation's side. Defaults to `false`.
    *
    * Only supported on Android.
    *

--- a/packages/native-stack/src/views/NativeStackView.native.tsx
+++ b/packages/native-stack/src/views/NativeStackView.native.tsx
@@ -114,6 +114,7 @@ type SceneViewProps = {
   onAppear: () => void;
   onDisappear: () => void;
   onDismissed: () => void;
+  onHeaderBackButtonClicked: () => void;
 };
 
 const SceneView = ({
@@ -124,6 +125,7 @@ const SceneView = ({
   onAppear,
   onDisappear,
   onDismissed,
+  onHeaderBackButtonClicked,
 }: SceneViewProps) => {
   const { route, navigation, options, render } = descriptor;
   const {
@@ -202,12 +204,7 @@ const SceneView = ({
       onAppear={onAppear}
       onDisappear={onDisappear}
       onDismissed={onDismissed}
-      onHeaderBackButtonClicked={() => {
-        navigation.dispatch({
-          ...StackActions.pop(),
-          source: route.key,
-        });
-      }}
+      onHeaderBackButtonClicked={onHeaderBackButtonClicked}
       isNativeStack
     >
       <HeaderShownContext.Provider
@@ -335,6 +332,13 @@ function NativeStackViewInner({ state, navigation, descriptors }: Props) {
               });
 
               setNextDismissedKey(route.key);
+            }}
+            onHeaderBackButtonClicked={() => {
+              navigation.dispatch({
+                ...StackActions.pop(),
+                source: route.key,
+                target: state.key,
+              });
             }}
           />
         );

--- a/packages/native-stack/src/views/NativeStackView.native.tsx
+++ b/packages/native-stack/src/views/NativeStackView.native.tsx
@@ -134,6 +134,7 @@ const SceneView = ({
     gestureEnabled,
     header,
     headerShown,
+    nativeBackButtonDismissalEnabled = false,
     orientation,
     statusBarAnimation,
     statusBarHidden,
@@ -189,6 +190,7 @@ const SceneView = ({
             false
           : gestureEnabled
       }
+      nativeBackButtonDismissalEnabled={nativeBackButtonDismissalEnabled}
       replaceAnimation={animationTypeForReplace}
       stackPresentation={presentation === 'card' ? 'push' : presentation}
       stackAnimation={animation}
@@ -200,6 +202,12 @@ const SceneView = ({
       onAppear={onAppear}
       onDisappear={onDisappear}
       onDismissed={onDismissed}
+      onHeaderBackButtonClicked={() => {
+        navigation.dispatch({
+          ...StackActions.pop(),
+          source: route.key,
+        });
+      }}
       isNativeStack
     >
       <HeaderShownContext.Provider

--- a/packages/native-stack/src/views/NativeStackView.native.tsx
+++ b/packages/native-stack/src/views/NativeStackView.native.tsx
@@ -281,8 +281,8 @@ function NativeStackViewInner({ state, navigation, descriptors }: Props) {
     if (dismissedRouteName) {
       const message =
         `The screen '${dismissedRouteName}' was removed natively but didn't get removed from JS state. ` +
-        `This can happen if the action was prevented in a 'beforeRemove' listener, which is not fully supported in native-stack.\n\n` +
-        `Consider using 'gestureEnabled: false' to prevent back gesture and use a custom back button with 'headerLeft' option to override the native behavior.`;
+        `This can happen if the action was prevented in a 'beforeRemove' listener, which is not fully supported in native-stack on iOS.\n\n` +
+        `Consider using 'gestureEnabled: false' to prevent back gesture and use a custom back button with 'headerLeft' option to override the native iOS behavior.`;
 
       console.error(message);
     }


### PR DESCRIPTION
**Motivation**

This PR adds `nativeBackButtonDismissalEnabled` prop to `native-stack` v6. This prop enables the developers to prevent going back with the header back button on Android.

The implementation was discussed in _great_ detail in the `react-native-screens` repo in https://github.com/software-mansion/react-native-screens/pull/801

Fixes https://github.com/react-navigation/react-navigation/issues/10328

**Test plan**

To test the change you can use [this Snack](https://snack.expo.dev/Sj3BtIgCP)

### Before

https://user-images.githubusercontent.com/39658211/154259015-42f0ea11-96f2-47e4-a5c5-46cea14ab148.mov

### After

https://user-images.githubusercontent.com/39658211/154259086-0c2f5aa9-6f94-49a5-9e8d-a81a3e548c1c.mov
