### PR TITLE
refactor: avoid concat to get configs

### DIFF
--- a/packages/core/src/getStateFromPath.tsx
+++ b/packages/core/src/getStateFromPath.tsx
@@ -107,16 +107,14 @@ export default function getStateFromPath<ParamList extends {}>(
   }
 
   // Create a normalized configs array which will be easier to use
-  const configs = ([] as RouteConfig[])
-    .concat(
-      ...Object.keys(screens).map((key) =>
-        createNormalizedConfigs(
-          key,
-          screens as PathConfigMap<object>,
-          [],
-          initialRoutes,
-          []
-        )
+  const configs = Object.keys(screens)
+    .flatMap((key) =>
+      createNormalizedConfigs(
+        key,
+        screens as PathConfigMap<object>,
+        [],
+        initialRoutes,
+        []
       )
     )
     .sort((a, b) => {


### PR DESCRIPTION
**Motivation**

In order to have more redeable code, I've refactored how it gets the configs in `getStateFromPaths` to let TS obtain its type and avoid casting it