### PR TITLE
fix: iOS back button menu in native-stack

### DIFF
--- a/packages/native-stack/src/views/NativeStackView.native.tsx
+++ b/packages/native-stack/src/views/NativeStackView.native.tsx
@@ -20,6 +20,7 @@ import {
   useSafeAreaFrame,
   useSafeAreaInsets,
 } from 'react-native-safe-area-context';
+import type { ScreenProps } from 'react-native-screens';
 import {
   Screen,
   ScreenStack,
@@ -113,7 +114,7 @@ type SceneViewProps = {
   onWillDisappear: () => void;
   onAppear: () => void;
   onDisappear: () => void;
-  onDismissed: () => void;
+  onDismissed: ScreenProps['onDismissed'];
 };
 
 const SceneView = ({
@@ -319,9 +320,9 @@ function NativeStackViewInner({ state, navigation, descriptors }: Props) {
                 target: route.key,
               });
             }}
-            onDismissed={() => {
+            onDismissed={(event) => {
               navigation.dispatch({
-                ...StackActions.pop(),
+                ...StackActions.pop(event.nativeEvent.dismissCount),
                 source: route.key,
                 target: state.key,
               });


### PR DESCRIPTION


# Motivation

Original PR: https://github.com/software-mansion/react-native-screens/pull/830

iOS 14 added a back button menu that isn't correctly handled in react-navigation v6. This PR fixes this by taking the number of screens that need to be dismissed from the native side.

This number is always 1 on Android: https://github.com/software-mansion/react-native-screens/pull/830/files#diff-6056183a278fe1325ac5dee21004ce6dad735d37b3b855a5de50bccf25ba789dR31

And it is computed on iOS: https://github.com/software-mansion/react-native-screens/pull/830/files#diff-e988f8ab84e7063d6cc9ad4e634806389882ce6727b5c95f3cfbc9f9d3921a67R531 which defaults to 1.

# Test plan

## Before

https://user-images.githubusercontent.com/39658211/155331514-6b562864-01b1-43bf-b9a9-87afaa5a84b4.mov


## After


https://user-images.githubusercontent.com/39658211/155331543-ca3cdb25-c997-45a6-9267-47fb0d46c292.mov



<details>
<summary>Code used for testing these changes</summary>
<br>

```jsx
import { NavigationContainer } from '@react-navigation/native';
import { createNativeStackNavigator } from '@react-navigation/native-stack';
import * as React from 'react';
import { Button, Text, View } from 'react-native';

function HomeScreen({ navigation }) {
  return (
    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
      <Text>Home Screen</Text>
      <Button
        title="Go to Details"
        onPress={() => navigation.navigate('Details')}
      />
    </View>
  );
}

function DetailsScreen({ navigation }) {
  return (
    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
      <Text>Details Screen</Text>
      <Button
        title="Go to Details... again"
        onPress={() => navigation.push('Details')}
      />
      <Button title="Go to Home" onPress={() => navigation.navigate('Home')} />
      <Button title="Go back" onPress={() => navigation.goBack()} />
      <Button
        title="Go back to first screen in stack"
        onPress={() => navigation.popToTop()}
      />
    </View>
  );
}

const Stack = createNativeStackNavigator();

function App() {
  return (
    <NavigationContainer>
      <Stack.Navigator initialRouteName="Home">
        <Stack.Screen name="Home" component={HomeScreen} />
        <Stack.Screen name="Details" component={DetailsScreen} />
      </Stack.Navigator>
    </NavigationContainer>
  );
}

export default App;

```

</details>

