### PR TITLE
Add transitionDuration property to native stack

### DIFF
--- a/packages/native-stack/src/types.tsx
+++ b/packages/native-stack/src/types.tsx
@@ -435,6 +435,17 @@ export type NativeStackNavigationOptions = {
    * Only supported on iOS and Android.
    */
   orientation?: ScreenProps['screenOrientation'];
+  /**
+   * The display orientation to use for the screen.
+   *
+   * Changes the duration (in milliseconds) of `slide_from_bottom`, `fade_from_bottom`, `fade` and `simple_push` transitions on iOS. Defaults to `350`.
+   * The duration of `default` and `flip` transitions isn't customizable.
+   *
+   * Only supported on iOS.
+   *
+   * @platform ios
+   */
+  transitionDuration?: number;
 };
 
 export type NativeStackNavigatorProps = DefaultNavigatorOptions<

--- a/packages/native-stack/src/views/NativeStackView.native.tsx
+++ b/packages/native-stack/src/views/NativeStackView.native.tsx
@@ -139,6 +139,7 @@ const SceneView = ({
     statusBarAnimation,
     statusBarHidden,
     statusBarStyle,
+    transitionDuration,
   } = options;
 
   let { presentation = 'card' } = options;
@@ -197,6 +198,7 @@ const SceneView = ({
       statusBarAnimation={statusBarAnimation}
       statusBarHidden={statusBarHidden}
       statusBarStyle={statusBarStyle}
+      transitionDuration={transitionDuration}
       onWillDisappear={onWillDisappear}
       onAppear={onAppear}
       onDisappear={onDisappear}


### PR DESCRIPTION
**Motivation**

`react-native-screens` support [transition duration](https://github.com/software-mansion/react-native-screens/pull/1259) for native stack navigator since [v3.11.0](https://github.com/software-mansion/react-native-screens/releases/tag/3.11.0) but it's simply not passed as an option to it in `react-navigation`. At this moment it works only on iOS.

**Test plan**

```
const screenOptions = {
  transitionDuration: 2000,
  animation: 'simple_push',
};

export const MainSubStackScreen = () => {
  return (
    <Stack.Navigator screenOptions={screenOptions}>
      <Stack.Screen name={'TestComponentScreen'} component={TestComponentScreen} />
      <Stack.Screen
        name={"SecondComponentScreen"}
        component={SecondComponentScreen}
      />
    </Stack.Navigator>
  );
};
```

Code doesn't pass TS tests due to availability of this property starting from `v3.11.0`, I'm not sure whether it's good to raise a minimum version or not just for a single property