### PR TITLE
Fix potential prototype pollution attacks

### DIFF
--- a/packages/core/src/useEventEmitter.tsx
+++ b/packages/core/src/useEventEmitter.tsx
@@ -21,7 +21,9 @@ export default function useEventEmitter<T extends Record<string, any>>(
     listenRef.current = listen;
   });
 
-  const listeners = React.useRef<Record<string, Record<string, Listeners>>>({});
+  const listeners = React.useRef<Record<string, Record<string, Listeners>>>(
+    Object.create(null)
+  );
 
   const create = React.useCallback((target: string) => {
     const removeListener = (type: string, callback: (data: any) => void) => {

--- a/packages/core/src/useKeyedChildListeners.tsx
+++ b/packages/core/src/useKeyedChildListeners.tsx
@@ -11,10 +11,12 @@ export default function useKeyedChildListeners() {
       string,
       KeyedListenerMap[K] | undefined
     >;
-  }>({
-    getState: {},
-    beforeRemove: {},
-  });
+  }>(
+    Object.assign(Object.create(null), {
+      getState: {},
+      beforeRemove: {},
+    })
+  );
 
   const addKeyedListener = React.useCallback(
     <T extends keyof KeyedListenerMap>(


### PR DESCRIPTION
Prevent event listeners of type `"__proto__"` to pollute the global Object prototype. This is fixed by creating objects with null prototype so they don't have a `__proto__` property.

**Motivation**

I found a potential [prototype pollution vulnerability](https://raw.githubusercontent.com/HoLyVieR/prototype-pollution-nsec18/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf) while reading the code of the package. I'm not sure if it has any security impact, but I think it's better to fix it anyway.

Please let me know if you need more information about this type of vulnerability and why this change is important.

**Test plan**

I tested that the changes compile ok. Also checked that no property of the Object prototype (such as `toString()` of `hasOwnProperty()`) is being accessed on the affected objects, since this change will set them to undefined.
