### PR TITLE
feat: add an ID prop to navigators

### DIFF
--- a/example/types.check.tsx
+++ b/example/types.check.tsx
@@ -27,7 +27,7 @@ type HomeDrawerParamList = {
 
 type HomeDrawerScreenProps<T extends keyof HomeDrawerParamList> =
   CompositeScreenProps<
-    DrawerScreenProps<HomeDrawerParamList, T>,
+    DrawerScreenProps<HomeDrawerParamList, T, 'LeftDrawer'>,
     RootStackScreenProps<keyof RootStackParamList>
   >;
 
@@ -38,7 +38,7 @@ type FeedTabParamList = {
 
 type FeedTabScreenProps<T extends keyof FeedTabParamList> =
   CompositeScreenProps<
-    BottomTabScreenProps<FeedTabParamList, T>,
+    BottomTabScreenProps<FeedTabParamList, T, 'BottomTabs'>,
     HomeDrawerScreenProps<keyof HomeDrawerParamList>
   >;
 
@@ -95,6 +95,7 @@ export const PostDetailsScreen = ({
   });
 
   expectTypeOf(navigation.getState().type).toEqualTypeOf<'stack'>();
+  expectTypeOf(navigation.getParent).parameter(0).toEqualTypeOf<undefined>();
 };
 
 export const FeedScreen = ({
@@ -124,6 +125,9 @@ export const FeedScreen = ({
     >();
 
   expectTypeOf(navigation.getState().type).toEqualTypeOf<'drawer'>();
+  expectTypeOf(navigation.getParent)
+    .parameter(0)
+    .toEqualTypeOf<'LeftDrawer' | undefined>();
 };
 
 export const PopularScreen = ({
@@ -153,4 +157,7 @@ export const PopularScreen = ({
     >();
 
   expectTypeOf(navigation.getState().type).toEqualTypeOf<'tab'>();
+  expectTypeOf(navigation.getParent)
+    .parameter(0)
+    .toEqualTypeOf<'LeftDrawer' | 'BottomTabs' | undefined>();
 };

--- a/package.json
+++ b/package.json
@@ -36,8 +36,7 @@
     "react": "17.0.1",
     "react-dom": "17.0.1",
     "react-native": "0.64.3",
-    "react-native-web": "~0.17.1",
-    "tsd": "^0.19.1"
+    "react-native-web": "~0.17.1"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",

--- a/packages/bottom-tabs/src/navigators/createBottomTabNavigator.tsx
+++ b/packages/bottom-tabs/src/navigators/createBottomTabNavigator.tsx
@@ -28,6 +28,7 @@ type Props = DefaultNavigatorOptions<
   BottomTabNavigationConfig;
 
 function BottomTabNavigator({
+  id,
   initialRouteName,
   backBehavior,
   children,
@@ -103,6 +104,7 @@ function BottomTabNavigator({
       BottomTabNavigationOptions,
       BottomTabNavigationEventMap
     >(TabRouter, {
+      id,
       initialRouteName,
       backBehavior,
       children,

--- a/packages/bottom-tabs/src/types.tsx
+++ b/packages/bottom-tabs/src/types.tsx
@@ -42,10 +42,12 @@ export type BottomTabNavigationHelpers = NavigationHelpers<
 
 export type BottomTabNavigationProp<
   ParamList extends ParamListBase,
-  RouteName extends keyof ParamList = keyof ParamList
+  RouteName extends keyof ParamList = keyof ParamList,
+  NavigatorID extends string | undefined = undefined
 > = NavigationProp<
   ParamList,
   RouteName,
+  NavigatorID,
   TabNavigationState<ParamList>,
   BottomTabNavigationOptions,
   BottomTabNavigationEventMap
@@ -54,9 +56,10 @@ export type BottomTabNavigationProp<
 
 export type BottomTabScreenProps<
   ParamList extends ParamListBase,
-  RouteName extends keyof ParamList = keyof ParamList
+  RouteName extends keyof ParamList = keyof ParamList,
+  NavigatorID extends string | undefined = undefined
 > = {
-  navigation: BottomTabNavigationProp<ParamList, RouteName>;
+  navigation: BottomTabNavigationProp<ParamList, RouteName, NavigatorID>;
   route: RouteProp<ParamList, RouteName>;
 };
 

--- a/packages/core/src/SceneView.tsx
+++ b/packages/core/src/SceneView.tsx
@@ -14,7 +14,13 @@ import useOptionsGetters from './useOptionsGetters';
 
 type Props<State extends NavigationState, ScreenOptions extends {}> = {
   screen: RouteConfigComponent<ParamListBase, string> & { name: string };
-  navigation: NavigationProp<ParamListBase, string, State, ScreenOptions>;
+  navigation: NavigationProp<
+    ParamListBase,
+    string,
+    string | undefined,
+    State,
+    ScreenOptions
+  >;
   route: Route<string>;
   routeState: NavigationState | PartialState<NavigationState> | undefined;
   getState: () => State;

--- a/packages/core/src/__tests__/index.test.tsx
+++ b/packages/core/src/__tests__/index.test.tsx
@@ -1344,6 +1344,164 @@ it('resets state of a nested child in a navigator', () => {
   });
 });
 
+it('gets immediate parent with getParent()', () => {
+  const TestNavigator = (props: any): any => {
+    const { state, descriptors } = useNavigationBuilder(MockRouter, props);
+
+    return descriptors[state.routes[state.index].key].render();
+  };
+
+  const TestComponent = ({ route, navigation }: any): any =>
+    `${route.name} [${navigation
+      .getParent()
+      .getState()
+      .routes.map((r: any) => r.name)
+      .join()}]`;
+
+  const onStateChange = jest.fn();
+
+  const element = render(
+    <BaseNavigationContainer onStateChange={onStateChange}>
+      <TestNavigator>
+        <Screen name="foo">
+          {() => (
+            <TestNavigator>
+              <Screen name="foo-a">
+                {() => (
+                  <TestNavigator>
+                    <Screen name="bar" component={TestComponent} />
+                  </TestNavigator>
+                )}
+              </Screen>
+            </TestNavigator>
+          )}
+        </Screen>
+      </TestNavigator>
+    </BaseNavigationContainer>
+  );
+
+  expect(element).toMatchInlineSnapshot(`"bar [foo-a]"`);
+});
+
+it('gets parent with a ID with getParent(id)', () => {
+  const TestNavigator = (props: any): any => {
+    const { state, descriptors } = useNavigationBuilder(MockRouter, props);
+
+    return descriptors[state.routes[state.index].key].render();
+  };
+
+  const TestComponent = ({ route, navigation }: any): any =>
+    `${route.name} [${navigation
+      .getParent('Test')
+      .getState()
+      .routes.map((r: any) => r.name)
+      .join()}]`;
+
+  const onStateChange = jest.fn();
+
+  const element = render(
+    <BaseNavigationContainer onStateChange={onStateChange}>
+      <TestNavigator id="Test">
+        <Screen name="foo">
+          {() => (
+            <TestNavigator>
+              <Screen name="foo-a">
+                {() => (
+                  <TestNavigator>
+                    <Screen name="bar" component={TestComponent} />
+                  </TestNavigator>
+                )}
+              </Screen>
+            </TestNavigator>
+          )}
+        </Screen>
+      </TestNavigator>
+    </BaseNavigationContainer>
+  );
+
+  expect(element).toMatchInlineSnapshot(`"bar [foo]"`);
+});
+
+it('gets self with a ID with getParent(id)', () => {
+  const TestNavigator = (props: any): any => {
+    const { state, descriptors } = useNavigationBuilder(MockRouter, props);
+
+    return descriptors[state.routes[state.index].key].render();
+  };
+
+  const TestComponent = ({ route, navigation }: any): any =>
+    `${route.name} [${navigation
+      .getParent('Test')
+      .getState()
+      .routes.map((r: any) => r.name)
+      .join()}]`;
+
+  const onStateChange = jest.fn();
+
+  const element = render(
+    <BaseNavigationContainer onStateChange={onStateChange}>
+      <TestNavigator>
+        <Screen name="foo">
+          {() => (
+            <TestNavigator>
+              <Screen name="foo-a">
+                {() => (
+                  <TestNavigator id="Test">
+                    <Screen name="bar" component={TestComponent} />
+                  </TestNavigator>
+                )}
+              </Screen>
+            </TestNavigator>
+          )}
+        </Screen>
+      </TestNavigator>
+    </BaseNavigationContainer>
+  );
+
+  expect(element).toMatchInlineSnapshot(`"bar [bar]"`);
+});
+
+it('throws when ID is not found with getParent(id)', () => {
+  const TestNavigator = (props: any): any => {
+    const { state, descriptors } = useNavigationBuilder(MockRouter, props);
+
+    return descriptors[state.routes[state.index].key].render();
+  };
+
+  const TestComponent = ({ route, navigation }: any): any =>
+    `${route.name} [${navigation
+      .getParent('Tes')
+      .getState()
+      .routes.map((r: any) => r.name)
+      .join()}]`;
+
+  const onStateChange = jest.fn();
+
+  const element = (
+    <BaseNavigationContainer onStateChange={onStateChange}>
+      <TestNavigator>
+        <Screen name="foo">
+          {() => (
+            <TestNavigator id="Test">
+              <Screen name="foo-a">
+                {() => (
+                  <TestNavigator>
+                    <Screen name="bar" component={TestComponent} />
+                  </TestNavigator>
+                )}
+              </Screen>
+            </TestNavigator>
+          )}
+        </Screen>
+      </TestNavigator>
+    </BaseNavigationContainer>
+  );
+
+  expect(() => render(element)).toThrowError(
+    `Couldn't find a parent navigator with the ID "Tes". Is this navigator nested under another navigator with this ID?`
+  );
+});
+
 it('gives access to internal state', () => {
   const TestNavigator = (props: any): any => {
     const { state, descriptors } = useNavigationBuilder(MockRouter, props);

--- a/packages/core/src/useDescriptors.tsx
+++ b/packages/core/src/useDescriptors.tsx
@@ -143,7 +143,14 @@ export default function useDescriptors<
       string,
       Descriptor<
         ScreenOptions,
-        NavigationProp<ParamListBase, string, State, ScreenOptions, EventMap> &
+        NavigationProp<
+          ParamListBase,
+          string,
+          string | undefined,
+          State,
+          ScreenOptions,
+          EventMap
+        > &
           ActionHelpers,
         RouteProp<ParamListBase>
       >

--- a/packages/core/src/useNavigationBuilder.tsx
+++ b/packages/core/src/useNavigationBuilder.tsx
@@ -645,6 +645,7 @@ export default function useNavigationBuilder<
     NavigationAction,
     EventMap
   >({
+    id: options.id,
     onAction,
     getState,
     emitter,

--- a/packages/core/src/useNavigationCache.tsx
+++ b/packages/core/src/useNavigationCache.tsx
@@ -32,7 +32,14 @@ type NavigationCache<
   EventMap extends Record<string, any>
 > = Record<
   string,
-  NavigationProp<ParamListBase, string, State, ScreenOptions, EventMap>
+  NavigationProp<
+    ParamListBase,
+    string,
+    string | undefined,
+    State,
+    ScreenOptions,
+    EventMap
+  >
 >;
 
 /**
@@ -133,6 +140,15 @@ export default function useNavigationCache<
         // FIXME: too much work to fix the types for now
         ...(emitter.create(route.key) as any),
         dispatch: (thunk: Thunk) => withStack(() => dispatch(thunk)),
+        getParent: (id?: string) => {
+          if (id !== undefined && id === rest.getId()) {
+            // If the passed id is the same as the current navigation id,
+            // we return the cached navigation object for the relevant route
+            return acc[route.key];
+          }
+
+          return rest.getParent(id);
+        },
         setOptions: (options: object) =>
           setOptions((o) => ({
             ...o,

--- a/packages/core/src/useNavigationHelpers.tsx
+++ b/packages/core/src/useNavigationHelpers.tsx
@@ -8,7 +8,7 @@ import {
 import * as React from 'react';
 
 import NavigationContext from './NavigationContext';
-import { NavigationHelpers, NavigationProp, PrivateValueStore } from './types';
+import { NavigationHelpers, PrivateValueStore } from './types';
 import UnhandledActionContext from './UnhandledActionContext';
 import type { NavigationEventEmitter } from './useEventEmitter';
 
@@ -17,6 +17,7 @@ import type { NavigationEventEmitter } from './useEventEmitter';
 PrivateValueStore;
 
 type Options<State extends NavigationState, Action extends NavigationAction> = {
+  id: string | undefined;
   onAction: (action: NavigationAction) => boolean;
   getState: () => State;
   emitter: NavigationEventEmitter<any>;
@@ -32,7 +33,13 @@ export default function useNavigationHelpers<
   ActionHelpers extends Record<string, () => void>,
   Action extends NavigationAction,
   EventMap extends Record<string, any>
->({ onAction, getState, emitter, router }: Options<State, Action>) {
+>({
+  id: navigatorId,
+  onAction,
+  getState,
+  emitter,
+  router,
+}: Options<State, Action>) {
   const onUnhandledAction = React.useContext(UnhandledActionContext);
   const parentNavigationHelpers = React.useContext(NavigationContext);
 
@@ -52,16 +59,13 @@ export default function useNavigationHelpers<
       ...CommonActions,
     };
 
-    const helpers = Object.keys(actions).reduce<Record<string, () => void>>(
-      (acc, name) => {
-        // @ts-expect-error: name is a valid key, but TypeScript is dumb
-        acc[name] = (...args: any) => dispatch(actions[name](...args));
-        return acc;
-      },
-      {}
-    );
+    const helpers = Object.keys(actions).reduce((acc, name) => {
+      // @ts-expect-error: name is a valid key, but TypeScript is dumb
+      acc[name] = (...args: any) => dispatch(actions[name](...args));
+      return acc;
+    }, {} as ActionHelpers);
 
-    return {
+    const navigationHelpers = {
       ...parentNavigationHelpers,
       ...helpers,
       dispatch,
@@ -82,12 +86,32 @@ export default function useNavigationHelpers<
           false
         );
       },
-      getParent: () => parentNavigationHelpers as any,
+      getId: () => navigatorId,
+      getParent: (id?: string) => {
+        if (id !== undefined) {
+          let current = navigationHelpers;
+
+          while (current && id !== current.getId()) {
+            current = current.getParent();
+          }
+
+          if (current == null) {
+            throw new Error(
+              `Couldn't find a parent navigator with the ID "${id}". Is this navigator nested under another navigator with this ID?`
+            );
+          }
+
+          return current;
+        }
+
+        return parentNavigationHelpers;
+      },
       getState,
-    } as NavigationHelpers<ParamListBase, EventMap> &
-      (NavigationProp<ParamListBase, string, any, any, any> | undefined) &
-      ActionHelpers;
+    } as NavigationHelpers<ParamListBase, EventMap> & ActionHelpers;
+
+    return navigationHelpers;
   }, [
+    navigatorId,
     emitter.emit,
     getState,
     onAction,

--- a/packages/drawer/src/navigators/createDrawerNavigator.tsx
+++ b/packages/drawer/src/navigators/createDrawerNavigator.tsx
@@ -29,6 +29,7 @@ type Props = DefaultNavigatorOptions<
   DrawerNavigationConfig;
 
 function DrawerNavigator({
+  id,
   initialRouteName,
   defaultStatus: customDefaultStatus,
   backBehavior,
@@ -112,6 +113,7 @@ function DrawerNavigator({
       DrawerNavigationOptions,
       DrawerNavigationEventMap
     >(DrawerRouter, {
+      id,
       initialRouteName,
       defaultStatus,
       backBehavior,

--- a/packages/drawer/src/types.tsx
+++ b/packages/drawer/src/types.tsx
@@ -253,10 +253,12 @@ export type DrawerNavigationHelpers = NavigationHelpers<
 
 export type DrawerNavigationProp<
   ParamList extends ParamListBase,
-  RouteName extends keyof ParamList = keyof ParamList
+  RouteName extends keyof ParamList = keyof ParamList,
+  NavigatorID extends string | undefined = undefined
 > = NavigationProp<
   ParamList,
   RouteName,
+  NavigatorID,
   DrawerNavigationState<ParamList>,
   DrawerNavigationOptions,
   DrawerNavigationEventMap
@@ -265,9 +267,10 @@ export type DrawerNavigationProp<
 
 export type DrawerScreenProps<
   ParamList extends ParamListBase,
-  RouteName extends keyof ParamList = keyof ParamList
+  RouteName extends keyof ParamList = keyof ParamList,
+  NavigatorID extends string | undefined = undefined
 > = {
-  navigation: DrawerNavigationProp<ParamList, RouteName>;
+  navigation: DrawerNavigationProp<ParamList, RouteName, NavigatorID>;
   route: RouteProp<ParamList, RouteName>;
 };
 

--- a/packages/material-bottom-tabs/src/navigators/createMaterialBottomTabNavigator.tsx
+++ b/packages/material-bottom-tabs/src/navigators/createMaterialBottomTabNavigator.tsx
@@ -27,6 +27,7 @@ type Props = DefaultNavigatorOptions<
   MaterialBottomTabNavigationConfig;
 
 function MaterialBottomTabNavigator({
+  id,
   initialRouteName,
   backBehavior,
   children,
@@ -42,6 +43,7 @@ function MaterialBottomTabNavigator({
       MaterialBottomTabNavigationOptions,
       MaterialBottomTabNavigationEventMap
     >(TabRouter, {
+      id,
       initialRouteName,
       backBehavior,
       children,

--- a/packages/material-bottom-tabs/src/types.tsx
+++ b/packages/material-bottom-tabs/src/types.tsx
@@ -24,10 +24,12 @@ export type MaterialBottomTabNavigationHelpers = NavigationHelpers<
 
 export type MaterialBottomTabNavigationProp<
   ParamList extends ParamListBase,
-  RouteName extends keyof ParamList = keyof ParamList
+  RouteName extends keyof ParamList = keyof ParamList,
+  NavigatorID extends string | undefined = undefined
 > = NavigationProp<
   ParamList,
   RouteName,
+  NavigatorID,
   TabNavigationState<ParamList>,
   MaterialBottomTabNavigationOptions,
   MaterialBottomTabNavigationEventMap
@@ -36,9 +38,14 @@ export type MaterialBottomTabNavigationProp<
 
 export type MaterialBottomTabScreenProps<
   ParamList extends ParamListBase,
-  RouteName extends keyof ParamList = keyof ParamList
+  RouteName extends keyof ParamList = keyof ParamList,
+  NavigatorID extends string | undefined = undefined
 > = {
-  navigation: MaterialBottomTabNavigationProp<ParamList, RouteName>;
+  navigation: MaterialBottomTabNavigationProp<
+    ParamList,
+    RouteName,
+    NavigatorID
+  >;
   route: RouteProp<ParamList, RouteName>;
 };
 

--- a/packages/material-top-tabs/src/navigators/createMaterialTopTabNavigator.tsx
+++ b/packages/material-top-tabs/src/navigators/createMaterialTopTabNavigator.tsx
@@ -28,6 +28,7 @@ type Props = DefaultNavigatorOptions<
   MaterialTopTabNavigationConfig;
 
 function MaterialTopTabNavigator({
+  id,
   initialRouteName,
   backBehavior,
   children,
@@ -121,6 +122,7 @@ function MaterialTopTabNavigator({
       MaterialTopTabNavigationOptions,
       MaterialTopTabNavigationEventMap
     >(TabRouter, {
+      id,
       initialRouteName,
       backBehavior,
       children,

--- a/packages/material-top-tabs/src/types.tsx
+++ b/packages/material-top-tabs/src/types.tsx
@@ -43,10 +43,12 @@ export type MaterialTopTabNavigationHelpers = NavigationHelpers<
 
 export type MaterialTopTabNavigationProp<
   ParamList extends ParamListBase,
-  RouteName extends keyof ParamList = keyof ParamList
+  RouteName extends keyof ParamList = keyof ParamList,
+  NavigatorID extends string | undefined = undefined
 > = NavigationProp<
   ParamList,
   RouteName,
+  NavigatorID,
   TabNavigationState<ParamList>,
   MaterialTopTabNavigationOptions,
   MaterialTopTabNavigationEventMap
@@ -55,9 +57,10 @@ export type MaterialTopTabNavigationProp<
 
 export type MaterialTopTabScreenProps<
   ParamList extends ParamListBase,
-  RouteName extends keyof ParamList = keyof ParamList
+  RouteName extends keyof ParamList = keyof ParamList,
+  NavigatorID extends string | undefined = undefined
 > = {
-  navigation: MaterialTopTabNavigationProp<ParamList, RouteName>;
+  navigation: MaterialTopTabNavigationProp<ParamList, RouteName, NavigatorID>;
   route: RouteProp<ParamList, RouteName>;
 };
 

--- a/packages/native-stack/src/navigators/createNativeStackNavigator.tsx
+++ b/packages/native-stack/src/navigators/createNativeStackNavigator.tsx
@@ -19,6 +19,7 @@ import type {
 import NativeStackView from '../views/NativeStackView';
 
 function NativeStackNavigator({
+  id,
   initialRouteName,
   children,
   screenListeners,
@@ -33,6 +34,7 @@ function NativeStackNavigator({
       NativeStackNavigationOptions,
       NativeStackNavigationEventMap
     >(StackRouter, {
+      id,
       initialRouteName,
       children,
       screenListeners,
@@ -41,6 +43,7 @@ function NativeStackNavigator({
 
   React.useEffect(
     () =>
+      // @ts-expect-error: there may not be a tab navigator in parent
       navigation?.addListener?.('tabPress', (e: any) => {
         const isFocused = navigation.isFocused();
 

--- a/packages/native-stack/src/types.tsx
+++ b/packages/native-stack/src/types.tsx
@@ -35,10 +35,12 @@ export type NativeStackNavigationEventMap = {
 
 export type NativeStackNavigationProp<
   ParamList extends ParamListBase,
-  RouteName extends keyof ParamList = string
+  RouteName extends keyof ParamList = string,
+  NavigatorID extends string | undefined = undefined
 > = NavigationProp<
   ParamList,
   RouteName,
+  NavigatorID,
   StackNavigationState<ParamList>,
   NativeStackNavigationOptions,
   NativeStackNavigationEventMap
@@ -47,9 +49,10 @@ export type NativeStackNavigationProp<
 
 export type NativeStackScreenProps<
   ParamList extends ParamListBase,
-  RouteName extends keyof ParamList = string
+  RouteName extends keyof ParamList = string,
+  NavigatorID extends string | undefined = undefined
 > = {
-  navigation: NativeStackNavigationProp<ParamList, RouteName>;
+  navigation: NativeStackNavigationProp<ParamList, RouteName, NavigatorID>;
   route: RouteProp<ParamList, RouteName>;
 };
 

--- a/packages/stack/src/navigators/createStackNavigator.tsx
+++ b/packages/stack/src/navigators/createStackNavigator.tsx
@@ -31,6 +31,7 @@ type Props = DefaultNavigatorOptions<
   StackNavigationConfig;
 
 function StackNavigator({
+  id,
   initialRouteName,
   children,
   screenListeners,
@@ -81,6 +82,7 @@ function StackNavigator({
       StackNavigationOptions,
       StackNavigationEventMap
     >(StackRouter, {
+      id,
       initialRouteName,
       children,
       screenListeners,
@@ -90,6 +92,7 @@ function StackNavigator({
 
   React.useEffect(
     () =>
+      // @ts-expect-error: there may not be a tab navigator in parent
       navigation.addListener?.('tabPress', (e) => {
         const isFocused = navigation.isFocused();
 
@@ -99,7 +102,7 @@ function StackNavigator({
           if (
             state.index > 0 &&
             isFocused &&
-            !(e as EventArg<'tabPress', true>).defaultPrevented
+            !(e as unknown as EventArg<'tabPress', true>).defaultPrevented
           ) {
             // When user taps on already focused tab and we're inside the tab,
             // reset the stack to replicate native behaviour

--- a/packages/stack/src/types.tsx
+++ b/packages/stack/src/types.tsx
@@ -49,10 +49,12 @@ export type StackNavigationHelpers = NavigationHelpers<
 
 export type StackNavigationProp<
   ParamList extends ParamListBase,
-  RouteName extends keyof ParamList = keyof ParamList
+  RouteName extends keyof ParamList = keyof ParamList,
+  NavigatorID extends string | undefined = undefined
 > = NavigationProp<
   ParamList,
   RouteName,
+  NavigatorID,
   StackNavigationState<ParamList>,
   StackNavigationOptions,
   StackNavigationEventMap
@@ -61,9 +63,10 @@ export type StackNavigationProp<
 
 export type StackScreenProps<
   ParamList extends ParamListBase,
-  RouteName extends keyof ParamList = keyof ParamList
+  RouteName extends keyof ParamList = keyof ParamList,
+  NavigatorID extends string | undefined = undefined
 > = {
-  navigation: StackNavigationProp<ParamList, RouteName>;
+  navigation: StackNavigationProp<ParamList, RouteName, NavigatorID>;
   route: RouteProp<ParamList, RouteName>;
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3970,11 +3970,6 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
-"@tsd/typescript@~4.5.2":
-  version "4.5.5"
-  resolved "https://registry.yarnpkg.com/@tsd/typescript/-/typescript-4.5.5.tgz#23fc27852d53987c4ba83bd3a9c1a6a24e957764"
-  integrity sha512-TxQ9QiUT94ZjKu++ta/iwTMVHsix4ApohnaHPTSd58WQuTjPIELP0tUYcW7lT6psz7yZiU4eRw+X4v/XV830Sw==
-
 "@types/accepts@*":
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/@types/accepts/-/accepts-1.3.5.tgz#c34bec115cfc746e04fe5a059df4ce7e7b391575"
@@ -4100,19 +4095,6 @@
   resolved "https://registry.yarnpkg.com/@types/deep-equal/-/deep-equal-1.0.1.tgz#71cfabb247c22bcc16d536111f50c0ed12476b03"
   integrity sha512-mMUu4nWHLBlHtxXY17Fg6+ucS/MnndyOWyOe7MmwkoMYxvfQU2ajtRaEvqSUv+aVkMqH/C0NCI8UoVfRNQ10yg==
 
-"@types/eslint@^7.2.13":
-  version "7.29.0"
-  resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-7.29.0.tgz#e56ddc8e542815272720bb0b4ccc2aff9c3e1c78"
-  integrity sha512-VNcvioYDH8/FxaeTKkM4/TiTwt6pBV9E3OfGmvaw8tPl0rrHCJ4Ll15HRT+pMiFAf/MLQvAzC+6RzUMEL9Ceng==
-  dependencies:
-    "@types/estree" "*"
-    "@types/json-schema" "*"
-
-"@types/estree@*":
-  version "0.0.51"
-  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.51.tgz#cfd70924a25a3fd32b218e5e420e6897e1ac4f40"
-  integrity sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==
-
 "@types/express-serve-static-core@^4.17.18":
   version "4.17.28"
   resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz#c47def9f34ec81dc6328d0b1b5303d1ec98d86b8"
@@ -4233,11 +4215,6 @@
   dependencies:
     jest-diff "^26.0.0"
     pretty-format "^26.0.0"
-
-"@types/json-schema@*":
-  version "7.0.11"
-  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
-  integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
 
 "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.7", "@types/json-schema@^7.0.8":
   version "7.0.9"
@@ -8698,20 +8675,6 @@ eslint-config-satya164@^3.1.10:
     eslint-plugin-react-hooks "^4.2.0"
     eslint-plugin-react-native "^3.10.0"
 
-eslint-formatter-pretty@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-formatter-pretty/-/eslint-formatter-pretty-4.1.0.tgz#7a6877c14ffe2672066c853587d89603e97c7708"
-  integrity sha512-IsUTtGxF1hrH6lMWiSl1WbGaiP01eT6kzywdY1U+zLc0MP+nwEnUiS9UI8IaOTUhTeQJLlCEWIbXINBH4YJbBQ==
-  dependencies:
-    "@types/eslint" "^7.2.13"
-    ansi-escapes "^4.2.1"
-    chalk "^4.1.0"
-    eslint-rule-docs "^1.1.5"
-    log-symbols "^4.0.0"
-    plur "^4.0.0"
-    string-width "^4.2.0"
-    supports-hyperlinks "^2.0.0"
-
 eslint-import-resolver-node@^0.3.6:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz#4048b958395da89668252001dbd9eca6b83bacbd"
@@ -8831,11 +8794,6 @@ eslint-rule-composer@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz#79320c927b0c5c0d3d3d2b76c8b4a488f25bbaf9"
   integrity sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==
-
-eslint-rule-docs@^1.1.5:
-  version "1.1.231"
-  resolved "https://registry.yarnpkg.com/eslint-rule-docs/-/eslint-rule-docs-1.1.231.tgz#648b978bc5a1bb740be5f28d07470f0926b9cdf1"
-  integrity sha512-egHz9A1WG7b8CS0x1P6P/Rj5FqZOjray/VjpJa14tMZalfRKvpE2ONJ3plCM7+PcinmU4tcmbPLv0VtwzSdLVA==
 
 eslint-scope@^4.0.3:
   version "4.0.3"
@@ -11485,11 +11443,6 @@ ipaddr.js@1.9.1, ipaddr.js@^1.9.0:
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"
   integrity sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==
 
-irregular-plurals@^3.2.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/irregular-plurals/-/irregular-plurals-3.3.0.tgz#67d0715d4361a60d9fd9ee80af3881c631a31ee2"
-  integrity sha512-MVBLKUTangM3EfRPFROhmWQQKRDsrgI83J8GS3jXy+OwYqiR2/aoWndYQ5416jLE3uaGgLH7ncme3X9y09gZ3g==
-
 is-absolute-url@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-absolute-url/-/is-absolute-url-2.1.0.tgz#50530dfb84fcc9aa7dbe7852e83a37b93b9f2aa6"
@@ -13410,7 +13363,7 @@ log-symbols@^2.2.0:
   dependencies:
     chalk "^2.0.1"
 
-log-symbols@^4.0.0, log-symbols@^4.1.0:
+log-symbols@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-4.1.0.tgz#3fbdbb95b4683ac9fc785111e792e558d4abd503"
   integrity sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==
@@ -13728,24 +13681,6 @@ meow@^8.0.0:
   dependencies:
     "@types/minimist" "^1.2.0"
     camelcase-keys "^6.2.2"
-    decamelize-keys "^1.1.0"
-    hard-rejection "^2.1.0"
-    minimist-options "4.1.0"
-    normalize-package-data "^3.0.0"
-    read-pkg-up "^7.0.1"
-    redent "^3.0.0"
-    trim-newlines "^3.0.0"
-    type-fest "^0.18.0"
-    yargs-parser "^20.2.3"
-
-meow@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/meow/-/meow-9.0.0.tgz#cd9510bc5cac9dee7d03c73ee1f9ad959f4ea364"
-  integrity sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==
-  dependencies:
-    "@types/minimist" "^1.2.0"
-    camelcase-keys "^6.2.2"
-    decamelize "^1.2.0"
     decamelize-keys "^1.1.0"
     hard-rejection "^2.1.0"
     minimist-options "4.1.0"
@@ -16132,13 +16067,6 @@ plist@^3.0.1, plist@^3.0.4:
     base64-js "^1.5.1"
     xmlbuilder "^9.0.7"
 
-plur@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/plur/-/plur-4.0.0.tgz#729aedb08f452645fe8c58ef115bf16b0a73ef84"
-  integrity sha512-4UGewrYgqDFw9vV6zNV+ADmPAUAfJPKtGvb/VdpQAx25X5f3xXdGdyOEVFwkl8Hl/tl7+xbeHqSEM+D5/TirUg==
-  dependencies:
-    irregular-plurals "^3.2.0"
-
 pngjs@3.4.0, pngjs@^3.0.0, pngjs@^3.3.0, pngjs@^3.3.3:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/pngjs/-/pngjs-3.4.0.tgz#99ca7d725965fb655814eaf65f38f12bbdbf555f"
@@ -17944,7 +17872,7 @@ read-pkg-up@^3.0.0:
     find-up "^2.0.0"
     read-pkg "^3.0.0"
 
-read-pkg-up@^7.0.0, read-pkg-up@^7.0.1:
+read-pkg-up@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-7.0.1.tgz#f3a6135758459733ae2b95638056e1854e7ef507"
   integrity sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==
@@ -20227,18 +20155,6 @@ tsconfig-paths@^3.12.0:
     json5 "^1.0.1"
     minimist "^1.2.0"
     strip-bom "^3.0.0"
-
-tsd@^0.19.1:
-  version "0.19.1"
-  resolved "https://registry.yarnpkg.com/tsd/-/tsd-0.19.1.tgz#c37891ad907d6ce2122e4a20c99cceca5767d713"
-  integrity sha512-pSwchclr+ADdxlahRUQXUrdAIOjXx1T1PQV+fLfVLuo/S4z+T00YU84fH8iPlZxyA2pWgJjo42BG1p9SDb4NOw==
-  dependencies:
-    "@tsd/typescript" "~4.5.2"
-    eslint-formatter-pretty "^4.1.0"
-    globby "^11.0.1"
-    meow "^9.0.0"
-    path-exists "^4.0.0"
-    read-pkg-up "^7.0.0"
 
 tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.14.1"


### PR DESCRIPTION
When we have nested navigators, we often may want control over which navigator should handle an action that we dispatch. This is often handled automatically, e.g. if you navigate to a screen named `Settings`, the navigator which contains the `Settings` screen will handle the action. But in some cases, it's not possible to figure out the navigator automatically.

Some example cases:

We may want to have nested drawers to have a drawer on the left, and one on the right - and still be able to open/close them. We can use `getParent` to achieve this:

```js
navigation.getParent().openDrawer();
```

However, this is prone to error if we nest another navigator inside (e.g. a stack). So we need a way to distinguish between which drawer we want to target.

An alternative way to distinguish different navigators is to specify the `key` of the navigator in the `target` field of the action:

```js
navigation.dispatch({
  ...DrawerActions.openDrawer(),
  target: 'keyOfTheDrawer',
});
```

However, this has a few problems:

- It's not straightforward to get the `key` of the navigator since the `key` is generated by React Navigation.
- It's not type-safe. Nothing ensures that the `key` is valid.

We may also want to call `setOptions` on a parent navigator. The options don't bubble up unlike the actions, so it's important make sure to call it for the correct navigator. We can use `getParent` in this case as well, but it's prone to the same set of issues as the previous case.

There are also no alternatives for this unlike specifying `key` for actions.

This commit adds a `id` prop to navigators. Example:

```js
<Drawer.Navigator id="LeftDrawer">{/* ... */}</Drawer.Navigator>
```

Then we can use it along with `getParent` as follows:

```js
navigation.getParent('LeftDrawer').openDrawer();
```

No matter how many nested navigators are added, we can always find the correct navigator this way.

To make this work with type-checking, we'd pass a third generic to our `NavigationProp` or `ScreenProps` types:

```ts
type LeftDrawerScreenProps<T extends keyof LeftDrawerParamList> =
  DrawerScreenProps<LeftDrawerParamList, T, 'LeftDrawer'>;
```

This isn't the best way to do this, for example, the `id` prop on the navigator itself isn't type-safe. But supporting it with a good API is a lot of work, so for now, I've decided to go with this alternative approach.
