### PR TITLE
feat: add backgroundComponent prop to <Stack.Navigator>

### DIFF
--- a/packages/stack/src/types.tsx
+++ b/packages/stack/src/types.tsx
@@ -354,6 +354,10 @@ export type StackNavigationConfig = {
    * Defaults to `true`.
    */
   keyboardHandlingEnabled?: boolean;
+  /**
+   * Display a background component that can respond to touch events
+   */
+  backgroundComponent?: React.ReactNode;
 };
 
 export type StackHeaderLeftButtonProps = {

--- a/packages/stack/src/views/Stack/StackView.tsx
+++ b/packages/stack/src/views/Stack/StackView.tsx
@@ -437,6 +437,7 @@ export default class StackView extends React.Component<Props, State> {
         : 'screen',
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       descriptors: _,
+      backgroundComponent,
       ...rest
     } = this.props;
 
@@ -450,6 +451,7 @@ export default class StackView extends React.Component<Props, State> {
     return (
       <NavigationHelpersContext.Provider value={navigation}>
         <GestureHandlerWrapper style={styles.container}>
+          {backgroundComponent || null}
           <SafeAreaProviderCompat>
             <SafeAreaConsumer>
               {(insets) => (


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

**Motivation**

Hi there, so I was integrating a Unity view onto our app (https://github.com/azesmway/react-native-unity-play), unfortunately on Android the component seems to crash on mount/unmount so I have to find a way to keep the component always mounted on background. Just display an absolute view under <NavigationContainer /> wouldn't work, because then the absolute view doesn't receive touch inputs (not sure why). Hence the need to inject a backgroundComponent into the stack navigator.

**Test plan**

Tested & working on our app

**Code formatting**
