### PR TITLE
fix(bottom-tabs): pass `renderTouchable` to BottomNavigation

### DIFF
--- a/packages/material-bottom-tabs/src/views/MaterialBottomTabView.tsx
+++ b/packages/material-bottom-tabs/src/views/MaterialBottomTabView.tsx
@@ -155,7 +155,7 @@ function MaterialBottomTabViewInner({
                 />
               );
             }
-          : undefined
+          : rest.renderTouchable
       }
       renderIcon={({ route, focused, color }) => {
         const { options } = descriptors[route.key];


### PR DESCRIPTION
Fixes #10478

Please provide enough information so that others can review your pull request:

**Motivation**

In my case I want to be able to achieve an effect similar to the iOS Facebook app that renders a gradient on iOS when a tab is pressed.

Here's what this achieves:


https://user-images.githubusercontent.com/697707/161528224-16d02499-2d73-4c52-9f2e-288ff866f510.mov

Via code like:

```tsx
const renderTouchable = (props) => (
    <Pressable {...props} style={styles.flex}>
      {({pressed}) => {
        return (
          <LinearGradient
            colors={pressed ? BOTTOM_PRESSED_COLORS : BOTTOM_UNPRESSED_COLORS}
            start={{x: 0, y: 0}}
            end={{x: 0, y: 0.85}}
            style={styles.bottomGradient}
          >
            {props.children}
          </LinearGradient>
        );
      }}
    </Pressable>
  );

      <Tab.Navigator
        ...
        renderTouchable={Platform.OS === 'ios' ? renderTouchable : undefined}
      >
```