### PR TITLE
fix: wrong setParams type if route does not have params

### DIFF
--- a/example/types.check.tsx
+++ b/example/types.check.tsx
@@ -1,9 +1,16 @@
-import type { BottomTabScreenProps } from '@react-navigation/bottom-tabs';
-import type { DrawerScreenProps } from '@react-navigation/drawer';
+import type {
+  BottomTabNavigationOptions,
+  BottomTabScreenProps,
+} from '@react-navigation/bottom-tabs';
+import type {
+  DrawerNavigationOptions,
+  DrawerScreenProps,
+} from '@react-navigation/drawer';
 import type {
   CompositeScreenProps,
   NavigatorScreenParams,
 } from '@react-navigation/native';
+import type { StackNavigationOptions } from '@react-navigation/stack';
 import {
   createStackNavigator,
   StackScreenProps,
@@ -70,10 +77,9 @@ export const PostDetailsScreen = ({
     .parameter(0)
     .toEqualTypeOf<keyof RootStackParamList>();
 
-  expectTypeOf(navigation.setOptions).parameter(0).toMatchTypeOf<{
-    title?: string;
-    headerShown?: boolean;
-  }>();
+  expectTypeOf(navigation.setOptions)
+    .parameter(0)
+    .toMatchTypeOf<StackNavigationOptions>();
 
   expectTypeOf(navigation.addListener)
     .parameter(0)
@@ -113,10 +119,12 @@ export const FeedScreen = ({
 
   expectTypeOf(navigation.openDrawer).toBeFunction();
 
-  expectTypeOf(navigation.setOptions).parameter(0).toMatchTypeOf<{
-    title?: string;
-    lazy?: boolean;
-  }>();
+  expectTypeOf(navigation.setOptions)
+    .parameter(0)
+    .toMatchTypeOf<StackNavigationOptions>();
+  expectTypeOf(navigation.setOptions)
+    .parameter(0)
+    .toMatchTypeOf<DrawerNavigationOptions>();
 
   expectTypeOf(navigation.addListener)
     .parameter(0)
@@ -145,16 +153,58 @@ export const PopularScreen = ({
 
   expectTypeOf(navigation.openDrawer).toBeFunction();
 
-  expectTypeOf(navigation.setOptions).parameter(0).toMatchTypeOf<{
-    title?: string;
-    taBarLabel?: string;
-  }>();
+  expectTypeOf(navigation.setOptions)
+    .parameter(0)
+    .toMatchTypeOf<StackNavigationOptions>();
+  expectTypeOf(navigation.setOptions)
+    .parameter(0)
+    .toMatchTypeOf<DrawerNavigationOptions>();
+  expectTypeOf(navigation.setOptions)
+    .parameter(0)
+    .toMatchTypeOf<BottomTabNavigationOptions>();
 
   expectTypeOf(navigation.addListener)
     .parameter(0)
     .toEqualTypeOf<
       'focus' | 'blur' | 'state' | 'beforeRemove' | 'tabPress' | 'tabLongPress'
     >();
+
+  expectTypeOf(navigation.setParams)
+    .parameter(0)
+    .toEqualTypeOf<Partial<FeedTabParamList['Popular']>>();
+
+  expectTypeOf(navigation.getState().type).toEqualTypeOf<'tab'>();
+  expectTypeOf(navigation.getParent)
+    .parameter(0)
+    .toEqualTypeOf<'LeftDrawer' | 'BottomTabs' | undefined>();
+};
+
+export const LatestScreen = ({
+  navigation,
+  route,
+}: FeedTabScreenProps<'Latest'>) => {
+  expectTypeOf(route.name).toEqualTypeOf<'Latest'>();
+
+  expectTypeOf(navigation.push)
+    .parameter(0)
+    .toEqualTypeOf<keyof RootStackParamList>();
+  expectTypeOf(navigation.jumpTo)
+    .parameter(0)
+    .toEqualTypeOf<keyof HomeDrawerParamList>();
+
+  expectTypeOf(navigation.openDrawer).toBeFunction();
+
+  expectTypeOf(navigation.setOptions)
+    .parameter(0)
+    .toMatchTypeOf<StackNavigationOptions>();
+  expectTypeOf(navigation.setOptions)
+    .parameter(0)
+    .toMatchTypeOf<DrawerNavigationOptions>();
+  expectTypeOf(navigation.setOptions)
+    .parameter(0)
+    .toMatchTypeOf<BottomTabNavigationOptions>();
+
+  expectTypeOf(navigation.setParams).parameter(0).toEqualTypeOf<undefined>();
 
   expectTypeOf(navigation.getState().type).toEqualTypeOf<'tab'>();
   expectTypeOf(navigation.getParent)

--- a/packages/core/src/types.tsx
+++ b/packages/core/src/types.tsx
@@ -325,7 +325,11 @@ export type NavigationProp<
    *
    * @param params Params object for the current route.
    */
-  setParams(params: Partial<ParamList[RouteName]>): void;
+  setParams(
+    params: ParamList[RouteName] extends undefined
+      ? undefined
+      : Partial<ParamList[RouteName]>
+  ): void;
 
   /**
    * Update the options for the route.


### PR DESCRIPTION
**Motivation**

Fixes #10471

If a RouteList type has a route with params set to undefined, for example:

```ts
type ExampleRouteList = {
  HasArgs: {someArg?: string};
  NoArgs: undefined;
};
```

Then `navigation.setParams` for `NoArgs` would be typed as `(params: Partial<unknown>): void`, since `NavigationProp` would type it as `(params: Partial<RouteList[RouteName]>): void`.

This would cause issues with `CompositeScreenProps` because a route with `undefined` params would not extend the `NavigationProp` type correctly, so that screen would not actually get all the options the parent navigators have available.

Conditionally setting `setParams` to `undefined` if `RouteList[RouteName]` extends `undefined` fixes this issue.

**Test plan**

Adding a test case in `example/types.check.tsx` for `LatestScreen`, which has params set to `undefined`, showed that this was indeed an issue because `setOptions` would fail the checks.

After the fix, these checks now pass for all screens, including the `LatestScreen`.

I also fixed the `setOptions` type checks so that they explicitly check that all the parent navigator screen options are available, instead of just a hand-full.

**Code formatting**

`yarn test`, `yarn lint` and `yarn typescript` all pass with these changes, and I have ran them locally before commiting.
