### PR TITLE
useBottomTabBarHeight behaviour changed when it's not in the bottom tabs navigator

### DIFF
--- a/packages/bottom-tabs/src/utils/useBottomTabBarHeight.tsx
+++ b/packages/bottom-tabs/src/utils/useBottomTabBarHeight.tsx
@@ -3,7 +3,9 @@ import warnOnce from 'warn-once';
 
 import BottomTabBarHeightContext from './BottomTabBarHeightContext';
 
-export default function useFloatingBottomTabBarHeight(ignore_warning:boolean = false) {
+export default function useFloatingBottomTabBarHeight(
+  ignore_warning: boolean = false
+) {
   const height = React.useContext(BottomTabBarHeightContext);
 
   if (height === undefined) {

--- a/packages/bottom-tabs/src/utils/useBottomTabBarHeight.tsx
+++ b/packages/bottom-tabs/src/utils/useBottomTabBarHeight.tsx
@@ -1,14 +1,18 @@
 import * as React from 'react';
+import warnOnce from 'warn-once';
 
 import BottomTabBarHeightContext from './BottomTabBarHeightContext';
 
-export default function useFloatingBottomTabBarHeight() {
+export default function useFloatingBottomTabBarHeight(ignore_warning = false) {
   const height = React.useContext(BottomTabBarHeightContext);
 
   if (height === undefined) {
-    throw new Error(
-      "Couldn't find the bottom tab bar height. Are you inside a screen in Bottom Tab Navigator?"
-    );
+    if(!ignore_warning)
+      warnOnce(
+        true,
+        "Couldn't find the bottom tab bar height (will return 0). Are you inside a screen in Bottom Tab Navigator?\n\nYou can ignore this warning by passing true to the useBottomTabBarHeight hook.\nuseBottomTabBarHeight(true)\n"
+      );
+    return 0;
   }
 
   return height;

--- a/packages/bottom-tabs/src/utils/useBottomTabBarHeight.tsx
+++ b/packages/bottom-tabs/src/utils/useBottomTabBarHeight.tsx
@@ -9,7 +9,7 @@ export default function useFloatingBottomTabBarHeight(
   const height = React.useContext(BottomTabBarHeightContext);
 
   if (height === undefined) {
-    if(!ignore_warning)
+    if (!ignore_warning)
       warnOnce(
         true,
         "Couldn't find the bottom tab bar height (will return 0). Are you inside a screen in Bottom Tab Navigator?\n\nYou can ignore this warning by passing true to the useBottomTabBarHeight hook.\nuseBottomTabBarHeight(true)\n"

--- a/packages/bottom-tabs/src/utils/useBottomTabBarHeight.tsx
+++ b/packages/bottom-tabs/src/utils/useBottomTabBarHeight.tsx
@@ -3,7 +3,7 @@ import warnOnce from 'warn-once';
 
 import BottomTabBarHeightContext from './BottomTabBarHeightContext';
 
-export default function useFloatingBottomTabBarHeight(ignore_warning = false) {
+export default function useFloatingBottomTabBarHeight(ignore_warning:boolean = false) {
   const height = React.useContext(BottomTabBarHeightContext);
 
   if (height === undefined) {


### PR DESCRIPTION
Using `useBottomTabBarHeight` hook out of the Bottom Tab Bar now warns the developer once instead of trowing an error.

**Motivation**

Using the `useBottomTabBarHeight` in a component (that is usable across the app) is difficult because that component might not be always inside a Bottom Tab Navigator. Current behaviour trows an error in this situation but in most use cases if there isn't a bottom tab bar you won't need its height either so 0 height would solve it.

**Test plan**

The warn-once warning instead of the error.

![Simulator Screen Shot - iPhone 12 - 2022-04-15 at 10 31 07](https://user-images.githubusercontent.com/15310365/163540239-5fac527e-f431-4b85-af26-00933d2dca48.png)

**Code formatting**

Look around. Match the style of the rest of the codebase. Run `yarn lint --fix` before committing.
