### PR TITLE
fix unintentional empty items

### DIFF
--- a/packages/native/src/useLinking.tsx
+++ b/packages/native/src/useLinking.tsx
@@ -98,8 +98,9 @@ const createMemoryHistory = () => {
       interrupt();
 
       const id = window.history.state?.id ?? nanoid();
+      const currentIndex = items.findIndex((item) => item.id === id);
 
-      if (!items.length || items.findIndex((item) => item.id === id) < 0) {
+      if (!items.length || currentIndex < 0) {
         // There are two scenarios for creating an array with only one history record:
         // - When loaded id not found in the items array, this function by default will replace
         //   the first item. We need to keep only the new updated object, otherwise it will break
@@ -109,6 +110,9 @@ const createMemoryHistory = () => {
         items = [{ path, state, id }];
         index = 0;
       } else {
+        // Fix createMemoryHistory.index variable's value
+        // as it may go out of sync when navigating in the browser.
+        index = Math.max(currentIndex, 0);
         items[index] = { path, state, id };
       }
 


### PR DESCRIPTION
**Motivation**

Fix error thrown while navigating.


Explain the **motivation** for making this change. What existing problem does the pull request solve?

Navigating in the browser is causing the index to go out of sync and from time to time it's over the length of the items.
Then by assigning to items array with `items[index]` syntax, it creates empty values which causes later `findIndex` calls to throw an error:

```js
undefined is not an object (evaluating 'item.id')
```
