### PR TITLE
fix: navigation outside app when history delta is -1

### DIFF
--- a/packages/native/src/useLinking.tsx
+++ b/packages/native/src/useLinking.tsx
@@ -592,7 +592,8 @@ export default function useLinking(
               // We couldn't find an existing entry to go back to, so we'll go back by the delta
               // This won't be correct if multiple routes were pushed in one go before
               // Usually this shouldn't happen and this is a fallback for that
-              await history.go(historyDelta);
+              // Add Math.max to guard going to < 0 index
+              await history.go(Math.max(historyDelta, 0));
             }
 
             // Store the updated state as well as fix the path if incorrect


### PR DESCRIPTION
Opening PR as the issue is with navigation which navigates outside the app when history navigation is -1. I had fixed it by adding another additional if check when history is -1 but adding Math.max() check makes more sense.