### PR TITLE
BugFix: Native stack custom header not respecting screen orientation …

### DIFF
--- a/packages/native-stack/src/views/NativeStackView.native.tsx
+++ b/packages/native-stack/src/views/NativeStackView.native.tsx
@@ -24,6 +24,7 @@ import type { ScreenProps } from 'react-native-screens';
 import {
   Screen,
   ScreenStack,
+  ScreenStackHeaderConfig,
   StackPresentationTypes,
 } from 'react-native-screens';
 import warnOnce from 'warn-once';
@@ -216,25 +217,28 @@ const SceneView = ({
               }
             >
               {header !== undefined && headerShown !== false ? (
-                <View
-                  onLayout={(e) => {
-                    setCustomHeaderHeight(e.nativeEvent.layout.height);
-                  }}
-                >
-                  {header({
-                    back: previousDescriptor
-                      ? {
-                          title: getHeaderTitle(
-                            previousDescriptor.options,
-                            previousDescriptor.route.name
-                          ),
-                        }
-                      : undefined,
-                    options,
-                    route,
-                    navigation,
-                  })}
-                </View>
+                <>
+                  <ScreenStackHeaderConfig hidden />
+                  <View
+                    onLayout={(e) => {
+                      setCustomHeaderHeight(e.nativeEvent.layout.height);
+                    }}
+                  >
+                    {header({
+                      back: previousDescriptor
+                        ? {
+                            title: getHeaderTitle(
+                              previousDescriptor.options,
+                              previousDescriptor.route.name
+                            ),
+                          }
+                        : undefined,
+                      options,
+                      route,
+                      navigation,
+                    })}
+                  </View>
+                </>
               ) : (
                 <HeaderConfig
                   {...options}


### PR DESCRIPTION
…property

**Motivation**

When using custom header component in native stack, navigating from that screen to another with no header but screenOption = { orientation: 'landscape' }, and from there navigation.goBack(), the screen stays in landscape on android.
With built-in header that doesn't happen.

**Test plan**

Need two screens, one with a custom header, second doesn't need a header. Second screen options should include orientation: 'landscape'.
Navigate from first screen to the second, after that navigation.goBack().
Previously on android the screen was left also on landscape after goBack, now it rotates back to the original position.

