### PR TITLE
Fix potential prototype pollution attacks (alternate approach)

### DIFF
--- a/packages/core/src/useEventEmitter.tsx
+++ b/packages/core/src/useEventEmitter.tsx
@@ -22,6 +22,7 @@ export default function useEventEmitter<T extends Record<string, any>>(
   });
 
   const listeners = React.useRef<Record<string, Record<string, Listeners>>>({});
+  Object.setPrototypeOf(listeners.current, null);
 
   const create = React.useCallback((target: string) => {
     const removeListener = (type: string, callback: (data: any) => void) => {

--- a/packages/core/src/useKeyedChildListeners.tsx
+++ b/packages/core/src/useKeyedChildListeners.tsx
@@ -15,6 +15,7 @@ export default function useKeyedChildListeners() {
     getState: {},
     beforeRemove: {},
   });
+  Object.setPrototypeOf(keyedListeners, null);
 
   const addKeyedListener = React.useCallback(
     <T extends keyof KeyedListenerMap>(


### PR DESCRIPTION
Prevent event listeners of type `__proto__` to pollute the global Object prototype. This is fixed by setting the objects' prototype to null, so they don't have a `__proto__` property.

**Motivation**

This fixes the same problem as  #10455, but requires less changes and makes it clearer that the code is secure. Both  #10455 and this PR should fix the problem, so any of those could be merged (but not both, as it would be redundant).

**Test plan**

I tested that the changes compile ok. Also checked that no property of the Object prototype (such as `toString()` of `hasOwnProperty()`) is being accessed on the affected objects, since this change will set them to undefined.