### PR TITLE
Prevent Object properties to be used as parsing functions

### DIFF
--- a/packages/core/src/__tests__/getPathFromState.test.tsx
+++ b/packages/core/src/__tests__/getPathFromState.test.tsx
@@ -902,6 +902,54 @@ it('keeps query params if path is empty', () => {
   ).toEqual(path);
 });
 
+it('does not use Object.prototype properties as parsing functions', () => {
+  const path = '/?toString=42';
+  const config = {
+    screens: {
+      Foo: {
+        screens: {
+          Foe: 'foe',
+          Bar: {
+            screens: {
+              Qux: {
+                path: '',
+                parse: {},
+              },
+              Baz: 'baz',
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: 'Foo',
+        state: {
+          routes: [
+            {
+              name: 'Bar',
+              state: {
+                routes: [{ name: 'Qux', params: { toString: 42 } }],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getPathFromState<object>(state, config)).toBe(path);
+  expect(
+    getPathFromState<object>(
+      getStateFromPath<object>(path, config) as State,
+      config
+    )
+  ).toEqual(path);
+});
+
 it('cuts nested configs too', () => {
   const path = '/foo/baz';
   const config = {

--- a/packages/core/src/getStateFromPath.tsx
+++ b/packages/core/src/getStateFromPath.tsx
@@ -565,7 +565,10 @@ const parseQueryParams = (
 
   if (parseConfig) {
     Object.keys(params).forEach((name) => {
-      if (parseConfig[name] && typeof params[name] === 'string') {
+      if (
+        Object.hasOwnProperty.call(parseConfig, name) &&
+        typeof params[name] === 'string'
+      ) {
         params[name] = parseConfig[name](params[name] as string);
       }
     });


### PR DESCRIPTION
Please provide enough information so that others can review your pull request.

**Motivation**

`parseQueryParams()` could had unexpected behavior when parameter names where valid `Object.prototype` properties. For example:

```
> parseQueryParams('?toString=42', {})
[Object: null prototype] { toString: '[object Object]' }
```

The code above was returning `{toString: '[object Object]'}` instead of the expected `{toString: '42'}`.

**Test plan**

Added a unit test reproducing the bug.
