### PR TITLE
Fix useReanimatedTransitionProgress throwing errors after upgrade to v6

### DIFF
--- a/packages/native-stack/src/views/NativeStackView.native.tsx
+++ b/packages/native-stack/src/views/NativeStackView.native.tsx
@@ -22,8 +22,8 @@ import {
 } from 'react-native-safe-area-context';
 import type { ScreenProps } from 'react-native-screens';
 import {
-  ScreenContext,
   Screen as DefaultScreen,
+  ScreenContext,
   ScreenStack,
   StackPresentationTypes,
 } from 'react-native-screens';

--- a/packages/native-stack/src/views/NativeStackView.native.tsx
+++ b/packages/native-stack/src/views/NativeStackView.native.tsx
@@ -22,7 +22,8 @@ import {
 } from 'react-native-safe-area-context';
 import type { ScreenProps } from 'react-native-screens';
 import {
-  Screen,
+  ScreenContext,
+  Screen as DefaultScreen,
   ScreenStack,
   StackPresentationTypes,
 } from 'react-native-screens';
@@ -87,6 +88,9 @@ const MaybeNestedStack = ({
       {children}
     </DebugContainer>
   );
+
+  const ContextScreen = React.useContext(ScreenContext);
+  const Screen = ContextScreen || DefaultScreen;
 
   if (isHeaderInModal) {
     return (
@@ -175,6 +179,9 @@ const SceneView = ({
     React.useState(defaultHeaderHeight);
 
   const headerHeight = header ? customHeaderHeight : defaultHeaderHeight;
+
+  const ContextScreen = React.useContext(ScreenContext);
+  const Screen = ContextScreen || DefaultScreen;
 
   return (
     <Screen


### PR DESCRIPTION
**Motivation**

Currently, trying to use [useReanimatedTransitionProgress](https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md#usereanimatedtransitionprogress) from react-native-screens results in the following error:
`Error: Couldn't find values for reanimated transition progress. Are you inside a screen in Native Stack?`

**Reproduction**:
https://github.com/aleqsio/use-reanimated-transition-repro/blob/master/App.tsx

As @WoLewicki  pointed out, this is due to react navigation v6 not using a `Screen` from `ScreenContext`, instead using the default import. The fix is to use the screen from context if available. 

After this change the reproduction app works as expected.



---
Screenshots:

![simulator_screenshot_1124636B-7D6A-44B2-9703-8A0F60DD59C9](https://user-images.githubusercontent.com/5597580/168055840-b4ac35e9-bb77-4fad-affb-b3c37e70065a.png)

![simulator_screenshot_8BCDF351-86C5-4BF6-919E-9B19FEA152BD](https://user-images.githubusercontent.com/5597580/168055798-fd11f764-ee97-4a84-9ca0-d4f1c1c4d96e.png)


