### PR TITLE
prevent `history.go()` navigation outside bounds

### DIFF
--- a/packages/native/src/__mocks__/window.tsx
+++ b/packages/native/src/__mocks__/window.tsx
@@ -7,6 +7,9 @@ let index = 0;
 let currentState: any = null;
 
 const history = {
+  get length() {
+    return entries.length;
+  },
   get state() {
     return currentState;
   },
@@ -34,8 +37,10 @@ const history = {
         (n < 0 && Math.abs(n) <= index)
       ) {
         index += n;
-        Object.assign(location, new URL(entries[index].href));
-        listeners.forEach((cb) => cb);
+        const entry = entries[index];
+        Object.assign(location, new URL(entry.href));
+        currentState = entry.state;
+        listeners.forEach((cb) => cb());
       }
     }, 0);
   },

--- a/packages/native/src/__tests__/createMemoryHistory.test.tsx
+++ b/packages/native/src/__tests__/createMemoryHistory.test.tsx
@@ -1,0 +1,179 @@
+import type { NavigationState } from '@react-navigation/core';
+
+import { createMemoryHistory } from '../../src/useLinking';
+import window from '../__mocks__/window';
+
+// @ts-expect-error: practically window is same as global, so we can ignore the error
+global.window = window;
+
+// eslint-disable-next-line import/extensions
+jest.mock('../useLinking', () => require('../useLinking.tsx'));
+
+it('will not attempt to navigate beyond whatever browser history it is possible to know about', () => {
+  jest.useFakeTimers();
+  const windowGoSpy = jest.spyOn(window.history, 'go');
+
+  // Given a new memory history
+  const history = createMemoryHistory();
+
+  // And a window history that is initialized in an empty state (i.e. a single null item)
+  expect(window.history.length).toBe(1);
+
+  // Expect our memory history to have a length property and for it to be 0 because we haven't added any thing to it yet
+  expect(history.length).toBe(0);
+
+  const mockStateOne: NavigationState = {
+    key: 'stack-123',
+    index: 0,
+    routeNames: ['One', 'Two', 'Three'],
+    routes: [
+      {
+        name: 'One',
+        path: '/route-one',
+        key: 'One-23',
+        params: undefined,
+      },
+    ],
+    type: 'stack',
+    stale: false,
+  };
+
+  // When we add a path and state value then our index value will be zero and it will have a length
+  history.replace({ path: '/route-one', state: mockStateOne });
+  expect(history.index).toBe(0);
+  expect(history.length).toBe(1);
+
+  // When we try to call history.go() with a negative value and there is nowhere to navigate to
+  // Then window.history.go() should not be called at all
+  history.go(-1);
+  jest.runAllTimers();
+  expect(windowGoSpy).not.toBeCalled();
+  expect(history.index).toBe(0);
+
+  // When we push another item then window history should stay synced with memory history and our index should advance
+  const mockStateTwo: NavigationState = {
+    key: 'stack-123',
+    index: 1,
+    routeNames: ['One', 'Two', 'Three'],
+    routes: [
+      {
+        name: 'One',
+        path: '/route-one',
+        key: 'One-23',
+        params: undefined,
+      },
+      {
+        name: 'Two',
+        path: '/route-two',
+        key: 'Two-34',
+        params: {},
+      },
+    ],
+    type: 'stack',
+    stale: false,
+  };
+  history.push({ path: '/route-two', state: mockStateTwo });
+  expect(history.length).toBe(2);
+  expect(window.history.length).toBe(2);
+  expect(history.index).toBe(1);
+
+  // When we navigate back then our memory history should still have a length of 2, but our index will have updated
+  history.go(-1);
+  jest.runAllTimers();
+  expect(history.length).toBe(2);
+  expect(window.history.length).toBe(2);
+  expect(windowGoSpy).toHaveBeenCalledTimes(1);
+  expect(history.index).toBe(0);
+
+  // When we navigate forward once then we should only see our index change
+  history.go(1);
+  jest.runAllTimers();
+  expect(history.length).toBe(2);
+  expect(window.history.length).toBe(2);
+  expect(windowGoSpy).toHaveBeenCalledTimes(2);
+  expect(history.index).toBe(1);
+
+  // If we try to go very far outside of the current bounds of memory history then we
+  // will find ourselves in the same place.
+  history.go(10);
+  jest.runAllTimers();
+  expect(history.length).toBe(2);
+  expect(window.history.length).toBe(2);
+  expect(windowGoSpy).toHaveBeenCalledTimes(2);
+  expect(history.index).toBe(1);
+
+  // Navigate back to the first index
+  history.go(-1);
+  jest.runAllTimers();
+  expect(history.index).toBe(0);
+  expect(history.length).toBe(2);
+  expect(windowGoSpy).toHaveBeenCalledTimes(3);
+
+  const item = history.get(0);
+  expect(window.history.state).toEqual({ id: item.id });
+
+  // Next replace the state and verify the item we are replacing
+  // has the same id but the path has changed
+  const mockStateThree: NavigationState = {
+    key: 'stack-123',
+    index: 0,
+    routeNames: ['One', 'Two', 'Three'],
+    routes: [
+      {
+        name: 'Three',
+        path: '/route-three',
+        key: 'Three-23',
+        params: undefined,
+      },
+      {
+        name: 'Two',
+        path: '/route-two',
+        key: 'Two-23',
+        params: undefined,
+      },
+    ],
+    type: 'stack',
+    stale: false,
+  };
+  history.replace({ path: '/route-three', state: mockStateThree });
+  expect(history.index).toBe(0);
+  expect(history.length).toBe(2);
+
+  const replacedItem = history.get(0);
+  expect(item.path).toBe('/route-one');
+  expect(replacedItem.path).toBe('/route-three');
+  expect(item.id).toEqual(replacedItem.id);
+  expect(window.history.state).toEqual({ id: replacedItem.id });
+
+  // Push another item
+  const mockStateFour: NavigationState = {
+    key: 'stack-123',
+    index: 1,
+    routeNames: ['One', 'Two', 'Three'],
+    routes: [
+      {
+        name: 'Three',
+        path: '/route-three',
+        key: 'Three-23',
+        params: undefined,
+      },
+      {
+        name: 'One',
+        path: '/route-one',
+        key: 'One-23',
+        params: undefined,
+      },
+    ],
+    type: 'stack',
+    stale: false,
+  };
+
+  // Pushing a new route will remove any items after the new index
+  history.push({ path: '/route-one', state: mockStateFour });
+  expect(history.index).toBe(1);
+  expect(history.length).toBe(2);
+  expect(window.history.length).toBe(2);
+  expect(history.get(0).path).toBe('/route-three');
+  const newItem = history.get(1);
+  expect(window.history.state).toEqual({ id: newItem.id });
+});


### PR DESCRIPTION
**Motivation**

As the length of a browser's history cannot be used to accurately determine whether a user will be taken out of a react-navigation app as a workaround this PR will guard against unexpected behavior by instead moving only within the upper or lower bounds of the memory history. If we are trying to navigate to an index that is beyond what we have in memory history this is probably a sign that our `state.history` or `state.routes` are out of sync with the memory history and we will calculate a delta that will not bring us where we expect.

I am interested in looking into the scenarios where `state.history` or `state.routes` are not in sync - but it seems unclear what the expected behavior should be.

**Issue:**

https://github.com/react-navigation/react-navigation/issues/10481

**Test plan**

**Automated**

- As part of this PR `createMemoryHistory()` was exported so it a unit test could be created and simulate state changes that trigger changes to the memory history.

**Manual**

- Copy the minimal reproduction similar to the linked issue into a new managed expo app with navigation template.
- Run the example website.
- Navigate directly to the alternate screen (not the `initialRouteName`) via browser's url in a new tab to ensure fresh browser history.
- Navigate back to the `Home` route.
- Verify that you are not navigated out of the app.

<details>
 <summary>Minimal Reproduction Code</summary>
 
```js
const linking = {
  prefixes: [Linking.createURL('/')],
  config: {
    initialRouteName: 'Home',
    screens: {
      Home: {
        path: 'home',
      },
      Test: {
        path: 'test',
      },
    },
  },
};

export default function Navigation() {
  return (
    <NavigationContainer
      linking={linking}
    >
      <Navigator />
    </NavigationContainer>
  );
}

const Tab = createBottomTabNavigator();

const TestScreen = ({route, to}) => {
  const linkTo = useLinkTo();
  return (
    <View style={{padding: 20}}>
      <Text>1. In a new tab navigate directly to /test via browser url bar</Text>
      <Text>2. Navigate to home via button</Text>
      <Text style={{fontSize: 24, padding: 20}}>Current Route: {route.name}</Text>
      <Button title={to} onPress={() => linkTo(to)}/>
    </View>
  );
}

function Navigator() {
  return (
    <Tab.Navigator initialRouteName="Home">
      <Tab.Screen name="Home" component={(props) => <TestScreen {...props} to="/test"/>} />
      <Tab.Screen name="Test" component={(props) => <TestScreen {...props} to="/home" />} />
    </Tab.Navigator>
  );
}
```
</details>