### PR TITLE
add `homeIndicatorHidden` to native stack navigator options

### DIFF
--- a/packages/native-stack/package.json
+++ b/packages/native-stack/package.json
@@ -52,7 +52,7 @@
     "react": "17.0.1",
     "react-native": "~0.64.3",
     "react-native-builder-bob": "^0.18.1",
-    "react-native-screens": "^3.3.0",
+    "react-native-screens": "^3.11.0",
     "typescript": "^4.3.2"
   },
   "peerDependencies": {
@@ -60,7 +60,7 @@
     "react": "*",
     "react-native": "*",
     "react-native-safe-area-context": ">= 3.0.0",
-    "react-native-screens": ">= 3.0.0"
+    "react-native-screens": ">= 3.11.0"
   },
   "react-native-builder-bob": {
     "source": "src",

--- a/packages/native-stack/src/types.tsx
+++ b/packages/native-stack/src/types.tsx
@@ -382,6 +382,14 @@ export type NativeStackNavigationOptions = {
    */
   gestureEnabled?: boolean;
   /**
+   * Whether the home indicator should be hidden on this screen. Defaults to `false`.
+   *
+   * Only supported on iOS.
+   *
+   * @platform ios
+   */
+  homeIndicatorHidden?: boolean;
+  /**
    * The type of animation to use when this screen replaces another screen. Defaults to `pop`.
    *
    * Supported values:

--- a/packages/native-stack/src/views/NativeStackView.native.tsx
+++ b/packages/native-stack/src/views/NativeStackView.native.tsx
@@ -139,6 +139,7 @@ const SceneView = ({
     statusBarAnimation,
     statusBarHidden,
     statusBarStyle,
+    homeIndicatorHidden,
   } = options;
 
   let { presentation = 'card' } = options;
@@ -197,6 +198,7 @@ const SceneView = ({
       statusBarAnimation={statusBarAnimation}
       statusBarHidden={statusBarHidden}
       statusBarStyle={statusBarStyle}
+      homeIndicatorHidden={homeIndicatorHidden}
       onWillDisappear={onWillDisappear}
       onAppear={onAppear}
       onDisappear={onDisappear}


### PR DESCRIPTION
**Motivation**
Allows hiding the home indicator for native navigators, groups or views. This is based on https://github.com/software-mansion/react-native-screens/pull/1267 from @WoLewicki which was released with [react-native-screens@3.11.0](https://github.com/software-mansion/react-native-screens/releases/tag/3.11.0)

**Test plan**
I tested it with the demo app and with our own project. Works like charm and makes [react-native-home-indicator](https://github.com/flowkey/react-native-home-indicator) obsolete