### PR TITLE
Expose `LinkingContext`

### DIFF
--- a/packages/native/src/index.tsx
+++ b/packages/native/src/index.tsx
@@ -10,4 +10,5 @@ export { default as useLinkBuilder } from './useLinkBuilder';
 export { default as useLinkProps } from './useLinkProps';
 export { default as useLinkTo } from './useLinkTo';
 export { default as useScrollToTop } from './useScrollToTop';
+export { default as LinkingContext } from './LinkingContext';
 export * from '@react-navigation/core';

--- a/packages/native/src/index.tsx
+++ b/packages/native/src/index.tsx
@@ -1,4 +1,5 @@
 export { default as Link } from './Link';
+export { default as LinkingContext } from './LinkingContext';
 export { default as NavigationContainer } from './NavigationContainer';
 export { default as ServerContainer } from './ServerContainer';
 export { default as DarkTheme } from './theming/DarkTheme';
@@ -10,5 +11,4 @@ export { default as useLinkBuilder } from './useLinkBuilder';
 export { default as useLinkProps } from './useLinkProps';
 export { default as useLinkTo } from './useLinkTo';
 export { default as useScrollToTop } from './useScrollToTop';
-export { default as LinkingContext } from './LinkingContext';
 export * from '@react-navigation/core';


### PR DESCRIPTION
Without this, it is impossible to build your own hooks using `getPathFromState` and `getStateFromAction`.

This addresses https://github.com/react-navigation/react-navigation/discussions/10517

**Motivation**

This lets `solito` implement a `replace('/users/fernando')` logic using URLs.

**Test plan**

It's only exporting a variable.
