### PR TITLE
Explicitly set a boolean value for the `detachInactiveScreens` prop

### DIFF
--- a/packages/stack/src/navigators/createStackNavigator.tsx
+++ b/packages/stack/src/navigators/createStackNavigator.tsx
@@ -123,6 +123,7 @@ function StackNavigator({
         state={state}
         descriptors={descriptors}
         navigation={navigation}
+        detachInactiveScreens={rest.detachInactiveScreens ?? false}
       />
     </NavigationContent>
   );


### PR DESCRIPTION
The value of the `detachInactiveScreens`, with which one renders the navigator returned from the call to `createStackNavigator` is not kept between renders, i.e. it is rendered with the correct value but then it falls back to `undefined`. This has some unintended consequences down the hierarchy of components and is currently crashing our React Native app when we seek to open the app from any deep links

- createStackComponent -> 
  - StackView -> 
  - CardStack -> ( if `detachInactiveScreens` is undefined, then its default value is derived from platform checks )
  - MaybeScreenContainer -> ( renders the `Screens.ScreenContainer` and `Screens.Screen` from `software-mansion/react-native-screens` with the `enabled` set incorrectly
  - ScreenContainer (`software-mansion/react-native-screens`) -> unpacks the props and completely [ignores](https://github.com/software-mansion/react-native-screens/blob/main/src/index.native.tsx#L340) the `ENABLE_SCREENS`'s default value as we're rendering this component with a value. Calling `enableScreens` to set the  `ENABLE_SCREENS` [has no effect](https://github.com/software-mansion/react-native-screens/blob/main/src/index.native.tsx#L49), thus we cannot toggle to not opt-in to the new architecture and we get crashes