### PR TITLE
Add `Screen` option as `displayName`

### DIFF
--- a/packages/core/src/useNavigationBuilder.tsx
+++ b/packages/core/src/useNavigationBuilder.tsx
@@ -77,7 +77,7 @@ const getRouteConfigsFromChildren = <
     ScreenConfigWithParent<State, ScreenOptions, EventMap>[]
   >((acc, child) => {
     if (React.isValidElement(child)) {
-      if (child.type === Screen) {
+      if (child.type === Screen || (child.type as any)?.displayName === 'Screen') {
         // We can only extract the config from `Screen` elements
         // If something else was rendered, it's probably a bug
 


### PR DESCRIPTION
Small internal change to allow a custom `Screen` component with the `displayName` property.

Sorry for the `as any` – it's the only acceptable type that I know of here.

[This sandbox](https://codesandbox.io/s/reverent-night-r14syo?file=/src/App.js) demonstrates the `displayName` feature. The `ReadChildren` component that it loops through its children and lists their display names.


## **Motivation**

While this isn't necessary as a documented API, it will allow `expo-auto-navigation` to inject its own `Screen` component without needing a hacky wrapper function.

## **Test plan**

This doesn't affect any UI, so as long as it passes the TS types, it should be fine.
