### PR TITLE
fix(drawer): fix `onReanimatedPropsChange` is not a supported event type with Reanimated 3

### DIFF
--- a/packages/drawer/src/views/modern/Overlay.tsx
+++ b/packages/drawer/src/views/modern/Overlay.tsx
@@ -7,6 +7,8 @@ import Animated, {
 
 const PROGRESS_EPSILON = 0.05;
 
+Animated.addWhitelistedNativeProps({ importantForAccessibility: true });
+
 type Props = React.ComponentProps<typeof Animated.View> & {
   progress: Animated.SharedValue<number>;
   onPress: () => void;


### PR DESCRIPTION
**Motivation**

When using `@react-navigation/drawer@6.4.1` with `react-native@0.69.0-rc.6` + `reanimated@3.0.0-rc.0`, it throws an error and crashes the app:

```
 `onReanimatedPropsChange` is not a supported event type for REAModule. Supported events are: ``
```

![Simulator Screen Shot - iPhone 13 - 2022-06-17 at 14 56 42](https://user-images.githubusercontent.com/23186058/174227899-3ee9766c-d7ae-4783-b9c4-4013ba50ff4f.png)

This is likely to be introduced by the Reanimated 3 re-write, 
https://github.com/software-mansion/react-native-reanimated/blob/2.8.0/ios/REAModule.m#L173
https://github.com/software-mansion/react-native-reanimated/blob/3.0.0-rc.0/ios/REAModule.mm#L273

I don't have enough knowledge of Swift / Reanimated to understand what's actually going on, but this PR resolves the issue. 

**Test plan**

Switch to the minimal reproducible example branch https://github.com/nujhong/react-navigation/pull/new/minimal-reproducible-example, do a clean re-installation, and run the example
- `yarn install`
- `npx pod-install`
- `yarn ios`



