### PR TITLE
fix: use top inset for header height on ipad

### DIFF
--- a/packages/native-stack/src/views/NativeStackView.native.tsx
+++ b/packages/native-stack/src/views/NativeStackView.native.tsx
@@ -161,7 +161,7 @@ const SceneView = ({
 
   // Modals are fullscreen in landscape only on iPhone
   const isIPhone =
-    Platform.OS === 'ios' && !(Platform.isPad && Platform.isTVOS);
+    Platform.OS === 'ios' && !(Platform.isPad || Platform.isTVOS);
   const isLandscape = frame.width > frame.height;
 
   const topInset = isModal || (isIPhone && isLandscape) ? 0 : insets.top;


### PR DESCRIPTION
This fix uses the top inset for iPad header height calculation in the native stack.
There is a misplaced condition that uses `&&` when it should be `||`.
I hope to have this fix in some version of `react-navigation` soon.

Fixes: #10609