### PR TITLE
chore: remove detox references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,24 +45,22 @@ Remember to add tests for your change if possible. Run the unit tests by:
 yarn test
 ```
 
-Running the e2e tests with Detox (on iOS) requires the following:
-
-- Mac with macOS (at least macOS High Sierra 10.13.6)
-- Xcode 10.1+ with Xcode command line tools
-
-First you need to install `applesimutils` and `detox-cli`:
+Running the e2e tests with Playwright requires building the [example app](/example/) for web:
 
 ```sh
-brew tap wix/brew
-brew install applesimutils
-yarn global add detox-cli
+yarn example expo build:web --no-pwa
 ```
 
-Then you can build and run the tests:
+Before running tests configure Playwright with:
 
 ```sh
-detox build -c ios.sim.debug
-detox test -c ios.sim.debug
+yarn playwright install
+```
+
+Run the e2e tests by:
+
+```sh
+yarn example test:e2e
 ```
 
 ### Commit message convention

--- a/package.json
+++ b/package.json
@@ -82,27 +82,5 @@
     "useTabs": false,
     "singleQuote": true,
     "trailingComma": "es5"
-  },
-  "detox": {
-    "test-runner": "jest",
-    "runner-config": "example/e2e/config.json",
-    "configurations": {
-      "ios.sim.debug": {
-        "binaryPath": "example/ios/build/Build/Products/Debug-iphonesimulator/ReactNavigationExample.app",
-        "build": "set -o pipefail; xcodebuild -workspace example/ios/ReactNavigationExample.xcworkspace -scheme ReactNavigationExample -configuration Debug -sdk iphonesimulator -derivedDataPath example/ios/build",
-        "type": "ios.simulator",
-        "device": {
-          "type": "iPhone 11 Pro"
-        }
-      },
-      "ios.sim.release": {
-        "binaryPath": "example/ios/build/Build/Products/Release-iphonesimulator/ReactNavigationExample.app",
-        "build": "export RCT_NO_LAUNCH_PACKAGER=true; set -o pipefail; xcodebuild -workspace example/ios/ReactNavigationExample.xcworkspace -scheme ReactNavigationExample -configuration Release -sdk iphonesimulator -derivedDataPath example/ios/build",
-        "type": "ios.simulator",
-        "device": {
-          "type": "iPhone 11 Pro"
-        }
-      }
-    }
   }
 }


### PR DESCRIPTION
Clean-up PR removing references to detox as react-navigation repo doesn't use the detox package for e2e tests anymore.

- removed detox config from package.json
- updated CONTRUBUTING.md to use playwright in place of detox 
