### PR TITLE
fix: ensure same @types/react version in repo

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -50,7 +50,7 @@
     "@types/koa": "^2.13.3",
     "@types/mock-require": "^2.0.0",
     "@types/node-fetch": "^2.5.10",
-    "@types/react": "~17.0.21",
+    "@types/react": "^17.0.47",
     "@types/react-dom": "~17.0.11",
     "@types/react-native": "~0.68.1",
     "babel-loader": "^8.2.2",

--- a/packages/bottom-tabs/package.json
+++ b/packages/bottom-tabs/package.json
@@ -44,7 +44,7 @@
     "@react-navigation/native": "^6.0.10",
     "@testing-library/react-native": "^7.2.0",
     "@types/color": "^3.0.1",
-    "@types/react": "^17.0.21",
+    "@types/react": "^17.0.47",
     "@types/react-native": "~0.68.1",
     "del-cli": "^3.0.1",
     "react": "17.0.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@testing-library/react-native": "^7.2.0",
-    "@types/react": "^17.0.21",
+    "@types/react": "^17.0.47",
     "@types/react-is": "^17.0.0",
     "del-cli": "^3.0.1",
     "immer": "^9.0.2",

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -44,7 +44,7 @@
     "@react-navigation/core": "^6.2.1",
     "@testing-library/react-native": "^7.2.0",
     "@types/deep-equal": "^1.0.1",
-    "@types/react": "^17.0.21",
+    "@types/react": "^17.0.47",
     "del-cli": "^3.0.1",
     "react": "17.0.2",
     "react-native-builder-bob": "^0.18.1",

--- a/packages/drawer/package.json
+++ b/packages/drawer/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@react-navigation/native": "^6.0.10",
     "@testing-library/react-native": "^7.2.0",
-    "@types/react": "^17.0.21",
+    "@types/react": "^17.0.47",
     "@types/react-native": "~0.68.1",
     "del-cli": "^3.0.1",
     "react": "17.0.2",

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -40,7 +40,7 @@
     "@react-native-masked-view/masked-view": "^0.2.4",
     "@react-navigation/native": "^6.0.10",
     "@testing-library/react-native": "^7.2.0",
-    "@types/react": "^17.0.21",
+    "@types/react": "^17.0.47",
     "@types/react-native": "~0.68.1",
     "del-cli": "^3.0.1",
     "react": "17.0.2",

--- a/packages/flipper-plugin-react-navigation/package.json
+++ b/packages/flipper-plugin-react-navigation/package.json
@@ -35,7 +35,7 @@
     "@babel/preset-react": "^7.12.13",
     "@babel/preset-typescript": "^7.13.0",
     "@react-navigation/core": "^6.2.1",
-    "@types/react": "^17.0.21",
+    "@types/react": "^17.0.47",
     "@types/react-dom": "^17.0.11",
     "@types/react-virtualized-auto-sizer": "^1.0.1",
     "@types/react-window": "^1.8.5",

--- a/packages/material-bottom-tabs/package.json
+++ b/packages/material-bottom-tabs/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@react-navigation/native": "^6.0.10",
     "@testing-library/react-native": "^7.2.0",
-    "@types/react": "^17.0.21",
+    "@types/react": "^17.0.47",
     "@types/react-native": "~0.68.1",
     "@types/react-native-vector-icons": "^6.4.10",
     "del-cli": "^3.0.1",

--- a/packages/material-top-tabs/package.json
+++ b/packages/material-top-tabs/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@react-navigation/native": "^6.0.10",
     "@testing-library/react-native": "^7.2.0",
-    "@types/react": "^17.0.21",
+    "@types/react": "^17.0.47",
     "@types/react-native": "~0.68.1",
     "del-cli": "^3.0.1",
     "react": "17.0.2",

--- a/packages/native-stack/package.json
+++ b/packages/native-stack/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@react-navigation/native": "^6.0.10",
     "@testing-library/react-native": "^7.2.0",
-    "@types/react": "^17.0.21",
+    "@types/react": "^17.0.47",
     "@types/react-native": "~0.68.1",
     "react": "17.0.2",
     "react-native": "~0.68.2",

--- a/packages/native/package.json
+++ b/packages/native/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@testing-library/react-native": "^7.2.0",
-    "@types/react": "^17.0.21",
+    "@types/react": "^17.0.47",
     "@types/react-dom": "^17.0.11",
     "@types/react-native": "~0.68.1",
     "del-cli": "^3.0.1",

--- a/packages/stack/package.json
+++ b/packages/stack/package.json
@@ -48,7 +48,7 @@
     "@react-navigation/native": "^6.0.10",
     "@testing-library/react-native": "^7.2.0",
     "@types/color": "^3.0.1",
-    "@types/react": "^17.0.21",
+    "@types/react": "^17.0.47",
     "@types/react-native": "~0.68.1",
     "del-cli": "^3.0.1",
     "react": "17.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4795,16 +4795,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@~17.0.21":
-  version "17.0.38"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.38.tgz#f24249fefd89357d5fa71f739a686b8d7c7202bd"
-  integrity sha512-SI92X1IA+FMnP3qM5m4QReluXzhcmovhZnLNm3pyeQlooi02qI7sLiepEYqT678uNiyc25XfCqxREFpy3W7YhQ==
-  dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "*"
-    csstype "^3.0.2"
-
-"@types/react@^17", "@types/react@^17.0.21":
+"@types/react@*", "@types/react@^17", "@types/react@^17.0.47":
   version "17.0.47"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.47.tgz#4ee71aaf4c5a9e290e03aa4d0d313c5d666b3b78"
   integrity sha512-mk0BL8zBinf2ozNr3qPnlu1oyVTYq+4V7WA76RgxUAtf0Em/Wbid38KN6n4abEkvO4xMTBWmnP1FtQzgkEiJoA==


### PR DESCRIPTION
**Motivation**

After the upgrade of dependencies in https://github.com/react-navigation/react-navigation/pull/10655 CI is failing while building packages. The problem seems to lay in the inconsistency of taking types from the `@types/react` package. This PR unifies the `@types/react` package version in the repository.


**Test plan**

```sh
yarn
yarn lint
yarn typescript
yarn lerna run prepare
```
