### PR TITLE
fix: make event listeners idempotent

### DIFF
--- a/packages/core/src/useChildListeners.tsx
+++ b/packages/core/src/useChildListeners.tsx
@@ -21,7 +21,7 @@ export default function useChildListeners() {
       return () => {
         const index = listeners[type].indexOf(listener);
 
-        if (!removed) {
+        if (!removed && index > -1) {
           removed = true;
           listeners[type].splice(index, 1);
         }

--- a/packages/core/src/useChildListeners.tsx
+++ b/packages/core/src/useChildListeners.tsx
@@ -17,10 +17,14 @@ export default function useChildListeners() {
     <T extends keyof ListenerMap>(type: T, listener: ListenerMap[T]) => {
       listeners[type].push(listener);
 
+      let removed = false;
       return () => {
         const index = listeners[type].indexOf(listener);
 
-        listeners[type].splice(index, 1);
+        if (!removed) {
+          removed = true;
+          listeners[type].splice(index, 1);
+        }
       };
     },
     [listeners]

--- a/packages/core/src/useEventEmitter.tsx
+++ b/packages/core/src/useEventEmitter.tsx
@@ -35,7 +35,9 @@ export default function useEventEmitter<T extends Record<string, any>>(
 
       const index = callbacks.indexOf(callback);
 
-      callbacks.splice(index, 1);
+      if (index > -1) {
+        callbacks.splice(index, 1);
+      }
     };
 
     const addListener = (type: string, callback: (data: any) => void) => {

--- a/packages/core/src/useEventEmitter.tsx
+++ b/packages/core/src/useEventEmitter.tsx
@@ -24,6 +24,7 @@ export default function useEventEmitter<T extends Record<string, any>>(
   const listeners = React.useRef<Record<string, Record<string, Listeners>>>({});
 
   const create = React.useCallback((target: string) => {
+    let removed = false;
     const removeListener = (type: string, callback: (data: any) => void) => {
       const callbacks = listeners.current[type]
         ? listeners.current[type][target]
@@ -35,7 +36,10 @@ export default function useEventEmitter<T extends Record<string, any>>(
 
       const index = callbacks.indexOf(callback);
 
-      callbacks.splice(index, 1);
+      if (!removed || index !== -1) {
+        removed = true;
+        callbacks.splice(index, 1);
+      }
     };
 
     const addListener = (type: string, callback: (data: any) => void) => {


### PR DESCRIPTION
**Motivation**

This PR prevents removing more event listeners than necessary when called `unsubscribe` multiple times.

Fixes https://github.com/react-navigation/react-navigation/issues/10664

**Test plan**

Automatic tests:
```sh
yarn test
```


<details>
<summary>Manual testing snippet:</summary>
<br>

```jsx
import { NavigationContainer } from '@react-navigation/native';
import { createNativeStackNavigator } from '@react-navigation/native-stack';
import * as React from 'react';
import { Button, Text, View } from 'react-native';

function SettingsScreen({ navigation }: any) {
  return (
    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
      <Text>Settings Screen</Text>
      <Button
        title="Go to third"
        onPress={() => navigation.navigate('nested', { screen: 'third' })}
      />
    </View>
  );
}

function ProfileScreen({ navigation }: any) {
  React.useEffect(() => {
    const unsubscribe = navigation.addListener('focus', () => {
      console.log('[TESTING] LISTENER ONE');
    });
    unsubscribe();

    navigation.addListener('focus', () => {
      console.log('[TESTING] LISTENER TWO');
    });
    unsubscribe();
  }, [navigation]);

  return (
    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
      <Text>Profile Screen</Text>
      <Button
        title="Go to Settings"
        onPress={() => navigation.navigate('Settings')}
      />
    </View>
  );
}

function NestedScreen({ navigation }: any) {
  React.useEffect(() => {
    const unsubscribe = navigation.addListener('focus', () => {
      console.log('[TESTING] LISTENER THREE');
    });
    unsubscribe();

    navigation.addListener('focus', () => {
      console.log('[TESTING] LISTENER FOUR');
    });
    unsubscribe();
  }, [navigation]);

  return (
    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
      <Text>Nested Screen</Text>
      <Button
        title="Go to fourth"
        onPress={() => navigation.navigate('fourth')}
      />
    </View>
  );
}

const SettingsStack = createNativeStackNavigator();
const NestedStack = createNativeStackNavigator();

export default function App() {
  return (
    <NavigationContainer>
      <SettingsStack.Navigator>
        <SettingsStack.Screen name="Profile" component={ProfileScreen} />
        <SettingsStack.Screen name="Settings" component={SettingsScreen} />
        <SettingsStack.Screen name="nested">
          {() => (
            <NestedStack.Navigator>
              <NestedStack.Screen name="third" component={NestedScreen} />
              <NestedStack.Screen name="fourth" component={SettingsScreen} />
            </NestedStack.Navigator>
          )}
        </SettingsStack.Screen>
      </SettingsStack.Navigator>
    </NavigationContainer>
  );
}
```

</details>


Passed lint, typescript & test.
