### PR TITLE
fix: explicitly set gestureDirection default value in native-stack

### DIFF
--- a/packages/native-stack/src/types.tsx
+++ b/packages/native-stack/src/types.tsx
@@ -325,7 +325,7 @@ export type NativeStackNavigationOptions = {
    */
   headerBackButtonMenuEnabled?: boolean;
   /**
-   * Whether the home indicator should be hidden on this screen. Defaults to `false`.
+   * Whether the home indicator should prefer to stay hidden on this screen. Defaults to `false`.
    *
    * @platform ios
    */
@@ -384,9 +384,11 @@ export type NativeStackNavigationOptions = {
   /**
    * Sets the direction in which you should swipe to dismiss the screen.
    * When using `vertical` option, options `fullScreenSwipeEnabled: true`, `customAnimationOnSwipe: true` and `stackAnimation: 'slide_from_bottom'` are set by default.
-   * The following values are supported:
+   *
+   * Supported values:
    * - `vertical` – dismiss screen vertically
    * - `horizontal` – dismiss screen horizontally (default)
+   *
    * @platform ios
    */
   gestureDirection?: ScreenProps['swipeDirection'];
@@ -447,6 +449,13 @@ export type NativeStackNavigationOptions = {
    */
   animation?: ScreenProps['stackAnimation'];
   /**
+   * Changes the duration (in milliseconds) of `slide_from_bottom`, `fade_from_bottom`, `fade` and `simple_push` transitions on iOS. Defaults to `350`.
+   * The duration of `default` and `flip` transitions isn't customizable.
+   *
+   * @platform ios
+   */
+  animationDuration?: number;
+  /**
    * How should the screen be presented.
    *
    * Supported values:
@@ -477,13 +486,6 @@ export type NativeStackNavigationOptions = {
    * Only supported on iOS and Android.
    */
   orientation?: ScreenProps['screenOrientation'];
-  /**
-   * Changes the duration (in milliseconds) of `slide_from_bottom`, `fade_from_bottom`, `fade` and `simple_push` transitions on iOS. Defaults to `350`.
-   * The duration of `default` and `flip` transitions isn't customizable.
-   *
-   * @platform ios
-   */
-  animationDuration?: number;
 };
 
 export type NativeStackNavigatorProps = DefaultNavigatorOptions<

--- a/packages/native-stack/src/types.tsx
+++ b/packages/native-stack/src/types.tsx
@@ -383,7 +383,7 @@ export type NativeStackNavigationOptions = {
   statusBarTranslucent?: boolean;
   /**
    * Sets the direction in which you should swipe to dismiss the screen.
-   * When using `vertical` option, options `fullScreenSwipeEnabled: true`, `customAnimationOnSwipe: true` and `stackAnimation: 'slide_from_bottom'` are set by default.
+   * When using `vertical` option, options `fullScreenGestureEnabled: true`, `customAnimationOnGesture: true` and `animation: 'slide_from_bottom'` are set by default.
    *
    * Supported values:
    * - `vertical` – dismiss screen vertically

--- a/packages/native-stack/src/views/NativeStackView.native.tsx
+++ b/packages/native-stack/src/views/NativeStackView.native.tsx
@@ -148,13 +148,9 @@ const SceneView = ({
     animation,
     customAnimationOnGesture,
     fullScreenGestureEnabled,
-    gestureDirection,
     presentation = 'card',
+    gestureDirection = presentation === 'card' ? 'horizontal' : 'vertical',
   } = options;
-
-  if (gestureDirection === undefined) {
-    gestureDirection = presentation === 'card' ? 'horizontal' : 'vertical';
-  }
 
   if (gestureDirection === 'vertical') {
     // for `vertical` direction to work, we need to set `fullScreenGestureEnabled` to `true`

--- a/packages/native-stack/src/views/NativeStackView.native.tsx
+++ b/packages/native-stack/src/views/NativeStackView.native.tsx
@@ -328,6 +328,13 @@ function NativeStackViewInner({ state, navigation, descriptors }: Props) {
           ? descriptors[previousKey]
           : undefined;
 
+        // workaround for rn-screens where gestureDirection has to be set on both
+        // current and previous screen - software-mansion/react-native-screens/pull/1509
+        const { gestureDirection } = descriptor.options;
+        if (gestureDirection && previousDescriptor) {
+          previousDescriptor.options.gestureDirection = gestureDirection;
+        }
+
         return (
           <SceneView
             key={route.key}

--- a/packages/native-stack/src/views/NativeStackView.native.tsx
+++ b/packages/native-stack/src/views/NativeStackView.native.tsx
@@ -154,7 +154,7 @@ const SceneView = ({
     gestureDirection = presentation === 'card' ? 'horizontal' : 'vertical',
   } = options;
 
-  if (gestureDirection === 'vertical') {
+  if (gestureDirection === 'vertical' && Platform.OS === 'ios') {
     // for `vertical` direction to work, we need to set `fullScreenGestureEnabled` to `true`
     // so the screen can be dismissed from any point on screen.
     // `customAnimationOnGesture` needs to be set to `true` so the `animation` set by user can be used,

--- a/packages/native-stack/src/views/NativeStackView.native.tsx
+++ b/packages/native-stack/src/views/NativeStackView.native.tsx
@@ -142,20 +142,24 @@ const SceneView = ({
     statusBarStyle,
     statusBarTranslucent,
     statusBarColor,
-    gestureDirection = 'horizontal',
   } = options;
 
   let {
     animation,
     customAnimationOnGesture,
     fullScreenGestureEnabled,
+    gestureDirection,
     presentation = 'card',
   } = options;
 
+  if (gestureDirection === undefined) {
+    gestureDirection = presentation === 'card' ? 'horizontal' : 'vertical';
+  }
+
   if (gestureDirection === 'vertical') {
-    // for `vertical` direction to work, we need to set `fullScreenSwipeEnabled` to `true`
+    // for `vertical` direction to work, we need to set `fullScreenGestureEnabled` to `true`
     // so the screen can be dismissed from any point on screen.
-    // `customAnimationOnGesture` needs to be set to `true` so the `stackAnimation` set by user can be used,
+    // `customAnimationOnGesture` needs to be set to `true` so the `animation` set by user can be used,
     // otherwise `simple_push` will be used.
     // Also, the default animation for this direction seems to be `slide_from_bottom`.
     if (fullScreenGestureEnabled === undefined) {

--- a/packages/native-stack/src/views/NativeStackView.native.tsx
+++ b/packages/native-stack/src/views/NativeStackView.native.tsx
@@ -115,6 +115,7 @@ type SceneViewProps = {
   onAppear: () => void;
   onDisappear: () => void;
   onDismissed: ScreenProps['onDismissed'];
+  gestureDirectionOverride?: ScreenProps['swipeDirection'];
 };
 
 const SceneView = ({
@@ -125,6 +126,7 @@ const SceneView = ({
   onAppear,
   onDisappear,
   onDismissed,
+  gestureDirectionOverride,
 }: SceneViewProps) => {
   const { route, navigation, options, render } = descriptor;
   const {
@@ -228,7 +230,7 @@ const SceneView = ({
       statusBarStyle={statusBarStyle}
       statusBarColor={statusBarColor}
       statusBarTranslucent={statusBarTranslucent}
-      swipeDirection={gestureDirection}
+      swipeDirection={gestureDirectionOverride ?? gestureDirection}
       transitionDuration={animationDuration}
       onWillDisappear={onWillDisappear}
       onAppear={onAppear}
@@ -324,16 +326,19 @@ function NativeStackViewInner({ state, navigation, descriptors }: Props) {
       {state.routes.map((route, index) => {
         const descriptor = descriptors[route.key];
         const previousKey = state.routes[index - 1]?.key;
+        const nextKey = state.routes[index + 1]?.key;
         const previousDescriptor = previousKey
           ? descriptors[previousKey]
           : undefined;
+        const nextDescriptor = nextKey ? descriptors[nextKey] : undefined;
 
         // workaround for rn-screens where gestureDirection has to be set on both
         // current and previous screen - software-mansion/react-native-screens/pull/1509
-        const { gestureDirection } = descriptor.options;
-        if (gestureDirection && previousDescriptor) {
-          previousDescriptor.options.gestureDirection = gestureDirection;
-        }
+        const nextGestureDirection = nextDescriptor?.options.gestureDirection;
+        const gestureDirection =
+          nextGestureDirection != null
+            ? nextGestureDirection
+            : descriptor.options.gestureDirection;
 
         return (
           <SceneView
@@ -371,6 +376,7 @@ function NativeStackViewInner({ state, navigation, descriptors }: Props) {
 
               setNextDismissedKey(route.key);
             }}
+            gestureDirectionOverride={gestureDirection}
           />
         );
       })}

--- a/packages/native-stack/src/views/NativeStackView.tsx
+++ b/packages/native-stack/src/views/NativeStackView.tsx
@@ -42,7 +42,7 @@ export default function NativeStackView({ state, descriptors }: Props) {
           const previousDescriptor = previousKey
             ? descriptors[previousKey]
             : undefined;
-          const nexDescriptor = nextKey ? descriptors[nextKey] : undefined;
+          const nextDescriptor = nextKey ? descriptors[nextKey] : undefined;
           const { options, navigation, render } = descriptors[route.key];
 
           const {
@@ -64,7 +64,7 @@ export default function NativeStackView({ state, descriptors }: Props) {
             contentStyle,
           } = options;
 
-          const nextPresentation = nexDescriptor?.options.presentation;
+          const nextPresentation = nextDescriptor?.options.presentation;
 
           return (
             <Screen


### PR DESCRIPTION
** Motivation **

This PR cleans up native-stack's new props docs and sets `gestureDirection` default value depending on `presentation` prop.