### PR TITLE
fix: typo in useFocusEffect with async function error

### DIFF
--- a/packages/core/src/useFocusEffect.tsx
+++ b/packages/core/src/useFocusEffect.tsx
@@ -52,7 +52,7 @@ export default function useFocusEffect(effect: EffectCallback) {
             'Instead, write the async function inside your effect ' +
             'and call it immediately:\n\n' +
             'useFocusEffect(\n' +
-            '  React.useCallback() => {\n' +
+            '  React.useCallback(() => {\n' +
             '    async function fetchData() {\n' +
             '      // You can await here\n' +
             '      const response = await MyAPI.getData(someId);\n' +


### PR DESCRIPTION
Unmatched parentheses in the sample code included in the error message when an async function is passed to `useFocusEffect`.

**Motivation**

People who copy/paste from the error message and adapt it to their requirements would have a syntax error.

**Test plan**

Pass an async function to useFocusEffect, check that the parens are balanced in the sample code shown in the error message.