### PR TITLE
fix: add helpful error when using legacy implementation with reanimated v3

### DIFF
--- a/packages/drawer/src/views/DrawerView.tsx
+++ b/packages/drawer/src/views/DrawerView.tsx
@@ -84,6 +84,16 @@ function DrawerViewBase({
   // @ts-expect-error: the type definitions are incomplete
   useLegacyImplementation = !Reanimated.isConfigured?.(),
 }: Props) {
+  // Reanimated v3 dropped legacy v1 syntax
+  const legacyImplemenationNotAvailable =
+    Reanimated.interpolateNode === undefined;
+
+  if (useLegacyImplementation && legacyImplemenationNotAvailable) {
+    throw new Error(
+      'Legacy drawer implementation is not available with Reanimated 3 as it no longer includes support for Reanimated 1 legacy API.'
+    );
+  }
+
   const Drawer: React.ComponentType<DrawerProps> = useLegacyImplementation
     ? require('./legacy/Drawer').default
     : require('./modern/Drawer').default;


### PR DESCRIPTION
**Motivation**

As Reanimated 3 will not support Reanimated 1 syntax anymore we need to show a helpful message describing the problem. 

The blog post [Announcing Reanimated 3](https://blog.swmansion.com/announcing-reanimated-3-16167428c5f7)

**Test plan**

Change should not have an effect on applications that use Reanimated 1 & 2. 
When using Reanimated 3 with `useLegacyImplementation` enabled there should be an error explaining the problem.
