### PR TITLE
fix: getComponent dynamic loading component optimization

### DIFF
--- a/packages/core/src/SceneView.tsx
+++ b/packages/core/src/SceneView.tsx
@@ -115,9 +115,10 @@ export default function SceneView<
     ]
   );
 
-  const ScreenComponent = screen.getComponent
-    ? screen.getComponent()
-    : screen.component;
+  const ScreenComponent = React.useMemo(
+    () => screen.getComponent?.() ?? screen.component,
+    [screen]
+  );
 
   return (
     <NavigationStateContext.Provider value={context}>


### PR DESCRIPTION
**Motivation**
Loading components dynamically on the web with [`loadable-component`](https://loadable-components.com/), the `getComponent` method creates a problem: the rendering of a new page causes the previous page to reload the component

