### PR TITLE
Fix linking path

### DIFF
--- a/packages/core/src/__tests__/getStateFromPath.test.tsx
+++ b/packages/core/src/__tests__/getStateFromPath.test.tsx
@@ -893,6 +893,48 @@ it('returns matching screen if path is empty', () => {
   ).toEqual(changePath(state, '/'));
 });
 
+it('returns matching screen if path is only slash', () => {
+  const path = '/';
+  const config = {
+    screens: {
+      Foo: {
+        screens: {
+          Foe: 'foe',
+          Bar: {
+            screens: {
+              Qux: '',
+              Baz: 'baz',
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: 'Foo',
+        state: {
+          routes: [
+            {
+              name: 'Bar',
+              state: {
+                routes: [{ name: 'Qux', path }],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getStateFromPath<object>(path, config)).toEqual(state);
+  expect(
+    getStateFromPath<object>(getPathFromState<object>(state, config), config)
+  ).toEqual(changePath(state, '/'));
+});
+
 it('returns matching screen with params if path is empty', () => {
   const path = '?foo=42';
   const config = {

--- a/packages/native/src/__tests__/extractPathFromURL.test.tsx
+++ b/packages/native/src/__tests__/extractPathFromURL.test.tsx
@@ -68,6 +68,14 @@ it('extracts path from URL with protocol and host', () => {
       'scheme:///example.com/some/path'
     )
   ).toBe('/some/path');
+
+  expect(
+    extractPathFromURL(['scheme://example.com'], 'scheme://example.com/')
+  ).toBe('/');
+
+  expect(
+    extractPathFromURL(['scheme://example.com'], 'scheme://example.com')
+  ).toBe('');
 });
 
 it('extracts path from URL with protocol and host with wildcard', () => {

--- a/packages/native/src/useLinking.native.tsx
+++ b/packages/native/src/useLinking.native.tsx
@@ -123,7 +123,7 @@ export default function useLinking(
 
       const path = extractPathFromURL(prefixesRef.current, url);
 
-      return path
+      return path !== undefined
         ? getStateFromPathRef.current(path, configRef.current)
         : undefined;
     },


### PR DESCRIPTION
**Motivation**

At the moment, a linking url without a path (with or without an ending slash) cannot match the linking configuration, as it is ignored.

Consider the following linking configuration:
```
{
  prefixes: ['https://myapp.com/'],
  config: {
    screens: {
      MyScreen: '',
    },
  },
};
```
If the received linking url is equal to `https://myapp.com/` it won't be matching `MyScreen` as the empty path is ignore. To be able to match an empty path, we need to change the path validation (see change in `useLinking.native.tsx`).

The `getStateFromPath` function is already able to match an empty string. Tests have been added to clearly expose the expected behaviour. 

**Test plan**

Use a deeplink url without a path in your app and match that deeplink in your linking configuration using an empty path.