### PR TITLE
fix: fixed `focused` value in `tabBarIcon`

### DIFF
--- a/packages/bottom-tabs/src/views/TabBarIcon.tsx
+++ b/packages/bottom-tabs/src/views/TabBarIcon.tsx
@@ -1,4 +1,5 @@
 import type { Route } from '@react-navigation/native';
+import { useIsFocused } from '@react-navigation/native';
 import React from 'react';
 import {
   StyleProp,
@@ -40,6 +41,7 @@ export default function TabBarIcon({
   style,
 }: Props) {
   const size = 25;
+  const focused = useIsFocused();
 
   // We render the icon twice at the same position on top of each other:
   // active and inactive one, so we can fade between them.
@@ -49,14 +51,14 @@ export default function TabBarIcon({
     >
       <View style={[styles.icon, { opacity: activeOpacity }]}>
         {renderIcon({
-          focused: true,
+          focused,
           size,
           color: activeTintColor,
         })}
       </View>
       <View style={[styles.icon, { opacity: inactiveOpacity }]}>
         {renderIcon({
-          focused: false,
+          focused,
           size,
           color: inactiveTintColor,
         })}


### PR DESCRIPTION
**Motivation**

When accessing `focused` in `tabBarIcon`, it returns both `true` and `false`. It should return either true or false depending on focus. This pull request fixes this problem. 

**Test plan**

Add `focused` prop [here](https://github.com/kyawthura-gg/react-navigation/blob/12be3abb3f067c3f3e7741516eda57c542c9dedc/example/src/Screens/BottomTabs.tsx#L25) and try `console.log(focused)`. It will return either `true` or `false`.
