### PR TITLE
feat: expose tab press events

### DIFF
--- a/packages/bottom-tabs/src/types.tsx
+++ b/packages/bottom-tabs/src/types.tsx
@@ -25,11 +25,14 @@ export type BottomTabNavigationEventMap = {
   /**
    * Event which fires on tapping on the tab in the tab bar.
    */
-  tabPress: { data: undefined; canPreventDefault: true };
+  tabPress: {
+    data: GestureResponderEvent | React.MouseEvent<HTMLElement, MouseEvent>;
+    canPreventDefault: true;
+  };
   /**
    * Event which fires on long press on the tab in the tab bar.
    */
-  tabLongPress: { data: undefined };
+  tabLongPress: { data: GestureResponderEvent };
 };
 
 export type LabelPosition = 'beside-icon' | 'below-icon';

--- a/packages/bottom-tabs/src/views/BottomTabBar.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabBar.tsx
@@ -11,6 +11,7 @@ import {
 import React from 'react';
 import {
   Animated,
+  GestureResponderEvent,
   LayoutChangeEvent,
   Platform,
   StyleProp,
@@ -296,11 +297,14 @@ export default function BottomTabBar({
           const focused = index === state.index;
           const { options } = descriptors[route.key];
 
-          const onPress = () => {
+          const onPress = (
+            e: GestureResponderEvent | React.MouseEvent<HTMLElement, MouseEvent>
+          ) => {
             const event = navigation.emit({
               type: 'tabPress',
               target: route.key,
               canPreventDefault: true,
+              data: e,
             });
 
             if (!focused && !event.defaultPrevented) {
@@ -311,10 +315,11 @@ export default function BottomTabBar({
             }
           };
 
-          const onLongPress = () => {
+          const onLongPress = (e: GestureResponderEvent) => {
             navigation.emit({
               type: 'tabLongPress',
               target: route.key,
+              data: e,
             });
           };
 


### PR DESCRIPTION
Exposing the press event on tab buttons

**Motivation**

Press event can be useful in number of cases, in my case I need the timestamp of the native event occurrence 

**Test plan**
Listen for the event on tabPress

`
<Tab.Navigator
                screenListeners={params => {
                    return {
                        tabPress: event => { /*event will contain data property with original press event*/
}
}...
`