### PR TITLE
chore: export NativeStackNavigatorProps

### DIFF
--- a/packages/native-stack/src/index.tsx
+++ b/packages/native-stack/src/index.tsx
@@ -16,5 +16,6 @@ export type {
   NativeStackNavigationEventMap,
   NativeStackNavigationOptions,
   NativeStackNavigationProp,
+  NativeStackNavigatorProps,
   NativeStackScreenProps,
 } from './types';


### PR DESCRIPTION
Seems like an oversight that this type wasn't being exported. It's needed for the props type for a native stack navigator.
