### PR TITLE
fix: migrate off setNativeProps

### DIFF
--- a/packages/stack/src/views/Stack/Card.tsx
+++ b/packages/stack/src/views/Stack/Card.tsx
@@ -67,6 +67,10 @@ type Props = ViewProps & {
   contentStyle?: StyleProp<ViewStyle>;
 };
 
+type State = {
+  pointerEvents: ViewProps['pointerEvents'];
+};
+
 const GESTURE_VELOCITY_IMPACT = 0.3;
 
 const TRUE = 1;
@@ -89,7 +93,7 @@ const hasOpacityStyle = (style: any) => {
   return false;
 };
 
-export default class Card extends React.Component<Props> {
+export default class Card extends React.Component<Props, State> {
   static defaultProps = {
     shadowEnabled: false,
     gestureEnabled: true,
@@ -102,6 +106,10 @@ export default class Card extends React.Component<Props> {
       style ? (
         <Animated.View pointerEvents="none" style={[styles.overlay, style]} />
       ) : null,
+  };
+
+  state: State = {
+    pointerEvents: 'auto',
   };
 
   componentDidMount() {
@@ -242,7 +250,7 @@ export default class Card extends React.Component<Props> {
   private setPointerEventsEnabled = (enabled: boolean) => {
     const pointerEvents = enabled ? 'box-none' : 'none';
 
-    this.contentRef.current?.setNativeProps({ pointerEvents });
+    this.setState((state) => ({ ...state, pointerEvents }));
   };
 
   private handleStartInteraction = () => {
@@ -425,8 +433,6 @@ export default class Card extends React.Component<Props> {
     }
   }
 
-  private contentRef = React.createRef<View>();
-
   render() {
     const {
       styleInterpolator,
@@ -555,7 +561,7 @@ export default class Card extends React.Component<Props> {
                   />
                 ) : null}
                 <CardSheet
-                  ref={this.contentRef}
+                  pointerEvents={this.state.pointerEvents}
                   enabled={pageOverflowEnabled}
                   layout={layout}
                   style={contentStyle}


### PR DESCRIPTION
### Motivation

In order to fully support Fabric in @react-navigation/stack we need to remove the use of `setNativeProps` as stated in the official migrating documentation: [Moving setNativeProps to state](https://reactnative.dev/docs/next/new-architecture-library-intro#moving-setnativeprops-to-state)

Fixes #10720

### Test plan

TBD
