### PR TITLE
chore: use npm-run-all to sequentially run tasks

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -8,8 +8,9 @@
     "client": "expo start --dev-client",
     "web": "expo start --web",
     "android": "expo run:android",
-    "ios": "expo run:ios",
-    "preios": "pod-install",
+    "ios": "npm-run-all -s pod-install run:ios",
+    "run:ios": "expo run:ios",
+    "pod-install": "pod-install",
     "server": "nodemon -e '.js,.ts,.tsx' --exec \"babel-node -i '/node_modules[/\\](?react-native)/' -x '.web.tsx,.web.ts,.web.js,.tsx,.ts,.js' --config-file ./server/babel.config.js server\"",
     "test:e2e": "npx playwright test --config=e2e/playwright.config.ts"
   },

--- a/package.json
+++ b/package.json
@@ -20,8 +20,9 @@
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
     "typescript": "tsc --noEmit --composite false",
     "test": "jest",
-    "prerelease": "lerna run clean",
-    "release": "lerna publish",
+    "clean": "lerna run clean",
+    "publish": "lerna publish",
+    "release": "npm-run-all -s clean publish",
     "example": "yarn workspace @react-navigation/example"
   },
   "engines": {
@@ -47,6 +48,7 @@
     "jest": "^26.6.3",
     "lerna": "^4.0.0",
     "metro-react-native-babel-preset": "^0.66.0",
+    "npm-run-all": "^4.1.5",
     "prettier": "^2.3.0",
     "typescript": "^4.7.4"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -18905,6 +18905,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"memorystream@npm:^0.3.1":
+  version: 0.3.1
+  resolution: "memorystream@npm:0.3.1"
+  checksum: f18b42440d24d09516d01466c06adf797df7873f0d40aa7db02e5fb9ed83074e5e65412d0720901d7069363465f82dc4f8bcb44f0cde271567a61426ce6ca2e9
+  languageName: node
+  linkType: hard
+
 "meow@npm:^6.1.1":
   version: 6.1.1
   resolution: "meow@npm:6.1.1"
@@ -20792,6 +20799,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"npm-run-all@npm:^4.1.5":
+  version: 4.1.5
+  resolution: "npm-run-all@npm:4.1.5"
+  dependencies:
+    ansi-styles: ^3.2.1
+    chalk: ^2.4.1
+    cross-spawn: ^6.0.5
+    memorystream: ^0.3.1
+    minimatch: ^3.0.4
+    pidtree: ^0.3.0
+    read-pkg: ^3.0.0
+    shell-quote: ^1.6.1
+    string.prototype.padend: ^3.0.0
+  bin:
+    npm-run-all: bin/npm-run-all/index.js
+    run-p: bin/run-p/index.js
+    run-s: bin/run-s/index.js
+  checksum: 373b72c6a36564da13c1642c1fd9bb4dcc756bce7a3648f883772f02661095319820834ff813762d2fee403e9b40c1cd27c8685807c107440f10eb19c006d4a0
+  languageName: node
+  linkType: hard
+
 "npm-run-path@npm:^2.0.0":
   version: 2.0.2
   resolution: "npm-run-path@npm:2.0.2"
@@ -21920,6 +21948,15 @@ __metadata:
   version: 2.3.1
   resolution: "picomatch@npm:2.3.1"
   checksum: 050c865ce81119c4822c45d3c84f1ced46f93a0126febae20737bd05ca20589c564d6e9226977df859ed5e03dc73f02584a2b0faad36e896936238238b0446cf
+  languageName: node
+  linkType: hard
+
+"pidtree@npm:^0.3.0":
+  version: 0.3.1
+  resolution: "pidtree@npm:0.3.1"
+  bin:
+    pidtree: bin/pidtree.js
+  checksum: eb49025099f1af89a4696f7673351421f13420f3397b963c901fe23a1c9c2ff50f4750321970d4472c0ffbb065e4a6c3c27f75e226cc62284b19e21d32ce7012
   languageName: node
   linkType: hard
 
@@ -25240,6 +25277,7 @@ __metadata:
     jest: ^26.6.3
     lerna: ^4.0.0
     metro-react-native-babel-preset: ^0.66.0
+    npm-run-all: ^4.1.5
     prettier: ^2.3.0
     react-native-web: 0.17.7
     typescript: ^4.7.4
@@ -26576,6 +26614,17 @@ __metadata:
     regexp.prototype.flags: ^1.3.1
     side-channel: ^1.0.4
   checksum: 07aca53ddd8a096a8bd0560eb8574386c6b3887a6a06b40a98abd42c94dadeed3296261fca22fec59a1ed970d199bdeb450fcb6a7390193588d9c6b5f48fe842
+  languageName: node
+  linkType: hard
+
+"string.prototype.padend@npm:^3.0.0":
+  version: 3.1.3
+  resolution: "string.prototype.padend@npm:3.1.3"
+  dependencies:
+    call-bind: ^1.0.2
+    define-properties: ^1.1.3
+    es-abstract: ^1.19.1
+  checksum: ef9ee0542c17975629bc6d21497e8faaa142d873e9f07fb65de2a955df402a1eac45cbed375045a759501e9d4ef80e589e11f0e12103c20df0770e47f6b59bc7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Berry (new version of yarn) removed support for life cycle scripts like `pre` and `post`. 

This PR uses `npm-run-all` to sequentially run tasks in order to mimic the behavior of life cycle scripts.
