### PR TITLE
fix: `PanGestureHandlerGestureEvent` is a type and should be exported as such

### DIFF
--- a/packages/drawer/src/views/GestureHandlerNative.tsx
+++ b/packages/drawer/src/views/GestureHandlerNative.tsx
@@ -16,9 +16,9 @@ export function PanGestureHandler(props: PanGestureHandlerProperties) {
   );
 }
 
+export type { PanGestureHandlerGestureEvent } from 'react-native-gesture-handler';
 export {
   GestureHandlerRootView,
   State as GestureState,
-  PanGestureHandlerGestureEvent,
   TapGestureHandler,
 } from 'react-native-gesture-handler';

--- a/packages/stack/src/views/GestureHandlerNative.tsx
+++ b/packages/stack/src/views/GestureHandlerNative.tsx
@@ -16,8 +16,8 @@ export function PanGestureHandler(props: PanGestureHandlerProperties) {
   );
 }
 
+export type { PanGestureHandlerGestureEvent } from 'react-native-gesture-handler';
 export {
   GestureHandlerRootView,
   State as GestureState,
-  PanGestureHandlerGestureEvent,
 } from 'react-native-gesture-handler';


### PR DESCRIPTION
**Motivation**

`PanGestureHandlerGestureEvent` is exported as a value, but is a type. This makes it included in the transpiled published code, which is incorrect and makes `esbuild` error it tries to consume the code (for example with https://microsoft.github.io/rnx-kit/docs/tools/metro-serializer-esbuild).

**Test plan**

There should not be any special test plans here, and the issue only happens when a non-standard RN/Metro setup is used. I tried the fix on my app using the ESBuild serializer mentioned above and it fixed the issue.
