### PR TITLE
refactor!: drop support for key property in navigate

### DIFF
--- a/example/src/Screens/NativeStack.tsx
+++ b/example/src/Screens/NativeStack.tsx
@@ -42,6 +42,13 @@ const ArticleScreen = ({
           Replace with feed
         </Button>
         <Button
+          mode="contained"
+          onPress={() => navigation.popTo('Albums')}
+          style={styles.button}
+        >
+          Pop to Albums
+        </Button>
+        <Button
           mode="outlined"
           onPress={() => navigation.pop()}
           style={styles.button}

--- a/example/src/Screens/SimpleStack.tsx
+++ b/example/src/Screens/SimpleStack.tsx
@@ -35,6 +35,13 @@ const ArticleScreen = ({
           Replace with feed
         </Button>
         <Button
+          mode="contained"
+          onPress={() => navigation.popTo('Albums')}
+          style={styles.button}
+        >
+          Pop to Albums
+        </Button>
+        <Button
           mode="outlined"
           onPress={() =>
             navigation.setParams({

--- a/packages/core/src/__tests__/useOnAction.test.tsx
+++ b/packages/core/src/__tests__/useOnAction.test.tsx
@@ -3,6 +3,7 @@ import {
   NavigationState,
   ParamListBase,
   Router,
+  StackActions,
   StackRouter,
 } from '@react-navigation/routers';
 import { act, render } from '@testing-library/react-native';
@@ -621,7 +622,7 @@ it("prevents removing a screen with 'beforeRemove' event", () => {
     type: 'stack',
   });
 
-  act(() => ref.current?.navigate('foo'));
+  act(() => ref.current?.dispatch(StackActions.popTo('foo')));
 
   expect(onStateChange).toBeCalledTimes(2);
   expect(onBeforeRemove).toBeCalledTimes(1);
@@ -641,7 +642,7 @@ it("prevents removing a screen with 'beforeRemove' event", () => {
 
   shouldPrevent = false;
 
-  act(() => ref.current?.navigate('foo'));
+  act(() => ref.current?.dispatch(StackActions.popTo('foo')));
 
   expect(onStateChange).toBeCalledTimes(3);
   expect(onStateChange).toBeCalledWith({
@@ -771,7 +772,7 @@ it("prevents removing a child screen with 'beforeRemove' event", () => {
     type: 'stack',
   });
 
-  act(() => ref.current?.navigate('foo'));
+  act(() => ref.current?.dispatch(StackActions.popTo('foo')));
 
   expect(onStateChange).toBeCalledTimes(2);
   expect(onBeforeRemove).toBeCalledTimes(1);
@@ -802,7 +803,7 @@ it("prevents removing a child screen with 'beforeRemove' event", () => {
 
   shouldPrevent = false;
 
-  act(() => ref.current?.navigate('foo'));
+  act(() => ref.current?.dispatch(StackActions.popTo('foo')));
 
   expect(onStateChange).toBeCalledTimes(3);
   expect(onStateChange).toBeCalledWith({
@@ -950,7 +951,7 @@ it("prevents removing a grand child screen with 'beforeRemove' event", () => {
     type: 'stack',
   });
 
-  act(() => ref.current?.navigate('foo'));
+  act(() => ref.current?.dispatch(StackActions.popTo('foo')));
 
   expect(onStateChange).toBeCalledTimes(2);
   expect(onBeforeRemove).toBeCalledTimes(1);
@@ -994,7 +995,7 @@ it("prevents removing a grand child screen with 'beforeRemove' event", () => {
 
   shouldPrevent = false;
 
-  act(() => ref.current?.navigate('foo'));
+  act(() => ref.current?.dispatch(StackActions.popTo('foo')));
 
   expect(onStateChange).toBeCalledTimes(3);
   expect(onStateChange).toBeCalledWith({
@@ -1141,7 +1142,7 @@ it("prevents removing by multiple screens with 'beforeRemove' event", () => {
   expect(onStateChange).toBeCalledTimes(1);
   expect(onStateChange).toBeCalledWith(preventedState);
 
-  act(() => ref.current?.navigate('foo'));
+  act(() => ref.current?.dispatch(StackActions.popTo('foo')));
 
   expect(onStateChange).toBeCalledTimes(1);
   expect(onBeforeRemove.lex).toBeCalledTimes(1);
@@ -1150,7 +1151,7 @@ it("prevents removing by multiple screens with 'beforeRemove' event", () => {
 
   shouldPrevent.lex = false;
 
-  act(() => ref.current?.navigate('foo'));
+  act(() => ref.current?.dispatch(StackActions.popTo('foo')));
 
   expect(onStateChange).toBeCalledTimes(1);
   expect(onBeforeRemove.baz).toBeCalledTimes(1);
@@ -1159,7 +1160,7 @@ it("prevents removing by multiple screens with 'beforeRemove' event", () => {
 
   shouldPrevent.baz = false;
 
-  act(() => ref.current?.navigate('foo'));
+  act(() => ref.current?.dispatch(StackActions.popTo('foo')));
 
   expect(onStateChange).toBeCalledTimes(1);
   expect(onBeforeRemove.bar).toBeCalledTimes(1);
@@ -1168,7 +1169,7 @@ it("prevents removing by multiple screens with 'beforeRemove' event", () => {
 
   shouldPrevent.bar = false;
 
-  act(() => ref.current?.navigate('foo'));
+  act(() => ref.current?.dispatch(StackActions.popTo('foo')));
 
   expect(onStateChange).toBeCalledTimes(2);
   expect(onStateChange).toBeCalledWith({

--- a/packages/core/src/__tests__/usePreventRemove.test.tsx
+++ b/packages/core/src/__tests__/usePreventRemove.test.tsx
@@ -1,4 +1,8 @@
-import { ParamListBase, StackRouter } from '@react-navigation/routers';
+import {
+  ParamListBase,
+  StackActions,
+  StackRouter,
+} from '@react-navigation/routers';
 import { act, render } from '@testing-library/react-native';
 import * as React from 'react';
 
@@ -97,7 +101,7 @@ it("prevents removing a screen with 'usePreventRemove' hook", () => {
     type: 'stack',
   });
 
-  act(() => ref.current?.navigate('foo'));
+  act(() => ref.current?.dispatch(StackActions.popTo('foo')));
 
   expect(onStateChange).toBeCalledTimes(2);
   expect(onPreventRemove).toBeCalledTimes(1);
@@ -118,7 +122,7 @@ it("prevents removing a screen with 'usePreventRemove' hook", () => {
   shouldContinue = true;
 
   act(() => ref.current?.navigate('bar'));
-  act(() => ref.current?.navigate('foo'));
+  act(() => ref.current?.dispatch(StackActions.popTo('foo')));
 
   expect(onStateChange).toBeCalledTimes(4);
   expect(onStateChange).toBeCalledWith({
@@ -209,7 +213,7 @@ it("prevents removing a screen when 'usePreventRemove' hook is called multiple t
     type: 'stack',
   });
 
-  act(() => ref.current?.navigate('foo'));
+  act(() => ref.current?.dispatch(StackActions.popTo('foo')));
 
   expect(onStateChange).toBeCalledTimes(2);
   expect(onPreventRemove).toBeCalledTimes(1);
@@ -230,7 +234,7 @@ it("prevents removing a screen when 'usePreventRemove' hook is called multiple t
   shouldContinue = true;
 
   act(() => ref.current?.navigate('bar'));
-  act(() => ref.current?.navigate('foo'));
+  act(() => ref.current?.dispatch(StackActions.popTo('foo')));
 
   expect(onStateChange).toBeCalledTimes(4);
   expect(onStateChange).toBeCalledWith({
@@ -314,7 +318,7 @@ it("should have no effect when 'usePreventRemove' hook is set to false", () => {
     type: 'stack',
   });
 
-  act(() => ref.current?.navigate('foo'));
+  act(() => ref.current?.dispatch(StackActions.popTo('foo')));
 
   expect(onStateChange).toBeCalledTimes(3);
 
@@ -328,7 +332,7 @@ it("should have no effect when 'usePreventRemove' hook is set to false", () => {
   });
 
   act(() => ref.current?.navigate('bar'));
-  act(() => ref.current?.navigate('foo'));
+  act(() => ref.current?.dispatch(StackActions.popTo('foo')));
 
   expect(onStateChange).toBeCalledTimes(5);
   expect(onStateChange).toBeCalledWith({
@@ -436,7 +440,7 @@ it("prevents removing a child screen with 'usePreventRemove' hook", () => {
     type: 'stack',
   });
 
-  act(() => ref.current?.navigate('foo'));
+  act(() => ref.current?.dispatch(StackActions.popTo('foo')));
 
   expect(onStateChange).toBeCalledTimes(2);
   expect(onPreventRemove).toBeCalledTimes(1);
@@ -465,7 +469,7 @@ it("prevents removing a child screen with 'usePreventRemove' hook", () => {
     type: 'stack',
   });
 
-  act(() => ref.current?.navigate('foo'));
+  act(() => ref.current?.dispatch(StackActions.popTo('foo')));
 
   expect(onStateChange).toBeCalledTimes(2);
   expect(ref.current?.getRootState()).toEqual({
@@ -495,7 +499,7 @@ it("prevents removing a child screen with 'usePreventRemove' hook", () => {
   shouldContinue = true;
 
   act(() => ref.current?.navigate('bar'));
-  act(() => ref.current?.navigate('foo'));
+  act(() => ref.current?.dispatch(StackActions.popTo('foo')));
 
   expect(onStateChange).toBeCalledTimes(4);
   expect(onStateChange).toBeCalledWith({
@@ -620,7 +624,7 @@ it("prevents removing a grand child screen with 'usePreventRemove' hook", () => 
     type: 'stack',
   });
 
-  act(() => ref.current?.navigate('foo'));
+  act(() => ref.current?.dispatch(StackActions.popTo('foo')));
 
   expect(onStateChange).toBeCalledTimes(2);
   expect(onPreventRemove).toBeCalledTimes(1);
@@ -665,7 +669,7 @@ it("prevents removing a grand child screen with 'usePreventRemove' hook", () => 
   shouldContinue = true;
 
   act(() => ref.current?.navigate('bar'));
-  act(() => ref.current?.navigate('foo'));
+  act(() => ref.current?.dispatch(StackActions.popTo('foo')));
 
   expect(onStateChange).toBeCalledTimes(4);
   expect(onStateChange).toBeCalledWith({
@@ -794,7 +798,7 @@ it("prevents removing by multiple screens with 'usePreventRemove' hook", () => {
   expect(onStateChange).toBeCalledTimes(1);
   expect(onStateChange).toBeCalledWith(preventedState);
 
-  act(() => ref.current?.navigate('foo'));
+  act(() => ref.current?.dispatch(StackActions.popTo('foo')));
 
   expect(onStateChange).toBeCalledTimes(1);
   expect(onPreventRemove.lex).toBeCalledTimes(1);
@@ -803,7 +807,7 @@ it("prevents removing by multiple screens with 'usePreventRemove' hook", () => {
 
   shouldContinue.lex = false;
 
-  act(() => ref.current?.navigate('foo'));
+  act(() => ref.current?.dispatch(StackActions.popTo('foo')));
 
   expect(onStateChange).toBeCalledTimes(1);
   expect(onPreventRemove.baz).toBeCalledTimes(1);
@@ -812,7 +816,7 @@ it("prevents removing by multiple screens with 'usePreventRemove' hook", () => {
 
   shouldContinue.baz = false;
 
-  act(() => ref.current?.navigate('foo'));
+  act(() => ref.current?.dispatch(StackActions.popTo('foo')));
 
   expect(onStateChange).toBeCalledTimes(1);
   expect(onPreventRemove.bar).toBeCalledTimes(1);
@@ -821,7 +825,7 @@ it("prevents removing by multiple screens with 'usePreventRemove' hook", () => {
 
   shouldContinue.bar = false;
 
-  act(() => ref.current?.navigate('foo'));
+  act(() => ref.current?.dispatch(StackActions.popTo('foo')));
 
   expect(onStateChange).toBeCalledTimes(2);
   expect(onStateChange).toBeCalledWith({

--- a/packages/core/src/types.tsx
+++ b/packages/core/src/types.tsx
@@ -192,7 +192,7 @@ type NavigationHelpersCommon<
    * @param [params] Params object for the route.
    */
   navigate<RouteName extends keyof ParamList>(
-    ...args: // this first condition allows us to iterate over a union type
+    ...args: // This condition allows us to iterate over a union type
     // This is to avoid getting a union of all the params from `ParamList[RouteName]`,
     // which will get our types all mixed up if a union RouteName is passed in.
     RouteName extends unknown
@@ -209,13 +209,14 @@ type NavigationHelpersCommon<
   /**
    * Navigate to a route in current navigation tree.
    *
-   * @param route Object with `key` or `name` for the route to navigate to, and a `params` object.
+   * @param route Object with `name` for the route to navigate to, and a `params` object.
    */
   navigate<RouteName extends keyof ParamList>(
     options: RouteName extends unknown
       ? {
           name: RouteName;
           params: ParamList[RouteName];
+          path?: string;
           merge?: boolean;
         }
       : never

--- a/packages/core/src/types.tsx
+++ b/packages/core/src/types.tsx
@@ -213,14 +213,11 @@ type NavigationHelpersCommon<
    */
   navigate<RouteName extends keyof ParamList>(
     options: RouteName extends unknown
-      ?
-          | { key: string; params?: ParamList[RouteName]; merge?: boolean }
-          | {
-              name: RouteName;
-              key?: string;
-              params: ParamList[RouteName];
-              merge?: boolean;
-            }
+      ? {
+          name: RouteName;
+          params: ParamList[RouteName];
+          merge?: boolean;
+        }
       : never
   ): void;
 

--- a/packages/routers/src/CommonActions.tsx
+++ b/packages/routers/src/CommonActions.tsx
@@ -15,21 +15,12 @@ export type Action =
     }
   | {
       type: 'NAVIGATE';
-      payload:
-        | {
-            key: string;
-            name?: undefined;
-            params?: object;
-            path?: string;
-            merge?: boolean;
-          }
-        | {
-            name: string;
-            key?: string;
-            params?: object;
-            path?: string;
-            merge?: boolean;
-          };
+      payload: {
+        name: string;
+        params?: object;
+        path?: string;
+        merge?: boolean;
+      };
       source?: string;
       target?: string;
     }
@@ -50,17 +41,12 @@ export function goBack(): Action {
   return { type: 'GO_BACK' };
 }
 
-export function navigate(
-  options:
-    | { key: string; params?: object; path?: string; merge?: boolean }
-    | {
-        name: string;
-        key?: string;
-        params?: object;
-        path?: string;
-        merge?: boolean;
-      }
-): Action;
+export function navigate(options: {
+  name: string;
+  params?: object;
+  path?: string;
+  merge?: boolean;
+}): Action;
 // eslint-disable-next-line no-redeclare
 export function navigate(name: string, params?: object): Action;
 // eslint-disable-next-line no-redeclare
@@ -70,9 +56,9 @@ export function navigate(...args: any): Action {
   } else {
     const payload = args[0] || {};
 
-    if (!payload.hasOwnProperty('key') && !payload.hasOwnProperty('name')) {
+    if (!payload.hasOwnProperty('name')) {
       throw new Error(
-        'You need to specify name or key when calling navigate with an object as the argument. See https://reactnavigation.org/docs/navigation-actions#navigate for usage.'
+        'You need to specify a name when calling navigate with an object as the argument. See https://reactnavigation.org/docs/navigation-actions#navigate for usage.'
       );
     }
 

--- a/packages/routers/src/TabRouter.tsx
+++ b/packages/routers/src/TabRouter.tsx
@@ -294,17 +294,9 @@ export default function TabRouter({
       switch (action.type) {
         case 'JUMP_TO':
         case 'NAVIGATE': {
-          let index = -1;
-
-          if (action.type === 'NAVIGATE' && action.payload.key) {
-            index = state.routes.findIndex(
-              (route) => route.key === action.payload.key
-            );
-          } else {
-            index = state.routes.findIndex(
-              (route) => route.name === action.payload.name
-            );
-          }
+          const index = state.routes.findIndex(
+            (route) => route.name === action.payload.name
+          );
 
           if (index === -1) {
             return null;

--- a/packages/routers/src/__tests__/CommonActions.test.tsx
+++ b/packages/routers/src/__tests__/CommonActions.test.tsx
@@ -1,8 +1,8 @@
 import * as CommonActions from '../CommonActions';
 
-it('throws if NAVIGATE is called without key or name', () => {
+it('throws if NAVIGATE is called without name', () => {
   // @ts-expect-error: we're explicitly using an invalid argument here
   expect(() => CommonActions.navigate({})).toThrowError(
-    'You need to specify name or key when calling navigate with an object as the argument.'
+    'You need to specify a name when calling navigate with an object as the argument.'
   );
 });

--- a/packages/routers/src/__tests__/StackRouter.test.tsx
+++ b/packages/routers/src/__tests__/StackRouter.test.tsx
@@ -366,81 +366,6 @@ it('handles navigate action', () => {
       options
     )
   ).toBe(null);
-
-  expect(
-    router.getStateForAction(
-      {
-        stale: false,
-        type: 'stack',
-        key: 'root',
-        index: 1,
-        routeNames: ['baz', 'bar', 'qux'],
-        routes: [
-          { key: 'baz-0', name: 'baz' },
-          { key: 'bar-0', name: 'bar' },
-        ],
-      },
-      CommonActions.navigate({ key: 'unknown' }),
-      options
-    )
-  ).toBe(null);
-
-  expect(
-    router.getStateForAction(
-      {
-        stale: false,
-        type: 'stack',
-        key: 'root',
-        index: 1,
-        routeNames: ['baz', 'bar', 'qux'],
-        routes: [
-          { key: 'baz-0', name: 'baz' },
-          { key: 'bar', name: 'bar' },
-        ],
-      },
-      {
-        type: 'NAVIGATE',
-        payload: { key: 'baz-0', name: 'baz' },
-      },
-      options
-    )
-  ).toEqual({
-    stale: false,
-    type: 'stack',
-    key: 'root',
-    index: 0,
-    routeNames: ['baz', 'bar', 'qux'],
-    routes: [{ key: 'baz-0', name: 'baz' }],
-  });
-
-  expect(
-    router.getStateForAction(
-      {
-        stale: false,
-        type: 'stack',
-        key: 'root',
-        index: 1,
-        routeNames: ['baz', 'bar', 'qux'],
-        routes: [
-          { key: 'baz-0', name: 'baz' },
-          { key: 'bar', name: 'bar' },
-        ],
-      },
-      CommonActions.navigate({ key: 'baz-1', name: 'baz' }),
-      options
-    )
-  ).toEqual({
-    stale: false,
-    type: 'stack',
-    key: 'root',
-    index: 2,
-    routeNames: ['baz', 'bar', 'qux'],
-    routes: [
-      { key: 'baz-0', name: 'baz' },
-      { key: 'bar', name: 'bar' },
-      { key: 'baz-1', name: 'baz' },
-    ],
-  });
 });
 
 it("doesn't navigate to nonexistent screen", () => {
@@ -465,28 +390,6 @@ it("doesn't navigate to nonexistent screen", () => {
         ],
       },
       CommonActions.navigate('far', { answer: 42 }),
-      options
-    )
-  ).toBe(null);
-
-  expect(
-    router.getStateForAction(
-      {
-        stale: false,
-        type: 'stack',
-        key: 'root',
-        index: 1,
-        routeNames: ['baz', 'bar', 'qux'],
-        routes: [
-          { key: 'baz', name: 'baz' },
-          { key: 'bar', name: 'bar' },
-        ],
-      },
-      CommonActions.navigate({
-        name: 'far',
-        key: 'test',
-        params: { answer: 42 },
-      }),
       options
     )
   ).toBe(null);
@@ -582,39 +485,6 @@ it('ensures unique ID for navigate', () => {
       { key: 'bar', name: 'bar' },
       { key: 'bar-test', name: 'bar', params: { foo: 'a' } },
       { key: 'bar-test', name: 'bar', params: { foo: 'b' } },
-    ],
-  });
-
-  expect(
-    router.getStateForAction(
-      {
-        stale: false,
-        type: 'stack',
-        key: 'root',
-        index: 1,
-        routeNames: ['baz', 'bar', 'qux'],
-        routes: [
-          { key: 'bar', name: 'bar' },
-          { key: 'bar-test', name: 'bar', params: { foo: 'a' } },
-        ],
-      },
-      CommonActions.navigate({
-        key: 'test',
-        name: 'bar',
-        params: { foo: 'a' },
-      }),
-      options
-    )
-  ).toEqual({
-    stale: false,
-    type: 'stack',
-    key: 'root',
-    index: 2,
-    routeNames: ['baz', 'bar', 'qux'],
-    routes: [
-      { key: 'bar', name: 'bar' },
-      { key: 'bar-test', name: 'bar', params: { foo: 'a' } },
-      { key: 'test', name: 'bar', params: { foo: 'a' } },
     ],
   });
 });

--- a/packages/routers/src/__tests__/StackRouter.test.tsx
+++ b/packages/routers/src/__tests__/StackRouter.test.tsx
@@ -316,9 +316,13 @@ it('handles navigate action', () => {
     stale: false,
     type: 'stack',
     key: 'root',
-    index: 0,
+    index: 2,
     routeNames: ['baz', 'bar', 'qux'],
-    routes: [{ key: 'baz', name: 'baz', params: { answer: 42 } }],
+    routes: [
+      { key: 'baz', name: 'baz' },
+      { key: 'bar', name: 'bar' },
+      { key: 'baz-test', name: 'baz', params: { answer: 42 } },
+    ],
   });
 
   expect(
@@ -348,24 +352,6 @@ it('handles navigate action', () => {
       { key: 'bar', name: 'bar', params: { answer: 96 } },
     ],
   });
-
-  expect(
-    router.getStateForAction(
-      {
-        stale: false,
-        type: 'stack',
-        key: 'root',
-        index: 1,
-        routeNames: ['baz', 'bar', 'qux'],
-        routes: [
-          { key: 'baz', name: 'baz' },
-          { key: 'bar', name: 'bar' },
-        ],
-      },
-      CommonActions.navigate('unknown'),
-      options
-    )
-  ).toBe(null);
 });
 
 it("doesn't navigate to nonexistent screen", () => {
@@ -1186,12 +1172,11 @@ it('adds path on navigate if provided', () => {
         stale: false,
         type: 'stack',
         key: 'root',
-        index: 2,
+        index: 1,
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'baz', name: 'baz' },
           { key: 'bar', name: 'bar', params: { answer: 42 } },
-          { key: 'qux', name: 'qux' },
         ],
       },
 
@@ -1297,12 +1282,11 @@ it("doesn't remove existing path on navigate if not provided", () => {
         stale: false,
         type: 'stack',
         key: 'root',
-        index: 2,
+        index: 1,
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'baz', name: 'baz' },
           { key: 'bar', name: 'bar', path: '/foo/bar' },
-          { key: 'qux', name: 'qux' },
         ],
       },
 
@@ -1325,7 +1309,128 @@ it("doesn't remove existing path on navigate if not provided", () => {
   });
 });
 
-it("doesn't merge params on navigate to an existing screen", () => {
+it('handles popTo action', () => {
+  const router = StackRouter({});
+  const options: RouterConfigOptions = {
+    routeNames: ['baz', 'bar', 'qux'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+
+  expect(
+    router.getStateForAction(
+      {
+        stale: false,
+        type: 'stack',
+        key: 'root',
+        index: 1,
+        routeNames: ['baz', 'bar', 'qux'],
+        routes: [
+          { key: 'baz', name: 'baz' },
+          { key: 'bar', name: 'bar' },
+        ],
+      },
+      StackActions.popTo('qux', { answer: 42 }),
+      options
+    )
+  ).toEqual({
+    stale: false,
+    type: 'stack',
+    key: 'root',
+    index: 1,
+    routeNames: ['baz', 'bar', 'qux'],
+    routes: [
+      { key: 'baz', name: 'baz' },
+      {
+        key: 'qux-test',
+        name: 'qux',
+        params: { answer: 42 },
+      },
+    ],
+  });
+
+  expect(
+    router.getStateForAction(
+      {
+        stale: false,
+        type: 'stack',
+        key: 'root',
+        index: 1,
+        routeNames: ['baz', 'bar', 'qux'],
+        routes: [
+          { key: 'baz', name: 'baz' },
+          { key: 'bar', name: 'bar' },
+        ],
+      },
+      StackActions.popTo('baz', { answer: 42 }),
+      options
+    )
+  ).toEqual({
+    stale: false,
+    type: 'stack',
+    key: 'root',
+    index: 0,
+    routeNames: ['baz', 'bar', 'qux'],
+    routes: [{ key: 'baz', name: 'baz', params: { answer: 42 } }],
+  });
+
+  expect(
+    router.getStateForAction(
+      {
+        stale: false,
+        type: 'stack',
+        key: 'root',
+        index: 1,
+        routeNames: ['baz', 'bar', 'qux'],
+        routes: [
+          { key: 'baz', name: 'baz' },
+          { key: 'bar', name: 'bar', params: { answer: 42 } },
+        ],
+      },
+      StackActions.popTo('bar', { answer: 96 }),
+      options
+    )
+  ).toEqual({
+    stale: false,
+    type: 'stack',
+    key: 'root',
+    index: 1,
+    routeNames: ['baz', 'bar', 'qux'],
+    routes: [
+      { key: 'baz', name: 'baz' },
+      { key: 'bar', name: 'bar', params: { answer: 96 } },
+    ],
+  });
+});
+
+it("doesn't popTo to nonexistent screen", () => {
+  const router = StackRouter({});
+  const options: RouterConfigOptions = {
+    routeNames: ['baz', 'bar', 'qux'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+
+  expect(
+    router.getStateForAction(
+      {
+        stale: false,
+        type: 'stack',
+        key: 'root',
+        index: 1,
+        routeNames: ['baz', 'bar', 'qux'],
+        routes: [
+          { key: 'baz', name: 'baz' },
+          { key: 'bar', name: 'bar' },
+        ],
+      },
+      CommonActions.navigate('far', { answer: 42 }),
+      options
+    )
+  ).toBe(null);
+});
+
+it("doesn't merge params on popTo to an existing screen", () => {
   const router = StackRouter({});
   const options: RouterConfigOptions = {
     routeNames: ['baz', 'bar', 'qux'],
@@ -1349,7 +1454,7 @@ it("doesn't merge params on navigate to an existing screen", () => {
           { key: 'qux', name: 'qux' },
         ],
       },
-      CommonActions.navigate('bar'),
+      StackActions.popTo('bar'),
       options
     )
   ).toEqual({
@@ -1377,7 +1482,7 @@ it("doesn't merge params on navigate to an existing screen", () => {
           { key: 'bar', name: 'bar', params: { answer: 42 } },
         ],
       },
-      CommonActions.navigate('bar', { fruit: 'orange' }),
+      StackActions.popTo('bar', { fruit: 'orange' }),
       options
     )
   ).toEqual({
@@ -1393,7 +1498,7 @@ it("doesn't merge params on navigate to an existing screen", () => {
   });
 });
 
-it('merges params on navigate to an existing screen if merge: true', () => {
+it('merges params on popTo to an existing screen if merge: true', () => {
   const router = StackRouter({});
   const options: RouterConfigOptions = {
     routeNames: ['baz', 'bar', 'qux'],
@@ -1419,10 +1524,7 @@ it('merges params on navigate to an existing screen if merge: true', () => {
         ],
       },
 
-      CommonActions.navigate({
-        name: 'bar',
-        merge: true,
-      }),
+      StackActions.popTo('bar', {}, true),
       options
     )
   ).toEqual({
@@ -1450,11 +1552,7 @@ it('merges params on navigate to an existing screen if merge: true', () => {
           { key: 'bar', name: 'bar', params: { answer: 42 } },
         ],
       },
-      CommonActions.navigate({
-        name: 'bar',
-        params: { fruit: 'orange' },
-        merge: true,
-      }),
+      StackActions.popTo('bar', { fruit: 'orange' }, true),
       options
     )
   ).toEqual({
@@ -1486,11 +1584,7 @@ it('merges params on navigate to an existing screen if merge: true', () => {
           { key: 'bar', name: 'bar', params: { answer: 42 } },
         ],
       },
-      CommonActions.navigate({
-        name: 'baz',
-        params: { color: 'black' },
-        merge: true,
-      }),
+      StackActions.popTo('baz', { color: 'black' }, true),
       options
     )
   ).toEqual({

--- a/packages/routers/src/__tests__/TabRouter.test.tsx
+++ b/packages/routers/src/__tests__/TabRouter.test.tsx
@@ -647,39 +647,6 @@ it('handles navigate action', () => {
         index: 1,
         routeNames: ['baz', 'bar'],
         routes: [
-          { key: 'baz-1', name: 'baz' },
-          { key: 'bar-1', name: 'bar' },
-        ],
-        history: [{ type: 'route', key: 'bar-1' }],
-      },
-      CommonActions.navigate({ key: 'bar-1', params: { answer: 42 } }),
-      options
-    )
-  ).toEqual({
-    stale: false,
-    type: 'tab',
-    key: 'root',
-    index: 1,
-    routeNames: ['baz', 'bar'],
-    routes: [
-      { key: 'baz-1', name: 'baz' },
-      { key: 'bar-1', name: 'bar', params: { answer: 42 } },
-    ],
-    history: [
-      { type: 'route', key: 'baz-1' },
-      { type: 'route', key: 'bar-1' },
-    ],
-  });
-
-  expect(
-    router.getStateForAction(
-      {
-        stale: false,
-        type: 'tab',
-        key: 'root',
-        index: 1,
-        routeNames: ['baz', 'bar'],
-        routes: [
           { key: 'baz', name: 'baz' },
           { key: 'bar', name: 'bar' },
         ],
@@ -744,29 +711,6 @@ it("doesn't navigate to nonexistent screen", () => {
         history: [{ type: 'route', key: 'bar' }],
       },
       CommonActions.navigate('foo', { answer: 42 }),
-      options
-    )
-  ).toBe(null);
-
-  expect(
-    router.getStateForAction(
-      {
-        stale: false,
-        type: 'tab',
-        key: 'root',
-        index: 1,
-        routeNames: ['baz', 'bar'],
-        routes: [
-          { key: 'baz', name: 'baz' },
-          { key: 'bar', name: 'bar' },
-        ],
-        history: [{ type: 'route', key: 'bar' }],
-      },
-      CommonActions.navigate({
-        name: 'foo',
-        key: 'test',
-        params: { answer: 42 },
-      }),
       options
     )
   ).toBe(null);

--- a/packages/stack/src/views/Stack/StackView.tsx
+++ b/packages/stack/src/views/Stack/StackView.tsx
@@ -3,6 +3,7 @@ import {
   SafeAreaProviderCompat,
 } from '@react-navigation/elements';
 import {
+  CommonActions,
   ParamListBase,
   Route,
   StackActions,
@@ -328,7 +329,18 @@ export default class StackView extends React.Component<Props, State> {
     ) {
       // If route isn't present in current state, but was closing, assume that a close animation was cancelled
       // So we need to add this route back to the state
-      navigation.navigate(route);
+      navigation.dispatch((state) => {
+        const routes = [
+          ...state.routes.filter((r) => r.key !== route.key),
+          route,
+        ];
+
+        return CommonActions.reset({
+          ...state,
+          routes,
+          index: routes.length - 1,
+        });
+      });
     } else {
       this.setState((state) => ({
         routes: state.replacingRouteKeys.length


### PR DESCRIPTION
BREAKING CHANGE: Previously, you could specify a route `key` to navigate to, e.g.
`navigation.navigate({ key: 'someuniquekey' })`. It's problematic since `key` is an internal
implementation detail and created by the library internally - which makes it weird to use. None
of the other actions support such usage either.

In addition, we have already added a better API (`getId`) which can be used for similar use
cases - and gives users full control since they provide the ID and it's not autogenerated by the
library.

So this change removes the `key` option from the `navigate` action.