### PR TITLE
feat!: add `popTo` method for stack and remove going back behaviour of `navigate`

### DIFF
--- a/example/src/Screens/NativeStack.tsx
+++ b/example/src/Screens/NativeStack.tsx
@@ -42,6 +42,13 @@ const ArticleScreen = ({
           Replace with feed
         </Button>
         <Button
+          mode="contained"
+          onPress={() => navigation.popTo('Albums')}
+          style={styles.button}
+        >
+          Pop to Albums
+        </Button>
+        <Button
           mode="outlined"
           onPress={() => navigation.pop()}
           style={styles.button}

--- a/example/src/Screens/SimpleStack.tsx
+++ b/example/src/Screens/SimpleStack.tsx
@@ -35,6 +35,13 @@ const ArticleScreen = ({
           Replace with feed
         </Button>
         <Button
+          mode="contained"
+          onPress={() => navigation.popTo('Albums')}
+          style={styles.button}
+        >
+          Pop to Albums
+        </Button>
+        <Button
           mode="outlined"
           onPress={() =>
             navigation.setParams({

--- a/packages/core/src/__tests__/useOnAction.test.tsx
+++ b/packages/core/src/__tests__/useOnAction.test.tsx
@@ -3,6 +3,7 @@ import {
   NavigationState,
   ParamListBase,
   Router,
+  StackActions,
   StackRouter,
 } from '@react-navigation/routers';
 import { act, render } from '@testing-library/react-native';
@@ -621,7 +622,7 @@ it("prevents removing a screen with 'beforeRemove' event", () => {
     type: 'stack',
   });
 
-  act(() => ref.current?.navigate('foo'));
+  act(() => ref.current?.dispatch(StackActions.popTo('foo')));
 
   expect(onStateChange).toBeCalledTimes(2);
   expect(onBeforeRemove).toBeCalledTimes(1);
@@ -641,7 +642,7 @@ it("prevents removing a screen with 'beforeRemove' event", () => {
 
   shouldPrevent = false;
 
-  act(() => ref.current?.navigate('foo'));
+  act(() => ref.current?.dispatch(StackActions.popTo('foo')));
 
   expect(onStateChange).toBeCalledTimes(3);
   expect(onStateChange).toBeCalledWith({
@@ -771,7 +772,7 @@ it("prevents removing a child screen with 'beforeRemove' event", () => {
     type: 'stack',
   });
 
-  act(() => ref.current?.navigate('foo'));
+  act(() => ref.current?.dispatch(StackActions.popTo('foo')));
 
   expect(onStateChange).toBeCalledTimes(2);
   expect(onBeforeRemove).toBeCalledTimes(1);
@@ -802,7 +803,7 @@ it("prevents removing a child screen with 'beforeRemove' event", () => {
 
   shouldPrevent = false;
 
-  act(() => ref.current?.navigate('foo'));
+  act(() => ref.current?.dispatch(StackActions.popTo('foo')));
 
   expect(onStateChange).toBeCalledTimes(3);
   expect(onStateChange).toBeCalledWith({
@@ -950,7 +951,7 @@ it("prevents removing a grand child screen with 'beforeRemove' event", () => {
     type: 'stack',
   });
 
-  act(() => ref.current?.navigate('foo'));
+  act(() => ref.current?.dispatch(StackActions.popTo('foo')));
 
   expect(onStateChange).toBeCalledTimes(2);
   expect(onBeforeRemove).toBeCalledTimes(1);
@@ -994,7 +995,7 @@ it("prevents removing a grand child screen with 'beforeRemove' event", () => {
 
   shouldPrevent = false;
 
-  act(() => ref.current?.navigate('foo'));
+  act(() => ref.current?.dispatch(StackActions.popTo('foo')));
 
   expect(onStateChange).toBeCalledTimes(3);
   expect(onStateChange).toBeCalledWith({
@@ -1141,7 +1142,7 @@ it("prevents removing by multiple screens with 'beforeRemove' event", () => {
   expect(onStateChange).toBeCalledTimes(1);
   expect(onStateChange).toBeCalledWith(preventedState);
 
-  act(() => ref.current?.navigate('foo'));
+  act(() => ref.current?.dispatch(StackActions.popTo('foo')));
 
   expect(onStateChange).toBeCalledTimes(1);
   expect(onBeforeRemove.lex).toBeCalledTimes(1);
@@ -1150,7 +1151,7 @@ it("prevents removing by multiple screens with 'beforeRemove' event", () => {
 
   shouldPrevent.lex = false;
 
-  act(() => ref.current?.navigate('foo'));
+  act(() => ref.current?.dispatch(StackActions.popTo('foo')));
 
   expect(onStateChange).toBeCalledTimes(1);
   expect(onBeforeRemove.baz).toBeCalledTimes(1);
@@ -1159,7 +1160,7 @@ it("prevents removing by multiple screens with 'beforeRemove' event", () => {
 
   shouldPrevent.baz = false;
 
-  act(() => ref.current?.navigate('foo'));
+  act(() => ref.current?.dispatch(StackActions.popTo('foo')));
 
   expect(onStateChange).toBeCalledTimes(1);
   expect(onBeforeRemove.bar).toBeCalledTimes(1);
@@ -1168,7 +1169,7 @@ it("prevents removing by multiple screens with 'beforeRemove' event", () => {
 
   shouldPrevent.bar = false;
 
-  act(() => ref.current?.navigate('foo'));
+  act(() => ref.current?.dispatch(StackActions.popTo('foo')));
 
   expect(onStateChange).toBeCalledTimes(2);
   expect(onStateChange).toBeCalledWith({

--- a/packages/core/src/__tests__/usePreventRemove.test.tsx
+++ b/packages/core/src/__tests__/usePreventRemove.test.tsx
@@ -1,4 +1,8 @@
-import { ParamListBase, StackRouter } from '@react-navigation/routers';
+import {
+  ParamListBase,
+  StackActions,
+  StackRouter,
+} from '@react-navigation/routers';
 import { act, render } from '@testing-library/react-native';
 import * as React from 'react';
 
@@ -97,7 +101,7 @@ it("prevents removing a screen with 'usePreventRemove' hook", () => {
     type: 'stack',
   });
 
-  act(() => ref.current?.navigate('foo'));
+  act(() => ref.current?.dispatch(StackActions.popTo('foo')));
 
   expect(onStateChange).toBeCalledTimes(2);
   expect(onPreventRemove).toBeCalledTimes(1);
@@ -118,7 +122,7 @@ it("prevents removing a screen with 'usePreventRemove' hook", () => {
   shouldContinue = true;
 
   act(() => ref.current?.navigate('bar'));
-  act(() => ref.current?.navigate('foo'));
+  act(() => ref.current?.dispatch(StackActions.popTo('foo')));
 
   expect(onStateChange).toBeCalledTimes(4);
   expect(onStateChange).toBeCalledWith({
@@ -209,7 +213,7 @@ it("prevents removing a screen when 'usePreventRemove' hook is called multiple t
     type: 'stack',
   });
 
-  act(() => ref.current?.navigate('foo'));
+  act(() => ref.current?.dispatch(StackActions.popTo('foo')));
 
   expect(onStateChange).toBeCalledTimes(2);
   expect(onPreventRemove).toBeCalledTimes(1);
@@ -230,7 +234,7 @@ it("prevents removing a screen when 'usePreventRemove' hook is called multiple t
   shouldContinue = true;
 
   act(() => ref.current?.navigate('bar'));
-  act(() => ref.current?.navigate('foo'));
+  act(() => ref.current?.dispatch(StackActions.popTo('foo')));
 
   expect(onStateChange).toBeCalledTimes(4);
   expect(onStateChange).toBeCalledWith({
@@ -314,7 +318,7 @@ it("should have no effect when 'usePreventRemove' hook is set to false", () => {
     type: 'stack',
   });
 
-  act(() => ref.current?.navigate('foo'));
+  act(() => ref.current?.dispatch(StackActions.popTo('foo')));
 
   expect(onStateChange).toBeCalledTimes(3);
 
@@ -328,7 +332,7 @@ it("should have no effect when 'usePreventRemove' hook is set to false", () => {
   });
 
   act(() => ref.current?.navigate('bar'));
-  act(() => ref.current?.navigate('foo'));
+  act(() => ref.current?.dispatch(StackActions.popTo('foo')));
 
   expect(onStateChange).toBeCalledTimes(5);
   expect(onStateChange).toBeCalledWith({
@@ -436,7 +440,7 @@ it("prevents removing a child screen with 'usePreventRemove' hook", () => {
     type: 'stack',
   });
 
-  act(() => ref.current?.navigate('foo'));
+  act(() => ref.current?.dispatch(StackActions.popTo('foo')));
 
   expect(onStateChange).toBeCalledTimes(2);
   expect(onPreventRemove).toBeCalledTimes(1);
@@ -465,7 +469,7 @@ it("prevents removing a child screen with 'usePreventRemove' hook", () => {
     type: 'stack',
   });
 
-  act(() => ref.current?.navigate('foo'));
+  act(() => ref.current?.dispatch(StackActions.popTo('foo')));
 
   expect(onStateChange).toBeCalledTimes(2);
   expect(ref.current?.getRootState()).toEqual({
@@ -495,7 +499,7 @@ it("prevents removing a child screen with 'usePreventRemove' hook", () => {
   shouldContinue = true;
 
   act(() => ref.current?.navigate('bar'));
-  act(() => ref.current?.navigate('foo'));
+  act(() => ref.current?.dispatch(StackActions.popTo('foo')));
 
   expect(onStateChange).toBeCalledTimes(4);
   expect(onStateChange).toBeCalledWith({
@@ -620,7 +624,7 @@ it("prevents removing a grand child screen with 'usePreventRemove' hook", () => 
     type: 'stack',
   });
 
-  act(() => ref.current?.navigate('foo'));
+  act(() => ref.current?.dispatch(StackActions.popTo('foo')));
 
   expect(onStateChange).toBeCalledTimes(2);
   expect(onPreventRemove).toBeCalledTimes(1);
@@ -665,7 +669,7 @@ it("prevents removing a grand child screen with 'usePreventRemove' hook", () => 
   shouldContinue = true;
 
   act(() => ref.current?.navigate('bar'));
-  act(() => ref.current?.navigate('foo'));
+  act(() => ref.current?.dispatch(StackActions.popTo('foo')));
 
   expect(onStateChange).toBeCalledTimes(4);
   expect(onStateChange).toBeCalledWith({
@@ -794,7 +798,7 @@ it("prevents removing by multiple screens with 'usePreventRemove' hook", () => {
   expect(onStateChange).toBeCalledTimes(1);
   expect(onStateChange).toBeCalledWith(preventedState);
 
-  act(() => ref.current?.navigate('foo'));
+  act(() => ref.current?.dispatch(StackActions.popTo('foo')));
 
   expect(onStateChange).toBeCalledTimes(1);
   expect(onPreventRemove.lex).toBeCalledTimes(1);
@@ -803,7 +807,7 @@ it("prevents removing by multiple screens with 'usePreventRemove' hook", () => {
 
   shouldContinue.lex = false;
 
-  act(() => ref.current?.navigate('foo'));
+  act(() => ref.current?.dispatch(StackActions.popTo('foo')));
 
   expect(onStateChange).toBeCalledTimes(1);
   expect(onPreventRemove.baz).toBeCalledTimes(1);
@@ -812,7 +816,7 @@ it("prevents removing by multiple screens with 'usePreventRemove' hook", () => {
 
   shouldContinue.baz = false;
 
-  act(() => ref.current?.navigate('foo'));
+  act(() => ref.current?.dispatch(StackActions.popTo('foo')));
 
   expect(onStateChange).toBeCalledTimes(1);
   expect(onPreventRemove.bar).toBeCalledTimes(1);
@@ -821,7 +825,7 @@ it("prevents removing by multiple screens with 'usePreventRemove' hook", () => {
 
   shouldContinue.bar = false;
 
-  act(() => ref.current?.navigate('foo'));
+  act(() => ref.current?.dispatch(StackActions.popTo('foo')));
 
   expect(onStateChange).toBeCalledTimes(2);
   expect(onStateChange).toBeCalledWith({

--- a/packages/core/src/types.tsx
+++ b/packages/core/src/types.tsx
@@ -192,7 +192,7 @@ type NavigationHelpersCommon<
    * @param [params] Params object for the route.
    */
   navigate<RouteName extends keyof ParamList>(
-    ...args: // this first condition allows us to iterate over a union type
+    ...args: // This condition allows us to iterate over a union type
     // This is to avoid getting a union of all the params from `ParamList[RouteName]`,
     // which will get our types all mixed up if a union RouteName is passed in.
     RouteName extends unknown
@@ -209,13 +209,14 @@ type NavigationHelpersCommon<
   /**
    * Navigate to a route in current navigation tree.
    *
-   * @param route Object with `key` or `name` for the route to navigate to, and a `params` object.
+   * @param route Object with `name` for the route to navigate to, and a `params` object.
    */
   navigate<RouteName extends keyof ParamList>(
     options: RouteName extends unknown
       ? {
           name: RouteName;
           params: ParamList[RouteName];
+          path?: string;
           merge?: boolean;
         }
       : never

--- a/packages/routers/src/__tests__/StackRouter.test.tsx
+++ b/packages/routers/src/__tests__/StackRouter.test.tsx
@@ -316,9 +316,13 @@ it('handles navigate action', () => {
     stale: false,
     type: 'stack',
     key: 'root',
-    index: 0,
+    index: 2,
     routeNames: ['baz', 'bar', 'qux'],
-    routes: [{ key: 'baz', name: 'baz', params: { answer: 42 } }],
+    routes: [
+      { key: 'baz', name: 'baz' },
+      { key: 'bar', name: 'bar' },
+      { key: 'baz-test', name: 'baz', params: { answer: 42 } },
+    ],
   });
 
   expect(
@@ -348,24 +352,6 @@ it('handles navigate action', () => {
       { key: 'bar', name: 'bar', params: { answer: 96 } },
     ],
   });
-
-  expect(
-    router.getStateForAction(
-      {
-        stale: false,
-        type: 'stack',
-        key: 'root',
-        index: 1,
-        routeNames: ['baz', 'bar', 'qux'],
-        routes: [
-          { key: 'baz', name: 'baz' },
-          { key: 'bar', name: 'bar' },
-        ],
-      },
-      CommonActions.navigate('unknown'),
-      options
-    )
-  ).toBe(null);
 });
 
 it("doesn't navigate to nonexistent screen", () => {
@@ -1186,12 +1172,11 @@ it('adds path on navigate if provided', () => {
         stale: false,
         type: 'stack',
         key: 'root',
-        index: 2,
+        index: 1,
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'baz', name: 'baz' },
           { key: 'bar', name: 'bar', params: { answer: 42 } },
-          { key: 'qux', name: 'qux' },
         ],
       },
 
@@ -1297,12 +1282,11 @@ it("doesn't remove existing path on navigate if not provided", () => {
         stale: false,
         type: 'stack',
         key: 'root',
-        index: 2,
+        index: 1,
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'baz', name: 'baz' },
           { key: 'bar', name: 'bar', path: '/foo/bar' },
-          { key: 'qux', name: 'qux' },
         ],
       },
 
@@ -1325,7 +1309,128 @@ it("doesn't remove existing path on navigate if not provided", () => {
   });
 });
 
-it("doesn't merge params on navigate to an existing screen", () => {
+it('handles popTo action', () => {
+  const router = StackRouter({});
+  const options: RouterConfigOptions = {
+    routeNames: ['baz', 'bar', 'qux'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+
+  expect(
+    router.getStateForAction(
+      {
+        stale: false,
+        type: 'stack',
+        key: 'root',
+        index: 1,
+        routeNames: ['baz', 'bar', 'qux'],
+        routes: [
+          { key: 'baz', name: 'baz' },
+          { key: 'bar', name: 'bar' },
+        ],
+      },
+      StackActions.popTo('qux', { answer: 42 }),
+      options
+    )
+  ).toEqual({
+    stale: false,
+    type: 'stack',
+    key: 'root',
+    index: 1,
+    routeNames: ['baz', 'bar', 'qux'],
+    routes: [
+      { key: 'baz', name: 'baz' },
+      {
+        key: 'qux-test',
+        name: 'qux',
+        params: { answer: 42 },
+      },
+    ],
+  });
+
+  expect(
+    router.getStateForAction(
+      {
+        stale: false,
+        type: 'stack',
+        key: 'root',
+        index: 1,
+        routeNames: ['baz', 'bar', 'qux'],
+        routes: [
+          { key: 'baz', name: 'baz' },
+          { key: 'bar', name: 'bar' },
+        ],
+      },
+      StackActions.popTo('baz', { answer: 42 }),
+      options
+    )
+  ).toEqual({
+    stale: false,
+    type: 'stack',
+    key: 'root',
+    index: 0,
+    routeNames: ['baz', 'bar', 'qux'],
+    routes: [{ key: 'baz', name: 'baz', params: { answer: 42 } }],
+  });
+
+  expect(
+    router.getStateForAction(
+      {
+        stale: false,
+        type: 'stack',
+        key: 'root',
+        index: 1,
+        routeNames: ['baz', 'bar', 'qux'],
+        routes: [
+          { key: 'baz', name: 'baz' },
+          { key: 'bar', name: 'bar', params: { answer: 42 } },
+        ],
+      },
+      StackActions.popTo('bar', { answer: 96 }),
+      options
+    )
+  ).toEqual({
+    stale: false,
+    type: 'stack',
+    key: 'root',
+    index: 1,
+    routeNames: ['baz', 'bar', 'qux'],
+    routes: [
+      { key: 'baz', name: 'baz' },
+      { key: 'bar', name: 'bar', params: { answer: 96 } },
+    ],
+  });
+});
+
+it("doesn't popTo to nonexistent screen", () => {
+  const router = StackRouter({});
+  const options: RouterConfigOptions = {
+    routeNames: ['baz', 'bar', 'qux'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+
+  expect(
+    router.getStateForAction(
+      {
+        stale: false,
+        type: 'stack',
+        key: 'root',
+        index: 1,
+        routeNames: ['baz', 'bar', 'qux'],
+        routes: [
+          { key: 'baz', name: 'baz' },
+          { key: 'bar', name: 'bar' },
+        ],
+      },
+      CommonActions.navigate('far', { answer: 42 }),
+      options
+    )
+  ).toBe(null);
+});
+
+it("doesn't merge params on popTo to an existing screen", () => {
   const router = StackRouter({});
   const options: RouterConfigOptions = {
     routeNames: ['baz', 'bar', 'qux'],
@@ -1349,7 +1454,7 @@ it("doesn't merge params on navigate to an existing screen", () => {
           { key: 'qux', name: 'qux' },
         ],
       },
-      CommonActions.navigate('bar'),
+      StackActions.popTo('bar'),
       options
     )
   ).toEqual({
@@ -1377,7 +1482,7 @@ it("doesn't merge params on navigate to an existing screen", () => {
           { key: 'bar', name: 'bar', params: { answer: 42 } },
         ],
       },
-      CommonActions.navigate('bar', { fruit: 'orange' }),
+      StackActions.popTo('bar', { fruit: 'orange' }),
       options
     )
   ).toEqual({
@@ -1393,7 +1498,7 @@ it("doesn't merge params on navigate to an existing screen", () => {
   });
 });
 
-it('merges params on navigate to an existing screen if merge: true', () => {
+it('merges params on popTo to an existing screen if merge: true', () => {
   const router = StackRouter({});
   const options: RouterConfigOptions = {
     routeNames: ['baz', 'bar', 'qux'],
@@ -1419,10 +1524,7 @@ it('merges params on navigate to an existing screen if merge: true', () => {
         ],
       },
 
-      CommonActions.navigate({
-        name: 'bar',
-        merge: true,
-      }),
+      StackActions.popTo('bar', {}, true),
       options
     )
   ).toEqual({
@@ -1450,11 +1552,7 @@ it('merges params on navigate to an existing screen if merge: true', () => {
           { key: 'bar', name: 'bar', params: { answer: 42 } },
         ],
       },
-      CommonActions.navigate({
-        name: 'bar',
-        params: { fruit: 'orange' },
-        merge: true,
-      }),
+      StackActions.popTo('bar', { fruit: 'orange' }, true),
       options
     )
   ).toEqual({
@@ -1486,11 +1584,7 @@ it('merges params on navigate to an existing screen if merge: true', () => {
           { key: 'bar', name: 'bar', params: { answer: 42 } },
         ],
       },
-      CommonActions.navigate({
-        name: 'baz',
-        params: { color: 'black' },
-        merge: true,
-      }),
+      StackActions.popTo('baz', { color: 'black' }, true),
       options
     )
   ).toEqual({


### PR DESCRIPTION
BREAKING CHANGE: Previously, `navigate` method navigated back if the screen
already exists in the stack. I have seen many people get confused by this
behavior. This behavior is also used for sending params to a previous
screen in the documentation. However, it's also problematic since it could
either push or pop the screens based on the scenario.

This removes the going back behavior from `navigate` and adds a new method
`popTo` to go back to a specific screen in the stack.

The methods now behave as follows:

- `navigate(screenName)` will stay on the current screen if the screen is
already focused, otherwise push a new screen to the stack.
- `popTo(screenName)` will go back to the screen if it exists in the stack,
otherwise pop the current screen and add this screen to the stack.
- To achieve the previous behavior with `navigate`, you can use the `getId`
prop in which case it'll go to the screen with the matching ID and push or
pop screens accordingly.
