### PR TITLE
fix!: align onReady callback and navigationRef.isReady

### DIFF
--- a/example/src/index.tsx
+++ b/example/src/index.tsx
@@ -22,6 +22,7 @@ import {
   StackScreenProps,
 } from '@react-navigation/stack';
 import { createURL } from 'expo-linking';
+import * as SplashScreen from 'expo-splash-screen';
 import * as React from 'react';
 import {
   Dimensions,
@@ -50,8 +51,10 @@ import NotFound from './Screens/NotFound';
 import SettingsItem from './Shared/SettingsItem';
 
 if (Platform.OS !== 'web') {
-  LogBox.ignoreLogs(['Require cycle:']);
+  LogBox.ignoreLogs(['The native module for Flipper seems unavailable']);
 }
+
+SplashScreen.preventAutoHideAsync();
 
 const Drawer = createDrawerNavigator<RootDrawerParamList>();
 const Stack = createStackNavigator<RootStackParamList>();
@@ -148,6 +151,7 @@ export default function App() {
       <NavigationContainer
         ref={navigationRef}
         initialState={initialState}
+        onReady={() => SplashScreen.hideAsync()}
         onStateChange={(state) =>
           AsyncStorage?.setItem(
             NAVIGATION_PERSISTENCE_KEY,

--- a/packages/core/src/__tests__/BaseNavigationContainer.test.tsx
+++ b/packages/core/src/__tests__/BaseNavigationContainer.test.tsx
@@ -734,6 +734,40 @@ it("throws if the ref hasn't finished initializing", () => {
   render(element);
 });
 
+it('fires onReady after navigator is rendered', () => {
+  const ref = createNavigationContainerRef<ParamListBase>();
+
+  const TestNavigator = (props: any) => {
+    const { state, descriptors } = useNavigationBuilder(MockRouter, props);
+
+    return descriptors[state.routes[state.index].key].render();
+  };
+
+  const onReady = jest.fn();
+
+  const element = (
+    <BaseNavigationContainer ref={ref} onReady={onReady}>
+      {null}
+    </BaseNavigationContainer>
+  );
+
+  const root = render(element);
+
+  expect(onReady).not.toBeCalled();
+  expect(ref.current?.isReady()).toBe(false);
+
+  root.rerender(
+    <BaseNavigationContainer ref={ref} onReady={onReady}>
+      <TestNavigator>
+        <Screen name="foo">{() => null}</Screen>
+      </TestNavigator>
+    </BaseNavigationContainer>
+  );
+
+  expect(onReady).toHaveBeenCalledTimes(1);
+  expect(ref.current?.isReady()).toBe(true);
+});
+
 it('invokes the unhandled action listener with the unhandled action', () => {
   const ref = createNavigationContainerRef<ParamListBase>();
   const fn = jest.fn();
@@ -811,7 +845,7 @@ it('works with state change events in independent nested container', () => {
 
   expect(onStateChange).toBeCalledWith({
     index: 1,
-    key: '15',
+    key: '16',
     routeNames: ['qux', 'lex'],
     routes: [
       { key: 'qux', name: 'qux' },
@@ -823,7 +857,7 @@ it('works with state change events in independent nested container', () => {
 
   expect(ref.current?.getRootState()).toEqual({
     index: 1,
-    key: '15',
+    key: '16',
     routeNames: ['qux', 'lex'],
     routes: [
       { key: 'qux', name: 'qux' },

--- a/packages/core/src/types.tsx
+++ b/packages/core/src/types.tsx
@@ -296,6 +296,10 @@ export type NavigationContainerProps = {
    */
   onStateChange?: (state: NavigationState | undefined) => void;
   /**
+   * Callback which is called after the navigation tree mounts.
+   */
+  onReady?: () => void;
+  /**
    * Callback which is called when an action is not handled.
    */
   onUnhandledAction?: (action: NavigationAction) => void;

--- a/packages/native/src/NavigationContainer.tsx
+++ b/packages/native/src/NavigationContainer.tsx
@@ -33,7 +33,6 @@ type Props<ParamList extends {}> = NavigationContainerProps & {
   linking?: LinkingOptions<ParamList>;
   fallback?: React.ReactNode;
   documentTitle?: DocumentTitleOptions;
-  onReady?: () => void;
 };
 
 /**
@@ -43,6 +42,7 @@ type Props<ParamList extends {}> = NavigationContainerProps & {
  * @param props.initialState Initial state object for the navigation tree. When deep link handling is enabled, this will override deep links when specified. Make sure that you don't specify an `initialState` when there's a deep link (`Linking.getInitialURL()`).
  * @param props.onReady Callback which is called after the navigation tree mounts.
  * @param props.onStateChange Callback which is called with the latest navigation state when it changes.
+ * @param props.onUnhandledAction Callback which is called when an action is not handled.
  * @param props.theme Theme object for the navigators.
  * @param props.linking Options for deep linking. Deep link handling is enabled when this prop is provided, unless `linking.enabled` is `false`.
  * @param props.fallback Fallback component to render until we have finished getting initial state when linking is enabled. Defaults to `null`.
@@ -56,7 +56,6 @@ function NavigationContainerInner(
     linking,
     fallback = null,
     documentTitle,
-    onReady,
     ...rest
   }: Props<ParamListBase>,
   ref?: React.Ref<NavigationContainerRef<ParamListBase> | null>
@@ -106,21 +105,10 @@ function NavigationContainerInner(
 
   const linkingContext = React.useMemo(() => ({ options: linking }), [linking]);
 
-  const isReady = rest.initialState != null || !isLinkingEnabled || isResolved;
+  const isLinkingReady =
+    rest.initialState != null || !isLinkingEnabled || isResolved;
 
-  const onReadyRef = React.useRef(onReady);
-
-  React.useEffect(() => {
-    onReadyRef.current = onReady;
-  });
-
-  React.useEffect(() => {
-    if (isReady) {
-      onReadyRef.current?.();
-    }
-  }, [isReady]);
-
-  if (!isReady) {
+  if (!isLinkingReady) {
     // This is temporary until we have Suspense for data-fetching
     // Then the fallback will be handled by a parent `Suspense` component
     return fallback as React.ReactElement;


### PR DESCRIPTION
BREAKING CHANGE: Previously, the `onReady` prop and `navigationRef.isReady()` work slightly
differently. The `onReady` callback fired when `NavigationContainer` finishes mounting and deep links is resolved. The `navigationRef.isReady()` method additionally checks if there are any navigators rendered - which may not be `true` if the user is rendering their navigators conditionally inside a
`NavigationContainer`.

This changes `onReady` to work similar to `navigationRef.isReady()`. The `onReady` callback will now fire only when there are navigators rendered - reflecting the value of `navigationRef.isReady()`.
