### PR TITLE
feat: add freezeOnBlur prop 

### DIFF
--- a/packages/bottom-tabs/src/types.tsx
+++ b/packages/bottom-tabs/src/types.tsx
@@ -244,6 +244,15 @@ export type BottomTabNavigationOptions = HeaderOptions & {
    * Defaults to `false`.
    */
   unmountOnBlur?: boolean;
+
+  /**
+   * Whether inactive screens should be suspended from re-rendering. Defaults to `false`.
+   * Defaults to `true` when `enableFreeze()` is run at the top of the application.
+   * Requires `react-native-screens` version >=3.16.0.
+   *
+   * Only supported on iOS and Android.
+   */
+  freezeOnBlur?: boolean;
 };
 
 export type BottomTabDescriptor = Descriptor<

--- a/packages/bottom-tabs/src/views/BottomTabView.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabView.tsx
@@ -110,6 +110,7 @@ export default function BottomTabView(props: Props) {
           }
 
           const {
+            freezeOnBlur,
             header = ({ layout, options }: BottomTabHeaderProps) => (
               <Header
                 {...options}
@@ -117,6 +118,9 @@ export default function BottomTabView(props: Props) {
                 title={getHeaderTitle(options, route.name)}
               />
             ),
+            headerShown,
+            headerStatusBarHeight,
+            headerTransparent,
           } = descriptor.options;
 
           return (
@@ -125,17 +129,16 @@ export default function BottomTabView(props: Props) {
               style={[StyleSheet.absoluteFill, { zIndex: isFocused ? 0 : -1 }]}
               visible={isFocused}
               enabled={detachInactiveScreens}
+              freezeOnBlur={freezeOnBlur}
             >
               <BottomTabBarHeightContext.Provider value={tabBarHeight}>
                 <Screen
                   focused={isFocused}
                   route={descriptor.route}
                   navigation={descriptor.navigation}
-                  headerShown={descriptor.options.headerShown}
-                  headerTransparent={descriptor.options.headerTransparent}
-                  headerStatusBarHeight={
-                    descriptor.options.headerStatusBarHeight
-                  }
+                  headerShown={headerShown}
+                  headerStatusBarHeight={headerStatusBarHeight}
+                  headerTransparent={headerTransparent}
                   header={header({
                     layout: dimensions,
                     route: descriptor.route,

--- a/packages/bottom-tabs/src/views/ScreenFallback.tsx
+++ b/packages/bottom-tabs/src/views/ScreenFallback.tsx
@@ -6,6 +6,7 @@ type Props = {
   visible: boolean;
   children: React.ReactNode;
   enabled: boolean;
+  freezeOnBlur?: boolean;
   style?: StyleProp<ViewStyle>;
 };
 

--- a/packages/drawer/src/types.tsx
+++ b/packages/drawer/src/types.tsx
@@ -211,6 +211,15 @@ export type DrawerNavigationOptions = HeaderOptions & {
    * Defaults to `false`.
    */
   unmountOnBlur?: boolean;
+
+  /**
+   * Whether inactive screens should be suspended from re-rendering. Defaults to `false`.
+   * Defaults to `true` when `enableFreeze()` is run at the top of the application.
+   * Requires `react-native-screens` version >=3.16.0.
+   *
+   * Only supported on iOS and Android.
+   */
+  freezeOnBlur?: boolean;
 };
 
 export type DrawerContentComponentProps = {

--- a/packages/drawer/src/views/DrawerView.tsx
+++ b/packages/drawer/src/views/DrawerView.tsx
@@ -230,6 +230,7 @@ function DrawerViewBase({
           }
 
           const {
+            freezeOnBlur,
             header = ({ layout, options }: DrawerHeaderProps) => (
               <Header
                 {...options}
@@ -241,6 +242,9 @@ function DrawerViewBase({
                 }
               />
             ),
+            headerShown,
+            headerStatusBarHeight,
+            headerTransparent,
             sceneContainerStyle,
           } = descriptor.options;
 
@@ -250,14 +254,15 @@ function DrawerViewBase({
               style={[StyleSheet.absoluteFill, { zIndex: isFocused ? 0 : -1 }]}
               visible={isFocused}
               enabled={detachInactiveScreens}
+              freezeOnBlur={freezeOnBlur}
             >
               <Screen
                 focused={isFocused}
                 route={descriptor.route}
                 navigation={descriptor.navigation}
-                headerShown={descriptor.options.headerShown}
-                headerTransparent={descriptor.options.headerTransparent}
-                headerStatusBarHeight={descriptor.options.headerStatusBarHeight}
+                headerShown={headerShown}
+                headerStatusBarHeight={headerStatusBarHeight}
+                headerTransparent={headerTransparent}
                 header={header({
                   layout: dimensions,
                   route: descriptor.route,

--- a/packages/drawer/src/views/ScreenFallback.tsx
+++ b/packages/drawer/src/views/ScreenFallback.tsx
@@ -6,6 +6,7 @@ type Props = {
   visible: boolean;
   children: React.ReactNode;
   enabled: boolean;
+  freezeOnBlur?: boolean;
   style?: StyleProp<ViewStyle>;
 };
 

--- a/packages/native-stack/src/types.tsx
+++ b/packages/native-stack/src/types.tsx
@@ -486,6 +486,11 @@ export type NativeStackNavigationOptions = {
    * Only supported on iOS and Android.
    */
   orientation?: ScreenProps['screenOrientation'];
+  /**
+   * Whether inactive screens should be suspended from re-rendering. Defaults to `false`.
+   * Defaults to `true` when `enableFreeze()` is run at the top of the application.
+   */
+  freezeOnBlur?: boolean;
 };
 
 export type NativeStackNavigatorProps = DefaultNavigatorOptions<

--- a/packages/native-stack/src/types.tsx
+++ b/packages/native-stack/src/types.tsx
@@ -489,6 +489,9 @@ export type NativeStackNavigationOptions = {
   /**
    * Whether inactive screens should be suspended from re-rendering. Defaults to `false`.
    * Defaults to `true` when `enableFreeze()` is run at the top of the application.
+   * Requires `react-native-screens` version >=3.16.0.
+   *
+   * Only supported on iOS and Android.
    */
   freezeOnBlur?: boolean;
 };

--- a/packages/native-stack/src/views/NativeStackView.native.tsx
+++ b/packages/native-stack/src/views/NativeStackView.native.tsx
@@ -268,7 +268,7 @@ const SceneView = ({
       isNativeStack
       nativeBackButtonDismissalEnabled={false} // on Android
       onHeaderBackButtonClicked={onHeaderBackButtonClicked}
-      // @ts-expect-error props not exported from rn-screens
+      // @ts-ignore props not exported from rn-screens
       preventNativeDismiss={isRemovePrevented} // on iOS
       onNativeDismissCancelled={onNativeDismissCancelled}
       // this prop is available since rn-screens 3.16

--- a/packages/native-stack/src/views/NativeStackView.native.tsx
+++ b/packages/native-stack/src/views/NativeStackView.native.tsx
@@ -120,7 +120,7 @@ type SceneViewProps = {
   onAppear: () => void;
   onDisappear: () => void;
   onDismissed: ScreenProps['onDismissed'];
-  onHeaderBackButtonClicked: () => void;
+  onHeaderBackButtonClicked: ScreenProps['onHeaderBackButtonClicked'];
   onNativeDismissCancelled: ScreenProps['onDismissed'];
 };
 
@@ -239,7 +239,6 @@ const SceneView = ({
       enabled
       style={StyleSheet.absoluteFill}
       customAnimationOnSwipe={customAnimationOnGesture}
-      freezeOnBlur={freezeOnBlur}
       fullScreenSwipeEnabled={fullScreenGestureEnabled}
       gestureEnabled={
         isAndroid
@@ -267,12 +266,13 @@ const SceneView = ({
       onDisappear={onDisappear}
       onDismissed={onDismissed}
       isNativeStack
-      // Props for enabling preventing removal in native-stack
       nativeBackButtonDismissalEnabled={false} // on Android
-      // @ts-expect-error prop not publicly exported from rn-screens
-      preventNativeDismiss={isRemovePrevented} // on iOS
       onHeaderBackButtonClicked={onHeaderBackButtonClicked}
+      // @ts-expect-error props not exported from rn-screens
+      preventNativeDismiss={isRemovePrevented} // on iOS
       onNativeDismissCancelled={onNativeDismissCancelled}
+      // this prop is available since rn-screens 3.16
+      freezeOnBlur={freezeOnBlur}
     >
       <NavigationContext.Provider value={navigation}>
         <NavigationRouteContext.Provider value={route}>

--- a/packages/native-stack/src/views/NativeStackView.native.tsx
+++ b/packages/native-stack/src/views/NativeStackView.native.tsx
@@ -153,6 +153,7 @@ const SceneView = ({
     statusBarStyle,
     statusBarTranslucent,
     statusBarColor,
+    freezeOnBlur,
   } = options;
 
   let {
@@ -238,6 +239,7 @@ const SceneView = ({
       enabled
       style={StyleSheet.absoluteFill}
       customAnimationOnSwipe={customAnimationOnGesture}
+      freezeOnBlur={freezeOnBlur}
       fullScreenSwipeEnabled={fullScreenGestureEnabled}
       gestureEnabled={
         isAndroid

--- a/packages/stack/src/types.tsx
+++ b/packages/stack/src/types.tsx
@@ -333,6 +333,14 @@ export type StackNavigationOptions = StackHeaderOptions &
      * Defaults to `true`.
      */
     keyboardHandlingEnabled?: boolean;
+    /**
+     * Whether inactive screens should be suspended from re-rendering. Defaults to `false`.
+     * Defaults to `true` when `enableFreeze()` is run at the top of the application.
+     * Requires `react-native-screens` version >=3.16.0.
+     *
+     * Only supported on iOS and Android.
+     */
+    freezeOnBlur?: boolean;
   };
 
 export type StackNavigationConfig = {

--- a/packages/stack/src/views/Screens.tsx
+++ b/packages/stack/src/views/Screens.tsx
@@ -26,15 +26,22 @@ export const MaybeScreenContainer = ({
 export const MaybeScreen = ({
   enabled,
   active,
+  freezeOnBlur,
   ...rest
 }: ViewProps & {
   enabled: boolean;
   active: 0 | 1 | Animated.AnimatedInterpolation;
   children: React.ReactNode;
+  freezeOnBlur?: boolean;
 }) => {
   if (Screens != null) {
     return (
-      <Screens.Screen enabled={enabled} activityState={active} {...rest} />
+      <Screens.Screen
+        enabled={enabled}
+        activityState={active}
+        freezeOnBlur={freezeOnBlur}
+        {...rest}
+      />
     );
   }
 

--- a/packages/stack/src/views/Screens.tsx
+++ b/packages/stack/src/views/Screens.tsx
@@ -26,7 +26,6 @@ export const MaybeScreenContainer = ({
 export const MaybeScreen = ({
   enabled,
   active,
-  freezeOnBlur,
   ...rest
 }: ViewProps & {
   enabled: boolean;
@@ -36,12 +35,7 @@ export const MaybeScreen = ({
 }) => {
   if (Screens != null) {
     return (
-      <Screens.Screen
-        enabled={enabled}
-        activityState={active}
-        freezeOnBlur={freezeOnBlur}
-        {...rest}
-      />
+      <Screens.Screen enabled={enabled} activityState={active} {...rest} />
     );
   }
 

--- a/packages/stack/src/views/Stack/CardStack.tsx
+++ b/packages/stack/src/views/Stack/CardStack.tsx
@@ -604,6 +604,7 @@ export default class CardStack extends React.Component<Props, State> {
               headerTransparent,
               headerStyle,
               headerTintColor,
+              freezeOnBlur,
             } = scene.descriptor.options;
 
             const safeAreaInsetTop = insets.top;
@@ -656,6 +657,7 @@ export default class CardStack extends React.Component<Props, State> {
                 style={StyleSheet.absoluteFill}
                 enabled={detachInactiveScreens}
                 active={isScreenActive}
+                freezeOnBlur={freezeOnBlur}
                 pointerEvents="box-none"
               >
                 <CardContainer


### PR DESCRIPTION
### Motivation

Since version v3.9.0 `react-native-screens` exposed `enableFreeze()` function which allows to suspend all hidden screens from rendering with the use of `react-freeze` library.

This PR adds a new prop called `freezeOnBlur` which makes it possible to decide per screen which screen should be suspended from rendering.

### Test plan

This feature needs `react-native-screens` with version >=3.16 so as of today we're not able to test this prop within Expo Go.

#### Update screens to the newest version

`yarn up react-native-screens`

#### Run example in bare-workflow

`yarn example ios`
`yarn example android`

#### Use code samples below to test the feature

Only a visible screen should `console.log` in native-stack. 
In stack, two top-most screens should `console.log`.

<details>
<summary>Code example for Stack and Native-Stack</summary>
<br>

```jsx
import { NavigationContainer } from '@react-navigation/native';
// import { createStackNavigator } from '@react-navigation/stack';
import { createNativeStackNavigator } from '@react-navigation/native-stack';
import * as React from 'react';
import { Button, ScrollView, Text, View } from 'react-native';
// import { enableFreeze } from 'react-native-screens';

// enableFreeze();

const store = new Set<Dispatch>();

type Dispatch = (value: number) => void;

function useValue() {
  const [value, setValue] = React.useState<number>(0); // integer state

  React.useEffect(() => {
    const dispatch = (value: number) => {
      setValue(value);
    };
    store.add(dispatch);
    return () => store.delete(dispatch);
  }, [setValue]);

  return value;
}

function HomeScreen({ navigation }: any) {
  const value = useValue();
  return (
    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
      <Text>Home Screen {value}</Text>
      <Button
        title="Go to Details"
        onPress={() => navigation.navigate('Details')}
      />
    </View>
  );
}

function DetailsScreen({ navigation }: any) {
  const value = useValue();
  // only 1 'render' should appear at the time
  console.log('render', value);
  return (
    <ScrollView>
      <View style={{ height: 400 }} />
      <Text style={{ alignSelf: 'center' }}>Details Screen {value}</Text>
      <Button
        title="Go to Details"
        onPress={() => navigation.push('Details')}
      />
      <View style={{ height: 800 }} />
    </ScrollView>
  );
}

const Stack = createNativeStackNavigator();
// const Stack = createStackNavigator();

function App() {
  React.useEffect(() => {
    let timer = 0;
    const interval = setInterval(() => {
      timer = timer + 1;
      store.forEach((dispatch) => dispatch(timer));
    }, 3000);
    return () => clearInterval(interval);
  }, []);

  return (
    <NavigationContainer>
      <Stack.Navigator
        initialRouteName="Home"
        screenOptions={{
          freezeOnBlur: true,
        }}
      >
        <Stack.Screen name="Home" component={HomeScreen} />
        <Stack.Screen name="Details" component={DetailsScreen} />
      </Stack.Navigator>
    </NavigationContainer>
  );
}

export default App;

```

</details>


Only a visible screen should `console.log`

<details>
<summary>Code example for BottomTab and Drawer navigator</summary>
<br>

```jsx
import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
// import { createDrawerNavigator } from '@react-navigation/drawer';
import { NavigationContainer } from '@react-navigation/native';
import * as React from 'react';
import { Text, View } from 'react-native';

const store = new Set<Dispatch>();

type Dispatch = (value: number) => void;

function useValue() {
  const [value, setValue] = React.useState<number>(0); // integer state

  React.useEffect(() => {
    const dispatch = (value: number) => {
      setValue(value);
    };
    store.add(dispatch);
    return () => store.delete(dispatch);
  }, [setValue]);

  return value;
}

function HomeScreen() {
  return (
    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
      <Text>Home!</Text>
    </View>
  );
}

function DetailsScreen() {
  const value = useValue();
  // only 1 'render' should appear at the time
  console.log('render', value);
  return (
    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
      <Text>Details!</Text>
      <Text style={{ alignSelf: 'center' }}>Details Screen {value}</Text>
    </View>
  );
}
const Tab = createBottomTabNavigator();
// const Tab = createDrawerNavigator();

export default function App() {
  React.useEffect(() => {
    let timer = 0;
    const interval = setInterval(() => {
      timer = timer + 1;
      store.forEach((dispatch) => dispatch(timer));
    }, 3000);
    return () => clearInterval(interval);
  }, []);

  return (
    <NavigationContainer>
      <Tab.Navigator screenOptions={{ freezeOnBlur: true }}>
        <Tab.Screen name="Home" component={HomeScreen} />
        <Tab.Screen name="Details" component={DetailsScreen} />
        <Tab.Screen name="Settings" component={DetailsScreen} />
        <Tab.Screen name="Profile" component={DetailsScreen} />
      </Tab.Navigator>
    </NavigationContainer>
  );
}

```

</details>

#### Static

- [x] yarn lint
- [x] yarn typescript
- [x] yarn test
- [x] yarn lerna run prepack 


