### PR TITLE
fix: restore native behavior of back button

### DIFF
--- a/packages/native-stack/src/views/NativeStackView.native.tsx
+++ b/packages/native-stack/src/views/NativeStackView.native.tsx
@@ -311,7 +311,7 @@ const SceneView = ({
                   headerBackTitle={
                     options.headerBackTitle !== undefined
                       ? options.headerBackTitle
-                      : headerBack?.title
+                      : undefined
                   }
                   canGoBack={headerBack !== undefined}
                 />


### PR DESCRIPTION
# Motivation

Unfortunately the changes from #10761 caused an issue I reported on the react-native-screens repo. (See software-mansion/react-native-screens#1589)

Essentially, the [documentation](https://reactnavigation.org/docs/native-stack-navigator#headerbacktitle) states that per native behavior, the back button on iOS will automatically use the title of the previous screen or "Back" if there's not enough space. However, with the latest version of react-navigation, the back button was the title of the previous screen no matter what. In some cases, this caused the title of the current screen to be completely pushed off the screen.

In UIKit this happens when the title of the back button is deliberately set, or when a custom UIBarButtonItem is set as the back button. `react-native-screens` creates a custom UIBarButtonItem when the header config component has a value defined for `headerBackTitle`. 

By leaving headerBackTitle undefined here, we let the system automatically determine what to set as the back button title. In my testing, system will choose the correct value even if the previous screen's `title` or `headerTitle` is set differently from the route name.

# Before
![Long screen title causing the back button to take up too much space in the header](https://user-images.githubusercontent.com/3422979/190471788-92865a32-cf7f-4798-8f6d-ff5533197cc6.gif)

_Long screen title causing the back button to take up too much space in the header_

# After 
![Long screen title causing the back button to shorten to "Back"](https://user-images.githubusercontent.com/3422979/190471970-f2b19022-3ceb-4785-85f2-5e62cc136535.gif)

_Long screen title causing the back button to shorten to "Back"_

![If the screen's title is short enough it will remain the title of the back button](https://user-images.githubusercontent.com/3422979/190472342-bfc9de7b-c93c-4237-a0a3-a97b0ab5b848.gif)

_If the screen's title is short enough it will remain the title of the back button_