### PR TITLE
feat(drawer): add drawer status events

### DIFF
--- a/example/types.check.tsx
+++ b/example/types.check.tsx
@@ -121,7 +121,13 @@ export const FeedScreen = ({
   expectTypeOf(navigation.addListener)
     .parameter(0)
     .toEqualTypeOf<
-      'focus' | 'blur' | 'state' | 'beforeRemove' | 'drawerItemPress'
+      | 'focus'
+      | 'blur'
+      | 'state'
+      | 'beforeRemove'
+      | 'drawerItemPress'
+      | 'drawerOpened'
+      | 'drawerClosed'
     >();
 
   expectTypeOf(navigation.getState().type).toEqualTypeOf<'drawer'>();

--- a/packages/drawer/src/types.tsx
+++ b/packages/drawer/src/types.tsx
@@ -243,6 +243,14 @@ export type DrawerNavigationEventMap = {
    * Event which fires on tapping on the item in the drawer menu.
    */
   drawerItemPress: { data: undefined; canPreventDefault: true };
+  /**
+   * Event which fires when the drawer is opened.
+   */
+  drawerOpened: { data: undefined };
+  /**
+   * Event which fires when the drawer is closed.
+   */
+  drawerClosed: { data: undefined };
 };
 
 export type DrawerNavigationHelpers = NavigationHelpers<
@@ -290,6 +298,7 @@ export type DrawerProps = {
   gestureHandlerProps?: React.ComponentProps<typeof PanGestureHandler>;
   hideStatusBarOnOpen: boolean;
   keyboardDismissMode: 'none' | 'on-drag';
+  onDrawerAnimationComplete: (open: boolean) => void;
   onClose: () => void;
   onOpen: () => void;
   open: boolean;

--- a/packages/drawer/src/views/DrawerView.tsx
+++ b/packages/drawer/src/views/DrawerView.tsx
@@ -141,6 +141,21 @@ function DrawerViewBase({
     });
   }, [navigation, state.key]);
 
+  const onDrawerAnimationComplete = React.useCallback(
+    (isOpen: boolean) => {
+      if (isOpen) {
+        navigation.emit({
+          type: 'drawerOpened',
+        });
+      } else {
+        navigation.emit({
+          type: 'drawerClosed',
+        });
+      }
+    },
+    [navigation]
+  );
+
   React.useEffect(() => {
     if (drawerStatus === defaultStatus || drawerType === 'permanent') {
       return;
@@ -282,6 +297,7 @@ function DrawerViewBase({
         open={drawerStatus !== 'closed'}
         onOpen={handleDrawerOpen}
         onClose={handleDrawerClose}
+        onDrawerAnimationComplete={onDrawerAnimationComplete}
         gestureHandlerProps={gestureHandlerProps}
         swipeEnabled={swipeEnabled}
         swipeEdgeWidth={swipeEdgeWidth}

--- a/packages/drawer/src/views/legacy/Drawer.tsx
+++ b/packages/drawer/src/views/legacy/Drawer.tsx
@@ -285,6 +285,7 @@ export default class DrawerView extends React.Component<DrawerProps> {
         call([this.isOpen], ([value]: readonly Binary[]) => {
           const open = Boolean(value);
           this.handleEndInteraction();
+          this.props.onDrawerAnimationComplete(open);
 
           if (open !== this.props.open) {
             // Sync drawer's state after animation finished


### PR DESCRIPTION
**Motivation**

Issue: https://github.com/Expensify/App/issues/8292

We have a text input on a screen of a drawer. When the screen gets focus. It focusses the input and this creates an issue in the safari browser. It seems like when animation is ongoing we should not focus.

This PR adds two events `drawerOpened` and `drawerClosed`. It will be fired, when the animation completes. This will be the right time to focus the text input.

**Test plan**

Test with the code below and observe it notifies when the drawer is either opened or closed for both implementation (legacy and modern). Remove `useLegacyImplementation` from the code to test modern implementation. 

I see there are some issues. It fires when the app loads. I will create another PR to fix that issues.

<details>
<summary>Code example for testing</summary>

```javascript
import * as React from 'react';
import { Text, View } from 'react-native';
import { createDrawerNavigator } from '@react-navigation/drawer';
import { NavigationContainer } from '@react-navigation/native';

function HomeScreen({ navigation }) {
  React.useEffect(() => {
    const listners = [
      navigation.addListener('drawerOpened', () => alert('Drawer opened!')),
      navigation.addListener('drawerClosed', () => alert('Drawer closed!')),
    ];

    return () => {
      listners.forEach((unsubs) => unsubs());
    };
  });
  return (
    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
      <Text>Drawer status events</Text>
    </View>
  );
}

const Drawer = createDrawerNavigator();

export default function App() {
  return (
    <NavigationContainer>
      <Drawer.Navigator initialRouteName="Home" useLegacyImplementation>
        <Drawer.Screen name="Home" component={HomeScreen} />
      </Drawer.Navigator>
    </NavigationContainer>
  );
}

```
</details>

https://user-images.githubusercontent.com/77761491/190592387-efeef429-e1f6-40c6-8dec-30ac19ac7c17.mov

