### PR TITLE
fix: add additional check before running `animate` in `componentDidUpdate`

### DIFF
--- a/packages/stack/src/views/Stack/Card.tsx
+++ b/packages/stack/src/views/Stack/Card.tsx
@@ -136,11 +136,12 @@ export default class Card extends React.Component<Props, State> {
     const toValue = this.getAnimateToValue(this.props);
 
     if (
-      this.getAnimateToValue(prevProps) !== toValue ||
-      this.lastToValue !== toValue
+      closing !== prevProps.closing &&
+      (this.getAnimateToValue(prevProps) !== toValue ||
+        this.lastToValue !== toValue)
     ) {
       // We need to trigger the animation when route was closed
-      // Thr route might have been closed by a `POP` action or by a gesture
+      // The route might have been closed by a `POP` action or by a gesture
       // When route was closed due to a gesture, the animation would've happened already
       // It's still important to trigger the animation so that `onClose` is called
       // If `onClose` is not called, cleanup step won't be performed for gestures

--- a/packages/stack/src/views/Stack/Card.tsx
+++ b/packages/stack/src/views/Stack/Card.tsx
@@ -67,6 +67,10 @@ type Props = ViewProps & {
   contentStyle?: StyleProp<ViewStyle>;
 };
 
+type State = {
+  pointerEvents: ViewProps['pointerEvents'];
+};
+
 const GESTURE_VELOCITY_IMPACT = 0.3;
 
 const TRUE = 1;
@@ -89,7 +93,7 @@ const hasOpacityStyle = (style: any) => {
   return false;
 };
 
-export default class Card extends React.Component<Props> {
+export default class Card extends React.Component<Props, State> {
   static defaultProps = {
     shadowEnabled: false,
     gestureEnabled: true,
@@ -102,6 +106,10 @@ export default class Card extends React.Component<Props> {
       style ? (
         <Animated.View pointerEvents="none" style={[styles.overlay, style]} />
       ) : null,
+  };
+
+  state: State = {
+    pointerEvents: 'auto',
   };
 
   componentDidMount() {
@@ -242,7 +250,7 @@ export default class Card extends React.Component<Props> {
   private setPointerEventsEnabled = (enabled: boolean) => {
     const pointerEvents = enabled ? 'box-none' : 'none';
 
-    this.contentRef.current?.setNativeProps({ pointerEvents });
+    this.setState((state) => ({ ...state, pointerEvents }));
   };
 
   private handleStartInteraction = () => {
@@ -425,8 +433,6 @@ export default class Card extends React.Component<Props> {
     }
   }
 
-  private contentRef = React.createRef<View>();
-
   render() {
     const {
       styleInterpolator,
@@ -555,7 +561,7 @@ export default class Card extends React.Component<Props> {
                   />
                 ) : null}
                 <CardSheet
-                  ref={this.contentRef}
+                  pointerEvents={this.state.pointerEvents}
                   enabled={pageOverflowEnabled}
                   layout={layout}
                   style={contentStyle}

--- a/packages/stack/src/views/Stack/Card.tsx
+++ b/packages/stack/src/views/Stack/Card.tsx
@@ -71,6 +71,12 @@ type State = {
   pointerEvents: ViewProps['pointerEvents'];
 };
 
+const POINTER_EVENTS: ViewProps['pointerEvents'][] = [
+  'auto',
+  'box-none',
+  'none',
+];
+
 const GESTURE_VELOCITY_IMPACT = 0.3;
 
 const TRUE = 1;
@@ -115,6 +121,10 @@ export default class Card extends React.Component<Props, State> {
   componentDidMount() {
     this.animate({ closing: this.props.closing });
     this.isCurrentlyMounted = true;
+
+    this.pointerEvents.addListener(({ value }) => {
+      this.setState({ pointerEvents: POINTER_EVENTS[value] });
+    });
   }
 
   componentDidUpdate(prevProps: Props) {
@@ -175,6 +185,11 @@ export default class Card extends React.Component<Props, State> {
   private pendingGestureCallback: number | undefined;
 
   private lastToValue: number | undefined;
+
+  // setNativeProps is getting removed in Fabric architecture
+  // in our case migrating to component state is not possible as we change
+  // pointerEvents inside componentDidUpdate
+  private pointerEvents = new Animated.Value(POINTER_EVENTS.indexOf('auto'));
 
   private animate = ({
     closing,
@@ -249,9 +264,11 @@ export default class Card extends React.Component<Props, State> {
   };
 
   private setPointerEventsEnabled = (enabled: boolean) => {
-    const pointerEvents = enabled ? 'box-none' : 'none';
+    const pointerEvents = enabled
+      ? POINTER_EVENTS.indexOf('box-none')
+      : POINTER_EVENTS.indexOf('none');
 
-    this.setState((state) => ({ ...state, pointerEvents }));
+    this.pointerEvents.setValue(pointerEvents);
   };
 
   private handleStartInteraction = () => {

--- a/packages/stack/src/views/Stack/Card.tsx
+++ b/packages/stack/src/views/Stack/Card.tsx
@@ -71,12 +71,6 @@ type State = {
   pointerEvents: ViewProps['pointerEvents'];
 };
 
-const POINTER_EVENTS: ViewProps['pointerEvents'][] = [
-  'auto',
-  'box-none',
-  'none',
-];
-
 const GESTURE_VELOCITY_IMPACT = 0.3;
 
 const TRUE = 1;
@@ -121,10 +115,6 @@ export default class Card extends React.Component<Props, State> {
   componentDidMount() {
     this.animate({ closing: this.props.closing });
     this.isCurrentlyMounted = true;
-
-    this.pointerEvents.addListener(({ value }) => {
-      this.setState({ pointerEvents: POINTER_EVENTS[value] });
-    });
   }
 
   componentDidUpdate(prevProps: Props) {
@@ -185,11 +175,6 @@ export default class Card extends React.Component<Props, State> {
   private pendingGestureCallback: number | undefined;
 
   private lastToValue: number | undefined;
-
-  // setNativeProps is getting removed in Fabric architecture
-  // in our case migrating to component state is not possible as we change
-  // pointerEvents inside componentDidUpdate
-  private pointerEvents = new Animated.Value(POINTER_EVENTS.indexOf('auto'));
 
   private animate = ({
     closing,
@@ -264,11 +249,9 @@ export default class Card extends React.Component<Props, State> {
   };
 
   private setPointerEventsEnabled = (enabled: boolean) => {
-    const pointerEvents = enabled
-      ? POINTER_EVENTS.indexOf('box-none')
-      : POINTER_EVENTS.indexOf('none');
+    const pointerEvents = enabled ? 'box-none' : 'none';
 
-    this.pointerEvents.setValue(pointerEvents);
+    this.setState({ pointerEvents });
   };
 
   private handleStartInteraction = () => {


### PR DESCRIPTION
### Motivation

Changed introduced in https://github.com/react-navigation/react-navigation/pull/10767 created a regression reported in https://github.com/react-navigation/react-navigation/issues/10856 which made it impossible to close a modal with a gesture.

As we want to change pointer-events on Card in `componentDidUpdate` previous use of `setNativeProps` in this context made a lot of sense. Since `setNativeProps` is going to be removed in the new architecture we had to migrate it to the component state as stated [in the migration guide](https://reactnative.dev/docs/next/new-architecture-library-intro#moving-setnativeprops-to-state).

This PR adds an additional `closing !== prevProps.closing` check on top of https://github.com/react-navigation/react-navigation/pull/10767 within `componentDidUpdate` in `Card.tsx`.

### Test plan

ModalStack example

### Recordings

#### Before

https://user-images.githubusercontent.com/39658211/191483144-53085424-5051-4273-a2bb-75a1ffd2c2b2.mov

#### After

https://user-images.githubusercontent.com/39658211/191483170-0071b54d-1a2e-4d28-ae14-09dce69bcb4b.mov

####  Issue the aforementioned PR fixed originally still works

https://user-images.githubusercontent.com/39658211/191483548-9bf3f357-9471-44f5-ad7a-2d5bbb87851d.mov



