### PR TITLE
fix: #10909 reanimated v3 not installable

### DIFF
--- a/packages/drawer/package.json
+++ b/packages/drawer/package.json
@@ -65,7 +65,7 @@
     "react": "*",
     "react-native": "*",
     "react-native-gesture-handler": ">= 1.0.0",
-    "react-native-reanimated": ">= 1.0.0",
+    "react-native-reanimated": ">= 1.0.0 || >= 3.0.0-rc",
     "react-native-safe-area-context": ">= 3.0.0",
     "react-native-screens": ">= 3.0.0"
   },


### PR DESCRIPTION
**Motivation**

When trying to install the `rc` version of reanimated v3 there is an error as described in #10909

**Test plan**

Installation testing works
