### PR TITLE
feat!: introduce href to back button

### DIFF
--- a/packages/drawer/src/views/DrawerItem.tsx
+++ b/packages/drawer/src/views/DrawerItem.tsx
@@ -1,9 +1,8 @@
-import { PlatformPressable } from '@react-navigation/elements';
-import { CommonActions, Link, Route, useTheme } from '@react-navigation/native';
+import { LinkPressable } from '@react-navigation/elements';
+import { Route, useTheme } from '@react-navigation/native';
 import Color from 'color';
 import * as React from 'react';
 import {
-  Platform,
   StyleProp,
   StyleSheet,
   Text,
@@ -87,65 +86,6 @@ type Props = {
   allowFontScaling?: boolean;
 };
 
-const LinkPressable = ({
-  route,
-  href,
-  children,
-  style,
-  onPress,
-  onLongPress,
-  onPressIn,
-  onPressOut,
-  accessibilityRole,
-  ...rest
-}: Omit<React.ComponentProps<typeof PlatformPressable>, 'style'> & {
-  style: StyleProp<ViewStyle>;
-} & {
-  route: Route<string>;
-  href?: string;
-  children: React.ReactNode;
-  onPress?: () => void;
-}) => {
-  if (Platform.OS === 'web') {
-    // React Native Web doesn't forward `onClick` if we use `TouchableWithoutFeedback`.
-    // We need to use `onClick` to be able to prevent default browser handling of links.
-    return (
-      <Link
-        {...rest}
-        href={href}
-        action={CommonActions.navigate(route.name, route.params)}
-        style={[styles.button, style]}
-        onPress={(e: any) => {
-          if (
-            !(e.metaKey || e.altKey || e.ctrlKey || e.shiftKey) && // ignore clicks with modifier keys
-            (e.button == null || e.button === 0) // ignore everything but left clicks
-          ) {
-            e.preventDefault();
-            onPress?.(e);
-          }
-        }}
-        // types for PressableProps and TextProps are incompatible with each other by `null` so we
-        // can't use {...rest} for these 3 props
-        onLongPress={onLongPress ?? undefined}
-        onPressIn={onPressIn ?? undefined}
-        onPressOut={onPressOut ?? undefined}
-      >
-        {children}
-      </Link>
-    );
-  } else {
-    return (
-      <PlatformPressable
-        {...rest}
-        accessibilityRole={accessibilityRole}
-        onPress={onPress}
-      >
-        <View style={style}>{children}</View>
-      </PlatformPressable>
-    );
-  }
-};
-
 /**
  * A component used to show an action item with an icon and a label in a navigation drawer.
  */
@@ -154,7 +94,6 @@ export default function DrawerItem(props: Props) {
 
   const {
     route,
-    href,
     icon,
     label,
     labelStyle,
@@ -193,7 +132,6 @@ export default function DrawerItem(props: Props) {
         pressColor={pressColor}
         pressOpacity={pressOpacity}
         route={route}
-        href={href}
       >
         <React.Fragment>
           {iconNode}
@@ -241,8 +179,5 @@ const styles = StyleSheet.create({
   label: {
     marginRight: 32,
     flex: 1,
-  },
-  button: {
-    display: 'flex',
   },
 });

--- a/packages/elements/src/Header/HeaderBackButton.tsx
+++ b/packages/elements/src/Header/HeaderBackButton.tsx
@@ -10,11 +10,12 @@ import {
   View,
 } from 'react-native';
 
+import LinkPressable from '../LinkPressable';
 import MaskedView from '../MaskedView';
-import PlatformPressable from '../PlatformPressable';
 import type { HeaderBackButtonProps } from '../types';
 
 export default function HeaderBackButton({
+  previousRoute,
   disabled,
   allowFontScaling,
   backImage,
@@ -144,8 +145,9 @@ export default function HeaderBackButton({
   const handlePress = () => onPress && requestAnimationFrame(onPress);
 
   return (
-    <PlatformPressable
+    <LinkPressable
       disabled={disabled}
+      route={previousRoute}
       accessible
       accessibilityRole="button"
       accessibilityLabel={accessibilityLabel}
@@ -164,7 +166,7 @@ export default function HeaderBackButton({
         {renderBackImage()}
         {renderLabel()}
       </React.Fragment>
-    </PlatformPressable>
+    </LinkPressable>
   );
 }
 

--- a/packages/elements/src/LinkPressable.tsx
+++ b/packages/elements/src/LinkPressable.tsx
@@ -1,0 +1,75 @@
+import {
+  CommonActions,
+  Link,
+  Route,
+  useLinkBuilder,
+} from '@react-navigation/native';
+import * as React from 'react';
+import { Platform, StyleProp, StyleSheet, View, ViewStyle } from 'react-native';
+
+import PlatformPressable from './PlatformPressable';
+
+export default function LinkPressable({
+  route,
+  children,
+  style,
+  onPress,
+  onLongPress,
+  onPressIn,
+  onPressOut,
+  accessibilityRole,
+  ...rest
+}: Omit<React.ComponentProps<typeof PlatformPressable>, 'style'> & {
+  style: StyleProp<ViewStyle>;
+} & {
+  route?: Route<string>;
+  children: React.ReactNode;
+  onPress?: () => void;
+}) {
+  const { buildHref } = useLinkBuilder();
+
+  if (Platform.OS === 'web' && route) {
+    // React Native Web doesn't forward `onClick` if we use `TouchableWithoutFeedback`.
+    // We need to use `onClick` to be able to prevent default browser handling of links.
+    return (
+      <Link
+        {...rest}
+        href={buildHref(route.name, route.params)}
+        action={CommonActions.navigate(route.name, route.params)}
+        style={[styles.button, style]}
+        onPress={(e: any) => {
+          if (
+            !(e.metaKey || e.altKey || e.ctrlKey || e.shiftKey) && // ignore clicks with modifier keys
+            (e.button == null || e.button === 0) // ignore everything but left clicks
+          ) {
+            e.preventDefault();
+            onPress?.(e);
+          }
+        }}
+        // types for PressableProps and TextProps are incompatible with each other by `null` so we
+        // can't use {...rest} for these 3 props
+        onLongPress={onLongPress ?? undefined}
+        onPressIn={onPressIn ?? undefined}
+        onPressOut={onPressOut ?? undefined}
+      >
+        {children}
+      </Link>
+    );
+  } else {
+    return (
+      <PlatformPressable
+        {...rest}
+        accessibilityRole={accessibilityRole}
+        onPress={onPress}
+      >
+        <View style={style}>{children}</View>
+      </PlatformPressable>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  button: {
+    display: 'flex',
+  },
+});

--- a/packages/elements/src/index.tsx
+++ b/packages/elements/src/index.tsx
@@ -9,6 +9,7 @@ export { default as HeaderHeightContext } from './Header/HeaderHeightContext';
 export { default as HeaderShownContext } from './Header/HeaderShownContext';
 export { default as HeaderTitle } from './Header/HeaderTitle';
 export { default as useHeaderHeight } from './Header/useHeaderHeight';
+export { default as LinkPressable } from './LinkPressable';
 export { default as MissingIcon } from './MissingIcon';
 export { default as PlatformPressable } from './PlatformPressable';
 export { default as ResourceSavingView } from './ResourceSavingView';

--- a/packages/elements/src/types.tsx
+++ b/packages/elements/src/types.tsx
@@ -1,3 +1,4 @@
+import type { ParamListBase, RouteProp } from '@react-navigation/native';
 import type {
   Animated,
   LayoutChangeEvent,
@@ -167,6 +168,10 @@ export type HeaderButtonProps = {
 };
 
 export type HeaderBackButtonProps = HeaderButtonProps & {
+  /**
+   * Route object for the previous screen.
+   */
+  previousRoute?: RouteProp<ParamListBase>;
   /**
    * Whether the button is disabled.
    */

--- a/packages/native-stack/src/views/NativeStackView.tsx
+++ b/packages/native-stack/src/views/NativeStackView.tsx
@@ -78,6 +78,7 @@ export default function NativeStackView({ state, descriptors }: Props) {
           } = options;
 
           const nextPresentation = nextDescriptor?.options.presentation;
+          const previousRoute = state.routes.find((r) => r.key === previousKey);
 
           return (
             <Screen
@@ -110,6 +111,7 @@ export default function NativeStackView({ state, descriptors }: Props) {
                         : headerLeft === undefined && canGoBack
                         ? ({ tintColor }) => (
                             <HeaderBackButton
+                              previousRoute={previousRoute}
                               tintColor={tintColor}
                               backImage={
                                 headerBackImageSource !== undefined


### PR DESCRIPTION
### Motivation

In order to make the react-navigation web experience more 'native' this PR brings a link to a header back button. This makes UX more natural as users could now right-click to open a route in new tab or hover over to see where does 'go back' leads them.  

### Recordings

#### Before


https://user-images.githubusercontent.com/39658211/197540694-a3ac0d4e-c356-4f87-925f-d00df8411254.mov



#### After


https://user-images.githubusercontent.com/39658211/197540749-ac484bde-6485-4cae-ada3-4e8668252d2f.mov


### Test plan

<details>
<summary>Code example</summary>
<br>

```tsx
// import { createDrawerNavigator } from '@react-navigation/drawer';
import { NavigationContainer } from '@react-navigation/native';
import { createNativeStackNavigator } from '@react-navigation/native-stack';
// import { createStackNavigator } from '@react-navigation/stack';
import { createURL } from 'expo-linking';
import * as React from 'react';
import { Button, Text, View } from 'react-native';

const Stack = createNativeStackNavigator();
// const Stack = createStackNavigator();
// const Stack = createDrawerNavigator();

function HomeScreen({ navigation }: any) {
  return (
    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
      <Text>Home!</Text>
      <Button
        onPress={() => navigation.navigate('Detail')}
        title="To details"
      />
    </View>
  );
}

function DetailScreen() {
  return (
    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
      <Text>Details Screen</Text>
    </View>
  );
}

export default function App() {
  return (
    <NavigationContainer
      linking={{
        config: {
          screens: {
            Home: 'Home',
            Detail: 'Detail',
          },
        },
        prefixes: [createURL('/')],
      }}
    >
      <Stack.Navigator initialRouteName="Home">
        <Stack.Screen name="Home" component={HomeScreen} />
        <Stack.Screen name="Detail" component={DetailScreen} />
      </Stack.Navigator>
    </NavigationContainer>
  );
}

```

</details>



