### PR TITLE
fix: appending text from the drawer when coping the last text in the screen using a triple click in Chrome

### DIFF
--- a/packages/drawer/src/views/DrawerView.tsx
+++ b/packages/drawer/src/views/DrawerView.tsx
@@ -80,9 +80,12 @@ function DrawerViewBase({
   detachInactiveScreens = Platform.OS === 'web' ||
     Platform.OS === 'android' ||
     Platform.OS === 'ios',
-  // Reanimated 2 is not configured
-  // @ts-expect-error: the type definitions are incomplete
-  useLegacyImplementation = !Reanimated.isConfigured?.(),
+  // Running in chrome debugger
+  // @ts-expect-error
+  useLegacyImplementation = !global.nativeCallSyncHook ||
+    // Reanimated 2 is not configured
+    // @ts-expect-error: the type definitions are incomplete
+    !Reanimated.isConfigured?.(),
 }: Props) {
   // Reanimated v3 dropped legacy v1 syntax
   const legacyImplemenationNotAvailable =


### PR DESCRIPTION
When selecting the last text in the screen using a triple click in Chrome browser, the text inside the drawer got selected as well.

**Motivation**

Selecting the last text in the screen using triple click should work fine in all browsers.

this issue wasn't exist in previous versions but later we removed something belong to Chrome debugger which made this issue.

**Test plan**



https://user-images.githubusercontent.com/51829206/199290813-60ad2ded-47f7-4b54-9231-c710ab457283.mp4

