### PR TITLE
fix: migrate setNativeProps to state

### DIFF
--- a/packages/stack/src/views/Stack/Card.tsx
+++ b/packages/stack/src/views/Stack/Card.tsx
@@ -30,7 +30,7 @@ import {
   PanGestureHandlerGestureEvent,
 } from '../GestureHandler';
 import ModalStatusBarManager from '../ModalStatusBarManager';
-import CardSheet from './CardSheet';
+import CardSheet, { CardSheetRef } from './CardSheet';
 
 type Props = ViewProps & {
   interpolationIndex: number;
@@ -242,7 +242,7 @@ export default class Card extends React.Component<Props> {
   private setPointerEventsEnabled = (enabled: boolean) => {
     const pointerEvents = enabled ? 'box-none' : 'none';
 
-    this.contentRef.current?.setNativeProps({ pointerEvents });
+    this.ref.current?.setPointerEvents(pointerEvents);
   };
 
   private handleStartInteraction = () => {
@@ -425,7 +425,7 @@ export default class Card extends React.Component<Props> {
     }
   }
 
-  private contentRef = React.createRef<View>();
+  private ref = React.createRef<CardSheetRef>();
 
   render() {
     const {
@@ -555,7 +555,7 @@ export default class Card extends React.Component<Props> {
                   />
                 ) : null}
                 <CardSheet
-                  ref={this.contentRef}
+                  ref={this.ref}
                   enabled={pageOverflowEnabled}
                   layout={layout}
                   style={contentStyle}

--- a/packages/stack/src/views/Stack/CardSheet.tsx
+++ b/packages/stack/src/views/Stack/CardSheet.tsx
@@ -7,15 +7,27 @@ type Props = ViewProps & {
   children: React.ReactNode;
 };
 
+export type CardSheetRef = {
+  setPointerEvents: React.Dispatch<ViewProps['pointerEvents']>;
+};
+
 // This component will render a page which overflows the screen
 // if the container fills the body by comparing the size
 // This lets the document.body handle scrolling of the content
 // It's necessary for mobile browsers to be able to hide address bar on scroll
-export default React.forwardRef<View, Props>(function CardSheet(
+export default React.forwardRef<CardSheetRef, Props>(function CardSheet(
   { enabled, layout, style, ...rest },
   ref
 ) {
   const [fill, setFill] = React.useState(false);
+  // To avoid triggering a rerender in Card during animation we had to move
+  // the state to CardSheet. The `setPointerEvents` is then hoisted back to the Card.
+  const [pointerEvents, setPointerEvents] =
+    React.useState<ViewProps['pointerEvents']>('auto');
+
+  React.useImperativeHandle(ref, () => {
+    return { setPointerEvents };
+  });
 
   React.useEffect(() => {
     if (typeof document === 'undefined' || !document.body) {
@@ -32,7 +44,7 @@ export default React.forwardRef<View, Props>(function CardSheet(
   return (
     <View
       {...rest}
-      ref={ref}
+      pointerEvents={pointerEvents}
       style={[enabled && fill ? styles.page : styles.card, style]}
     />
   );


### PR DESCRIPTION
### Motivation

This PR is a third attempt to migrate `setNativeProps` to state in @react-navigation/stack following official [Moving setNativeProps to state](https://reactnative.dev/docs/next/new-architecture-library-intro#moving-setnativeprops-to-state) guide.

After issues with the implementation of https://github.com/react-navigation/react-navigation/pull/10767 and more problems with the fix in https://github.com/react-navigation/react-navigation/pull/10871 we had to take a step back and rethink where the problem lays with these implementations.

The solution was to move the state inside the CardSheet component and use `useImperativeHandle` to hoist a setter function up to Card to avoid triggering a rerender during Card `animate` function. 

Thanks so much @satya164 for pointing that out!

### Fabric before

https://user-images.githubusercontent.com/39658211/199431622-82cff53c-f7bc-4dfc-a6d5-2baaa6bb5899.mov


https://user-images.githubusercontent.com/39658211/199436874-06824710-9bc8-497b-ab67-6ed05d8fbe6c.mov


### Fabric after

https://user-images.githubusercontent.com/39658211/199431638-fee93609-18e9-4908-b47e-6c6240be3429.mov


https://user-images.githubusercontent.com/39658211/199437620-6388e91a-14dd-43ee-b5e7-8a578fe07328.mov



### Test plan

New bare application on Fabric Architecture.

<details>
<summary>Code snippet</summary>
<br>

```jsx
import {NavigationContainer} from '@react-navigation/native';
import {
  CardStyleInterpolators,
  createStackNavigator,
} from '@react-navigation/stack';
import * as React from 'react';
import {Button, Easing, Pressable, Text, View} from 'react-native';

function HomeScreen({navigation}) {
  const isFabric = !!global?.nativeFabricUIManager;

  return (
    <View
      style={{
        flex: 1,
        alignItems: 'center',
        justifyContent: 'center',
      }}>
      <Text>Fabric enabled: {isFabric.toString()}</Text>
      <Button
        title="Go to Details"
        onPress={() => navigation.navigate('Details')}
      />
    </View>
  );
}

function DetailsScreen({navigation}) {
  const [value, toggle] = React.useReducer(s => !s, false);

  const isFabric = !!global?.nativeFabricUIManager;

  console.log(isFabric);

  return (
    <Pressable
      style={{
        flex: 1,
        alignItems: 'center',
        justifyContent: 'center',
        backgroundColor: value ? 'palevioletred' : 'wheat',
      }}
      onPressIn={toggle}
      onPressOut={toggle}>
      <Text>Details Screen</Text>
      <Text>When going back you shouldn't be able to tap ON THIS screen</Text>
      <Button
        title="Go to Overview"
        onPress={() => navigation.navigate('Home')}
      />
    </Pressable>
  );
}
const Stack = createStackNavigator();

const config = {
  animation: 'timing',
  config: {
    duration: 4000,
    easing: Easing.out(Easing.poly(5)),
  },
};

function App() {
  return (
    <NavigationContainer>
      <Stack.Navigator
        detachInactiveScreens={false}
        screenOptions={{
          gestureEnabled: true,
          cardStyleInterpolator: CardStyleInterpolators.forHorizontalIOS,
          transitionSpec: {
            open: config,
            close: config,
          },
        }}>
        <Stack.Screen name="Home" component={HomeScreen} />
        <Stack.Screen
          name="Details"
          component={DetailsScreen}
          options={{title: 'Details'}}
        />
      </Stack.Navigator>
    </NavigationContainer>
  );
}

export default App;

```
</details>