### PR TITLE
fix: supersede Platform.isTVOS for Platform.isTV

### DIFF
--- a/packages/elements/src/Header/getDefaultHeaderHeight.tsx
+++ b/packages/elements/src/Header/getDefaultHeaderHeight.tsx
@@ -12,7 +12,7 @@ export default function getDefaultHeaderHeight(
   const isLandscape = layout.width > layout.height;
 
   if (Platform.OS === 'ios') {
-    if (Platform.isPad || Platform.isTVOS) {
+    if (Platform.isPad || Platform.isTV) {
       if (modalPresentation) {
         headerHeight = 56;
       } else {

--- a/packages/native-stack/src/views/NativeStackView.native.tsx
+++ b/packages/native-stack/src/views/NativeStackView.native.tsx
@@ -204,8 +204,7 @@ const SceneView = ({
   const isModal = presentation === 'modal' || presentation === 'formSheet';
 
   // Modals are fullscreen in landscape only on iPhone
-  const isIPhone =
-    Platform.OS === 'ios' && !(Platform.isPad || Platform.isTV);
+  const isIPhone = Platform.OS === 'ios' && !(Platform.isPad || Platform.isTV);
   const isLandscape = frame.width > frame.height;
 
   const isParentHeaderShown = React.useContext(HeaderShownContext);

--- a/packages/native-stack/src/views/NativeStackView.native.tsx
+++ b/packages/native-stack/src/views/NativeStackView.native.tsx
@@ -205,7 +205,7 @@ const SceneView = ({
 
   // Modals are fullscreen in landscape only on iPhone
   const isIPhone =
-    Platform.OS === 'ios' && !(Platform.isPad || Platform.isTVOS);
+    Platform.OS === 'ios' && !(Platform.isPad || Platform.isTV);
   const isLandscape = frame.width > frame.height;
 
   const isParentHeaderShown = React.useContext(HeaderShownContext);

--- a/packages/stack/src/TransitionConfigs/CardStyleInterpolators.tsx
+++ b/packages/stack/src/TransitionConfigs/CardStyleInterpolators.tsx
@@ -101,7 +101,7 @@ export function forModalPresentationIOS({
   const hasNotchIos =
     Platform.OS === 'ios' &&
     !Platform.isPad &&
-    !Platform.isTVOS &&
+    !Platform.isTV &&
     insets.top > 20;
   const isLandscape = screen.width > screen.height;
   const topOffset = isLandscape ? 0 : 10;


### PR DESCRIPTION
**Motivation**

This PR supersedes a deprecated `Platform.isTVOS` which got removed in https://github.com/facebook/react-native/pull/34071 for the currently used standard - a `Platform.isTV` check.

`Platform.isTV` check exists since react-native `v0.61` that way no breaking changes are introduced to react-navigation.

Ref: https://github.com/software-mansion/react-native-screens/pull/1605
