### PR TITLE
HeaderConfig: Updates hideShadow to allow native iOS behavior to be applied

### DIFF
--- a/packages/native-stack/src/views/HeaderConfig.tsx
+++ b/packages/native-stack/src/views/HeaderConfig.tsx
@@ -180,7 +180,8 @@ export default function HeaderConfig({
         hideShadow={
           headerShadowVisible === false ||
           headerBackground != null ||
-          headerTransparent
+          // On iOS, even transparent headers have a border (called shadow in this property)
+          (Platform.OS !== 'ios' && headerTransparent) 
         }
         largeTitle={headerLargeTitle}
         largeTitleBackgroundColor={headerLargeStyleFlattened.backgroundColor}

--- a/packages/native-stack/src/views/HeaderConfig.tsx
+++ b/packages/native-stack/src/views/HeaderConfig.tsx
@@ -181,7 +181,7 @@ export default function HeaderConfig({
           headerShadowVisible === false ||
           headerBackground != null ||
           // On iOS, even transparent headers have a border (called shadow in this property)
-          (Platform.OS !== 'ios' && headerTransparent) 
+          (Platform.OS !== 'ios' && headerTransparent)
         }
         largeTitle={headerLargeTitle}
         largeTitleBackgroundColor={headerLargeStyleFlattened.backgroundColor}

--- a/packages/native-stack/src/views/HeaderConfig.tsx
+++ b/packages/native-stack/src/views/HeaderConfig.tsx
@@ -180,8 +180,7 @@ export default function HeaderConfig({
         hideShadow={
           headerShadowVisible === false ||
           headerBackground != null ||
-          // On iOS, even transparent headers have a border (called shadow in this property)
-          (Platform.OS !== 'ios' && headerTransparent)
+          (headerTransparent && headerShadowVisible !== true)
         }
         largeTitle={headerLargeTitle}
         largeTitleBackgroundColor={headerLargeStyleFlattened.backgroundColor}


### PR DESCRIPTION
**Motivation**

As reported in [#10845](https://github.com/react-navigation/react-navigation/issues/10845), the behavior that native software in the iOS ecosystem applies is that even transparent headers _can_ have a border in the NavigationBar/TopBar. In React Navigation, it was assumed that `headerTransparent=true` would also imply `hideShadow=true`, which would prevent this behavior (and therefore, make the behavior of this library inconsistent with native apps)

This fix allows the behavior to continue on Android, while allowing the native iOS behavior to be present (also providing the option to hide it forcefully).

Issue here: https://github.com/react-navigation/react-navigation/issues/10845

**Test plan**

- Configure a NativeStack to have a transparent header on iOS
- Observe that this does not affect the `hideShadow` property on iOS
- Observe that behavior on Android is unchanged

| Bug  | Expected |
:-------------------------:|:-------------------------:
![](https://user-images.githubusercontent.com/753361/201132528-4c40ec0d-c239-4f05-98a5-46a8b09f6a3c.png)  |  ![](https://user-images.githubusercontent.com/753361/201132408-c95f528a-2f91-4765-9743-42c6f319b4ae.png)


The change must pass lint, typescript and tests: ✅ 
