### PR TITLE
chore: migrate classic updates to EAS

### DIFF
--- a/.github/workflows/expo-preview.yml
+++ b/.github/workflows/expo-preview.yml
@@ -15,26 +15,40 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Setup Expo
-        uses: expo/expo-github-action@v6
+        uses: expo/expo-github-action@v7
         with:
+          eas-version: latest
           token: ${{ secrets.EXPO_TOKEN }}
 
       - name: Publish Expo app
         working-directory: ./example
-        run: yarn expo-cli publish --release-channel=pr-${{ github.event.number }}
+        run: CI=1 eas update --branch=${{ github.head_ref }} --message="$(git log -1 --pretty=%B)"
         env:
           EXPO_USE_DEV_SERVER: true
 
-      - name: Get expo link
+      - name: Get expo config
         id: expo
-        run: echo "::set-output name=path::@react-navigation/react-navigation-example?release-channel=pr-${{ github.event.number }}"
+        run: echo "EXPO_CONFIG=$(npx expo config --json)" >> $GITHUB_OUTPUT
 
       - name: Comment on PR
         uses: actions/github-script@v3
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            const body = 'The Expo app for the example from this branch is ready!\n\n[expo.dev/${{ steps.expo.outputs.path }}](https://expo.dev/${{ steps.expo.outputs.path }})\n\n<a href="https://exp.host/${{ steps.expo.outputs.path }}"><img src="https://api.qrserver.com/v1/create-qr-code/?size=400x400&data=exp://exp.host/${{ steps.expo.outputs.path }}" height="200px" width="200px"></a>';
+            const config = JSON.parse('${{ steps.expo.outputs.EXPO_CONFIG }}');
+
+            const { sdkVersion } = config;
+            const { projectId } = config.extra.eas;
+            const channel = '${{ github.head_ref }}';
+
+            const url = `https://expo.dev/@react-navigation/react-navigation-example?serviceType=eas&distribution=expo-go&scheme=exp+react-navigation-example&channel=${channel}&sdkVersion=${sdkVersion}`;
+
+            const body = `The Expo app for the example from this branch is ready!
+
+            [${url}](${url})
+
+            <a href="${url}"><img src="https://qr.expo.dev/eas-update?appScheme=exp&projectId=${projectId}&channel=${channel}&runtimeVersion=exposdk:${sdkVersion}&host=u.expo.dev" height="200px" width="200px"></a>
+            `;
 
             const comments = await github.issues.listComments({
               issue_number: context.issue.number,

--- a/.github/workflows/expo.yml
+++ b/.github/workflows/expo.yml
@@ -17,10 +17,11 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Setup Expo
-        uses: expo/expo-github-action@v6
+        uses: expo/expo-github-action@v7
         with:
+          eas-version: latest
           token: ${{ secrets.EXPO_TOKEN }}
 
       - name: Publish Expo app
         working-directory: ./example
-        run: yarn expo-cli publish
+        run: npx eas update --auto

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -16,7 +16,7 @@
     <meta-data android:name="expo.modules.updates.EXPO_SDK_VERSION" android:value="46.0.0"/>
     <meta-data android:name="expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH" android:value="ALWAYS"/>
     <meta-data android:name="expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS" android:value="0"/>
-    <meta-data android:name="expo.modules.updates.EXPO_UPDATE_URL" android:value="https://exp.host/@react-navigation/react-navigation-example"/>
+    <meta-data android:name="expo.modules.updates.EXPO_UPDATE_URL" android:value="https://u.expo.dev/a7070fc4-41f3-403d-826d-292b5d868327"/>
     <activity android:name=".MainActivity" android:label="@string/app_name" android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode" android:launchMode="singleTask" android:windowSoftInputMode="adjustResize" android:theme="@style/Theme.App.SplashScreen" android:exported="true">
       <intent-filter>
         <action android:name="android.intent.action.MAIN"/>

--- a/example/app.json
+++ b/example/app.json
@@ -24,7 +24,8 @@
       "bundleIdentifier": "org.reactnavigation.example"
     },
     "updates": {
-      "fallbackToCacheTimeout": 0
+      "fallbackToCacheTimeout": 0,
+      "url": "https://u.expo.dev/a7070fc4-41f3-403d-826d-292b5d868327"
     },
     "assetBundlePatterns": [
       "**/*"
@@ -33,6 +34,14 @@
     "entryPoint": "App.tsx",
     "android": {
       "package": "org.reactnavigation.example"
+    },
+    "extra": {
+      "eas": {
+        "projectId": "a7070fc4-41f3-403d-826d-292b5d868327"
+      }
+    },
+    "runtimeVersion": {
+      "policy": "sdkVersion"
     }
   }
 }

--- a/example/ios/ReactNavigation/Supporting/Expo.plist
+++ b/example/ios/ReactNavigation/Supporting/Expo.plist
@@ -11,6 +11,6 @@
     <key>EXUpdatesSDKVersion</key>
     <string>46.0.0</string>
     <key>EXUpdatesURL</key>
-    <string>https://exp.host/@react-navigation/react-navigation-example</string>
+    <string>https://u.expo.dev/a7070fc4-41f3-403d-826d-292b5d868327</string>
   </dict>
 </plist>


### PR DESCRIPTION
## Motivation

Expo docs advise to migrate from classic updates (expo publish) to next-gen EAS Update.

https://docs.expo.dev/eas-update/migrate-to-eas-update/

## Actions taken

- `eas update:configure` in /example dir
- updated Github Actions bot comment to point to the EAS service

PS: Keep in mind that `eas update --auto` always resolves to HEAD on GitHub

