### PR TITLE
feat: expose tabBarGap option in material top tabs

### DIFF
--- a/packages/material-top-tabs/src/types.tsx
+++ b/packages/material-top-tabs/src/types.tsx
@@ -196,6 +196,11 @@ export type MaterialTopTabNavigationOptions = {
   tabBarStyle?: StyleProp<ViewStyle>;
 
   /**
+   * Gap between tabs
+   */
+  tabBarGap?: number;
+
+  /**
    * Whether to enable swipe gestures when this screen is focused.
    * Swipe gestures are enabled by default. Passing `false` will disable swipe gestures,
    * but the user can still switch tabs by pressing the tab bar.

--- a/packages/material-top-tabs/src/views/MaterialTopTabBar.tsx
+++ b/packages/material-top-tabs/src/views/MaterialTopTabBar.tsx
@@ -41,6 +41,7 @@ export default function TabBarTop({
         { backgroundColor: colors.primary },
         focusedOptions.tabBarIndicatorStyle,
       ]}
+      gap={focusedOptions.tabBarGap}
       indicatorContainerStyle={focusedOptions.tabBarIndicatorContainerStyle}
       contentContainerStyle={focusedOptions.tabBarContentContainerStyle}
       style={[{ backgroundColor: colors.card }, focusedOptions.tabBarStyle]}


### PR DESCRIPTION
This PR replaces #10984


**Motivation**

the new `tabBarGap` option helps to configure `gap` option of `react-native-tab-view` : see https://github.com/react-navigation/react-navigation/tree/main/packages/react-native-tab-view#gap

**Test plan**

Just set a tabBarGap option and check that there is a gap between tabs 

