### PR TITLE
fix: drawerstatuscontext should be exported

### DIFF
--- a/packages/drawer/src/index.tsx
+++ b/packages/drawer/src/index.tsx
@@ -18,6 +18,7 @@ export { default as DrawerView } from './views/DrawerView';
  */
 export { default as DrawerGestureContext } from './utils/DrawerGestureContext';
 export { default as DrawerProgressContext } from './utils/DrawerProgressContext';
+export { default as DrawerStatusContext } from './utils/DrawerStatusContext';
 export { default as getDrawerStatusFromState } from './utils/getDrawerStatusFromState';
 export { default as useDrawerProgress } from './utils/useDrawerProgress';
 export { default as useDrawerStatus } from './utils/useDrawerStatus';

--- a/packages/drawer/src/utils/DrawerStatusContext.tsx
+++ b/packages/drawer/src/utils/DrawerStatusContext.tsx
@@ -1,4 +1,8 @@
 import type { DrawerStatus } from '@react-navigation/native';
 import * as React from 'react';
 
-export default React.createContext<DrawerStatus | undefined>(undefined);
+const DrawerStatusContext = React.createContext<DrawerStatus | undefined>(
+  undefined
+);
+
+export default DrawerStatusContext;

--- a/packages/drawer/src/utils/DrawerStatusContext.tsx
+++ b/packages/drawer/src/utils/DrawerStatusContext.tsx
@@ -1,8 +1,4 @@
 import type { DrawerStatus } from '@react-navigation/native';
 import * as React from 'react';
 
-const DrawerStatusContext = React.createContext<DrawerStatus | undefined>(
-  undefined
-);
-
-export default DrawerStatusContext;
+export default React.createContext<DrawerStatus | undefined>(undefined);


### PR DESCRIPTION
**Motivation**

`DrawerStatusContext` should be exported and available to the library's users.
For example, someone might want to create a custom Drawer navigator using `useNavigationBuilder` and reuse this context.

(Previous PR: https://github.com/react-navigation/react-navigation/pull/10976)