### PR TITLE
feat!: add href to back button

### DIFF
--- a/packages/bottom-tabs/src/views/BottomTabItem.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabItem.tsx
@@ -1,11 +1,10 @@
-import { getLabel, Label } from '@react-navigation/elements';
-import { CommonActions, Link, Route, useTheme } from '@react-navigation/native';
+import { getLabel, Label, PlatformPressable } from '@react-navigation/elements';
+import { Route, useTheme } from '@react-navigation/native';
 import Color from 'color';
 import React from 'react';
 import {
   GestureResponderEvent,
   Platform,
-  Pressable,
   StyleProp,
   StyleSheet,
   TextStyle,
@@ -145,40 +144,19 @@ export function BottomTabItem({
     accessibilityRole,
     ...rest
   }: BottomTabBarButtonProps) => {
-    if (Platform.OS === 'web') {
-      // React Native Web doesn't forward `onClick` if we use `TouchableWithoutFeedback`.
-      // We need to use `onClick` to be able to prevent default browser handling of links.
-      return (
-        <Link
-          {...rest}
-          href={href}
-          action={CommonActions.navigate(route.name, route.params)}
-          style={[styles.button, style]}
-          onPress={(e: any) => {
-            if (
-              !(e.metaKey || e.altKey || e.ctrlKey || e.shiftKey) && // ignore clicks with modifier keys
-              (e.button == null || e.button === 0) // ignore everything but left clicks
-            ) {
-              e.preventDefault();
-              onPress?.(e);
-            }
-          }}
-        >
-          {children}
-        </Link>
-      );
-    } else {
-      return (
-        <Pressable
-          {...rest}
-          accessibilityRole={accessibilityRole}
-          onPress={onPress}
-          style={style}
-        >
-          {children}
-        </Pressable>
-      );
-    }
+    return (
+      <PlatformPressable
+        {...rest}
+        android_ripple={{ borderless: true }}
+        pressOpacity={1}
+        href={href}
+        accessibilityRole={accessibilityRole}
+        onPress={onPress}
+        style={style}
+      >
+        {children}
+      </PlatformPressable>
+    );
   },
   accessibilityLabel,
   testID,
@@ -323,8 +301,5 @@ const styles = StyleSheet.create({
   labelBeside: {
     fontSize: 13,
     marginLeft: 20,
-  },
-  button: {
-    display: 'flex',
   },
 });

--- a/packages/drawer/src/views/DrawerItem.tsx
+++ b/packages/drawer/src/views/DrawerItem.tsx
@@ -1,9 +1,8 @@
 import { PlatformPressable } from '@react-navigation/elements';
-import { CommonActions, Link, Route, useTheme } from '@react-navigation/native';
+import { Route, useTheme } from '@react-navigation/native';
 import Color from 'color';
 import * as React from 'react';
 import {
-  Platform,
   StyleProp,
   StyleSheet,
   Text,
@@ -96,65 +95,6 @@ type Props = {
   testID?: string;
 };
 
-const LinkPressable = ({
-  route,
-  href,
-  children,
-  style,
-  onPress,
-  onLongPress,
-  onPressIn,
-  onPressOut,
-  accessibilityRole,
-  ...rest
-}: Omit<React.ComponentProps<typeof PlatformPressable>, 'style'> & {
-  style: StyleProp<ViewStyle>;
-} & {
-  route: Route<string>;
-  href?: string;
-  children: React.ReactNode;
-  onPress?: () => void;
-}) => {
-  if (Platform.OS === 'web') {
-    // React Native Web doesn't forward `onClick` if we use `TouchableWithoutFeedback`.
-    // We need to use `onClick` to be able to prevent default browser handling of links.
-    return (
-      <Link
-        {...rest}
-        href={href}
-        action={CommonActions.navigate(route.name, route.params)}
-        style={[styles.button, style]}
-        onPress={(e: any) => {
-          if (
-            !(e.metaKey || e.altKey || e.ctrlKey || e.shiftKey) && // ignore clicks with modifier keys
-            (e.button == null || e.button === 0) // ignore everything but left clicks
-          ) {
-            e.preventDefault();
-            onPress?.(e);
-          }
-        }}
-        // types for PressableProps and TextProps are incompatible with each other by `null` so we
-        // can't use {...rest} for these 3 props
-        onLongPress={onLongPress ?? undefined}
-        onPressIn={onPressIn ?? undefined}
-        onPressOut={onPressOut ?? undefined}
-      >
-        {children}
-      </Link>
-    );
-  } else {
-    return (
-      <PlatformPressable
-        {...rest}
-        accessibilityRole={accessibilityRole}
-        onPress={onPress}
-      >
-        <View style={style}>{children}</View>
-      </PlatformPressable>
-    );
-  }
-};
-
 /**
  * A component used to show an action item with an icon and a label in a navigation drawer.
  */
@@ -162,7 +102,6 @@ export function DrawerItem(props: Props) {
   const { colors, fonts } = useTheme();
 
   const {
-    route,
     href,
     icon,
     label,
@@ -196,19 +135,17 @@ export function DrawerItem(props: Props) {
       {...rest}
       style={[styles.container, { borderRadius, backgroundColor }, style]}
     >
-      <LinkPressable
+      <PlatformPressable
         testID={testID}
         onPress={onPress}
-        style={[styles.wrapper, { borderRadius }]}
         accessibilityLabel={accessibilityLabel}
         accessibilityRole="button"
         accessibilityState={{ selected: focused }}
         pressColor={pressColor}
         pressOpacity={pressOpacity}
-        route={route}
         href={href}
       >
-        <React.Fragment>
+        <View style={[styles.wrapper, { borderRadius }]}>
           {iconNode}
           <View
             style={[
@@ -228,8 +165,8 @@ export function DrawerItem(props: Props) {
               label({ color, focused })
             )}
           </View>
-        </React.Fragment>
-      </LinkPressable>
+        </View>
+      </PlatformPressable>
     </View>
   );
 }
@@ -248,8 +185,5 @@ const styles = StyleSheet.create({
   label: {
     marginRight: 32,
     flex: 1,
-  },
-  button: {
-    display: 'flex',
   },
 });

--- a/packages/drawer/src/views/DrawerToggleButton.tsx
+++ b/packages/drawer/src/views/DrawerToggleButton.tsx
@@ -22,8 +22,6 @@ export function DrawerToggleButton({ tintColor, ...rest }: Props) {
   return (
     <PlatformPressable
       {...rest}
-      accessible
-      accessibilityRole="button"
       android_ripple={{ borderless: true }}
       onPress={() => navigation.dispatch(DrawerActions.toggleDrawer())}
       style={styles.touchable}

--- a/packages/elements/src/Header/HeaderBackButton.tsx
+++ b/packages/elements/src/Header/HeaderBackButton.tsx
@@ -148,27 +148,19 @@ export function HeaderBackButton({
     );
   };
 
-  const handlePress = (e: any) => {
-    const ignoreEvents =
-      !(e.metaKey || e.altKey || e.ctrlKey || e.shiftKey) && // ignore clicks with modifier keys
-      (e.button == null || e.button === 0); // ignore everything but left clicks
-
-    if (Platform.OS === 'web' && href && ignoreEvents) {
-      e.preventDefault();
+  const handlePress = () => {
+    if (onPress) {
+      requestAnimationFrame(() => onPress());
     }
-
-    return onPress && requestAnimationFrame(onPress);
   };
 
   return (
     <PlatformPressable
       disabled={disabled}
       href={href}
-      accessible
-      accessibilityRole={Platform.OS === 'web' && href ? 'link' : 'button'}
       accessibilityLabel={accessibilityLabel}
       testID={testID}
-      onPress={disabled ? undefined : handlePress}
+      onPress={handlePress}
       pressColor={pressColor}
       pressOpacity={pressOpacity}
       android_ripple={androidRipple}

--- a/packages/elements/src/Header/HeaderBackButton.tsx
+++ b/packages/elements/src/Header/HeaderBackButton.tsx
@@ -31,6 +31,7 @@ export function HeaderBackButton({
   accessibilityLabel = label && label !== 'Back' ? `${label}, back` : 'Go back',
   testID,
   style,
+  href,
 }: HeaderBackButtonProps) {
   const { colors, fonts } = useTheme();
   const { direction } = useLocale();
@@ -147,13 +148,24 @@ export function HeaderBackButton({
     );
   };
 
-  const handlePress = () => onPress && requestAnimationFrame(onPress);
+  const handlePress = (e: any) => {
+    const ignoreEvents =
+      !(e.metaKey || e.altKey || e.ctrlKey || e.shiftKey) && // ignore clicks with modifier keys
+      (e.button == null || e.button === 0); // ignore everything but left clicks
+
+    if (Platform.OS === 'web' && href && ignoreEvents) {
+      e.preventDefault();
+    }
+
+    return onPress && requestAnimationFrame(onPress);
+  };
 
   return (
     <PlatformPressable
       disabled={disabled}
+      href={href}
       accessible
-      accessibilityRole="button"
+      accessibilityRole={Platform.OS === 'web' && href ? 'link' : 'button'}
       accessibilityLabel={accessibilityLabel}
       testID={testID}
       onPress={disabled ? undefined : handlePress}

--- a/packages/elements/src/Header/HeaderBackContext.tsx
+++ b/packages/elements/src/Header/HeaderBackContext.tsx
@@ -1,6 +1,5 @@
 import { getNamedContext } from '../getNamedContext';
 
-export const HeaderBackContext = getNamedContext<{ title: string } | undefined>(
-  'HeaderBackContext',
-  undefined
-);
+export const HeaderBackContext = getNamedContext<
+  { title: string; href?: string } | undefined
+>('HeaderBackContext', undefined);

--- a/packages/elements/src/Header/HeaderBackContext.tsx
+++ b/packages/elements/src/Header/HeaderBackContext.tsx
@@ -1,5 +1,5 @@
 import { getNamedContext } from '../getNamedContext';
 
 export const HeaderBackContext = getNamedContext<
-  { title: string; href?: string } | undefined
+  { title: string | undefined; href: string | undefined } | undefined
 >('HeaderBackContext', undefined);

--- a/packages/elements/src/PlatformPressable.tsx
+++ b/packages/elements/src/PlatformPressable.tsx
@@ -15,6 +15,7 @@ export type Props = Omit<PressableProps, 'style'> & {
   pressColor?: string;
   pressOpacity?: number;
   style?: Animated.WithAnimatedValue<StyleProp<ViewStyle>>;
+  href?: string;
   children: React.ReactNode;
 };
 

--- a/packages/elements/src/PlatformPressable.tsx
+++ b/packages/elements/src/PlatformPressable.tsx
@@ -29,6 +29,8 @@ const ANDROID_SUPPORTS_RIPPLE =
  * PlatformPressable provides an abstraction on top of Pressable to handle platform differences.
  */
 export function PlatformPressable({
+  disabled,
+  onPress,
   onPressIn,
   onPressOut,
   android_ripple,
@@ -53,6 +55,26 @@ export function PlatformPressable({
     }).start();
   };
 
+  const handlePress = (e: GestureResponderEvent) => {
+    // @ts-expect-error: these properties exist on web, but not in React Native
+    const hasModifierKey = e.metaKey || e.altKey || e.ctrlKey || e.shiftKey; // ignore clicks with modifier keys
+    // @ts-expect-error: these properties exist on web, but not in React Native
+    const isLeftClick = e.button == null || e.button === 0; // only handle left clicks
+    const isSelfTarget = [undefined, null, '', 'self'].includes(
+      // @ts-expect-error: these properties exist on web, but not in React Native
+      e.currentTarget?.target
+    ); // let browser handle "target=_blank" etc.
+
+    if (Platform.OS === 'web' && rest.href != null) {
+      if (!hasModifierKey && isLeftClick && isSelfTarget) {
+        e.preventDefault();
+        onPress?.(e);
+      }
+    } else {
+      onPress?.(e);
+    }
+  };
+
   const handlePressIn = (e: GestureResponderEvent) => {
     animateTo(pressOpacity, 0);
     onPressIn?.(e);
@@ -65,6 +87,11 @@ export function PlatformPressable({
 
   return (
     <AnimatedPressable
+      accessible
+      accessibilityRole={
+        Platform.OS === 'web' && rest.href != null ? 'link' : 'button'
+      }
+      onPress={disabled ? undefined : handlePress}
       onPressIn={handlePressIn}
       onPressOut={handlePressOut}
       android_ripple={

--- a/packages/elements/src/types.tsx
+++ b/packages/elements/src/types.tsx
@@ -180,6 +180,10 @@ export type HeaderBackButtonProps = HeaderButtonProps & {
    */
   backImage?: (props: { tintColor: string }) => React.ReactNode;
   /**
+   * The `href` to use for the anchor tag on web
+   */
+  href?: string;
+  /**
    * Label text for the button. Usually the title of the previous screen.
    * By default, this is only shown on iOS.
    */

--- a/packages/native-stack/src/types.tsx
+++ b/packages/native-stack/src/types.tsx
@@ -72,7 +72,11 @@ export type NativeStackHeaderProps = {
     /**
      * Title of the previous screen.
      */
-    title: string;
+    title: string | undefined;
+    /**
+     * The `href` to use for the anchor tag on web
+     */
+    href: string | undefined;
   };
   /**
    * Options for the current screen.

--- a/packages/native-stack/src/views/NativeStackView.native.tsx
+++ b/packages/native-stack/src/views/NativeStackView.native.tsx
@@ -237,14 +237,19 @@ const SceneView = ({
 
   const headerTopInsetEnabled = topInset !== 0;
   const headerHeight = header ? customHeaderHeight : defaultHeaderHeight;
-  const headerBack = previousDescriptor
-    ? {
-        title: getHeaderTitle(
-          previousDescriptor.options,
-          previousDescriptor.route.name
-        ),
-      }
-    : parentHeaderBack;
+
+  const backTitle = previousDescriptor
+    ? getHeaderTitle(previousDescriptor.options, previousDescriptor.route.name)
+    : parentHeaderBack?.title;
+
+  const headerBack = React.useMemo(
+    () => ({
+      // No href needed for native
+      href: undefined,
+      title: backTitle,
+    }),
+    [backTitle]
+  );
 
   const isRemovePrevented = preventedRoutes[route.key]?.preventRemove;
 

--- a/packages/native-stack/src/views/NativeStackView.tsx
+++ b/packages/native-stack/src/views/NativeStackView.tsx
@@ -6,9 +6,10 @@ import {
   SafeAreaProviderCompat,
   Screen,
 } from '@react-navigation/elements';
-import type {
+import {
   ParamListBase,
   StackNavigationState,
+  useLinkTools,
 } from '@react-navigation/native';
 import * as React from 'react';
 import { Image, StyleSheet, View } from 'react-native';
@@ -33,6 +34,7 @@ const TRANSPARENT_PRESENTATIONS = [
 
 export function NativeStackView({ state, descriptors }: Props) {
   const parentHeaderBack = React.useContext(HeaderBackContext);
+  const { buildHref } = useLinkTools();
 
   return (
     <SafeAreaProviderCompat>
@@ -52,6 +54,10 @@ export function NativeStackView({ state, descriptors }: Props) {
                 title: getHeaderTitle(
                   previousDescriptor.options,
                   previousDescriptor.route.name
+                ),
+                href: buildHref(
+                  previousDescriptor.route.name,
+                  previousDescriptor.route.params
                 ),
               }
             : parentHeaderBack;
@@ -125,7 +131,7 @@ export function NativeStackView({ state, descriptors }: Props) {
                                   : undefined
                               }
                               onPress={navigation.goBack}
-                              canGoBack={canGoBack}
+                              href={headerBack.href}
                             />
                           )
                         : headerLeft

--- a/packages/native-stack/src/views/NativeStackView.tsx
+++ b/packages/native-stack/src/views/NativeStackView.tsx
@@ -130,6 +130,7 @@ export function NativeStackView({ state, descriptors }: Props) {
                                     )
                                   : undefined
                               }
+                              canGoBack={canGoBack}
                               onPress={navigation.goBack}
                               href={headerBack.href}
                             />

--- a/packages/native/src/useLinkProps.tsx
+++ b/packages/native/src/useLinkProps.tsx
@@ -80,18 +80,24 @@ export function useLinkProps<ParamList extends ReactNavigation.RootParamList>({
   const onPress = (
     e?: React.MouseEvent<HTMLAnchorElement, MouseEvent> | GestureResponderEvent
   ) => {
+    // @ts-expect-error: these properties exist on web, but not in React Native
+    const hasModifierKey = e.metaKey || e.altKey || e.ctrlKey || e.shiftKey; // ignore clicks with modifier keys
+    // @ts-expect-error: these properties exist on web, but not in React Native
+    const isLeftClick = e.button == null || e.button === 0; // only handle left clicks
+    const isSelfTarget = [undefined, null, '', 'self'].includes(
+      // @ts-expect-error: these properties exist on web, but not in React Native
+      e.currentTarget?.target
+    ); // let browser handle "target=_blank" etc.
+
     let shouldHandle = false;
 
     if (Platform.OS !== 'web' || !e) {
       shouldHandle = e ? !e.defaultPrevented : true;
     } else if (
       !e.defaultPrevented && // onPress prevented default
-      // @ts-expect-error: these properties exist on web, but not in React Native
-      !(e.metaKey || e.altKey || e.ctrlKey || e.shiftKey) && // ignore clicks with modifier keys
-      // @ts-expect-error: these properties exist on web, but not in React Native
-      (e.button == null || e.button === 0) && // ignore everything but left clicks
-      // @ts-expect-error: these properties exist on web, but not in React Native
-      [undefined, null, '', 'self'].includes(e.currentTarget?.target) // let browser handle "target=_blank" etc.
+      !hasModifierKey &&
+      isLeftClick &&
+      isSelfTarget
     ) {
       e.preventDefault();
       shouldHandle = true;

--- a/packages/stack/src/types.tsx
+++ b/packages/stack/src/types.tsx
@@ -198,6 +198,10 @@ export type StackHeaderProps = {
      * Title of the previous screen.
      */
     title: string;
+    /**
+     * The `href` to use for the anchor tag on web
+     */
+    href?: string;
   };
   /**
    * Animated nodes representing the progress of the animation.

--- a/packages/stack/src/types.tsx
+++ b/packages/stack/src/types.tsx
@@ -197,11 +197,11 @@ export type StackHeaderProps = {
     /**
      * Title of the previous screen.
      */
-    title: string;
+    title: string | undefined;
     /**
      * The `href` to use for the anchor tag on web
      */
-    href?: string;
+    href: string | undefined;
   };
   /**
    * Animated nodes representing the progress of the animation.

--- a/packages/stack/src/views/Header/Header.tsx
+++ b/packages/stack/src/views/Header/Header.tsx
@@ -66,6 +66,7 @@ export const Header = React.memo(function Header({
       }
       headerStatusBarHeight={statusBarHeight}
       onGoBack={back ? goBack : undefined}
+      href={back ? back.href : undefined}
       styleInterpolator={styleInterpolator}
     />
   );

--- a/packages/stack/src/views/Header/Header.tsx
+++ b/packages/stack/src/views/Header/Header.tsx
@@ -66,7 +66,7 @@ export const Header = React.memo(function Header({
       }
       headerStatusBarHeight={statusBarHeight}
       onGoBack={back ? goBack : undefined}
-      href={back ? back.href : undefined}
+      backHref={back ? back.href : undefined}
       styleInterpolator={styleInterpolator}
     />
   );

--- a/packages/stack/src/views/Header/HeaderContainer.tsx
+++ b/packages/stack/src/views/Header/HeaderContainer.tsx
@@ -4,6 +4,7 @@ import {
   NavigationRouteContext,
   ParamListBase,
   Route,
+  useLinkTools,
 } from '@react-navigation/native';
 import * as React from 'react';
 import { Animated, StyleProp, StyleSheet, View, ViewStyle } from 'react-native';
@@ -47,6 +48,7 @@ export function HeaderContainer({
 }: Props) {
   const focusedRoute = getFocusedRoute();
   const parentHeaderBack = React.useContext(HeaderBackContext);
+  const { buildHref } = useLinkTools();
 
   return (
     <Animated.View pointerEvents="box-none" style={style}>
@@ -78,7 +80,10 @@ export function HeaderContainer({
           const { options, route } = previousScene.descriptor;
 
           headerBack = previousScene
-            ? { title: getHeaderTitle(options, route.name) }
+            ? {
+                title: getHeaderTitle(options, route.name),
+                href: buildHref(route.name, route.params),
+              }
             : parentHeaderBack;
         }
 

--- a/packages/stack/src/views/Header/HeaderSegment.tsx
+++ b/packages/stack/src/views/Header/HeaderSegment.tsx
@@ -29,7 +29,7 @@ type Props = Omit<StackHeaderOptions, 'headerStatusBarHeight'> & {
   title: string;
   modal: boolean;
   onGoBack?: () => void;
-  href?: string;
+  backHref?: string;
   progress: SceneProgress;
   styleInterpolator: StackHeaderStyleInterpolator;
 };
@@ -106,11 +106,11 @@ export function HeaderSegment(props: Props) {
     layout,
     modal,
     onGoBack,
-    href,
+    backHref,
     headerTitle: title,
     headerLeft: left = onGoBack
       ? (props: HeaderBackButtonProps) => (
-          <HeaderBackButton {...props} href={href} />
+          <HeaderBackButton {...props} href={backHref} />
         )
       : undefined,
     headerRight: right,

--- a/packages/stack/src/views/Header/HeaderSegment.tsx
+++ b/packages/stack/src/views/Header/HeaderSegment.tsx
@@ -29,6 +29,7 @@ type Props = Omit<StackHeaderOptions, 'headerStatusBarHeight'> & {
   title: string;
   modal: boolean;
   onGoBack?: () => void;
+  href?: string;
   progress: SceneProgress;
   styleInterpolator: StackHeaderStyleInterpolator;
 };
@@ -105,9 +106,12 @@ export function HeaderSegment(props: Props) {
     layout,
     modal,
     onGoBack,
+    href,
     headerTitle: title,
     headerLeft: left = onGoBack
-      ? (props: HeaderBackButtonProps) => <HeaderBackButton {...props} />
+      ? (props: HeaderBackButtonProps) => (
+          <HeaderBackButton {...props} href={href} />
+        )
       : undefined,
     headerRight: right,
     headerBackImage,

--- a/packages/stack/src/views/Stack/CardContainer.tsx
+++ b/packages/stack/src/views/Stack/CardContainer.tsx
@@ -4,7 +4,12 @@ import {
   HeaderHeightContext,
   HeaderShownContext,
 } from '@react-navigation/elements';
-import { Route, useLocale, useTheme } from '@react-navigation/native';
+import {
+  Route,
+  useLinkTools,
+  useLocale,
+  useTheme,
+} from '@react-navigation/native';
 import * as React from 'react';
 import { Animated, StyleSheet, View } from 'react-native';
 
@@ -202,19 +207,22 @@ function CardContainerInner({
     transitionSpec,
   } = scene.descriptor.options;
 
+  const { buildHref } = useLinkTools();
   const previousScene = getPreviousScene({ route: scene.descriptor.route });
 
   let backTitle: string | undefined;
+  let href: string | undefined;
 
   if (previousScene) {
     const { options, route } = previousScene.descriptor;
 
     backTitle = getHeaderTitle(options, route.name);
+    href = buildHref(route.name, route.params);
   }
 
   const headerBack = React.useMemo(
-    () => (backTitle !== undefined ? { title: backTitle } : undefined),
-    [backTitle]
+    () => ({ title: backTitle, href }),
+    [backTitle, href]
   );
 
   return (


### PR DESCRIPTION
**Motivation**

In order to make the react-navigation web experience more 'native' this PR brings a link to a header back button. This makes UX more natural as users could now right-click to open a route in new tab or hover over to see where does 'go back' leads them.

<details>
<summary>Code example</summary>
<br>

```tsx




import { NavigationContainer } from '@react-navigation/native';
import { createStackNavigator } from '@react-navigation/stack';
import { createURL } from 'expo-linking';
import * as React from 'react';
import { Button, StyleSheet, View } from 'react-native';

function FirstScreen({ navigation }: any) {
  return (
    <View style={styles.container}>
      <Button
        title="Go to second"
        onPress={() => navigation.navigate('second')}
      />
    </View>
  );
}

function SecondScreen({ navigation }: any) {
  return (
    <View style={styles.container}>
      <Button
        title="Go to third"
        onPress={() => navigation.navigate('nested', { screen: 'third' })}
      />
    </View>
  );
}

function ThirdScreen({ navigation }: any) {
  return (
    <View style={styles.container}>
      <Button
        title="Go to fourth"
        onPress={() => navigation.navigate('fourth')}
      />
    </View>
  );
}

function FourthScreen({ navigation }: any) {
  return (
    <View style={styles.container}>
      <Button title="Go back" onPress={() => navigation.goBack()} />
    </View>
  );
}

const SettingsStack = createStackNavigator();
const NestedStack = createStackNavigator();

const linking = {
  prefixes: [createURL('/')],
  config: {
    screens: {
      first: 'First',
      second: 'Second',
      nested: {
        path: 'Nested',
        screens: {
          third: 'Third',
          fourth: 'Fourth',
        },
      },
    },
  },
};

export default function App() {
  return (
    <NavigationContainer linking={linking}>
      <SettingsStack.Navigator>
        <SettingsStack.Screen name="first" component={FirstScreen} />
        <SettingsStack.Screen name="second" component={SecondScreen} />
        <SettingsStack.Screen name="nested">
          {() => (
            <NestedStack.Navigator>
              <NestedStack.Screen name="third" component={ThirdScreen} />
              <NestedStack.Screen name="fourth" component={FourthScreen} />
            </NestedStack.Navigator>
          )}
        </SettingsStack.Screen>
      </SettingsStack.Navigator>
    </NavigationContainer>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    alignItems: 'center',
    justifyContent: 'center',
  },
});

```
</details>

