### PR TITLE
feat: split updating state to batches on long lists

### DIFF
--- a/packages/react-native-tab-view/src/TabBarIndicator.tsx
+++ b/packages/react-native-tab-view/src/TabBarIndicator.tsx
@@ -59,9 +59,12 @@ export default function TabBarIndicator<T extends Route>({
 
   const opacity = useAnimatedValue(isWidthDynamic ? 0 : 1);
 
-  const hasMeasuredTabWidths =
-    Boolean(layout.width) &&
-    navigationState.routes.every((_, i) => getTabWidth(i));
+  const indicatorVisible = isWidthDynamic
+    ? layout.width &&
+      navigationState.routes
+        .slice(0, navigationState.index)
+        .every((_, r) => getTabWidth(r))
+    : true;
 
   React.useEffect(() => {
     const fadeInIndicator = () => {
@@ -69,7 +72,7 @@ export default function TabBarIndicator<T extends Route>({
         !isIndicatorShown.current &&
         isWidthDynamic &&
         // We should fade-in the indicator when we have widths for all the tab items
-        hasMeasuredTabWidths
+        indicatorVisible
       ) {
         isIndicatorShown.current = true;
 
@@ -85,7 +88,7 @@ export default function TabBarIndicator<T extends Route>({
     fadeInIndicator();
 
     return () => opacity.stopAnimation();
-  }, [hasMeasuredTabWidths, isWidthDynamic, opacity]);
+  }, [indicatorVisible, isWidthDynamic, opacity]);
 
   const { routes } = navigationState;
 


### PR DESCRIPTION
**Motivation**

As reported here: https://github.com/satya164/react-native-tab-view/issues/1405, when using really long lists header wouldn't get all tab widths and therefore would stop rendering. If we have more than 10 routes we split rendering into multiple batches using onViewableItemsChanged.

**Test plan**

https://user-images.githubusercontent.com/52801365/204381404-47fe743c-e79a-45ba-9c05-08c8cdd9f92e.mp4

Launch Scrollable tab bar example and scroll.


The change must pass lint, typescript and tests.
