### PR TITLE
Fix: pass text component to label renderer

### DIFF
--- a/packages/bottom-tabs/src/views/BottomTabItem.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabItem.tsx
@@ -33,6 +33,7 @@ type Props = {
         focused: boolean;
         color: string;
         position: LabelPosition;
+        textComponent: React.ReactElement;
       }) => React.ReactNode);
   /**
    * Icon to display for the tab.
@@ -203,9 +204,8 @@ export default function BottomTabBarItem({
 
     const color = focused ? activeTintColor : inactiveTintColor;
 
-    if (typeof label === 'string') {
-      return (
-        <Text
+    const textComponent= (
+      <Text
           numberOfLines={1}
           style={[
             styles.label,
@@ -218,12 +218,16 @@ export default function BottomTabBarItem({
           {label}
         </Text>
       );
+
+    if (typeof label === 'string') {
+      return textComponent
     }
 
     return label({
       focused,
       color,
       position: horizontal ? 'beside-icon' : 'below-icon',
+      textComponent
     });
   };
 


### PR DESCRIPTION
Please provide enough information so that others can review your pull request.

**Motivation**
Pass in the original text component rendered with a string label in to the react component override to ensure complete customisability and flexibility of accessibility concern. This ensures we do not need to restyle and redesign the react component override to match what the text would be if we had passed in a string instead.

**Test plan**
We would aim to use this in the consumer like so:
```
const tabBarLabel = (props: {
    focused: boolean
    color: string
    position: LabelPosition
    textComponent: React.ReactElement
}) => {
    const dynamicBalance = "123" // <-- From Redux
    return React.cloneElement(props.textComponent, {
        accessibilityLabel: `Account ${dynamicBalance}`,
    })
}
```