### PR TITLE
Fix useScrollToTop not working when nesting multiple tab navigators

### DIFF
--- a/packages/native/src/useScrollToTop.tsx
+++ b/packages/native/src/useScrollToTop.tsx
@@ -109,7 +109,7 @@ export default function useScrollToTop(
     });
 
     return () => {
-      unsubscribers.forEach(unsubscribe => unsubscribe());
+      unsubscribers.forEach((unsubscribe) => unsubscribe());
     };
   }, [navigation, ref, route.key]);
 }

--- a/packages/native/src/useScrollToTop.tsx
+++ b/packages/native/src/useScrollToTop.tsx
@@ -57,7 +57,7 @@ export default function useScrollToTop(
     // We need to find the closest tab navigators and add the listener there
     while (currentNavigator) {
       if (currentNavigator.getState().type === 'tab') {
-        tabNavigators = tabNavigators.concat(currentNavigator);
+        tabNavigators.push(currentNavigator);
       }
       currentNavigator = currentNavigator.getParent();
     }

--- a/packages/native/src/useScrollToTop.tsx
+++ b/packages/native/src/useScrollToTop.tsx
@@ -50,25 +50,25 @@ export default function useScrollToTop(
   const route = useRoute();
 
   React.useEffect(() => {
-    let tabNavigators: NavigationProp<ReactNavigation.RootParamList>[] = [];
+    let tabNavigations: NavigationProp<ReactNavigation.RootParamList>[] = [];
     let currentNavigation = navigation;
 
-    // The screen might be inside another navigator such as stack nested in tabs
-    // The screen might be in multiple tab bars (as a top tab bar and a bottom tab bar and we want both events to work)
-    // We need to find the closest tab navigators and add the listener there
+    // If the screen is nested inside multiple tab navigators, we should scroll to top for any of them
+    // So we need to find all the parent tab navigators and add the listeners there
     while (currentNavigation) {
       if (currentNavigation.getState().type === 'tab') {
-        tabNavigators.push(currentNavigation);
+        tabNavigations.push(currentNavigation);
       }
+
       currentNavigation = currentNavigation.getParent();
     }
 
-    if (tabNavigators.length === 0) {
+    if (tabNavigations.length === 0) {
       return;
     }
 
-    const unsubscribers = tabNavigators.map((tabNavigator) => {
-      return tabNavigator.addListener(
+    const unsubscribers = tabNavigations.map((tab) => {
+      return tab.addListener(
         // We don't wanna import tab types here to avoid extra deps
         // in addition, there are multiple tab implementations
         // @ts-expect-error
@@ -78,9 +78,9 @@ export default function useScrollToTop(
           const isFocused = navigation.isFocused();
 
           // In a nested stack navigator, tab press resets the stack to first screen
-          // So we should scroll to top only when we are inside a tab navigator
-          const isTabNavigator =
-            tabNavigators.includes(navigation) ||
+          // So we should scroll to top only when we are on first screen
+          const isFirst =
+            tabNavigations.includes(navigation) ||
             navigation.getState().routes[0].key === route.key;
 
           // Run the operation in the next frame so we're sure all listeners have been run
@@ -88,12 +88,7 @@ export default function useScrollToTop(
           requestAnimationFrame(() => {
             const scrollable = getScrollableNode(ref) as ScrollableWrapper;
 
-            if (
-              isFocused &&
-              isTabNavigator &&
-              scrollable &&
-              !e.defaultPrevented
-            ) {
+            if (isFocused && isFirst && scrollable && !e.defaultPrevented) {
               if ('scrollToTop' in scrollable) {
                 scrollable.scrollToTop();
               } else if ('scrollTo' in scrollable) {

--- a/packages/native/src/useScrollToTop.tsx
+++ b/packages/native/src/useScrollToTop.tsx
@@ -1,5 +1,6 @@
 import { EventArg, useNavigation, useRoute } from '@react-navigation/core';
 import * as React from 'react';
+import type {NavigationProp} from '@react-navigation/native';
 
 type ScrollOptions = { x?: number; y?: number; animated?: boolean };
 
@@ -49,17 +50,17 @@ export default function useScrollToTop(
   const route = useRoute();
 
   React.useEffect(() => {
-    let tabNavigators = [];
-    let currentNavigator = navigation;
+    let tabNavigators: NavigationProp<ReactNavigation.RootParamList>[]= [];
+    let currentNavigation = navigation;
 
     // The screen might be inside another navigator such as stack nested in tabs
     // The screen might be in multiple tab bars (as a top tab bar and a bottom tab bar and we want both events to work)
     // We need to find the closest tab navigators and add the listener there
-    while (currentNavigator) {
-      if (currentNavigator.getState().type === 'tab') {
-        tabNavigators.push(currentNavigator);
+    while (currentNavigation) {
+      if (currentNavigation.getState().type === 'tab') {
+        tabNavigators.push(currentNavigation);
       }
-      currentNavigator = currentNavigator.getParent();
+      currentNavigation = currentNavigation.getParent();
     }
 
     if (tabNavigators.length === 0) {

--- a/packages/native/src/useScrollToTop.tsx
+++ b/packages/native/src/useScrollToTop.tsx
@@ -51,12 +51,12 @@ export default function useScrollToTop(
   React.useEffect(() => {
     let tabNavigators = [];
     let currentNavigator = navigation;
-    
-     // The screen might be inside another navigator such as stack nested in tabs
-     // The screen might be in multiple tab bars (as a top tab bar and a bottom tab bar and we want both events to work)
-     // We need to find the closest tab navigators and add the listener there
-     while (currentNavigator) {
-      if(currentNavigator.getState().type === 'tab') {
+
+    // The screen might be inside another navigator such as stack nested in tabs
+    // The screen might be in multiple tab bars (as a top tab bar and a bottom tab bar and we want both events to work)
+    // We need to find the closest tab navigators and add the listener there
+    while (currentNavigator) {
+      if (currentNavigator.getState().type === 'tab') {
         tabNavigators = tabNavigators.concat(currentNavigator);
       }
       currentNavigator = currentNavigator.getParent();
@@ -66,7 +66,7 @@ export default function useScrollToTop(
       return;
     }
 
-    const unsubscribers = tabNavigators.map(tabNavigator => {
+    const unsubscribers = tabNavigators.map((tabNavigator) => {
       return tabNavigator.addListener(
         // We don't wanna import tab types here to avoid extra deps
         // in addition, there are multiple tab implementations
@@ -87,7 +87,12 @@ export default function useScrollToTop(
           requestAnimationFrame(() => {
             const scrollable = getScrollableNode(ref) as ScrollableWrapper;
 
-            if (isFocused && isTabNavigator && scrollable && !e.defaultPrevented) {
+            if (
+              isFocused &&
+              isTabNavigator &&
+              scrollable &&
+              !e.defaultPrevented
+            ) {
               if ('scrollToTop' in scrollable) {
                 scrollable.scrollToTop();
               } else if ('scrollTo' in scrollable) {
@@ -101,10 +106,10 @@ export default function useScrollToTop(
           });
         }
       );
-    })
+    });
 
     return () => {
-        unsubscribers.map(unsubscribe => unsubscribe())
+      unsubscribers.map((unsubscribe) => unsubscribe());
     };
   }, [navigation, ref, route.key]);
 }

--- a/packages/native/src/useScrollToTop.tsx
+++ b/packages/native/src/useScrollToTop.tsx
@@ -1,6 +1,6 @@
 import { EventArg, useNavigation, useRoute } from '@react-navigation/core';
+import type { NavigationProp } from '@react-navigation/native';
 import * as React from 'react';
-import type {NavigationProp} from '@react-navigation/native';
 
 type ScrollOptions = { x?: number; y?: number; animated?: boolean };
 
@@ -50,7 +50,7 @@ export default function useScrollToTop(
   const route = useRoute();
 
   React.useEffect(() => {
-    let tabNavigators: NavigationProp<ReactNavigation.RootParamList>[]= [];
+    let tabNavigators: NavigationProp<ReactNavigation.RootParamList>[] = [];
     let currentNavigation = navigation;
 
     // The screen might be inside another navigator such as stack nested in tabs

--- a/packages/native/src/useScrollToTop.tsx
+++ b/packages/native/src/useScrollToTop.tsx
@@ -49,53 +49,62 @@ export default function useScrollToTop(
   const route = useRoute();
 
   React.useEffect(() => {
-    let current = navigation;
-
-    // The screen might be inside another navigator such as stack nested in tabs
-    // We need to find the closest tab navigator and add the listener there
-    while (current && current.getState().type !== 'tab') {
-      current = current.getParent();
+    let tabNavigators = [];
+    let currentNavigator = navigation;
+    
+     // The screen might be inside another navigator such as stack nested in tabs
+     // The screen might be in multiple tab bars (as a top tab bar and a bottom tab bar and we want both events to work)
+     // We need to find the closest tab navigators and add the listener there
+     while (currentNavigator) {
+      if(currentNavigator.getState().type === 'tab') {
+        tabNavigators = tabNavigators.concat(currentNavigator);
+      }
+      currentNavigator = currentNavigator.getParent();
     }
 
-    if (!current) {
+    if (tabNavigators.length === 0) {
       return;
     }
 
-    const unsubscribe = current.addListener(
-      // We don't wanna import tab types here to avoid extra deps
-      // in addition, there are multiple tab implementations
-      // @ts-expect-error
-      'tabPress',
-      (e: EventArg<'tabPress', true>) => {
-        // We should scroll to top only when the screen is focused
-        const isFocused = navigation.isFocused();
+    const unsubscribers = tabNavigators.map(tabNavigator => {
+      return tabNavigator.addListener(
+        // We don't wanna import tab types here to avoid extra deps
+        // in addition, there are multiple tab implementations
+        // @ts-expect-error
+        'tabPress',
+        (e: EventArg<'tabPress', true>) => {
+          // We should scroll to top only when the screen is focused
+          const isFocused = navigation.isFocused();
 
-        // In a nested stack navigator, tab press resets the stack to first screen
-        // So we should scroll to top only when we are on first screen
-        const isFirst =
-          navigation === current ||
-          navigation.getState().routes[0].key === route.key;
+          // In a nested stack navigator, tab press resets the stack to first screen
+          // So we should scroll to top only when we are inside a tab navigator
+          const isTabNavigator =
+            tabNavigators.includes(navigation) ||
+            navigation.getState().routes[0].key === route.key;
 
-        // Run the operation in the next frame so we're sure all listeners have been run
-        // This is necessary to know if preventDefault() has been called
-        requestAnimationFrame(() => {
-          const scrollable = getScrollableNode(ref) as ScrollableWrapper;
+          // Run the operation in the next frame so we're sure all listeners have been run
+          // This is necessary to know if preventDefault() has been called
+          requestAnimationFrame(() => {
+            const scrollable = getScrollableNode(ref) as ScrollableWrapper;
 
-          if (isFocused && isFirst && scrollable && !e.defaultPrevented) {
-            if ('scrollToTop' in scrollable) {
-              scrollable.scrollToTop();
-            } else if ('scrollTo' in scrollable) {
-              scrollable.scrollTo({ x: 0, y: 0, animated: true });
-            } else if ('scrollToOffset' in scrollable) {
-              scrollable.scrollToOffset({ offset: 0, animated: true });
-            } else if ('scrollResponderScrollTo' in scrollable) {
-              scrollable.scrollResponderScrollTo({ y: 0, animated: true });
+            if (isFocused && isTabNavigator && scrollable && !e.defaultPrevented) {
+              if ('scrollToTop' in scrollable) {
+                scrollable.scrollToTop();
+              } else if ('scrollTo' in scrollable) {
+                scrollable.scrollTo({ y: 0, animated: true });
+              } else if ('scrollToOffset' in scrollable) {
+                scrollable.scrollToOffset({ offset: 0, animated: true });
+              } else if ('scrollResponderScrollTo' in scrollable) {
+                scrollable.scrollResponderScrollTo({ y: 0, animated: true });
+              }
             }
-          }
-        });
-      }
-    );
+          });
+        }
+      );
+    })
 
-    return unsubscribe;
+    return () => {
+        unsubscribers.map(unsubscribe => unsubscribe())
+    };
   }, [navigation, ref, route.key]);
 }

--- a/packages/native/src/useScrollToTop.tsx
+++ b/packages/native/src/useScrollToTop.tsx
@@ -109,7 +109,7 @@ export default function useScrollToTop(
     });
 
     return () => {
-      unsubscribers.map((unsubscribe) => unsubscribe());
+      unsubscribers.forEach(unsubscribe => unsubscribe());
     };
   }, [navigation, ref, route.key]);
 }


### PR DESCRIPTION
**Motivation**

This PR answers this open issue: https://github.com/react-navigation/react-navigation/issues/11045

When tapping on a bottom tab, the screen scrolls back to the top. However, when adding a second tab navigator at the top of the screen, tapping the bottom tap does not automatically scroll to top anymore. Only tapping the top navigation tab will scroll the screen up. It is expected that the bottom tab tap will still scroll the screen to the top, just like tapping the status bar.

**Context**

This issue has previously been reported [here](https://github.com/react-navigation/react-navigation/issues/8586) by [@iirovi](https://github.com/iirovi), and a pull request to fix the issue has been proposed by [@Gregoirevda](https://github.com/Gregoirevda) [here](https://github.com/react-navigation/react-navigation/pull/9434). Recent changes on main automatically closed the pull request, so I'm posting his solution here again at @satya164's [request](https://github.com/react-navigation/react-navigation/pull/9434#issuecomment-1328345015).

We tested this solution on our app and it works perfectly well. Previously, tapping the bottom tab would not scroll back to the top when a top tab bar was present, but this fixes the issue. You can find the package versions in [the open issue](https://github.com/react-navigation/react-navigation/issues/11045).


**Behavior example**

Twitter has both top and bottom navigation bars. When tapping on the bottom tap, the screen scrolls back to the top. Tapping the top tab also scroll to the top.

<img src="https://user-images.githubusercontent.com/4307396/205150557-64787dfc-ed77-4a2f-88f3-205b05b6aead.mp4" width="300">

