### PR TITLE
fix: bump query-string version

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,7 +38,7 @@
     "@react-navigation/routers": "^6.1.5",
     "escape-string-regexp": "^4.0.0",
     "nanoid": "^3.1.23",
-    "query-string": "^7.0.0",
+    "query-string": "^7.1.3",
     "react-is": "^16.13.0",
     "use-latest-callback": "^0.1.5"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4762,7 +4762,7 @@ __metadata:
     escape-string-regexp: ^4.0.0
     immer: ^9.0.2
     nanoid: ^3.1.23
-    query-string: ^7.0.0
+    query-string: ^7.1.3
     react: 18.0.0
     react-is: ^16.13.0
     react-native-builder-bob: ^0.18.1
@@ -10183,6 +10183,13 @@ __metadata:
   version: 0.2.0
   resolution: "decode-uri-component@npm:0.2.0"
   checksum: f3749344ab9305ffcfe4bfe300e2dbb61fc6359e2b736812100a3b1b6db0a5668cba31a05e4b45d4d63dbf1a18dfa354cd3ca5bb3ededddabb8cd293f4404f94
+  languageName: node
+  linkType: hard
+
+"decode-uri-component@npm:^0.2.2":
+  version: 0.2.2
+  resolution: "decode-uri-component@npm:0.2.2"
+  checksum: 95476a7d28f267292ce745eac3524a9079058bbb35767b76e3ee87d42e34cd0275d2eb19d9d08c3e167f97556e8a2872747f5e65cbebcac8b0c98d83e285f139
   languageName: node
   linkType: hard
 
@@ -21644,15 +21651,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"query-string@npm:^7.0.0":
-  version: 7.1.0
-  resolution: "query-string@npm:7.1.0"
+"query-string@npm:^7.1.3":
+  version: 7.1.3
+  resolution: "query-string@npm:7.1.3"
   dependencies:
-    decode-uri-component: ^0.2.0
+    decode-uri-component: ^0.2.2
     filter-obj: ^1.1.0
     split-on-first: ^1.0.0
     strict-uri-encode: ^2.0.0
-  checksum: 4594a0a092772eb6854310feea85e34f8dcf70df494776a45b9e5be53621ffbcf930ae669974e4e171ce5e0f29a837e9821d48db843106dd94ee390f6f5ac857
+  checksum: 91af02dcd9cc9227a052841d5c2eecb80a0d6489d05625df506a097ef1c59037cfb5e907f39b84643cbfd535c955abec3e553d0130a7b510120c37d06e0f4346
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
fix vulnerability in decode-uri-component, dependency of query-string, fixed in version 7.1.3
more info
https://security.snyk.io/vuln/SNYK-JS-DECODEURICOMPONENT-3149970