### PR TITLE
refactor: use consistent naming for useBottomTabBarHeight

### DIFF
--- a/packages/bottom-tabs/src/utils/useBottomTabBarHeight.tsx
+++ b/packages/bottom-tabs/src/utils/useBottomTabBarHeight.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import BottomTabBarHeightContext from './BottomTabBarHeightContext';
 
-export default function useFloatingBottomTabBarHeight() {
+export default function useBottomTabBarHeight() {
   const height = React.useContext(BottomTabBarHeightContext);
 
   if (height === undefined) {


### PR DESCRIPTION
discrepancy makes it harder for consumers of this package to understand the internals

I've removed the template because of how simple this change is. Let me know if y'all would like me to expound on my reasoning for opening this.