### PR TITLE
fix: keep hash/fragment section for initial render

### DIFF
--- a/packages/native/src/createMemoryHistory.tsx
+++ b/packages/native/src/createMemoryHistory.tsx
@@ -84,6 +84,10 @@ export default function createMemoryHistory() {
 
       const id = window.history.state?.id ?? nanoid();
 
+      // Need to keep the hash part of the path if there was no previous history entry
+      // or the previous history entry had the same path
+      let pathWithHash = path;
+
       if (!items.length || items.findIndex((item) => item.id === id) < 0) {
         // There are two scenarios for creating an array with only one history record:
         // - When loaded id not found in the items array, this function by default will replace
@@ -91,13 +95,17 @@ export default function createMemoryHistory() {
         //   the page when navigating forward in history.
         // - This is the first time any state modifications are done
         //   So we need to push the entry as there's nothing to replace
-        items = [{ path, state, id }];
+        pathWithHash = pathWithHash + location.hash;
+        items = [{ path: pathWithHash, state, id }];
         index = 0;
       } else {
+        if (items[index].path === path) {
+          pathWithHash = pathWithHash + location.hash;
+        }
         items[index] = { path, state, id };
       }
 
-      window.history.replaceState({ id }, '', path);
+      window.history.replaceState({ id }, '', pathWithHash);
     },
 
     // `history.go(n)` is asynchronous, there are couple of things to keep in mind:


### PR DESCRIPTION
**Motivation**

Fixes this issue that I discovered https://github.com/react-navigation/react-navigation/issues/11026

**Test plan**

1. Run the example
2. Visit http://localhost:19006/simple-stack/article/gandalf#test
3. The with #test part still exists
4. Note that if you change the hash it will be gone (this is expected)
