### PR TITLE
fix: allow complex children in HeaderTitle

### DIFF
--- a/packages/elements/src/Header/HeaderTitle.tsx
+++ b/packages/elements/src/Header/HeaderTitle.tsx
@@ -11,7 +11,6 @@ import {
 
 type Props = Omit<TextProps, 'style'> & {
   tintColor?: string;
-  children?: string;
   style?: Animated.WithAnimatedValue<StyleProp<TextStyle>>;
 };
 


### PR DESCRIPTION
follow-up on https://github.com/react-navigation/react-navigation/pull/10449

**Motivation**

I have a custom header which looks like this:

```
import {HeaderTitle} from '@react-navigation/elements'

export const MyStackHeader = (props: StackHeaderProps) => {
  return (
      <HeaderTitle {...props}>
        <Text style={{color: 'red'}}>red</Text>
        <Text>black</Text>
      </HeaderTitle>
  )
}
...

// used then as follows
headerTitle: MyStackHeader,
```

Nesting <Text> is valid with `Animated.Text`, but with `HeaderTitle`, TS complains because it expects `children: string`. But because `HeaderTitle` is based on `Animated.Text`, it should allow such construct as well - it does work just fine at runtime.

**Test plan**

works fine:

<img width="238" alt="Screen Shot 2022-03-22 at 13 23 47" src="https://user-images.githubusercontent.com/1566403/159420409-4f74ed44-34ae-4dbb-83b8-dda90d5aa863.png">

