### PR TITLE
Prevent font scaling on tab bar item badge

### DIFF
--- a/packages/bottom-tabs/src/views/Badge.tsx
+++ b/packages/bottom-tabs/src/views/Badge.tsx
@@ -70,6 +70,7 @@ export default function Badge({
 
   return (
     <Animated.Text
+      allowFontScaling={false}
       numberOfLines={1}
       style={[
         {


### PR DESCRIPTION
**Motivation**

The layout on the tab bar badges breaks as soon as the user starts to change the OS settings for text size.
This is illustrated in #10219

**Test plan**

Set a badge on a tab bar item.
Increase the iOS or Android display text size.
Expect: The text in the tab bar badge doesn't change and the layout doesn't change,