### PR TITLE
fix: add `ScrollView` type to 'getScrollResponder'

### DIFF
--- a/packages/native/src/useScrollToTop.tsx
+++ b/packages/native/src/useScrollToTop.tsx
@@ -5,6 +5,7 @@ import {
   useRoute,
 } from '@react-navigation/core';
 import * as React from 'react';
+import type { ScrollView } from 'react-native';
 
 type ScrollOptions = { x?: number; y?: number; animated?: boolean };
 
@@ -15,7 +16,7 @@ type ScrollableView =
   | { scrollResponderScrollTo(options: ScrollOptions): void };
 
 type ScrollableWrapper =
-  | { getScrollResponder(): React.ReactNode }
+  | { getScrollResponder(): React.ReactNode | ScrollView }
   | { getNode(): ScrollableView }
   | ScrollableView;
 


### PR DESCRIPTION
Recreation of https://github.com/react-navigation/react-navigation/pull/10775 due to the git changes.

**Motivation**

Close https://github.com/react-navigation/react-navigation/issues/10722

`getScrollResponder` has a type error around `SectionList` due to missing type for `SectionList`

-----

FlatList - https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react-native/index.d.ts#L4057

```ts
    getScrollResponder: () => JSX.Element | null | undefined;
```

SectionList - https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react-native/index.d.ts#L4294

```ts
    getScrollResponder(): ScrollView | undefined;
```

**Test plan**

Use
- `@types/react`: `^18.0.15` 
- `@react-navigation/native`: `ken0nek/react-navigation.git#react-navigation-native-v6.1.1-gitpkg`

Check no errors for `useScrollToTop` with `SectionList`.

```ts
const sectionList = useRef<SectionList>(null);
useScrollToTop(sectionList);
```
