### PR TITLE
feat: wrapper option, to wrap screen content with suspense and error boundaries

### DIFF
--- a/packages/bottom-tabs/src/types.tsx
+++ b/packages/bottom-tabs/src/types.tsx
@@ -254,6 +254,11 @@ export type BottomTabNavigationOptions = HeaderOptions & {
    * Only supported on iOS and Android.
    */
   freezeOnBlur?: boolean;
+
+  /**
+   * A component to wrap the screen content with, useful for suspense and error boundaries.
+   */
+  wrapper?: (props: { children: React.ReactNode }) => JSX.Element;
 };
 
 export type BottomTabDescriptor = Descriptor<

--- a/packages/drawer/src/types.tsx
+++ b/packages/drawer/src/types.tsx
@@ -220,6 +220,11 @@ export type DrawerNavigationOptions = HeaderOptions & {
    * Only supported on iOS and Android.
    */
   freezeOnBlur?: boolean;
+
+  /**
+   * A component to wrap the screen content with, useful for suspense and error boundaries.
+   */
+  wrapper?: (props: { children: React.ReactNode }) => JSX.Element;
 };
 
 export type DrawerContentComponentProps = {

--- a/packages/drawer/src/views/DrawerView.tsx
+++ b/packages/drawer/src/views/DrawerView.tsx
@@ -246,6 +246,7 @@ function DrawerViewBase({
             headerStatusBarHeight,
             headerTransparent,
             sceneContainerStyle,
+            wrapper: Wrapper,
           } = descriptor.options;
 
           return (
@@ -272,7 +273,11 @@ function DrawerViewBase({
                 })}
                 style={sceneContainerStyle}
               >
-                {descriptor.render()}
+                {Wrapper ? (
+                  <Wrapper>{descriptor.render()}</Wrapper>
+                ) : (
+                  descriptor.render()
+                )}
               </Screen>
             </MaybeScreen>
           );

--- a/packages/material-bottom-tabs/src/types.tsx
+++ b/packages/material-bottom-tabs/src/types.tsx
@@ -87,6 +87,11 @@ export type MaterialBottomTabNavigationOptions = {
    * ID to locate this tab button in tests.
    */
   tabBarTestID?: string;
+
+  /**
+   * A component to wrap the screen content with, useful for suspense and error boundaries.
+   */
+  wrapper?: (props: { children: React.ReactNode }) => JSX.Element;
 };
 
 export type MaterialBottomTabDescriptor = Descriptor<
@@ -114,5 +119,6 @@ export type MaterialBottomTabNavigationConfig = Partial<
     | 'getColor'
     | 'getLabelText'
     | 'getTestID'
+    | 'wrapper'
   >
 >;

--- a/packages/material-bottom-tabs/src/views/MaterialBottomTabView.tsx
+++ b/packages/material-bottom-tabs/src/views/MaterialBottomTabView.tsx
@@ -132,7 +132,14 @@ function MaterialBottomTabViewInner({
           target: state.key,
         })
       }
-      renderScene={({ route }) => descriptors[route.key].render()}
+      renderScene={({ route }) => {
+        const {
+          options: { wrapper: Wrapper },
+          render,
+        } = descriptors[route.key];
+
+        return Wrapper ? <Wrapper>{render()}</Wrapper> : render();
+      }}
       renderTouchable={
         Platform.OS === 'web'
           ? ({

--- a/packages/material-top-tabs/src/types.tsx
+++ b/packages/material-top-tabs/src/types.tsx
@@ -245,6 +245,10 @@ export type MaterialTopTabNavigationOptions = {
    * By default, this renders `null`.
    */
   lazyPlaceholder?: () => React.ReactNode;
+  /**
+   * A component to wrap the screen content with, useful for suspense and error boundaries.
+   */
+  wrapper?: (props: { children: React.ReactNode }) => JSX.Element;
 };
 
 export type MaterialTopTabDescriptor = Descriptor<
@@ -277,6 +281,10 @@ export type MaterialTopTabNavigationConfig = Omit<
    * Function that returns a React element to display as the tab bar.
    */
   tabBar?: (props: MaterialTopTabBarProps) => React.ReactNode;
+  /**
+   * A component to wrap the screen content with, useful for suspense and error boundaries.
+   */
+  wrapper?: (props: { children: React.ReactNode }) => JSX.Element;
 };
 
 export type MaterialTopTabBarProps = SceneRendererProps & {

--- a/packages/material-top-tabs/src/views/MaterialTopTabView.tsx
+++ b/packages/material-top-tabs/src/views/MaterialTopTabView.tsx
@@ -55,7 +55,14 @@ export default function MaterialTopTabView({
           target: state.key,
         })
       }
-      renderScene={({ route }) => descriptors[route.key].render()}
+      renderScene={({ route }) => {
+        const {
+          options: { wrapper: Wrapper },
+          render,
+        } = descriptors[route.key];
+
+        return Wrapper ? <Wrapper>{render()}</Wrapper> : render();
+      }}
       navigationState={state}
       renderTabBar={renderTabBar}
       renderLazyPlaceholder={({ route }) =>

--- a/packages/native-stack/src/types.tsx
+++ b/packages/native-stack/src/types.tsx
@@ -494,6 +494,10 @@ export type NativeStackNavigationOptions = {
    * Only supported on iOS and Android.
    */
   freezeOnBlur?: boolean;
+  /**
+   * A component to wrap the screen content with, useful for suspense and error boundaries.
+   */
+  wrapper?: (props: { children: React.ReactNode }) => JSX.Element;
 };
 
 export type NativeStackNavigatorProps = DefaultNavigatorOptions<

--- a/packages/native-stack/src/views/NativeStackView.tsx
+++ b/packages/native-stack/src/views/NativeStackView.tsx
@@ -75,6 +75,7 @@ export default function NativeStackView({ state, descriptors }: Props) {
             headerBackTitle,
             presentation,
             contentStyle,
+            wrapper: Wrapper,
           } = options;
 
           const nextPresentation = nextDescriptor?.options.presentation;
@@ -169,7 +170,7 @@ export default function NativeStackView({ state, descriptors }: Props) {
             >
               <HeaderBackContext.Provider value={headerBack}>
                 <View style={[styles.contentContainer, contentStyle]}>
-                  {render()}
+                  {Wrapper ? <Wrapper>{render()}</Wrapper> : render()}
                 </View>
               </HeaderBackContext.Provider>
             </Screen>

--- a/packages/stack/src/types.tsx
+++ b/packages/stack/src/types.tsx
@@ -341,6 +341,10 @@ export type StackNavigationOptions = StackHeaderOptions &
      * Only supported on iOS and Android.
      */
     freezeOnBlur?: boolean;
+    /**
+     * A component to wrap the screen content with, useful for suspense and error boundaries.
+     */
+    wrapper?: (props: { children: React.ReactNode }) => JSX.Element;
   };
 
 export type StackNavigationConfig = {

--- a/packages/stack/src/views/Stack/Card.tsx
+++ b/packages/stack/src/views/Stack/Card.tsx
@@ -65,6 +65,7 @@ type Props = ViewProps & {
   styleInterpolator: StackCardStyleInterpolator;
   containerStyle?: StyleProp<ViewStyle>;
   contentStyle?: StyleProp<ViewStyle>;
+  wrapper?: (props: { children: React.ReactNode }) => JSX.Element;
 };
 
 const GESTURE_VELOCITY_IMPACT = 0.3;
@@ -446,6 +447,7 @@ export default class Card extends React.Component<Props> {
       children,
       containerStyle: customContainerStyle,
       contentStyle,
+      wrapper: Wrapper,
       ...rest
     } = this.props;
 
@@ -560,7 +562,7 @@ export default class Card extends React.Component<Props> {
                   layout={layout}
                   style={contentStyle}
                 >
-                  {children}
+                  {Wrapper ? <Wrapper>{children}</Wrapper> : children}
                 </CardSheet>
               </Animated.View>
             </PanGestureHandler>

--- a/packages/stack/src/views/Stack/CardContainer.tsx
+++ b/packages/stack/src/views/Stack/CardContainer.tsx
@@ -198,6 +198,7 @@ function CardContainer({
     headerMode,
     headerShown,
     transitionSpec,
+    wrapper,
   } = scene.descriptor.options;
 
   const previousScene = getPreviousScene({ route: scene.descriptor.route });
@@ -244,6 +245,7 @@ function CardContainer({
       pointerEvents={active ? 'box-none' : pointerEvents}
       pageOverflowEnabled={headerMode !== 'float' && presentation !== 'modal'}
       headerDarkContent={headerDarkContent}
+      wrapper={wrapper}
       containerStyle={
         hasAbsoluteFloatHeader && headerMode !== 'screen'
           ? { marginTop: headerHeight }


### PR DESCRIPTION
For apps that use `React.Suspense` ([Relay](https://relay.dev/docs/guided-tour/rendering/loading-states/), [React Query](https://react-query-v3.tanstack.com/guides/suspense) etc.) and/or error boundaries for each screen it can be awkard to wrap every screen with the required components in userland.

# Problem example

Given the following screen and suspense/error boundary wrappers:

```tsx
function HomeScreen() {
  const data = useQuery(); // A hook that will suspend
  return <Text>{data.text}</Text>;
}

function SuspenseBoundary({children}) {
  return (
    <ErrorBoundary>
      <React.Suspense fallback={<Text>Loading...</Text>}>
        {children}
      </React.Suspense>
    </ErrorBoundary>
  );
}
```

There are a few user-land options for handling wrapping every screen:

## Screen.children

This opts out of the `React.PureComponent` optimisations of React Navigation and becomes quite verbose with many routes.

<details>
<summary>Example</summary>

```tsx
function NavigatorRoot() {
  return (
    <Stack.Navigator>
      <Stack.Screen name="Home">
        {(props) => (
          <SuspenseBoundary>
            <HomeScreen {...props} />
          </SuspenseBoundary>
        )}
      </Stack.Screen>
    </Stack.Navigator>
  );
}
```
</details>

## Manually wrapping

This keeps the optimisations, but still painful with many routes.

<details>
<summary>Example</summary>

```tsx
function NavigatorRoot() {
  return (
    <Stack.Navigator>
      <Stack.Screen name="Home" component={HomeScreenWrapper} />
    </Stack.Navigator>
  );
}

function HomeScreenWrapper(props) {
  return (
    <SuspenseBoundary>
      <HomeScreen {...props} />
    </SuspenseBoundary>
  );
}
```
</details>

## Component factory

This is the currently the best user-land solution, but if we had support for providing a wrapper at the navigator level, this could be much simpler.

<details>
<summary>Example</summary>

```tsx
const HomeScreen = factoryToWrapWithSuspense(require('./HomeScreen'));

function NavigatorRoot() {
  return (
    <Stack.Navigator>
      <Stack.Screen name="Home" component={HomeScreen} />
    </Stack.Navigator>
  );
}

function factoryToWrapWithSuspense(module) {
  const Component = module.default;

  return (props) => (
    <SuspenseBoundary>
      <Component {...props} />
    </SuspenseBoundary>
  );
}
```
</details>

# Proposed solution

A `wrapper` option added to each navigator which allows the user to supply a component to wrap the content of the screen. This allows consistent behaviour across an entire navigator in addition to flexibility to alter the behaviour for each screen should that be required.

```tsx
function NavigatorRoot() {
  return (
    <Stack.Navigator screenOptions={{wrapper: SuspenseBoundary}}>
      <Stack.Screen name="Home" component={HomeScreen} />
      <Stack.Screen name="ScreenWithoutWrapper" component={AnotherScreen} options={{wrapper: null}} />
    </Stack.Navigator>
  );
}
```