### PR TITLE
docs: fix typo

### DIFF
--- a/packages/stack/src/types.tsx
+++ b/packages/stack/src/types.tsx
@@ -165,7 +165,7 @@ export type StackHeaderOptions = Omit<
   /**
    * Whether the back button title should be visible or not.
    *
-   * Defaults to `true` on iOS, `false on Android.
+   * Defaults to `true` on iOS, `false` on Android.
    */
   headerBackTitleVisible?: boolean;
   /**


### PR DESCRIPTION
Fixes a typo in headerBackTickVisible description after `false` keyword. (missing backtick)

```typescript
    /**
     * Whether the back button title should be visible or not.
     *
     * Defaults to `true` on iOS, `false on Android.
     */
    headerBackTitleVisible?: boolean;
```

