### PR TITLE
Add optional name to Group

### DIFF
--- a/packages/core/src/types.tsx
+++ b/packages/core/src/types.tsx
@@ -540,6 +540,11 @@ export type RouteGroupConfig<
   ScreenOptions extends {}
 > = {
   /**
+   * Optional name for the group.
+   */
+  name?: string;
+
+  /**
    * Optional key for the screens in this group.
    * If the key changes, all existing screens in this group will be removed or reset.
    */


### PR DESCRIPTION
Optional name property can make it easier to distinguish groups in the navigator. For example group of screens named onboarding, another group named profileTab, settingsTab...

Instead of writing a comment above the group we can write it as the name.
<img width="480" alt="image" src="https://user-images.githubusercontent.com/19948979/212166743-a12335ca-54f1-4f7e-9e8e-3d6a10bace12.png">

