### PR TITLE
[react-native-tab-view] Do not change layout state on empty width or height

### DIFF
--- a/packages/react-native-tab-view/src/TabBar.tsx
+++ b/packages/react-native-tab-view/src/TabBar.tsx
@@ -330,11 +330,14 @@ export default function TabBar<T extends Route>({
   const handleLayout = (e: LayoutChangeEvent) => {
     const { height, width } = e.nativeEvent.layout;
 
-    setLayout((layout) =>
-      layout.width === width && layout.height === height
-        ? layout
-        : { width, height }
-    );
+		// empty layouts event might occurs, we do not want to update state in those cases
+		if (height && width) {
+			setLayout((layout) =>
+				layout.width === width && layout.height === height
+					? layout
+					: { width, height }
+			);
+		}
   };
 
   const tabBarWidth = getTabBarWidth({


### PR DESCRIPTION
I have a stack navigator that has a page with a tab-navigator. If I push a page, the tab-navigator emit a layout event with width 0 and height 0 resulting in a graphical flicker when going back to that tab navigator.

By removing the empty layout event, it successfully remove my layout flickers.

### Structure :

- Stack Navigator
   - Home -> Tab Navigator
   - Settings
    
### Actions :
  Go to home page, then push Settings page, go back -> flicker occurs
  
I cannot do a video of it since it's on a work application unfortunately

**Motivation**

Having layout flicker on back is annoying for the user experience. This change fix it.

