### PR TITLE
feat: add tabBarInitialLayout to TabBar component

### DIFF
--- a/packages/react-native-tab-view/src/TabBar.tsx
+++ b/packages/react-native-tab-view/src/TabBar.tsx
@@ -58,6 +58,7 @@ export type Props<T extends Route> = SceneRendererProps & {
   ) => React.ReactElement;
   onTabPress?: (scene: Scene<T> & Event) => void;
   onTabLongPress?: (scene: Scene<T>) => void;
+  tabBarInitialLayout?: Partial<Layout>;
   tabStyle?: StyleProp<ViewStyle>;
   indicatorStyle?: StyleProp<ViewStyle>;
   indicatorContainerStyle?: StyleProp<ViewStyle>;
@@ -280,11 +281,16 @@ export default function TabBar<T extends Route>({
   renderIcon,
   renderLabel,
   renderTabBarItem,
+  tabBarInitialLayout,
   style,
   tabStyle,
   testID,
 }: Props<T>) {
-  const [layout, setLayout] = React.useState<Layout>({ width: 0, height: 0 });
+  const [layout, setLayout] = React.useState<Layout>({
+    width: 0,
+    height: 0,
+    ...tabBarInitialLayout,
+  });
   const [tabWidths, setTabWidths] = React.useState<Record<string, number>>({});
   const flatListRef = React.useRef<FlatList | null>(null);
   const isFirst = React.useRef(true);

--- a/packages/react-native-tab-view/src/TabView.tsx
+++ b/packages/react-native-tab-view/src/TabView.tsx
@@ -24,10 +24,14 @@ export type Props<T extends Route> = PagerProps & {
   renderScene: (props: SceneRendererProps & { route: T }) => React.ReactNode;
   renderLazyPlaceholder?: (props: { route: T }) => React.ReactNode;
   renderTabBar?: (
-    props: SceneRendererProps & { navigationState: NavigationState<T> }
+    props: SceneRendererProps & {
+      navigationState: NavigationState<T>;
+      tabBarInitialLayout?: Partial<Layout>;
+    }
   ) => React.ReactNode;
   tabBarPosition?: 'top' | 'bottom';
   initialLayout?: Partial<Layout>;
+  tabBarInitialLayout?: Partial<Layout>;
   lazy?: ((props: { route: T }) => boolean) | boolean;
   lazyPreloadDistance?: number;
   sceneContainerStyle?: StyleProp<ViewStyle>;
@@ -47,6 +51,7 @@ export default function TabView<T extends Route>({
   onSwipeEnd,
   renderLazyPlaceholder = () => null,
   renderTabBar = (props) => <TabBar {...props} />,
+  tabBarInitialLayout,
   sceneContainerStyle,
   pagerStyle,
   style,
@@ -106,6 +111,7 @@ export default function TabView<T extends Route>({
                 renderTabBar({
                   ...sceneRendererProps,
                   navigationState,
+                  tabBarInitialLayout,
                 })}
               {render(
                 navigationState.routes.map((route, i) => {
@@ -136,6 +142,7 @@ export default function TabView<T extends Route>({
                 renderTabBar({
                   ...sceneRendererProps,
                   navigationState,
+                  tabBarInitialLayout,
                 })}
             </React.Fragment>
           );


### PR DESCRIPTION
**Motivation**

Just like the TabView component, the TabBar component depends on onLayout to set up different parts of the component, like the indicator, which causes a flicker when the TabBar component mounts.

I've implemented the same approach as the TabView component. 

Passing tabBarInitialLayout to the Navigator component, which gets passed to react-native-tab-view's TabBar component, eases the flicker that happens on the component mount.
