### PR TITLE
feat: add tabBarShown option to bottom tab navigation bar

### DIFF
--- a/packages/bottom-tabs/src/types.tsx
+++ b/packages/bottom-tabs/src/types.tsx
@@ -269,6 +269,10 @@ export type BottomTabNavigationConfig = {
    */
   tabBar?: (props: BottomTabBarProps) => React.ReactNode;
   /**
+   * Function that returns a React element to display as the tab bar.
+   */
+  tabBarShown?: boolean;
+  /**
    * Safe area insets for the tab bar. This is used to avoid elements like the navigation bar on Android and bottom safe area on iOS.
    * By default, the device's safe area insets are automatically detected. You can override the behavior with this option.
    */
@@ -314,6 +318,7 @@ export type BottomTabBarProps = {
   descriptors: BottomTabDescriptorMap;
   navigation: NavigationHelpers<ParamListBase, BottomTabNavigationEventMap>;
   insets: EdgeInsets;
+  tabBarShown: boolean;
 };
 
 export type BottomTabBarButtonProps = Omit<

--- a/packages/bottom-tabs/src/types.tsx
+++ b/packages/bottom-tabs/src/types.tsx
@@ -270,7 +270,7 @@ export type BottomTabNavigationConfig = {
    */
   tabBar?: (props: BottomTabBarProps) => React.ReactNode;
   /**
-   * Function that returns a React element to display as the tab bar.
+   * Whether the tab bar gets shown. Defaults to `true`.
    */
   tabBarShown?: boolean;
   /**

--- a/packages/bottom-tabs/src/views/BottomTabBar.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabBar.tsx
@@ -131,6 +131,7 @@ export default function BottomTabBar({
   descriptors,
   insets,
   style,
+  tabBarShown,
 }: Props) {
   const { colors } = useTheme();
   const buildLink = useLinkBuilder();
@@ -156,7 +157,7 @@ export default function BottomTabBar({
 
   const onHeightChange = React.useContext(BottomTabBarHeightCallbackContext);
 
-  const shouldShowTabBar = !(tabBarHideOnKeyboard && isKeyboardShown);
+  const shouldShowTabBar = !(tabBarHideOnKeyboard && isKeyboardShown) && tabBarShown;
 
   const visibilityAnimationConfigRef = React.useRef(
     tabBarVisibilityAnimationConfig

--- a/packages/bottom-tabs/src/views/BottomTabView.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabView.tsx
@@ -42,6 +42,7 @@ export default function BottomTabView(props: Props) {
       Platform.OS === 'android' ||
       Platform.OS === 'ios',
     sceneContainerStyle,
+    tabBarShown = true,
   } = props;
 
   const focusedRouteKey = state.routes[state.index].key;
@@ -74,6 +75,7 @@ export default function BottomTabView(props: Props) {
             state: state,
             descriptors: descriptors,
             navigation: navigation,
+            tabBarShown: tabBarShown,
             insets: {
               top: safeAreaInsets?.top ?? insets?.top ?? 0,
               right: safeAreaInsets?.right ?? insets?.right ?? 0,


### PR DESCRIPTION
Add `tabBarShown` option to `BottomTabBar`.

**Motivation**

It is a common use case to hide `BottomTabBar` with smooth animation, e.g. scroll to hide like LinkedIn app.

This PR partially solves the issue: https://github.com/react-navigation/react-navigation/issues/958

Using `react-native-router-flux,` I did it like this `Actions.refresh({ hideTabBar: true/false })`.

**Test plan**

The following option will become available.

```tsx
const Tabs = createBottomTabNavigator();

<Tabs.Navigator tabBarShown={false}>
  // ...
```

https://user-images.githubusercontent.com/10719495/214465895-48dbf45a-4b8b-4737-8835-bdb6f3679bce.MOV
