### PR TITLE
feat: Add useFocusedTabPressed

### DIFF
--- a/packages/native/src/useFocusedTabPressed.tsx
+++ b/packages/native/src/useFocusedTabPressed.tsx
@@ -1,0 +1,52 @@
+import { useEffect } from "react";
+import {
+    EventArg,
+    NavigationProp,
+    useNavigation,
+    useRoute,
+  } from "@react-navigation/core";
+  
+  export default function useFocusedTabPressed(callback: () => void) {
+    const navigation = useNavigation();
+    const route = useRoute();
+  
+    useEffect(() => {
+      let tabNavigations: NavigationProp<ReactNavigation.RootParamList>[] = [];
+      let currentNavigation = navigation;
+  
+      while (currentNavigation) {
+        if (currentNavigation.getState().type === "tab") {
+          tabNavigations.push(currentNavigation);
+        }
+  
+        currentNavigation = currentNavigation.getParent();
+      }
+  
+      if (tabNavigations.length === 0) {
+        return;
+      }
+  
+      const unsubscribers = tabNavigations.map((tab) => {
+        return tab.addListener(
+          // @ts-expect-error
+          "tabPress",
+          (e: EventArg<"tabPress", true>) => {
+            const isFocused = navigation.isFocused();
+            const isFirst =
+              tabNavigations.includes(navigation) ||
+              navigation.getState().routes[0].key === route.key;
+            requestAnimationFrame(() => {
+              if (isFocused && isFirst && !e.defaultPrevented) {
+                callback();
+              }
+            });
+          }
+        );
+      });
+  
+      return () => {
+        unsubscribers.forEach((unsubscribe) => unsubscribe());
+      };
+    }, [navigation, callback, route.key]);
+  }
+  


### PR DESCRIPTION
**Motivation**
Sometimes you need to do an action when the currently focused bottom tab has been pressed. Loosely copied from `useScrollToTop`, this hook uses a callback parameter instead of a scroll ref, and invokes the callback when the currently focused tab bar is pressed.

Usage:
```
const someActionWhenFocusedTabPressedAgain = useCallback(() => { 
  // focused tab button was pressed again
}, []);

useFocusedTabPressed(someActionWhenFocusedTabPressedAgain);
```
Related:
https://react-navigation.canny.io/feature-requests/p/allow-function-in-usescrolltotop