### PR TITLE
feat: add support to override pager's overScrollMode

### DIFF
--- a/packages/react-native-tab-view/README.md
+++ b/packages/react-native-tab-view/README.md
@@ -324,6 +324,10 @@ Object containing the initial height and width of the screens. Passing this will
 />
 ```
 
+##### `overScrollMode`
+
+Used to override default value of pager's overScroll mode. Can be `auto`, `always` or `never` (Android only).
+
 ##### `sceneContainerStyle`
 
 Style to apply to the view wrapping each screen. You can pass this to override some default styles such as overflow clipping:

--- a/packages/react-native-tab-view/src/TabView.tsx
+++ b/packages/react-native-tab-view/src/TabView.tsx
@@ -53,6 +53,7 @@ export default function TabView<T extends Route>({
   swipeEnabled = true,
   tabBarPosition = 'top',
   animationEnabled = true,
+  overScrollMode,
 }: Props<T>) {
   const [layout, setLayout] = React.useState({
     width: 0,
@@ -89,6 +90,7 @@ export default function TabView<T extends Route>({
         onSwipeEnd={onSwipeEnd}
         onIndexChange={jumpToIndex}
         animationEnabled={animationEnabled}
+        overScrollMode={overScrollMode}
         style={pagerStyle}
       >
         {({ position, render, addEnterListener, jumpTo }) => {


### PR DESCRIPTION
Add support to override pager's overScrollMode.

**Motivation**

The default value of `overScrollMode` in `react-native-pager-view` is set to `auto`, which makes the first and last scenes streched when over scroll the `TabView`. We should provide a way to change the default behavior.