### PR TITLE
fix: undefined colors property for material bottom tab

### DIFF
--- a/packages/material-bottom-tabs/src/views/MaterialBottomTabView.tsx
+++ b/packages/material-bottom-tabs/src/views/MaterialBottomTabView.tsx
@@ -111,7 +111,7 @@ function MaterialBottomTabViewInner({
     return {
       ...t,
       colors: {
-        ...t.colors,
+        ...t?.colors,
         ...colors,
         surface: colors.card,
       },


### PR DESCRIPTION
**Motivation**

Fixes unsafe access to an undefined property during theme change while using material bottom tab
With this the developer still gets the freedom on theming their navigations while not using react-native-paper's provider context

resolves #11208

**Test plan**

1. Toggle dark theme
2. DefaultTheme, DarkTheme or any custom theme created by a developer is passed to ```NavigationContainer``` theme props
3. An error gets thrown once a developer uses a different theme while using material bottom tab navigation
![Screenshot 2023-02-12 104831](https://user-images.githubusercontent.com/88238718/218290312-f9f733f3-d69b-431a-b6c1-5e76de946500.png)
