### PR TITLE
Fix #11028  export ScreenComponentType type

### DIFF
--- a/packages/core/src/types.tsx
+++ b/packages/core/src/types.tsx
@@ -440,7 +440,7 @@ export type ScreenListeners<
   >;
 }>;
 
-type ScreenComponentType<
+export type ScreenComponentType<
   ParamList extends ParamListBase,
   RouteName extends keyof ParamList
 > =


### PR DESCRIPTION
to able import it from `@react-navigation/core`:
```
import type { ScreenComponentType } from "@react-navigation/core";
...
<Drawer.Screen component={SomeScreen as | ScreenComponentType<RootSidebarParamList, 'Some'> | undefined} />
```

Please provide enough information so that others can review your pull request.

**Motivation**

Explain the **motivation** for making this change. What existing problem does the pull request solve?

If this pull request addresses an existing issue, link to the issue. If an issue is not present, describe the issue here.

**Test plan**

Describe the **steps to test this change** so that a reviewer can verify it. Provide screenshots or videos if the change affects UI.

The change must pass lint, typescript and tests.
