### PR TITLE
refactor: export label from bottom-tabs to elements package

### DIFF
--- a/packages/bottom-tabs/src/views/BottomTabBar.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabBar.tsx
@@ -1,4 +1,4 @@
-import { MissingIcon } from '@react-navigation/elements';
+import { getLabel, MissingIcon } from '@react-navigation/elements';
 import {
   CommonActions,
   NavigationContext,
@@ -319,11 +319,12 @@ export function BottomTabBar({
           };
 
           const label =
-            options.tabBarLabel !== undefined
+            typeof options.tabBarLabel === 'function'
               ? options.tabBarLabel
-              : options.title !== undefined
-              ? options.title
-              : route.name;
+              : getLabel(
+                  { label: options.tabBarLabel, title: options.title },
+                  route.name
+                );
 
           const accessibilityLabel =
             options.tabBarAccessibilityLabel !== undefined

--- a/packages/bottom-tabs/src/views/BottomTabItem.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabItem.tsx
@@ -1,3 +1,4 @@
+import { getLabel, Label } from '@react-navigation/elements';
 import { CommonActions, Link, Route, useTheme } from '@react-navigation/native';
 import Color from 'color';
 import React from 'react';
@@ -7,7 +8,6 @@ import {
   Pressable,
   StyleProp,
   StyleSheet,
-  Text,
   TextStyle,
   ViewStyle,
 } from 'react-native';
@@ -195,7 +195,7 @@ export function BottomTabItem({
   iconStyle,
   style,
 }: Props) {
-  const { colors, fonts } = useTheme();
+  const { colors } = useTheme();
 
   const activeTintColor =
     customActiveTintColor === undefined
@@ -214,38 +214,38 @@ export function BottomTabItem({
 
     const color = focused ? activeTintColor : inactiveTintColor;
 
-    if (typeof label === 'string') {
-      return (
-        <Text
-          numberOfLines={1}
-          style={[
-            { color },
-            fonts.regular,
-            styles.label,
-            horizontal ? styles.labelBeside : styles.labelBeneath,
-            labelStyle,
-          ]}
-          allowFontScaling={allowFontScaling}
-        >
-          {label}
-        </Text>
+    if (typeof label !== 'string') {
+      const { options } = descriptor;
+      const children = getLabel(
+        {
+          label:
+            typeof options.tabBarLabel === 'string'
+              ? options.tabBarLabel
+              : undefined,
+          title: options.title,
+        },
+        route.name
       );
+
+      return label({
+        focused,
+        color,
+        position: horizontal ? 'beside-icon' : 'below-icon',
+        children,
+      });
     }
 
-    const { options } = descriptor;
-    const children =
-      typeof options.tabBarLabel === 'string'
-        ? options.tabBarLabel
-        : options.title !== undefined
-        ? options.title
-        : route.name;
-
-    return label({
-      focused,
-      color,
-      position: horizontal ? 'beside-icon' : 'below-icon',
-      children,
-    });
+    return (
+      <Label
+        style={[
+          horizontal ? styles.labelBeside : styles.labelBeneath,
+          labelStyle,
+        ]}
+        allowFontScaling={allowFontScaling}
+      >
+        {label}
+      </Label>
+    );
   };
 
   const renderIcon = ({ focused }: { focused: boolean }) => {
@@ -316,10 +316,6 @@ const styles = StyleSheet.create({
   tabLandscape: {
     justifyContent: 'center',
     flexDirection: 'row',
-  },
-  label: {
-    textAlign: 'center',
-    backgroundColor: 'transparent',
   },
   labelBeneath: {
     fontSize: 10,

--- a/packages/elements/src/Label/Label.tsx
+++ b/packages/elements/src/Label/Label.tsx
@@ -1,0 +1,39 @@
+import { useTheme } from '@react-navigation/native';
+import * as React from 'react';
+import {
+  StyleProp,
+  StyleSheet,
+  Text,
+  TextProps,
+  TextStyle,
+} from 'react-native';
+
+type Props = Omit<TextProps, 'style'> & {
+  tintColor?: string;
+  children?: string;
+  style?: StyleProp<TextStyle>;
+};
+
+export function Label({ tintColor, style, ...rest }: Props) {
+  const { colors, fonts } = useTheme();
+
+  return (
+    <Text
+      numberOfLines={1}
+      {...rest}
+      style={[
+        fonts.regular,
+        styles.label,
+        { color: tintColor === undefined ? colors.text : tintColor },
+        style,
+      ]}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  label: {
+    textAlign: 'center',
+    backgroundColor: 'transparent',
+  },
+});

--- a/packages/elements/src/Label/getLabel.tsx
+++ b/packages/elements/src/Label/getLabel.tsx
@@ -1,0 +1,10 @@
+export function getLabel(
+  options: { label?: string; title?: string },
+  fallback: string
+): string {
+  return options.label !== undefined
+    ? options.label
+    : options.title !== undefined
+    ? options.title
+    : fallback;
+}

--- a/packages/elements/src/index.tsx
+++ b/packages/elements/src/index.tsx
@@ -9,6 +9,8 @@ export { HeaderHeightContext } from './Header/HeaderHeightContext';
 export { HeaderShownContext } from './Header/HeaderShownContext';
 export { HeaderTitle } from './Header/HeaderTitle';
 export { useHeaderHeight } from './Header/useHeaderHeight';
+export { getLabel } from './Label/getLabel';
+export { Label } from './Label/Label';
 export { MissingIcon } from './MissingIcon';
 export { PlatformPressable } from './PlatformPressable';
 export { ResourceSavingView } from './ResourceSavingView';


### PR DESCRIPTION
**Motivation**

Moves the default label component to the elements package, similar to the HeaderTitle component.
It uses logic similar to the Header element component.
Please let me know if this was not the intended refactor, I can fix it.

**Test plan**

There should be no visible changes in the bottom tabs examples in the example app. 
