### PR TITLE
feat: add animation prop to stack

### DIFF
--- a/packages/stack/src/TransitionConfigs/CardStyleInterpolators.tsx
+++ b/packages/stack/src/TransitionConfigs/CardStyleInterpolators.tsx
@@ -63,6 +63,13 @@ export function forHorizontalIOS({
   };
 }
 
+export function forHorizontalIOSInverted(
+  props: StackCardInterpolationProps
+): StackCardInterpolatedStyle {
+  props.inverted = new Animated.Value(-1);
+  return forHorizontalIOS(props);
+}
+
 /**
  * Standard iOS-style slide in from the bottom (used for modals).
  */

--- a/packages/stack/src/TransitionConfigs/TransitionPresets.tsx
+++ b/packages/stack/src/TransitionConfigs/TransitionPresets.tsx
@@ -1,6 +1,6 @@
 import { Platform } from 'react-native';
 
-import type { TransitionPreset } from '../types';
+import type { StackAnimationTypes, TransitionPreset } from '../types';
 import {
   forBottomSheetAndroid,
   forFadeFromBottomAndroid,
@@ -150,3 +150,19 @@ export const ModalTransition = Platform.select({
   ios: ModalPresentationIOS,
   default: BottomSheetAndroid,
 });
+
+type AnimationTransitionMap = {
+  [key in StackAnimationTypes]: TransitionPreset;
+};
+
+// TODO: Add proper transitions
+export const AnimationTransitions: AnimationTransitionMap = {
+  default: DefaultTransition,
+  fade: ModalFadeTransition,
+  fade_from_bottom: FadeFromBottomAndroid,
+  none: DefaultTransition,
+  simple_push: DefaultTransition,
+  slide_from_bottom: BottomSheetAndroid,
+  slide_from_left: DefaultTransition,
+  slide_from_right: SlideFromRightIOS,
+};

--- a/packages/stack/src/TransitionConfigs/TransitionPresets.tsx
+++ b/packages/stack/src/TransitionConfigs/TransitionPresets.tsx
@@ -6,6 +6,7 @@ import {
   forFadeFromBottomAndroid,
   forFadeFromCenter as forFadeCard,
   forHorizontalIOS,
+  forHorizontalIOSInverted,
   forModalPresentationIOS,
   forRevealFromBottomAndroid,
   forScaleFromCenterAndroid,
@@ -36,6 +37,11 @@ export const SlideFromRightIOS: TransitionPreset = {
   },
   cardStyleInterpolator: forHorizontalIOS,
   headerStyleInterpolator: forFade,
+};
+
+export const SlideFromLeftIOS: TransitionPreset = {
+  ...SlideFromRightIOS,
+  cardStyleInterpolator: forHorizontalIOSInverted,
 };
 
 /**
@@ -155,7 +161,6 @@ type AnimationTransitionMap = {
   [key in StackAnimationTypes]: TransitionPreset;
 };
 
-// TODO: Add proper transitions
 export const AnimationTransitions: AnimationTransitionMap = {
   default: DefaultTransition,
   fade: ModalFadeTransition,
@@ -163,6 +168,6 @@ export const AnimationTransitions: AnimationTransitionMap = {
   none: DefaultTransition,
   simple_push: DefaultTransition,
   slide_from_bottom: BottomSheetAndroid,
-  slide_from_left: DefaultTransition,
+  slide_from_left: SlideFromLeftIOS,
   slide_from_right: SlideFromRightIOS,
 };

--- a/packages/stack/src/TransitionConfigs/TransitionPresets.tsx
+++ b/packages/stack/src/TransitionConfigs/TransitionPresets.tsx
@@ -166,7 +166,6 @@ export const AnimationTransitions: AnimationTransitionMap = {
   fade: ModalFadeTransition,
   fade_from_bottom: FadeFromBottomAndroid,
   none: DefaultTransition,
-  simple_push: DefaultTransition,
   slide_from_bottom: BottomSheetAndroid,
   slide_from_left: SlideFromLeftIOS,
   slide_from_right: SlideFromRightIOS,

--- a/packages/stack/src/types.tsx
+++ b/packages/stack/src/types.tsx
@@ -83,7 +83,6 @@ export type StackAnimationTypes =
   | 'fade'
   | 'fade_from_bottom'
   | 'none'
-  | 'simple_push'
   | 'slide_from_bottom'
   | 'slide_from_right'
   | 'slide_from_left';
@@ -322,7 +321,7 @@ export type StackNavigationOptions = StackHeaderOptions &
      * Supported values:
      * - "default": use the platform default animation
      * - "fade": fade screen in or out
-     * - "simple_push": use the platform default animation, but without shadow and native header transition
+     * - "fade_from_bottom": fade screen in or out from bottom
      * - "slide_from_bottom": slide in the new screen from bottom
      * - "slide_from_right": slide in the new screen from right
      * - "slide_from_left": slide in the new screen from left

--- a/packages/stack/src/types.tsx
+++ b/packages/stack/src/types.tsx
@@ -322,10 +322,10 @@ export type StackNavigationOptions = StackHeaderOptions &
      * Supported values:
      * - "default": use the platform default animation
      * - "fade": fade screen in or out
-     * - "simple_push": use the platform default animation, but without shadow and native header transition (iOS only)
+     * - "simple_push": use the platform default animation, but without shadow and native header transition
      * - "slide_from_bottom": slide in the new screen from bottom
-     * - "slide_from_right": slide in the new screen from right (Android only, uses default animation on iOS)
-     * - "slide_from_left": slide in the new screen from left (Android only, uses default animation on iOS)
+     * - "slide_from_right": slide in the new screen from right
+     * - "slide_from_left": slide in the new screen from left
      * - "none": don't animate the screen
      *
      * Only supported on iOS and Android.

--- a/packages/stack/src/types.tsx
+++ b/packages/stack/src/types.tsx
@@ -78,6 +78,16 @@ export type GestureDirection =
   | 'vertical'
   | 'vertical-inverted';
 
+export type StackAnimationTypes =
+  | 'default'
+  | 'fade'
+  | 'fade_from_bottom'
+  | 'none'
+  | 'simple_push'
+  | 'slide_from_bottom'
+  | 'slide_from_right'
+  | 'slide_from_left';
+
 type SceneOptionsDefaults = TransitionPreset & {
   animationEnabled: boolean;
   gestureEnabled: boolean;
@@ -306,6 +316,21 @@ export type StackNavigationOptions = StackHeaderOptions &
      * When `pop` is used, the `pop` animation is applied to the screen being replaced.
      */
     animationTypeForReplace?: 'push' | 'pop';
+    /**
+     * How the screen should animate when pushed or popped.
+     *
+     * Supported values:
+     * - "default": use the platform default animation
+     * - "fade": fade screen in or out
+     * - "simple_push": use the platform default animation, but without shadow and native header transition (iOS only)
+     * - "slide_from_bottom": slide in the new screen from bottom
+     * - "slide_from_right": slide in the new screen from right (Android only, uses default animation on iOS)
+     * - "slide_from_left": slide in the new screen from left (Android only, uses default animation on iOS)
+     * - "none": don't animate the screen
+     *
+     * Only supported on iOS and Android.
+     */
+    animation?: StackAnimationTypes;
     /**
      * Whether you can use gestures to dismiss this screen. Defaults to `true` on iOS, `false` on Android.
      * Not supported on Web.

--- a/packages/stack/src/views/Stack/Card.tsx
+++ b/packages/stack/src/views/Stack/Card.tsx
@@ -16,6 +16,7 @@ import { forModalPresentationIOS } from '../../TransitionConfigs/CardStyleInterp
 import type {
   GestureDirection,
   Layout,
+  StackAnimationTypes,
   StackCardInterpolationProps,
   StackCardStyleInterpolator,
   TransitionSpec,
@@ -33,6 +34,7 @@ import ModalStatusBarManager from '../ModalStatusBarManager';
 import CardSheet, { CardSheetRef } from './CardSheet';
 
 type Props = ViewProps & {
+  animation?: StackAnimationTypes;
   interpolationIndex: number;
   closing: boolean;
   next?: Animated.AnimatedInterpolation<number>;

--- a/packages/stack/src/views/Stack/CardContainer.tsx
+++ b/packages/stack/src/views/Stack/CardContainer.tsx
@@ -184,6 +184,7 @@ function CardContainer({
   }, [pointerEvents, scene.progress.next]);
 
   const {
+    animation,
     presentation,
     animationEnabled,
     cardOverlay,
@@ -217,6 +218,7 @@ function CardContainer({
 
   return (
     <Card
+      animation={animation}
       interpolationIndex={interpolationIndex}
       gestureDirection={gestureDirection}
       layout={layout}

--- a/packages/stack/src/views/Stack/CardStack.tsx
+++ b/packages/stack/src/views/Stack/CardStack.tsx
@@ -23,6 +23,7 @@ import {
   forNoAnimation as forNoAnimationCard,
 } from '../../TransitionConfigs/CardStyleInterpolators';
 import {
+  AnimationTransitions,
   DefaultTransition,
   ModalFadeTransition,
   ModalTransition,
@@ -275,20 +276,29 @@ export default class CardStack extends React.Component<Props, State> {
           : DefaultTransition;
 
       const {
+        animation,
         animationEnabled = Platform.OS !== 'web' &&
           Platform.OS !== 'windows' &&
           Platform.OS !== 'macos',
         gestureEnabled = Platform.OS === 'ios' && animationEnabled,
         gestureDirection = defaultTransitionPreset.gestureDirection,
         transitionSpec = defaultTransitionPreset.transitionSpec,
+        headerStyleInterpolator = defaultTransitionPreset.headerStyleInterpolator,
+      } = optionsForTransitionConfig;
+
+      let {
         cardStyleInterpolator = animationEnabled === false
           ? forNoAnimationCard
           : defaultTransitionPreset.cardStyleInterpolator,
-        headerStyleInterpolator = defaultTransitionPreset.headerStyleInterpolator,
         cardOverlayEnabled = (Platform.OS !== 'ios' &&
           optionsForTransitionConfig.presentation !== 'transparentModal') ||
           getIsModalPresentation(cardStyleInterpolator),
       } = optionsForTransitionConfig;
+
+      if (animation != null) {
+        const transition = AnimationTransitions[animation];
+        cardStyleInterpolator = transition.cardStyleInterpolator;
+      }
 
       const headerMode: StackHeaderMode =
         descriptor.options.headerMode ??
@@ -310,6 +320,7 @@ export default class CardStack extends React.Component<Props, State> {
           ...descriptor,
           options: {
             ...descriptor.options,
+            animation,
             animationEnabled,
             cardOverlayEnabled,
             cardStyleInterpolator,

--- a/packages/stack/src/views/Stack/CardStack.tsx
+++ b/packages/stack/src/views/Stack/CardStack.tsx
@@ -296,8 +296,8 @@ export default class CardStack extends React.Component<Props, State> {
       } = optionsForTransitionConfig;
 
       if (animation != null) {
-        const transition = AnimationTransitions[animation];
-        cardStyleInterpolator = transition.cardStyleInterpolator;
+        cardStyleInterpolator =
+          AnimationTransitions[animation].cardStyleInterpolator;
       }
 
       const headerMode: StackHeaderMode =

--- a/packages/stack/src/views/Stack/StackView.tsx
+++ b/packages/stack/src/views/Stack/StackView.tsx
@@ -139,6 +139,11 @@ export default class StackView extends React.Component<Props, State> {
     const isAnimationEnabled = (key: string) => {
       const descriptor = props.descriptors[key] || state.descriptors[key];
 
+      const animation = descriptor?.options?.animation;
+      if (animation && animation === 'none') {
+        return false;
+      }
+
       return descriptor ? descriptor.options.animationEnabled !== false : true;
     };
 


### PR DESCRIPTION
PR with documentation: https://github.com/react-navigation/react-navigation.github.io/pull/1215

**Motivation**

This PR brings a new `animation` property to Stack, which adds a simpler way to animate a screen.

<details><summary>Code example</summary>
<p>

```javascript
import * as React from 'react';
import { Button, Text, View } from 'react-native';
import { NavigationContainer } from '@react-navigation/native';
import { createStackNavigator } from '@react-navigation/stack';

function FirstScreen({ navigation }: any) {
  return (
    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
      <Text>First Screen</Text>
      <Button
        title="Go to Second Screen"
        onPress={() => navigation.navigate('SecondScreen')}
      />
    </View>
  );
}

function SecondScreen() {
  return (
    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
      <Text>Second Screen</Text>
    </View>
  );
}

const Stack = createStackNavigator();

export default function App() {
  return (
    <NavigationContainer>
      <Stack.Navigator screenOptions={{ animation: 'slide_from_right' }}>
        <Stack.Screen name="FirstScreen" component={FirstScreen} />
        <Stack.Screen name="SecondScreen" component={SecondScreen} />
      </Stack.Navigator>
    </NavigationContainer>
  );
}
```

</p>
</details>