### PR TITLE
fix: inactive screen visible for one frame

### DIFF
--- a/packages/stack/src/views/Stack/CardStack.tsx
+++ b/packages/stack/src/views/Stack/CardStack.tsx
@@ -471,6 +471,8 @@ export class CardStack extends React.Component<Props, State> {
     return undefined;
   };
 
+  private lastActivityStateForIndex: Record<number, number> = {};
+
   render() {
     const {
       insets,
@@ -590,8 +592,9 @@ export class CardStack extends React.Component<Props, State> {
               | 1
               | 2 = 1;
 
-            if (index < self.length - activeScreensLimit - 1) {
+            if (index < self.length - activeScreensLimit - 1 || (this.lastActivityStateForIndex[index] === STATE_INACTIVE && index < self.length - activeScreensLimit)) {
               // screen should be inactive because it is too deep in the stack
+              // or it was inactive before and it will still be inactive after the transition.
               isScreenActive = STATE_INACTIVE;
             } else {
               const sceneForActivity = scenes[self.length - 1];
@@ -609,6 +612,7 @@ export class CardStack extends React.Component<Props, State> {
                   })
                 : STATE_TRANSITIONING_OR_BELOW_TOP;
             }
+            this.lastActivityStateForIndex[index] = isScreenActive;
 
             const {
               headerShown = true,


### PR DESCRIPTION
In a scenario when we have 3 screens pushed on the stack (let's name them A, B, C in the nesting order) and we navigate from C to B, the A screen was attached for about one frame (and it should not be since it will not be visible after transition), causing problems with libraries that subscribe to native attach/detach process.

It happened because when the third screen disappears, the length of the routes becomes smaller, so in our case length becomes `2`, `activeScreensLimit` is still `1`, so we do go into `else` in line `599` for screen `A`, which was inactive during the transition. In there, the `outputValue` is set correctly to `STATE_INACTIVE` for after the transition, but it is interpolated from `1` to `0`(`STATE_INACTIVE`) (lines `608-612`), so it gets the `1` value. The transition ends in the next frame, so it quickly becomes `0` again, but still was attached for this one frame.

The solution is to keep the information of what was the last state for each index, and if it was `STATE_INACTIVE` and will be such after the transition, there is no sense to make it visible. It would be nice to test it in many scenarios for sure.

@graszka22 can confirm that it fixes a problem with native attach/detach in their library.