### PR TITLE
fix: correct supported react-native-reanimated version

### DIFF
--- a/packages/drawer/package.json
+++ b/packages/drawer/package.json
@@ -66,7 +66,7 @@
     "react": "*",
     "react-native": "*",
     "react-native-gesture-handler": ">= 1.0.0",
-    "react-native-reanimated": ">= 1.0.0",
+    "react-native-reanimated": ">= 1.0.0 || >= 2.0.0 || >= 3.0.0",
     "react-native-safe-area-context": ">= 3.0.0",
     "react-native-screens": ">= 3.0.0"
   },

--- a/packages/react-native-drawer-layout/package.json
+++ b/packages/react-native-drawer-layout/package.json
@@ -50,7 +50,7 @@
     "react": "*",
     "react-native": "*",
     "react-native-gesture-handler": ">= 1.0.0",
-    "react-native-reanimated": ">= 1.0.0"
+    "react-native-reanimated": ">= 1.0.0 || >= 2.0.0 || >= 3.0.0"
   },
   "react-native-builder-bob": {
     "source": "src",


### PR DESCRIPTION
**Motivation**

After upgrading expo I got this error message:

> Invalid `RNReanimated.podspec` file: [react-native-reanimated] Multiple versions of Reanimated were detected. Only one instance of react-native-reanimated can be installed in a project. You need to resolve the conflict manually. Check out the documentation: https://docs.swmansion.com/react-native-reanimated/docs/next/fundamentals/troubleshooting#multiple-versions-of-reanimated-were-detected 

I noticed due the react-navigation peerDependency specification 1.x of reanimated was installed. After realizing that you do support reanimated 2 & 3 I investigated and found this example: https://stackoverflow.com/a/47310882/837709

**Test plan**

Everything should work as before.
