### PR TITLE
feat!: add a direction prop to NavigationContainer to specify rtl

### DIFF
--- a/example/src/Restart.native.tsx
+++ b/example/src/Restart.native.tsx
@@ -1,5 +1,0 @@
-import * as Updates from 'expo-updates';
-
-export function restartApp() {
-  Updates.reloadAsync();
-}

--- a/example/src/Restart.tsx
+++ b/example/src/Restart.tsx
@@ -1,1 +1,0 @@
-export function restartApp() {}

--- a/example/src/Screens/SimpleStack.tsx
+++ b/example/src/Screens/SimpleStack.tsx
@@ -1,6 +1,7 @@
 import type { ParamListBase } from '@react-navigation/native';
 import {
   createStackNavigator,
+  HeaderStyleInterpolators,
   StackNavigationOptions,
   StackScreenProps,
 } from '@react-navigation/stack';
@@ -137,7 +138,12 @@ export function SimpleStack({
   }, [navigation]);
 
   return (
-    <Stack.Navigator screenOptions={screenOptions}>
+    <Stack.Navigator
+      screenOptions={{
+        ...screenOptions,
+        headerStyleInterpolator: HeaderStyleInterpolators.forUIKit,
+      }}
+    >
       <Stack.Screen
         name="Article"
         component={ArticleScreen}

--- a/packages/drawer/src/views/DrawerContentScrollView.tsx
+++ b/packages/drawer/src/views/DrawerContentScrollView.tsx
@@ -1,10 +1,6 @@
+import { useLocale } from '@react-navigation/native';
 import * as React from 'react';
-import {
-  I18nManager,
-  ScrollView,
-  ScrollViewProps,
-  StyleSheet,
-} from 'react-native';
+import { ScrollView, ScrollViewProps, StyleSheet } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { DrawerPositionContext } from '../utils/DrawerPositionContext';
@@ -19,10 +15,12 @@ function DrawerContentScrollViewInner(
 ) {
   const drawerPosition = React.useContext(DrawerPositionContext);
   const insets = useSafeAreaInsets();
+  const { direction } = useLocale();
 
-  const isRight = I18nManager.getConstants().isRTL
-    ? drawerPosition === 'left'
-    : drawerPosition === 'right';
+  const isRight =
+    direction === 'rtl'
+      ? drawerPosition === 'left'
+      : drawerPosition === 'right';
 
   return (
     <ScrollView

--- a/packages/drawer/src/views/DrawerView.tsx
+++ b/packages/drawer/src/views/DrawerView.tsx
@@ -9,10 +9,11 @@ import {
   DrawerNavigationState,
   DrawerStatus,
   ParamListBase,
+  useLocale,
   useTheme,
 } from '@react-navigation/native';
 import * as React from 'react';
-import { BackHandler, I18nManager, Platform, StyleSheet } from 'react-native';
+import { BackHandler, Platform, StyleSheet } from 'react-native';
 import { Drawer } from 'react-native-drawer-layout';
 import { useSafeAreaFrame } from 'react-native-safe-area-context';
 import useLatestCallback from 'use-latest-callback';
@@ -51,10 +52,12 @@ function DrawerViewBase({
     Platform.OS === 'android' ||
     Platform.OS === 'ios',
 }: Props) {
+  const { direction } = useLocale();
+
   const focusedRouteKey = state.routes[state.index].key;
   const {
     drawerHideStatusBarOnOpen,
-    drawerPosition = I18nManager.getConstants().isRTL ? 'right' : 'left',
+    drawerPosition = direction === 'rtl' ? 'right' : 'left',
     drawerStatusBarAnimation,
     drawerStyle,
     drawerType,

--- a/packages/elements/src/Header/HeaderBackButton.tsx
+++ b/packages/elements/src/Header/HeaderBackButton.tsx
@@ -1,8 +1,7 @@
-import { useTheme } from '@react-navigation/native';
+import { useLocale, useTheme } from '@react-navigation/native';
 import * as React from 'react';
 import {
   Animated,
-  I18nManager,
   Image,
   LayoutChangeEvent,
   Platform,
@@ -34,6 +33,7 @@ export function HeaderBackButton({
   style,
 }: HeaderBackButtonProps) {
   const { colors, fonts } = useTheme();
+  const { direction } = useLocale();
 
   const [initialLabelWidth, setInitialLabelWidth] = React.useState<
     undefined | number
@@ -50,7 +50,11 @@ export function HeaderBackButton({
   const handleLabelLayout = (e: LayoutChangeEvent) => {
     onLabelLayout?.(e);
 
-    setInitialLabelWidth(e.nativeEvent.layout.x + e.nativeEvent.layout.width);
+    const { layout } = e.nativeEvent;
+
+    setInitialLabelWidth(
+      (direction === 'rtl' ? layout.y : layout.x) + layout.width
+    );
   };
 
   const shouldTruncateLabel = () => {
@@ -71,6 +75,7 @@ export function HeaderBackButton({
         <Image
           style={[
             styles.icon,
+            direction === 'rtl' && styles.flip,
             Boolean(labelVisible) && styles.iconWithLabel,
             Boolean(tintColor) && { tintColor },
           ]}
@@ -131,7 +136,7 @@ export function HeaderBackButton({
           <View style={styles.iconMaskContainer}>
             <Image
               source={require('../assets/back-icon-mask.png')}
-              style={styles.iconMask}
+              style={[styles.iconMask, direction === 'rtl' && styles.flip]}
             />
             <View style={styles.iconMaskFillerRect} />
           </View>
@@ -211,14 +216,12 @@ const styles = StyleSheet.create({
       marginRight: 22,
       marginVertical: 12,
       resizeMode: 'contain',
-      transform: [{ scaleX: I18nManager.getConstants().isRTL ? -1 : 1 }],
     },
     default: {
       height: 24,
       width: 24,
       margin: 3,
       resizeMode: 'contain',
-      transform: [{ scaleX: I18nManager.getConstants().isRTL ? -1 : 1 }],
     },
   }),
   iconWithLabel:
@@ -243,6 +246,8 @@ const styles = StyleSheet.create({
     marginVertical: 12,
     alignSelf: 'center',
     resizeMode: 'contain',
-    transform: [{ scaleX: I18nManager.getConstants().isRTL ? -1 : 1 }],
+  },
+  flip: {
+    transform: [{ scaleX: -1 }],
   },
 });

--- a/packages/native-stack/src/views/HeaderConfig.tsx
+++ b/packages/native-stack/src/views/HeaderConfig.tsx
@@ -1,13 +1,7 @@
 import { getHeaderTitle, HeaderTitle } from '@react-navigation/elements';
-import { Route, useTheme } from '@react-navigation/native';
+import { Route, useLocale, useTheme } from '@react-navigation/native';
 import * as React from 'react';
-import {
-  I18nManager,
-  Platform,
-  StyleSheet,
-  TextStyle,
-  View,
-} from 'react-native';
+import { Platform, StyleSheet, TextStyle, View } from 'react-native';
 import {
   isSearchBarAvailableForCurrentPlatform,
   ScreenStackHeaderBackButtonImage,
@@ -59,6 +53,7 @@ export function HeaderConfig({
   title,
   canGoBack,
 }: Props): JSX.Element {
+  const { direction } = useLocale();
   const { colors, fonts } = useTheme();
   const tintColor =
     headerTintColor ?? (Platform.OS === 'ios' ? colors.primary : colors.text);
@@ -202,7 +197,7 @@ export function HeaderConfig({
         backTitleFontSize={backTitleFontSize}
         blurEffect={headerBlurEffect}
         color={tintColor}
-        direction={I18nManager.getConstants().isRTL ? 'rtl' : 'ltr'}
+        direction={direction}
         disableBackButtonMenu={headerBackButtonMenuEnabled === false}
         hidden={headerShown === false}
         hideBackButton={headerBackVisible === false}

--- a/packages/native/src/LocaleDirContext.tsx
+++ b/packages/native/src/LocaleDirContext.tsx
@@ -1,0 +1,7 @@
+import * as React from 'react';
+
+import type { LocaleDirection } from './types';
+
+export const LocaleDirContext = React.createContext<LocaleDirection>('ltr');
+
+LocaleDirContext.displayName = 'LocaleDirContext';

--- a/packages/native/src/NavigationContainer.tsx
+++ b/packages/native/src/NavigationContainer.tsx
@@ -9,6 +9,7 @@ import {
   validatePathConfig,
 } from '@react-navigation/core';
 import * as React from 'react';
+import { I18nManager } from 'react-native';
 
 import { LinkingContext } from './LinkingContext';
 import { LocaleDirContext } from './LocaleDirContext';
@@ -60,7 +61,7 @@ type Props<ParamList extends {}> = NavigationContainerProps & {
  */
 function NavigationContainerInner(
   {
-    direction = 'ltr',
+    direction = I18nManager.getConstants().isRTL ? 'rtl' : 'ltr',
     theme = DefaultTheme,
     linking,
     fallback = null,

--- a/packages/native/src/NavigationContainer.tsx
+++ b/packages/native/src/NavigationContainer.tsx
@@ -11,9 +11,15 @@ import {
 import * as React from 'react';
 
 import { LinkingContext } from './LinkingContext';
+import { LocaleDirContext } from './LocaleDirContext';
 import { DefaultTheme } from './theming/DefaultTheme';
 import { ThemeProvider } from './theming/ThemeProvider';
-import type { DocumentTitleOptions, LinkingOptions, Theme } from './types';
+import type {
+  DocumentTitleOptions,
+  LinkingOptions,
+  LocaleDirection,
+  Theme,
+} from './types';
 import { useBackButton } from './useBackButton';
 import { useDocumentTitle } from './useDocumentTitle';
 import { useLinking } from './useLinking';
@@ -29,6 +35,7 @@ declare global {
 global.REACT_NAVIGATION_DEVTOOLS = new WeakMap();
 
 type Props<ParamList extends {}> = NavigationContainerProps & {
+  direction?: LocaleDirection;
   theme?: Theme;
   linking?: LinkingOptions<ParamList>;
   fallback?: React.ReactNode;
@@ -43,6 +50,7 @@ type Props<ParamList extends {}> = NavigationContainerProps & {
  * @param props.onReady Callback which is called after the navigation tree mounts.
  * @param props.onStateChange Callback which is called with the latest navigation state when it changes.
  * @param props.onUnhandledAction Callback which is called when an action is not handled.
+ * @param props.direction Text direction of the components. Defaults to `'ltr'`.
  * @param props.theme Theme object for the navigators.
  * @param props.linking Options for deep linking. Deep link handling is enabled when this prop is provided, unless `linking.enabled` is `false`.
  * @param props.fallback Fallback component to render until we have finished getting initial state when linking is enabled. Defaults to `null`.
@@ -52,6 +60,7 @@ type Props<ParamList extends {}> = NavigationContainerProps & {
  */
 function NavigationContainerInner(
   {
+    direction = 'ltr',
     theme = DefaultTheme,
     linking,
     fallback = null,
@@ -114,17 +123,19 @@ function NavigationContainerInner(
   }
 
   return (
-    <LinkingContext.Provider value={linkingContext}>
-      <ThemeProvider value={theme}>
-        <BaseNavigationContainer
-          {...rest}
-          initialState={
-            rest.initialState == null ? initialState : rest.initialState
-          }
-          ref={refContainer}
-        />
-      </ThemeProvider>
-    </LinkingContext.Provider>
+    <LocaleDirContext.Provider value={direction}>
+      <LinkingContext.Provider value={linkingContext}>
+        <ThemeProvider value={theme}>
+          <BaseNavigationContainer
+            {...rest}
+            initialState={
+              rest.initialState == null ? initialState : rest.initialState
+            }
+            ref={refContainer}
+          />
+        </ThemeProvider>
+      </LinkingContext.Provider>
+    </LocaleDirContext.Provider>
   );
 }
 

--- a/packages/native/src/index.tsx
+++ b/packages/native/src/index.tsx
@@ -10,5 +10,6 @@ export { useTheme } from './theming/useTheme';
 export * from './types';
 export { useLinkProps } from './useLinkProps';
 export { useLinkTools } from './useLinkTools';
+export { useLocale } from './useLocale';
 export { useScrollToTop } from './useScrollToTop';
 export * from '@react-navigation/core';

--- a/packages/native/src/types.tsx
+++ b/packages/native/src/types.tsx
@@ -6,6 +6,8 @@ import type {
   Route,
 } from '@react-navigation/core';
 
+export type LocaleDirection = 'ltr' | 'rtl';
+
 type FontStyle = {
   fontFamily: string;
   fontWeight:

--- a/packages/native/src/useLocale.tsx
+++ b/packages/native/src/useLocale.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+
+import { LocaleDirContext } from './LocaleDirContext';
+
+/**
+ * Hook to access the text direction specified in the `NavigationContainer`.
+ */
+export function useLocale() {
+  const direction = React.useContext(LocaleDirContext);
+
+  if (direction === undefined) {
+    throw new Error(
+      "Couldn't determine the text direction. Is your component inside NavigationContainer?"
+    );
+  }
+
+  return { direction };
+}

--- a/packages/react-native-drawer-layout/src/views/legacy/Drawer.tsx
+++ b/packages/react-native-drawer-layout/src/views/legacy/Drawer.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import {
-  I18nManager,
   InteractionManager,
   Keyboard,
   LayoutChangeEvent,
@@ -533,21 +532,9 @@ export class Drawer extends React.Component<Props> {
       drawerType === 'front' ? ANIMATED_ZERO : this.translateX;
 
     const drawerTranslateX =
-      drawerType === 'back'
-        ? I18nManager.getConstants().isRTL
-          ? multiply(
-              sub(this.containerWidth, this.drawerWidth),
-              isRight ? 1 : -1
-            )
-          : ANIMATED_ZERO
-        : this.translateX;
+      drawerType === 'back' ? ANIMATED_ZERO : this.translateX;
 
-    const offset =
-      drawerType === 'back'
-        ? 0
-        : I18nManager.getConstants().isRTL
-        ? '100%'
-        : multiply(this.drawerWidth, -1);
+    const offset = drawerType === 'back' ? 0 : '100%';
 
     // FIXME: Currently hitSlop is broken when on Android when drawer is on right
     // https://github.com/software-mansion/react-native-gesture-handler/issues/569

--- a/packages/react-native-drawer-layout/src/views/modern/Drawer.tsx
+++ b/packages/react-native-drawer-layout/src/views/modern/Drawer.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import {
-  I18nManager,
   InteractionManager,
   Keyboard,
   Platform,
@@ -312,10 +311,7 @@ export function Drawer({
     return translateX;
   });
 
-  const isRTL = I18nManager.getConstants().isRTL;
   const drawerAnimatedStyle = useAnimatedStyle(() => {
-    const distanceFromEdge = layout.width - drawerWidth;
-
     return {
       transform:
         drawerType === 'permanent'
@@ -326,14 +322,7 @@ export function Drawer({
               {
                 translateX:
                   // The drawer stays in place when `drawerType` is `back`
-                  (drawerType === 'back' ? 0 : translateX.value) +
-                  (drawerPosition === 'left'
-                    ? isRTL
-                      ? -distanceFromEdge
-                      : 0
-                    : isRTL
-                    ? 0
-                    : distanceFromEdge),
+                  drawerType === 'back' ? 0 : translateX.value,
               },
             ],
     };

--- a/packages/react-native-tab-view/src/types.tsx
+++ b/packages/react-native-tab-view/src/types.tsx
@@ -1,6 +1,8 @@
 import type { Animated } from 'react-native';
 import type { PagerViewProps } from 'react-native-pager-view';
 
+export type LocaleDirection = 'ltr' | 'rtl';
+
 export type Route = {
   key: string;
   icon?: string;

--- a/packages/stack/src/TransitionConfigs/HeaderStyleInterpolators.tsx
+++ b/packages/stack/src/TransitionConfigs/HeaderStyleInterpolators.tsx
@@ -1,11 +1,11 @@
-import { Animated, I18nManager } from 'react-native';
+import { Animated } from 'react-native';
 
 import type {
   StackHeaderInterpolatedStyle,
   StackHeaderInterpolationProps,
 } from '../types';
 
-const { add } = Animated;
+const { add, multiply } = Animated;
 
 /**
  * Standard UIKit style animation for the header where the title fades into the back button label.
@@ -13,6 +13,7 @@ const { add } = Animated;
 export function forUIKit({
   current,
   next,
+  direction,
   layouts,
 }: StackHeaderInterpolationProps): StackHeaderInterpolatedStyle {
   const defaultOffset = 100;
@@ -33,6 +34,8 @@ export function forUIKit({
   // When the current title is animating to right, it is centered in the right half of screen in middle of transition
   // The back title also animates in from this position
   const rightOffset = layouts.screen.width / 4;
+
+  const multiplier = direction === 'rtl' ? -1 : 1;
 
   const progress = add(
     current.progress.interpolate({
@@ -59,12 +62,13 @@ export function forUIKit({
     leftLabelStyle: {
       transform: [
         {
-          translateX: progress.interpolate({
-            inputRange: [0, 1, 2],
-            outputRange: I18nManager.getConstants().isRTL
-              ? [-rightOffset, 0, leftLabelOffset]
-              : [leftLabelOffset, 0, -rightOffset],
-          }),
+          translateX: multiply(
+            multiplier,
+            progress.interpolate({
+              inputRange: [0, 1, 2],
+              outputRange: [leftLabelOffset, 0, -rightOffset],
+            })
+          ),
         },
       ],
     },
@@ -81,24 +85,26 @@ export function forUIKit({
       }),
       transform: [
         {
-          translateX: progress.interpolate({
-            inputRange: [0.5, 1, 2],
-            outputRange: I18nManager.getConstants().isRTL
-              ? [-titleLeftOffset, 0, rightOffset]
-              : [rightOffset, 0, -titleLeftOffset],
-          }),
+          translateX: multiply(
+            multiplier,
+            progress.interpolate({
+              inputRange: [0.5, 1, 2],
+              outputRange: [rightOffset, 0, -titleLeftOffset],
+            })
+          ),
         },
       ],
     },
     backgroundStyle: {
       transform: [
         {
-          translateX: progress.interpolate({
-            inputRange: [0, 1, 2],
-            outputRange: I18nManager.getConstants().isRTL
-              ? [-layouts.screen.width, 0, layouts.screen.width]
-              : [layouts.screen.width, 0, -layouts.screen.width],
-          }),
+          translateX: multiply(
+            multiplier,
+            progress.interpolate({
+              inputRange: [0, 1, 2],
+              outputRange: [layouts.screen.width, 0, -layouts.screen.width],
+            })
+          ),
         },
       ],
     },
@@ -151,8 +157,10 @@ export function forFade({
 export function forSlideLeft({
   current,
   next,
+  direction,
   layouts: { screen },
 }: StackHeaderInterpolationProps): StackHeaderInterpolatedStyle {
+  const isRTL = direction === 'rtl';
   const progress = add(
     current.progress.interpolate({
       inputRange: [0, 1],
@@ -170,7 +178,7 @@ export function forSlideLeft({
 
   const translateX = progress.interpolate({
     inputRange: [0, 1, 2],
-    outputRange: I18nManager.getConstants().isRTL
+    outputRange: isRTL
       ? [-screen.width, 0, screen.width]
       : [screen.width, 0, -screen.width],
   });
@@ -191,8 +199,10 @@ export function forSlideLeft({
 export function forSlideRight({
   current,
   next,
+  direction,
   layouts: { screen },
 }: StackHeaderInterpolationProps): StackHeaderInterpolatedStyle {
+  const isRTL = direction === 'rtl';
   const progress = add(
     current.progress.interpolate({
       inputRange: [0, 1],
@@ -210,7 +220,7 @@ export function forSlideRight({
 
   const translateX = progress.interpolate({
     inputRange: [0, 1, 2],
-    outputRange: I18nManager.getConstants().isRTL
+    outputRange: isRTL
       ? [screen.width, 0, -screen.width]
       : [-screen.width, 0, screen.width],
   });

--- a/packages/stack/src/navigators/createStackNavigator.tsx
+++ b/packages/stack/src/navigators/createStackNavigator.tsx
@@ -8,6 +8,7 @@ import {
   StackNavigationState,
   StackRouter,
   StackRouterOptions,
+  useLocale,
   useNavigationBuilder,
 } from '@react-navigation/native';
 import * as React from 'react';
@@ -36,6 +37,7 @@ function StackNavigator({
   screenOptions,
   ...rest
 }: Props) {
+  const { direction } = useLocale();
   const { state, descriptors, navigation, NavigationContent } =
     useNavigationBuilder<
       StackNavigationState<ParamListBase>,
@@ -81,6 +83,7 @@ function StackNavigator({
     <NavigationContent>
       <StackView
         {...rest}
+        direction={direction}
         state={state}
         descriptors={descriptors}
         navigation={navigation}

--- a/packages/stack/src/types.tsx
+++ b/packages/stack/src/types.tsx
@@ -7,6 +7,7 @@ import type {
 } from '@react-navigation/elements';
 import type {
   Descriptor,
+  LocaleDirection,
   NavigationHelpers,
   NavigationProp,
   ParamListBase,
@@ -468,6 +469,10 @@ export type StackHeaderInterpolationProps = {
      */
     progress: Animated.AnimatedInterpolation<number>;
   };
+  /**
+   * Writing direction of the layout.
+   */
+  direction: LocaleDirection;
   /**
    * Layout measurements for various items we use for animation.
    */

--- a/packages/stack/src/utils/getDistanceForDirection.tsx
+++ b/packages/stack/src/utils/getDistanceForDirection.tsx
@@ -3,9 +3,10 @@ import { getInvertedMultiplier } from './getInvertedMultiplier';
 
 export function getDistanceForDirection(
   layout: Layout,
-  gestureDirection: GestureDirection
+  gestureDirection: GestureDirection,
+  isRTL: boolean
 ): number {
-  const multiplier = getInvertedMultiplier(gestureDirection);
+  const multiplier = getInvertedMultiplier(gestureDirection, isRTL);
 
   switch (gestureDirection) {
     case 'vertical':

--- a/packages/stack/src/utils/getInvertedMultiplier.tsx
+++ b/packages/stack/src/utils/getInvertedMultiplier.tsx
@@ -1,9 +1,8 @@
-import { I18nManager } from 'react-native';
-
 import type { GestureDirection } from '../types';
 
 export function getInvertedMultiplier(
-  gestureDirection: GestureDirection
+  gestureDirection: GestureDirection,
+  isRTL: boolean
 ): 1 | -1 {
   switch (gestureDirection) {
     case 'vertical':
@@ -11,8 +10,8 @@ export function getInvertedMultiplier(
     case 'vertical-inverted':
       return -1;
     case 'horizontal':
-      return I18nManager.getConstants().isRTL ? -1 : 1;
+      return isRTL ? -1 : 1;
     case 'horizontal-inverted':
-      return I18nManager.getConstants().isRTL ? 1 : -1;
+      return isRTL ? 1 : -1;
   }
 }

--- a/packages/stack/src/views/Header/HeaderSegment.tsx
+++ b/packages/stack/src/views/Header/HeaderSegment.tsx
@@ -5,6 +5,7 @@ import {
   HeaderBackButtonProps,
   HeaderTitle,
 } from '@react-navigation/elements';
+import { useLocale } from '@react-navigation/native';
 import * as React from 'react';
 import {
   Animated,
@@ -33,6 +34,8 @@ type Props = Omit<StackHeaderOptions, 'headerStatusBarHeight'> & {
 };
 
 export function HeaderSegment(props: Props) {
+  const { direction } = useLocale();
+
   const [leftLabelLayout, setLeftLabelLayout] = React.useState<
     Layout | undefined
   >(undefined);
@@ -84,6 +87,7 @@ export function HeaderSegment(props: Props) {
       styleInterpolator({
         current: { progress: current },
         next: next && { progress: next },
+        direction,
         layouts: {
           header: {
             height: headerHeight,

--- a/packages/stack/src/views/Stack/Card.tsx
+++ b/packages/stack/src/views/Stack/Card.tsx
@@ -1,3 +1,4 @@
+import type { LocaleDirection } from '@react-navigation/native';
 import Color from 'color';
 import * as React from 'react';
 import {
@@ -40,6 +41,7 @@ type Props = ViewProps & {
   gesture: Animated.Value;
   layout: Layout;
   insets: EdgeInsets;
+  direction: LocaleDirection;
   headerDarkContent: boolean | undefined;
   pageOverflowEnabled: boolean;
   gestureDirection: GestureDirection;
@@ -110,7 +112,7 @@ export class Card extends React.Component<Props> {
   }
 
   componentDidUpdate(prevProps: Props) {
-    const { layout, gestureDirection, closing } = this.props;
+    const { direction, layout, gestureDirection, closing } = this.props;
     const { width, height } = layout;
 
     if (width !== prevProps.layout.width) {
@@ -122,7 +124,9 @@ export class Card extends React.Component<Props> {
     }
 
     if (gestureDirection !== prevProps.gestureDirection) {
-      this.inverted.setValue(getInvertedMultiplier(gestureDirection));
+      this.inverted.setValue(
+        getInvertedMultiplier(gestureDirection, direction === 'rtl')
+      );
     }
 
     const toValue = this.getAnimateToValue(this.props);
@@ -151,7 +155,10 @@ export class Card extends React.Component<Props> {
   private isClosing = new Animated.Value(FALSE);
 
   private inverted = new Animated.Value(
-    getInvertedMultiplier(this.props.gestureDirection)
+    getInvertedMultiplier(
+      this.props.gestureDirection,
+      this.props.direction === 'rtl'
+    )
   );
 
   private layout = {
@@ -227,16 +234,22 @@ export class Card extends React.Component<Props> {
     closing,
     layout,
     gestureDirection,
+    direction,
   }: {
     closing?: boolean;
     layout: Layout;
     gestureDirection: GestureDirection;
+    direction: LocaleDirection;
   }) => {
     if (!closing) {
       return 0;
     }
 
-    return getDistanceForDirection(layout, gestureDirection);
+    return getDistanceForDirection(
+      layout,
+      gestureDirection,
+      direction === 'rtl'
+    );
   };
 
   private setPointerEventsEnabled = (enabled: boolean) => {
@@ -262,6 +275,7 @@ export class Card extends React.Component<Props> {
     nativeEvent,
   }: PanGestureHandlerGestureEvent) => {
     const {
+      direction,
       layout,
       onClose,
       onGestureBegin,
@@ -314,7 +328,7 @@ export class Card extends React.Component<Props> {
 
         const closing =
           (translation + velocity * gestureVelocityImpact) *
-            getInvertedMultiplier(gestureDirection) >
+            getInvertedMultiplier(gestureDirection, direction === 'rtl') >
           distance / 2
             ? velocity !== 0 || translation !== 0
             : this.props.closing;
@@ -378,7 +392,8 @@ export class Card extends React.Component<Props> {
   );
 
   private gestureActivationCriteria() {
-    const { layout, gestureDirection, gestureResponseDistance } = this.props;
+    const { direction, layout, gestureDirection, gestureResponseDistance } =
+      this.props;
     const enableTrackpadTwoFingerGesture = true;
 
     const distance =
@@ -405,7 +420,10 @@ export class Card extends React.Component<Props> {
       };
     } else {
       const hitSlop = -layout.width + distance;
-      const invertedMultiplier = getInvertedMultiplier(gestureDirection);
+      const invertedMultiplier = getInvertedMultiplier(
+        gestureDirection,
+        direction === 'rtl'
+      );
 
       if (invertedMultiplier === 1) {
         return {

--- a/packages/stack/src/views/Stack/Card.tsx
+++ b/packages/stack/src/views/Stack/Card.tsx
@@ -464,6 +464,19 @@ export class Card extends React.Component<Props> {
       children,
       containerStyle: customContainerStyle,
       contentStyle,
+      /* eslint-disable @typescript-eslint/no-unused-vars */
+      closing,
+      direction,
+      gestureResponseDistance,
+      gestureVelocityImpact,
+      onClose,
+      onGestureBegin,
+      onGestureCanceled,
+      onGestureEnd,
+      onOpen,
+      onTransition,
+      transitionSpec,
+      /* eslint-enable @typescript-eslint/no-unused-vars */
       ...rest
     } = this.props;
 

--- a/packages/stack/src/views/Stack/CardContainer.tsx
+++ b/packages/stack/src/views/Stack/CardContainer.tsx
@@ -4,7 +4,7 @@ import {
   HeaderHeightContext,
   HeaderShownContext,
 } from '@react-navigation/elements';
-import { Route, useTheme } from '@react-navigation/native';
+import { Route, useLocale, useTheme } from '@react-navigation/native';
 import * as React from 'react';
 import { Animated, StyleSheet, View } from 'react-native';
 
@@ -89,6 +89,8 @@ function CardContainerInner({
   safeAreaInsetTop,
   scene,
 }: Props) {
+  const { direction } = useLocale();
+
   const parentHeaderHeight = React.useContext(HeaderHeightContext);
 
   const { onPageChangeStart, onPageChangeCancel, onPageChangeConfirm } =
@@ -221,6 +223,7 @@ function CardContainerInner({
       gestureDirection={gestureDirection}
       layout={layout}
       insets={insets}
+      direction={direction}
       gesture={gesture}
       current={scene.progress.current}
       next={scene.progress.next}

--- a/packages/stack/src/views/Stack/CardStack.tsx
+++ b/packages/stack/src/views/Stack/CardStack.tsx
@@ -4,6 +4,7 @@ import {
   SafeAreaProviderCompat,
 } from '@react-navigation/elements';
 import type {
+  LocaleDirection,
   ParamListBase,
   Route,
   StackNavigationState,
@@ -47,6 +48,8 @@ type GestureValues = {
 };
 
 type Props = {
+  // eslint-disable-next-line react/no-unused-prop-types
+  direction: LocaleDirection;
   insets: EdgeInsets;
   state: StackNavigationState<ParamListBase>;
   descriptors: StackDescriptorMap;
@@ -162,7 +165,8 @@ const getHeaderHeights = (
 
 const getDistanceFromOptions = (
   layout: Layout,
-  descriptor?: StackDescriptor
+  descriptor: StackDescriptor,
+  isRTL: boolean
 ) => {
   const {
     presentation,
@@ -171,13 +175,14 @@ const getDistanceFromOptions = (
       : DefaultTransition.gestureDirection,
   } = (descriptor?.options || {}) as StackNavigationOptions;
 
-  return getDistanceForDirection(layout, gestureDirection);
+  return getDistanceForDirection(layout, gestureDirection, isRTL);
 };
 
 const getProgressFromGesture = (
   gesture: Animated.Value,
   layout: Layout,
-  descriptor?: StackDescriptor
+  descriptor: StackDescriptor,
+  isRTL: boolean
 ) => {
   const distance = getDistanceFromOptions(
     {
@@ -186,7 +191,8 @@ const getProgressFromGesture = (
       width: Math.max(1, layout.width),
       height: Math.max(1, layout.height),
     },
-    descriptor
+    descriptor,
+    isRTL
   );
 
   if (distance > 0) {
@@ -223,7 +229,11 @@ export class CardStack extends React.Component<Props, State> {
         new Animated.Value(
           props.openingRouteKeys.includes(curr.key) &&
           animationEnabled !== false
-            ? getDistanceFromOptions(state.layout, descriptor)
+            ? getDistanceFromOptions(
+                state.layout,
+                descriptor,
+                props.direction === 'rtl'
+              )
             : 0
         );
 
@@ -304,6 +314,8 @@ export class CardStack extends React.Component<Props, State> {
           ? 'float'
           : 'screen');
 
+      const isRTL = props.direction === 'rtl';
+
       const scene = {
         route,
         descriptor: {
@@ -324,7 +336,8 @@ export class CardStack extends React.Component<Props, State> {
           current: getProgressFromGesture(
             currentGesture,
             state.layout,
-            descriptor
+            descriptor,
+            isRTL
           ),
           next:
             nextGesture &&
@@ -332,14 +345,16 @@ export class CardStack extends React.Component<Props, State> {
               ? getProgressFromGesture(
                   nextGesture,
                   state.layout,
-                  nextDescriptor
+                  nextDescriptor,
+                  isRTL
                 )
               : undefined,
           previous: previousGesture
             ? getProgressFromGesture(
                 previousGesture,
                 state.layout,
-                previousDescriptor
+                previousDescriptor,
+                isRTL
               )
             : undefined,
         },

--- a/packages/stack/src/views/Stack/StackView.tsx
+++ b/packages/stack/src/views/Stack/StackView.tsx
@@ -4,6 +4,7 @@ import {
 } from '@react-navigation/elements';
 import {
   CommonActions,
+  LocaleDirection,
   ParamListBase,
   Route,
   StackActions,
@@ -11,10 +12,7 @@ import {
 } from '@react-navigation/native';
 import * as React from 'react';
 import { StyleSheet, View } from 'react-native';
-import {
-  EdgeInsets,
-  SafeAreaInsetsContext,
-} from 'react-native-safe-area-context';
+import { SafeAreaInsetsContext } from 'react-native-safe-area-context';
 
 import type {
   StackDescriptorMap,
@@ -30,6 +28,7 @@ import {
 import { CardStack } from './CardStack';
 
 type Props = StackNavigationConfig & {
+  direction: LocaleDirection;
   state: StackNavigationState<ParamListBase>;
   navigation: StackNavigationHelpers;
   descriptors: StackDescriptorMap;
@@ -448,7 +447,7 @@ export class StackView extends React.Component<Props, State> {
                   <HeaderShownContext.Consumer>
                     {(isParentHeaderShown) => (
                       <CardStack
-                        insets={insets as EdgeInsets}
+                        insets={insets!}
                         isParentHeaderShown={isParentHeaderShown}
                         isParentModal={isParentModal}
                         getPreviousRoute={this.getPreviousRoute}


### PR DESCRIPTION
BREAKING CHANGE: Previously the navigators tried to detect RTL automatically and
adjust the UI. However this is problematic since we cannot detect RTL in all cases
(e.g. on Web).

This adds an optional `direction` prop to `NavigationContainer` instead
so that user can specify when React Navigation's UI needs to be adjusted for RTL. It defaults to the value from `I18nManager` on native platforms, however it needs to be explicitly passed for Web.