### PR TITLE
Tabview tabbar horizontal padding for contentContainer

### DIFF
--- a/example/src/Screens/TabView/AutoWidthTabBar.tsx
+++ b/example/src/Screens/TabView/AutoWidthTabBar.tsx
@@ -49,7 +49,7 @@ export const AutoWidthTabBar = () => {
       contentContainerStyle={styles.tabbarContentContainer}
       labelStyle={styles.label}
       tabStyle={styles.tabStyle}
-      gap={40}
+      gap={20}
     />
   );
 
@@ -80,7 +80,7 @@ const styles = StyleSheet.create({
     backgroundColor: '#3f51b5',
   },
   tabbarContentContainer: {
-    paddingHorizontal: 20,
+    paddingHorizontal: 10,
   },
   indicator: {
     backgroundColor: '#ffeb3b',

--- a/example/src/Screens/TabView/AutoWidthTabBar.tsx
+++ b/example/src/Screens/TabView/AutoWidthTabBar.tsx
@@ -46,6 +46,7 @@ export const AutoWidthTabBar = () => {
       scrollEnabled
       indicatorStyle={styles.indicator}
       style={styles.tabbar}
+      contentContainerStyle={styles.tabbarContentContainer}
       labelStyle={styles.label}
       tabStyle={styles.tabStyle}
       gap={40}
@@ -77,6 +78,9 @@ AutoWidthTabBar.options = {
 const styles = StyleSheet.create({
   tabbar: {
     backgroundColor: '#3f51b5',
+  },
+  tabbarContentContainer: {
+    paddingHorizontal: 20,
   },
   indicator: {
     backgroundColor: '#ffeb3b',

--- a/example/src/Screens/TabView/AutoWidthTabBar.tsx
+++ b/example/src/Screens/TabView/AutoWidthTabBar.tsx
@@ -48,6 +48,7 @@ export const AutoWidthTabBar = () => {
       style={styles.tabbar}
       labelStyle={styles.label}
       tabStyle={styles.tabStyle}
+      gap={40}
     />
   );
 

--- a/example/src/Screens/TabView/CustomIndicator.tsx
+++ b/example/src/Screens/TabView/CustomIndicator.tsx
@@ -49,9 +49,11 @@ export const CustomIndicator = () => {
     props: SceneRendererProps & {
       navigationState: State;
       getTabWidth: (i: number) => number;
+      gap?: number;
+      width: number | string | undefined;
     }
   ) => {
-    const { position, navigationState, getTabWidth } = props;
+    const { position, getTabWidth, gap, width } = props;
     const inputRange = [
       0, 0.48, 0.49, 0.51, 0.52, 1, 1.48, 1.49, 1.51, 1.52, 2,
     ];
@@ -73,7 +75,9 @@ export const CustomIndicator = () => {
       inputRange: inputRange,
       outputRange: inputRange.map((x) => {
         const i = Math.round(x);
-        return i * getTabWidth(i) * (I18nManager.isRTL ? -1 : 1);
+        return (
+          (i * getTabWidth(i) + i * (gap ?? 0)) * (I18nManager.isRTL ? -1 : 1)
+        );
       }),
     });
 
@@ -82,7 +86,7 @@ export const CustomIndicator = () => {
         style={[
           styles.container,
           {
-            width: `${100 / navigationState.routes.length}%`,
+            width: width,
             transform: [{ translateX }] as any,
           },
         ]}
@@ -119,6 +123,7 @@ export const CustomIndicator = () => {
         renderBadge={renderBadge}
         renderIndicator={renderIndicator}
         style={styles.tabbar}
+        gap={40}
       />
     </View>
   );

--- a/example/src/Screens/TabView/CustomIndicator.tsx
+++ b/example/src/Screens/TabView/CustomIndicator.tsx
@@ -134,7 +134,7 @@ export const CustomIndicator = () => {
         renderIndicator={renderIndicator}
         style={styles.tabbar}
         contentContainerStyle={styles.tabbarContentContainer}
-        gap={40}
+        gap={20}
       />
     </View>
   );
@@ -168,7 +168,7 @@ const styles = StyleSheet.create({
     overflow: 'hidden',
   },
   tabbarContentContainer: {
-    paddingHorizontal: 20,
+    paddingHorizontal: 10,
   },
   icon: {
     backgroundColor: 'transparent',

--- a/example/src/Screens/TabView/CustomIndicator.tsx
+++ b/example/src/Screens/TabView/CustomIndicator.tsx
@@ -58,7 +58,7 @@ export const CustomIndicator = () => {
       navigationState: State;
       getTabWidth: (i: number) => number;
       gap?: number;
-      width: number | string | undefined;
+      width?: number | string;
       style?: StyleProp<ViewStyle>;
     }
   ) => {

--- a/example/src/Screens/TabView/CustomIndicator.tsx
+++ b/example/src/Screens/TabView/CustomIndicator.tsx
@@ -1,6 +1,14 @@
 import { Ionicons } from '@expo/vector-icons';
 import * as React from 'react';
-import { Animated, I18nManager, StyleSheet, Text, View } from 'react-native';
+import {
+  Animated,
+  I18nManager,
+  StyleProp,
+  StyleSheet,
+  Text,
+  View,
+  ViewStyle,
+} from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
   NavigationState,
@@ -51,9 +59,10 @@ export const CustomIndicator = () => {
       getTabWidth: (i: number) => number;
       gap?: number;
       width: number | string | undefined;
+      style?: StyleProp<ViewStyle>;
     }
   ) => {
-    const { position, getTabWidth, gap, width } = props;
+    const { position, getTabWidth, gap, width, style } = props;
     const inputRange = [
       0, 0.48, 0.49, 0.51, 0.52, 1, 1.48, 1.49, 1.51, 1.52, 2,
     ];
@@ -84,6 +93,7 @@ export const CustomIndicator = () => {
     return (
       <Animated.View
         style={[
+          style,
           styles.container,
           {
             width: width,
@@ -123,6 +133,7 @@ export const CustomIndicator = () => {
         renderBadge={renderBadge}
         renderIndicator={renderIndicator}
         style={styles.tabbar}
+        contentContainerStyle={styles.tabbarContentContainer}
         gap={40}
       />
     </View>
@@ -155,6 +166,9 @@ const styles = StyleSheet.create({
   tabbar: {
     backgroundColor: '#263238',
     overflow: 'hidden',
+  },
+  tabbarContentContainer: {
+    paddingHorizontal: 20,
   },
   icon: {
     backgroundColor: 'transparent',

--- a/example/src/Screens/TabView/ScrollableTabBar.tsx
+++ b/example/src/Screens/TabView/ScrollableTabBar.tsx
@@ -44,6 +44,7 @@ export const ScrollableTabBar = () => {
       style={styles.tabbar}
       tabStyle={styles.tab}
       labelStyle={styles.label}
+      gap={40}
     />
   );
 

--- a/example/src/Screens/TabView/ScrollableTabBar.tsx
+++ b/example/src/Screens/TabView/ScrollableTabBar.tsx
@@ -42,6 +42,7 @@ export const ScrollableTabBar = () => {
       scrollEnabled
       indicatorStyle={styles.indicator}
       style={styles.tabbar}
+      contentContainerStyle={styles.tabbarContentContainer}
       tabStyle={styles.tab}
       labelStyle={styles.label}
       gap={40}
@@ -74,6 +75,9 @@ ScrollableTabBar.options = {
 const styles = StyleSheet.create({
   tabbar: {
     backgroundColor: '#3f51b5',
+  },
+  tabbarContentContainer: {
+    paddingHorizontal: 20,
   },
   tab: {
     width: 120,

--- a/example/src/Screens/TabView/ScrollableTabBar.tsx
+++ b/example/src/Screens/TabView/ScrollableTabBar.tsx
@@ -45,7 +45,7 @@ export const ScrollableTabBar = () => {
       contentContainerStyle={styles.tabbarContentContainer}
       tabStyle={styles.tab}
       labelStyle={styles.label}
-      gap={40}
+      gap={20}
     />
   );
 
@@ -77,7 +77,7 @@ const styles = StyleSheet.create({
     backgroundColor: '#3f51b5',
   },
   tabbarContentContainer: {
-    paddingHorizontal: 20,
+    paddingHorizontal: 10,
   },
   tab: {
     width: 120,

--- a/example/src/Screens/TabView/TabBarIcon.tsx
+++ b/example/src/Screens/TabView/TabBarIcon.tsx
@@ -46,6 +46,7 @@ export const TabBarIcon = () => {
       indicatorStyle={styles.indicator}
       renderIcon={renderIcon}
       style={styles.tabbar}
+      contentContainerStyle={styles.tabbarContentContainer}
       gap={40}
     />
   );
@@ -76,6 +77,9 @@ TabBarIcon.options = {
 const styles = StyleSheet.create({
   tabbar: {
     backgroundColor: '#e91e63',
+  },
+  tabbarContentContainer: {
+    paddingHorizontal: '15%',
   },
   indicator: {
     backgroundColor: '#ffeb3b',

--- a/example/src/Screens/TabView/TabBarIcon.tsx
+++ b/example/src/Screens/TabView/TabBarIcon.tsx
@@ -47,7 +47,7 @@ export const TabBarIcon = () => {
       renderIcon={renderIcon}
       style={styles.tabbar}
       contentContainerStyle={styles.tabbarContentContainer}
-      gap={40}
+      gap={20}
     />
   );
 
@@ -79,7 +79,7 @@ const styles = StyleSheet.create({
     backgroundColor: '#e91e63',
   },
   tabbarContentContainer: {
-    paddingHorizontal: '15%',
+    paddingHorizontal: '10%',
   },
   indicator: {
     backgroundColor: '#ffeb3b',

--- a/example/src/Screens/TabView/TabBarIcon.tsx
+++ b/example/src/Screens/TabView/TabBarIcon.tsx
@@ -46,6 +46,7 @@ export const TabBarIcon = () => {
       indicatorStyle={styles.indicator}
       renderIcon={renderIcon}
       style={styles.tabbar}
+      gap={40}
     />
   );
 

--- a/packages/react-native-tab-view/src/TabBar.tsx
+++ b/packages/react-native-tab-view/src/TabBar.tsx
@@ -579,7 +579,7 @@ export function TabBar<T extends Route>({
   const contentContainerStyleMemoized = React.useMemo(
     () => [
       styles.tabContent,
-      scrollEnabled ? { width: tabBarWidth } : styles.container,
+      scrollEnabled ? { width: tabBarWidth } : null,
       contentContainerStyle,
     ],
     [contentContainerStyle, scrollEnabled, tabBarWidth]
@@ -690,9 +690,6 @@ export function TabBar<T extends Route>({
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-  },
   scroll: {
     overflow: Platform.select({ default: 'scroll', web: undefined }),
   },
@@ -709,6 +706,7 @@ const styles = StyleSheet.create({
     zIndex: 1,
   },
   tabContent: {
+    flexGrow: 1,
     flexDirection: 'row',
     flexWrap: 'nowrap',
   },

--- a/packages/react-native-tab-view/src/TabBar.tsx
+++ b/packages/react-native-tab-view/src/TabBar.tsx
@@ -359,10 +359,13 @@ export function TabBar<T extends Route>({
   renderTabBarItem,
   style,
   tabStyle,
+  layout: propLayout,
   testID,
   android_ripple,
 }: Props<T>) {
-  const [layout, setLayout] = React.useState<Layout>({ width: 0, height: 0 });
+  const [layout, setLayout] = React.useState<Layout>(
+    propLayout ?? { width: 0, height: 0 }
+  );
   const [tabWidths, setTabWidths] = React.useState<Record<string, number>>({});
   const flatListRef = React.useRef<FlatList | null>(null);
   const isFirst = React.useRef(true);

--- a/packages/react-native-tab-view/src/TabBar.tsx
+++ b/packages/react-native-tab-view/src/TabBar.tsx
@@ -126,7 +126,7 @@ const getComputedTabWidth = (
   flattenedWidth: FlattenedTabWidth,
   flattenedPaddingLeft: FlattenedTabPadding,
   flattenedPaddingRight: FlattenedTabPadding,
-  gap: number | undefined
+  gap?: number
 ) => {
   if (flattenedWidth === 'auto') {
     return tabWidths[routes[index].key] || 0;

--- a/packages/react-native-tab-view/src/TabBarIndicator.tsx
+++ b/packages/react-native-tab-view/src/TabBarIndicator.tsx
@@ -116,7 +116,7 @@ export function TabBarIndicator<T extends Route>({
               })
             : outputRange[0],
       },
-      { translateX: 0.5 }
+      { translateX: I18nManager.isRTL ? -0.5 : 0.5 }
     );
   }
 


### PR DESCRIPTION
Use `padding(Horizontal|Left|Right)` values on `contentContainerStyle` for better styling on TabBar in `react-native-tab-view`

**Motivation**

Useful to create a custom style or adding insets values on left and right padding on contentContainer.
Use case is similar to existing `gap` prop (that I also fixed in this PR)

It's also fix #8667 

**Test plan**

I use TabViews existing examples, I adding `gap` and `contentContainerStyle` `paddingHorizontal` to AutoWidthTabBar, CustomIndicator, ScrollableTabBar and TabBarIcon.
