### PR TITLE
fix: remove NonNullable to fix recursive infer in PathConfigMap

### DIFF
--- a/example/__typechecks__/common.check.tsx
+++ b/example/__typechecks__/common.check.tsx
@@ -8,11 +8,12 @@ import type {
   DrawerNavigationOptions,
   DrawerScreenProps,
 } from '@react-navigation/drawer';
-import type {
-  CompositeScreenProps,
-  NavigationAction,
-  NavigationHelpers,
-  NavigatorScreenParams,
+import {
+  type CompositeScreenProps,
+  type LinkingOptions,
+  type NavigationAction,
+  type NavigationHelpers,
+  type NavigatorScreenParams,
 } from '@react-navigation/native';
 import {
   createStackNavigator,
@@ -498,3 +499,34 @@ const FourthStack = createStackNavigator<FourthParamList, 'MyID'>();
 expectTypeOf(FourthStack.Navigator).parameter(0).toMatchTypeOf<{
   id: 'MyID';
 }>();
+
+/**
+ * Infer correct LinkingOptions
+ */
+export const linkingOptions: LinkingOptions<RootStackParamList> = {
+  prefixes: ['reactnavigation://'],
+  config: {
+    screens: {
+      Home: {
+        screens: {
+          Feed: {
+            screens: {
+              Popular: 'popular',
+              Latest: 'latest',
+              // @ts-expect-error "NonExistingRoute" does not exist in the FeedTabParamList
+              NonExistingRoute: 'non-existing',
+            },
+          },
+          Account: 'account',
+        },
+      },
+      PostDetails: 'post/:id',
+      Login: {
+        path: 'login',
+        // @ts-expect-error The Login route is not a nested navigator and should not have a screens object
+        screens: {},
+      },
+      NotFound: '*',
+    },
+  },
+};

--- a/example/src/Screens/NotFound.tsx
+++ b/example/src/Screens/NotFound.tsx
@@ -14,7 +14,7 @@ export const NotFound = ({
       <Text style={styles.title}>404 Not Found ({route.path})</Text>
       <Button
         variant="filled"
-        onPress={() => navigation.navigate('Home')}
+        onPress={() => navigation.navigate('Home', { screen: 'Examples' })}
         style={styles.button}
       >
         Go to home

--- a/example/src/screens.tsx
+++ b/example/src/screens.tsx
@@ -76,7 +76,7 @@ export type RootDrawerParamList = {
 };
 
 export type RootStackParamList = ExampleScreensParamList & {
-  Home: NavigatorScreenParams<RootDrawerParamList> | undefined;
+  Home: NavigatorScreenParams<RootDrawerParamList>;
   NotFound: undefined;
 };
 

--- a/packages/core/src/types.tsx
+++ b/packages/core/src/types.tsx
@@ -1005,9 +1005,9 @@ export type PathConfig<ParamList extends {}> = {
 };
 
 export type PathConfigMap<ParamList extends {}> = {
-  [RouteName in keyof ParamList]?: NonNullable<
-    ParamList[RouteName]
-  > extends NavigatorScreenParams<infer T extends {}>
+  [RouteName in keyof ParamList]?: ParamList[RouteName] extends NavigatorScreenParams<
+    infer T
+  >
     ? string | PathConfig<T>
     : string | Omit<PathConfig<{}>, 'screens' | 'initialRouteName'>;
 };


### PR DESCRIPTION
**Motivation**

Fixes https://github.com/react-navigation/react-navigation/issues/10876 and https://github.com/react-navigation/react-navigation/issues/9897

**Test plan**

This change breaks typescript in the example app because the linking config does not match how all the navigators is setup. This wasn't catched before because of this bug in the `PathConfigMap` type. For example we are configuring a link to the `Chat` screen inside `NativeStack` ([with the path "native-stack/chat"](https://github.com/react-navigation/react-navigation/blob/main/example/src/index.tsx#L178)) but the `Chat` route isn't configured in the `NativeStack` navigator: https://github.com/react-navigation/react-navigation/blob/main/example/src/Screens/NativeStack.tsx#L15

I will happily fix this but wanted some feedback on the actual change to `PathConfigMap` first before putting in the hour(s) to fix the example project. 

Also I would like some feedback on how we would like to change the example project. Should all the routes "Article", "Albums", "Chat", "Contacts", "NewsFeed" and "Dialog" exist in every navigator? Or should just the linking config match how each individual navigator is setup? This would probably mean that we cannot reduce all SCREEN_NAMES to create the config because all navigators have different param lists.

I also have a fix for the 6.x branch: https://github.com/react-navigation/react-navigation/compare/6.x...johankasperi:react-navigation:fix-pathconfig-recursive-infer?expand=1