### PR TITLE
fix: Added dependency array for react native web project (crashing react native reanimated 3.X)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,7 +27,13 @@
   "rules": {
     "import/no-default-export": "error",
     "simple-import-sort/imports": "error",
-    "simple-import-sort/exports": "error"
+    "simple-import-sort/exports": "error",
+    "react-hooks/exhaustive-deps": [
+      "warn",
+      {
+        "additionalHooks": "(useAnimatedStyle|useAnimatedProps|useDerivedValue)"
+      }
+    ]
   },
   "overrides": [{
     "files":["example/e2e/tests/*.ts"],

--- a/example/src/Screens/DrawerView.tsx
+++ b/example/src/Screens/DrawerView.tsx
@@ -19,7 +19,7 @@ const RealDrawer = () => {
         },
       ],
     };
-  });
+  }, [progress]);
 
   return (
     <View style={styles.realDrawerWrapper}>

--- a/packages/react-native-drawer-layout/src/views/modern/Drawer.tsx
+++ b/packages/react-native-drawer-layout/src/views/modern/Drawer.tsx
@@ -310,7 +310,7 @@ export function Drawer({
         : minmax(translationX.value - touchDistance, 0, drawerWidth);
 
     return translateX;
-  });
+  }, [touchStartX, drawerWidth, gestureState, drawerPosition, translationX]);
 
   const isRTL = I18nManager.getConstants().isRTL;
   const drawerAnimatedStyle = useAnimatedStyle(() => {

--- a/packages/react-native-drawer-layout/src/views/modern/Drawer.tsx
+++ b/packages/react-native-drawer-layout/src/views/modern/Drawer.tsx
@@ -367,7 +367,7 @@ export function Drawer({
           [getDrawerTranslationX(false), getDrawerTranslationX(true)],
           [0, 1]
         );
-  });
+  }, [translateX, drawerType]);
 
   return (
     <DrawerProgressContext.Provider value={progress}>

--- a/packages/react-native-drawer-layout/src/views/modern/Drawer.tsx
+++ b/packages/react-native-drawer-layout/src/views/modern/Drawer.tsx
@@ -310,7 +310,16 @@ export function Drawer({
         : minmax(translationX.value - touchDistance, 0, drawerWidth);
 
     return translateX;
-  }, [touchStartX, drawerWidth, gestureState, drawerPosition, translationX]);
+  }, [
+    drawerType,
+    gestureState,
+    minmax,
+    drawerPosition,
+    touchStartX,
+    drawerWidth,
+    layout,
+    translationX,
+  ]);
 
   const isRTL = I18nManager.getConstants().isRTL;
   const drawerAnimatedStyle = useAnimatedStyle(() => {
@@ -337,7 +346,7 @@ export function Drawer({
               },
             ],
     };
-  }, [touchStartX, drawerWidth, gestureState, drawerPosition, translationX]);
+  }, [layout, drawerWidth, drawerType, translateX, drawerPosition, isRTL]);
 
   const contentAnimatedStyle = useAnimatedStyle(() => {
     return {
@@ -357,7 +366,7 @@ export function Drawer({
               },
             ],
     };
-  }, [touchStartX, drawerWidth, gestureState, drawerPosition, translationX]);
+  }, [drawerType, translateX, drawerWidth, drawerPosition]);
 
   const progress = useDerivedValue(() => {
     return drawerType === 'permanent'
@@ -367,7 +376,7 @@ export function Drawer({
           [getDrawerTranslationX(false), getDrawerTranslationX(true)],
           [0, 1]
         );
-  }, [translateX, drawerType]);
+  }, [drawerType, interpolate, translateX, getDrawerTranslationX]);
 
   return (
     <DrawerProgressContext.Provider value={progress}>

--- a/packages/react-native-drawer-layout/src/views/modern/Drawer.tsx
+++ b/packages/react-native-drawer-layout/src/views/modern/Drawer.tsx
@@ -337,7 +337,7 @@ export function Drawer({
               },
             ],
     };
-  });
+  }, [touchStartX, drawerWidth, gestureState, drawerPosition, translationX]);
 
   const contentAnimatedStyle = useAnimatedStyle(() => {
     return {
@@ -357,7 +357,7 @@ export function Drawer({
               },
             ],
     };
-  });
+  }, [touchStartX, drawerWidth, gestureState, drawerPosition, translationX]);
 
   const progress = useDerivedValue(() => {
     return drawerType === 'permanent'

--- a/packages/react-native-drawer-layout/src/views/modern/Overlay.tsx
+++ b/packages/react-native-drawer-layout/src/views/modern/Overlay.tsx
@@ -30,7 +30,7 @@ export const Overlay = React.forwardRef(function Overlay(
       // We can send the overlay behind the screen to avoid it
       zIndex: progress.value > PROGRESS_EPSILON ? 0 : -1,
     };
-  });
+  }, [progress.value, PROGRESS_EPSILON]);
 
   const animatedProps = useAnimatedProps(() => {
     const active = progress.value > PROGRESS_EPSILON;
@@ -40,7 +40,7 @@ export const Overlay = React.forwardRef(function Overlay(
       accessibilityElementsHidden: !active,
       importantForAccessibility: active ? 'auto' : 'no-hide-descendants',
     } as const;
-  });
+  }, [progress.value, PROGRESS_EPSILON]);
 
   return (
     <Animated.View

--- a/packages/react-native-drawer-layout/src/views/modern/Overlay.tsx
+++ b/packages/react-native-drawer-layout/src/views/modern/Overlay.tsx
@@ -30,7 +30,7 @@ export const Overlay = React.forwardRef(function Overlay(
       // We can send the overlay behind the screen to avoid it
       zIndex: progress.value > PROGRESS_EPSILON ? 0 : -1,
     };
-  }, [progress.value, PROGRESS_EPSILON]);
+  }, [progress, PROGRESS_EPSILON]);
 
   const animatedProps = useAnimatedProps(() => {
     const active = progress.value > PROGRESS_EPSILON;
@@ -40,7 +40,7 @@ export const Overlay = React.forwardRef(function Overlay(
       accessibilityElementsHidden: !active,
       importantForAccessibility: active ? 'auto' : 'no-hide-descendants',
     } as const;
-  }, [progress.value, PROGRESS_EPSILON]);
+  }, [progress, PROGRESS_EPSILON]);
 
   return (
     <Animated.View


### PR DESCRIPTION
Please provide enough information so that others can review your pull request.

**Motivation**

Explain the **motivation** for making this change. What existing problem does the pull request solve?
I need to use react native reanimated v3 and I am facing the following issue on react native web.

https://github.com/react-navigation/react-navigation/issues/11483

If this pull request addresses an existing issue, link to the issue. If an issue is not present, describe the issue here.

https://github.com/react-navigation/react-navigation/issues/11483

**Test plan**
Describe the **steps to test this change** so that a reviewer can verify it. Provide screenshots or videos if the change affects UI.
Make sure the drawer works on react native web using react native reanimated v3.4.0

The change must pass lint, typescript and tests.
