### PR TITLE
[WIP] Support embedding into existing website

### DIFF
--- a/packages/drawer/src/views/DrawerView.tsx
+++ b/packages/drawer/src/views/DrawerView.tsx
@@ -247,6 +247,7 @@ function DrawerViewBase({
                   ...StyleSheet.absoluteFillObject,
                   position: 'relative',
                   zIndex: isFocused ? 0 : -1,
+                  maxHeight: '100vh', // so that drawer's content is scrollable
                 },
               ]}
               visible={isFocused}

--- a/packages/drawer/src/views/DrawerView.tsx
+++ b/packages/drawer/src/views/DrawerView.tsx
@@ -242,7 +242,13 @@ function DrawerViewBase({
           return (
             <MaybeScreen
               key={route.key}
-              style={[StyleSheet.absoluteFill, { zIndex: isFocused ? 0 : -1 }]}
+              style={[
+                {
+                  ...StyleSheet.absoluteFillObject,
+                  position: 'relative',
+                  zIndex: isFocused ? 0 : -1,
+                },
+              ]}
               visible={isFocused}
               enabled={detachInactiveScreens}
               freezeOnBlur={freezeOnBlur}

--- a/packages/elements/src/Screen.tsx
+++ b/packages/elements/src/Screen.tsx
@@ -80,7 +80,7 @@ export function Screen(props: Props) {
 
                 setHeaderHeight(height);
               }}
-              style={headerTransparent ? styles.absolute : null}
+              style={headerTransparent ? styles.absolute : styles.sticky}
             >
               {header}
             </View>
@@ -102,6 +102,12 @@ const styles = StyleSheet.create({
   },
   absolute: {
     position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+  },
+  sticky: {
+    position: 'sticky' as any,
     top: 0,
     left: 0,
     right: 0,

--- a/packages/native-stack/src/views/NativeStackView.tsx
+++ b/packages/native-stack/src/views/NativeStackView.tsx
@@ -152,8 +152,9 @@ export function NativeStackView({ state, descriptors }: Props) {
                 )
               }
               style={[
-                StyleSheet.absoluteFill,
                 {
+                  ...StyleSheet.absoluteFillObject,
+                  position: 'relative',
                   display:
                     isFocused ||
                     (nextPresentation != null &&

--- a/packages/stack/src/views/Header/HeaderContainer.tsx
+++ b/packages/stack/src/views/Header/HeaderContainer.tsx
@@ -49,7 +49,7 @@ export function HeaderContainer({
   const parentHeaderBack = React.useContext(HeaderBackContext);
 
   return (
-    <Animated.View pointerEvents="box-none" style={style}>
+    <Animated.View pointerEvents="box-none" style={[styles.sticky, style]}>
       {scenes.slice(-3).map((scene, i, self) => {
         if ((mode === 'screen' && i !== self.length - 1) || !scene) {
           return null;
@@ -179,6 +179,12 @@ export function HeaderContainer({
 const styles = StyleSheet.create({
   header: {
     position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+  },
+  sticky: {
+    position: 'sticky' as any,
     top: 0,
     left: 0,
     right: 0,

--- a/packages/stack/src/views/Stack/CardContainer.tsx
+++ b/packages/stack/src/views/Stack/CardContainer.tsx
@@ -272,8 +272,9 @@ function CardContainerInner({
             !focused
               ? 'none'
               : 'flex',
+          ...StyleSheet.absoluteFillObject,
+          position: 'relative',
         },
-        StyleSheet.absoluteFill,
       ]}
     >
       <View style={styles.container}>

--- a/packages/stack/src/views/Stack/CardSheet.tsx
+++ b/packages/stack/src/views/Stack/CardSheet.tsx
@@ -55,6 +55,5 @@ const styles = StyleSheet.create({
   },
   card: {
     flex: 1,
-    overflow: 'hidden',
   },
 });

--- a/packages/stack/src/views/Stack/CardStack.tsx
+++ b/packages/stack/src/views/Stack/CardStack.tsx
@@ -665,7 +665,10 @@ export class CardStack extends React.Component<Props, State> {
             return (
               <MaybeScreen
                 key={route.key}
-                style={StyleSheet.absoluteFill}
+                style={{
+                  ...StyleSheet.absoluteFillObject,
+                  position: 'relative',
+                }}
                 enabled={detachInactiveScreens}
                 active={isScreenActive}
                 freezeOnBlur={freezeOnBlur}


### PR DESCRIPTION
**Motivation**

We want to embed React Native application into our existing website which has header and footer.

Unfortunately currently `@react-navigation/stack` doesn't support this because `absolute` positioning is used which causes that those elements are not taken into account for `height` calculation. Basically end result is that whole tree has `height` of 0 and visually you see just blank page.

The fix seems pretty straightforward which I did in first commit of this PR - just replace  `absolute` positioning with `relative`. But unfortunately that breaks some things so in next commits I am fixing those issues.

Also note that we want single scrollbar and not double scrollbars (ie. main website and embedded app)

This PR is not complete and some components still need fixing.

Let us know if this is the right way to approach this issue and we're open to any suggestions/recommendations.

**Test plan**

This is still work in progress. So far I have tested this PR only in browser using Firefox 102

I tested with Example app from this repo.

To test how it would look like when embedded into website

`$ expo.js customize:web`
```diff
diff --git a/example/web/index.html b/example/web/index.html
index 67f728ce..d109f4c2 100644
--- a/example/web/index.html
+++ b/example/web/index.html
@@ -111,6 +111,12 @@
         </div>
       </form>
     </noscript>
-    <div id="root"></div>
+    <div>
+      <h1>Website's header</h1>
+      <div>
+        <div id="root"></div>
+      </div>
+      <h2>Some footer</h2>
+    </div>
   </body>
 </html>

```

When embedded into existing website:
* [x] **Main drawer**
* [x] **Native Stack**
* [x] **Simple Stack**
* [x] **Modal Stack**
* [x] **Regular + Modal Stack**
* [ ] **Float + Screen Header Stack** - *works almost fine, just have header issue when you "Push Feed" and then "Navigate to Album"*
* [ ] **Transparent Stack** - *works fine, except "Show Dialog" doesn't really work, it's added at bottom of page*
* [x] **Header Customization in Stack**
* [x] **Header Customization in Native Stack**
* [ ] **Bottom Tabs** - *completely broken*
* [ ] **Material Top Tabs** - *very broken*
* [ ] **Material Bottom Tabs** - *completely broken*
* [ ] **Dynamic Tabs** - *completely broken*
* [x] **Master Detail**
* [x] **Auth Flow**
* [x] **Prevent removing screen in Stack**
* [x] **Prevent removing screen in Native Stack**
* [x] **`<Link />`**

Note for some components there's a little element flicker (you can see what was behind for split-second) when clicking back arrow button.

When used as only app (current behavior):
* [x] **Native Stack**
* [ ] **Simple Stack** - *works fine, only header is sticky which wasn't before, but maybe that's fine?*
* [x] **Modal Stack**
* [ ] **Regular + Modal Stack** - *works fine, same issue with header being sticky when it wasn't before*
* [x] **Float + Screen Header Stack**
* [ ] **Transparent Stack** - *works fine, but same thing with having sticky header*
* [x] **Header Customization in Stack**
* [x] **Header Customization in Native Stack**
* [ ] **Bottom Tabs** - *pretty broken*
* [ ] **Material Top Tabs** - *works almost fine, only height is taken from longest tab even if it's not visible*
* [ ] **Material Bottom Tabs** - *pretty broken*
* [ ] **Dynamic Tabs** - *pretty broken*
* [x] **Master Detail**
* [ ] **Auth Flow** - works fine, but looks bit different than before, maybe that's fine?
* [ ] **Prevent removing screen in Stack** - *works fine, but same issue with header being sticky when it wasn't before*
* [x] **Prevent removing screen in Native Stack**
* [ ] **`<Link />`** - *works fine, but same issue with header being sticky when it wasn't before*

Also note that overscroll behavior at top and bottom changes a bit comparing how it was before and also this new sticky header is bit wobbly than solid position like it was before but that seems related to how browsers implement it. 


And here's example how it would look like if React Website embedded React Navigation's Example app 😄 

![attels](https://user-images.githubusercontent.com/651800/202281660-013eaac6-0945-40ba-aa9c-34d944aa24d2.png)

