### PR TITLE
fix: buggy behaviour of search bar / large title on Fabric with native stack v7

### DIFF
--- a/packages/native-stack/src/views/DebugContainer.native.tsx
+++ b/packages/native-stack/src/views/DebugContainer.native.tsx
@@ -9,12 +9,14 @@ type ContainerProps = ViewProps & {
   children: React.ReactNode;
 };
 
-// This view must *not* be flattened.
-// See https://github.com/software-mansion/react-native-screens/pull/1825
-// for detailed explanation.
-export function DebugContainer(props: ContainerProps) {
+/**
+ * This view must *not* be flattened.
+ * See https://github.com/software-mansion/react-native-screens/pull/1825
+ * for detailed explanation.
+ */
+export let DebugContainer = (props: ContainerProps) => {
   return <View {...props} collapsable={false} />;
-}
+};
 
 if (process.env.NODE_ENV !== 'production') {
   DebugContainer = (props: ContainerProps) => {

--- a/packages/native-stack/src/views/DebugContainer.native.tsx
+++ b/packages/native-stack/src/views/DebugContainer.native.tsx
@@ -13,7 +13,7 @@ type ContainerProps = ViewProps & {
 // See https://github.com/software-mansion/react-native-screens/pull/1825
 // for detailed explanation.
 export let DebugContainer = function(props: ContainerProps): React.ComponentType<ContainerProps> {
-  return <View {...props} collapsable={false} />;
+  return <View {...props} collapsable={false} /> as unknown as React.ComponentType<ContainerProps>;
 };
 
 if (process.env.NODE_ENV !== 'production') {

--- a/packages/native-stack/src/views/DebugContainer.native.tsx
+++ b/packages/native-stack/src/views/DebugContainer.native.tsx
@@ -9,8 +9,9 @@ type ContainerProps = ViewProps & {
   children: React.ReactNode;
 };
 
-export let DebugContainer =
-  View as unknown as React.ComponentType<ContainerProps>;
+export let DebugContainer = function(props: ContainerProps): React.ComponentType<ContainerProps> {
+  return <View {...props} collapsable={false} />;
+};
 
 if (process.env.NODE_ENV !== 'production') {
   DebugContainer = (props: ContainerProps) => {
@@ -20,11 +21,11 @@ if (process.env.NODE_ENV !== 'production') {
       // This is necessary for LogBox
       return (
         <AppContainer>
-          <View {...rest} />
+          <View {...rest} collapsable={false} />
         </AppContainer>
       );
     }
 
-    return <View {...rest} />;
+    return <View {...rest} collapsable={false} />;
   };
 }

--- a/packages/native-stack/src/views/DebugContainer.native.tsx
+++ b/packages/native-stack/src/views/DebugContainer.native.tsx
@@ -12,12 +12,8 @@ type ContainerProps = ViewProps & {
 // This view must *not* be flattened.
 // See https://github.com/software-mansion/react-native-screens/pull/1825
 // for detailed explanation.
-export let DebugContainer = function (
-  props: ContainerProps
-): React.ComponentType<ContainerProps> {
-  return (
-    <View {...props} collapsable={false} />
-  ) as unknown as React.ComponentType<ContainerProps>;
+export let DebugContainer = function (props: ContainerProps): JSX.Element {
+  return <View {...props} collapsable={false} />;
 };
 
 if (process.env.NODE_ENV !== 'production') {

--- a/packages/native-stack/src/views/DebugContainer.native.tsx
+++ b/packages/native-stack/src/views/DebugContainer.native.tsx
@@ -12,8 +12,12 @@ type ContainerProps = ViewProps & {
 // This view must *not* be flattened.
 // See https://github.com/software-mansion/react-native-screens/pull/1825
 // for detailed explanation.
-export let DebugContainer = function(props: ContainerProps): React.ComponentType<ContainerProps> {
-  return <View {...props} collapsable={false} /> as unknown as React.ComponentType<ContainerProps>;
+export let DebugContainer = function (
+  props: ContainerProps
+): React.ComponentType<ContainerProps> {
+  return (
+    <View {...props} collapsable={false} />
+  ) as unknown as React.ComponentType<ContainerProps>;
 };
 
 if (process.env.NODE_ENV !== 'production') {

--- a/packages/native-stack/src/views/DebugContainer.native.tsx
+++ b/packages/native-stack/src/views/DebugContainer.native.tsx
@@ -12,7 +12,7 @@ type ContainerProps = ViewProps & {
 // This view must *not* be flattened.
 // See https://github.com/software-mansion/react-native-screens/pull/1825
 // for detailed explanation.
-export let DebugContainer = function (props: ContainerProps): JSX.Element {
+export function DebugContainer(props: ContainerProps): JSX.Element {
   return <View {...props} collapsable={false} />;
 };
 

--- a/packages/native-stack/src/views/DebugContainer.native.tsx
+++ b/packages/native-stack/src/views/DebugContainer.native.tsx
@@ -12,9 +12,9 @@ type ContainerProps = ViewProps & {
 // This view must *not* be flattened.
 // See https://github.com/software-mansion/react-native-screens/pull/1825
 // for detailed explanation.
-export function DebugContainer(props: ContainerProps): JSX.Element {
+export function DebugContainer(props: ContainerProps) {
   return <View {...props} collapsable={false} />;
-};
+}
 
 if (process.env.NODE_ENV !== 'production') {
   DebugContainer = (props: ContainerProps) => {

--- a/packages/native-stack/src/views/DebugContainer.native.tsx
+++ b/packages/native-stack/src/views/DebugContainer.native.tsx
@@ -9,6 +9,9 @@ type ContainerProps = ViewProps & {
   children: React.ReactNode;
 };
 
+// This view must *not* be flattened.
+// See https://github.com/software-mansion/react-native-screens/pull/1825
+// for detailed explanation.
 export let DebugContainer = function(props: ContainerProps): React.ComponentType<ContainerProps> {
   return <View {...props} collapsable={false} />;
 };

--- a/packages/native-stack/src/views/NativeStackView.native.tsx
+++ b/packages/native-stack/src/views/NativeStackView.native.tsx
@@ -98,6 +98,7 @@ const MaybeNestedStack = ({
     return (
       <ScreenStack style={styles.container}>
         <Screen enabled style={StyleSheet.absoluteFill}>
+          {content}
           <HeaderConfig
             {...options}
             route={route}
@@ -105,7 +106,6 @@ const MaybeNestedStack = ({
             headerTopInsetEnabled={headerTopInsetEnabled}
             canGoBack
           />
-          {content}
         </Screen>
       </ScreenStack>
     );
@@ -291,31 +291,6 @@ const SceneView = ({
                 headerShown !== false ? headerHeight : parentHeaderHeight ?? 0
               }
             >
-              {/**
-               * `HeaderConfig` needs to be the direct child of `Screen` without any intermediate `View`
-               * We don't render it conditionally to make it possible to dynamically render a custom `header`
-               * Otherwise dynamically rendering a custom `header` leaves the native header visible
-               *
-               * https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md#screenstackheaderconfig
-               */}
-              <HeaderConfig
-                {...options}
-                route={route}
-                headerBackButtonMenuEnabled={
-                  isRemovePrevented !== undefined
-                    ? !isRemovePrevented
-                    : headerBackButtonMenuEnabled
-                }
-                headerShown={header !== undefined ? false : headerShown}
-                headerHeight={headerHeight}
-                headerBackTitle={
-                  options.headerBackTitle !== undefined
-                    ? options.headerBackTitle
-                    : undefined
-                }
-                headerTopInsetEnabled={headerTopInsetEnabled}
-                canGoBack={headerBack !== undefined}
-              />
               <View
                 accessibilityElementsHidden={!focused}
                 importantForAccessibility={
@@ -350,6 +325,31 @@ const SceneView = ({
                   </View>
                 ) : null}
               </View>
+              {/**
+               * `HeaderConfig` needs to be the direct child of `Screen` without any intermediate `View`
+               * We don't render it conditionally to make it possible to dynamically render a custom `header`
+               * Otherwise dynamically rendering a custom `header` leaves the native header visible
+               *
+               * https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md#screenstackheaderconfig
+               */}
+              <HeaderConfig
+                {...options}
+                route={route}
+                headerBackButtonMenuEnabled={
+                  isRemovePrevented !== undefined
+                    ? !isRemovePrevented
+                    : headerBackButtonMenuEnabled
+                }
+                headerShown={header !== undefined ? false : headerShown}
+                headerHeight={headerHeight}
+                headerBackTitle={
+                  options.headerBackTitle !== undefined
+                    ? options.headerBackTitle
+                    : undefined
+                }
+                headerTopInsetEnabled={headerTopInsetEnabled}
+                canGoBack={headerBack !== undefined}
+              />
             </HeaderHeightContext.Provider>
           </HeaderShownContext.Provider>
         </NavigationRouteContext.Provider>

--- a/packages/native-stack/src/views/NativeStackView.native.tsx
+++ b/packages/native-stack/src/views/NativeStackView.native.tsx
@@ -331,6 +331,10 @@ const SceneView = ({
                * Otherwise dynamically rendering a custom `header` leaves the native header visible
                *
                * https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md#screenstackheaderconfig
+               *
+               * HeaderConfig must not be first child of a Screen.
+               * See https://github.com/software-mansion/react-native-screens/pull/1825
+               * for detailed explanation
                */}
               <HeaderConfig
                 {...options}


### PR DESCRIPTION
**Motivation**

`UIKit` requires `ScrollView` to be at index 0 in given view's subview array to enable it's interaction with navigation bar. On Fabric `DebugContainer` view got flattened, however it was not removed from hierarchy -- instead the view was attached as first child of the `RNSScreenView` disabling system interaction between navigation bar and a scroll view. 

See

* https://github.com/software-mansion/react-native-screens/pull/1825

for broader context and explanation.

**Test plan**

### Before

https://github.com/software-mansion/react-native-screens/assets/50801299/3b89dee8-a307-44ba-a9f4-02e4dfdd95ac


### After

https://github.com/software-mansion/react-native-screens/assets/50801299/205f24d4-590b-402e-8b0a-848fd4482d59
