### PR TITLE
fix: Drawer on macos is registering clicks despite being inactive

### DIFF
--- a/packages/react-native-drawer-layout/src/views/modern/Drawer.tsx
+++ b/packages/react-native-drawer-layout/src/views/modern/Drawer.tsx
@@ -421,6 +421,11 @@ export function Drawer({
               drawerAnimatedStyle,
               drawerStyle as any,
             ]}
+            pointerEvents={
+              Platform.OS === 'macos' && drawerType !== 'permanent' && !isOpen
+                ? 'none'
+                : undefined
+            }
           >
             {renderDrawerContent()}
           </Animated.View>


### PR DESCRIPTION
Hey.

**Motivation**

If you use the drawer on react-native-macos, it will register click events even if the drawer is inactive, resulting in everything underneath the drawer being unclickable.

I suspect it's because of some `zIndex` layering issues (we set zIndex to -1 when inactive) going on, but not sure.

This PR addresses this issue by setting `pointerEvents` to `"none"` for react-native-macos.

**Test plan**

Try @react-navigation/drawer@7.0.0-alpha.2 on react-native-macos old arch (could be the same on new arch, I don't know). Anything under where the drawer would be cannot be clicked on.

Note: react-reanimated broke its react-native-macos support >= 2.0, I have a pending fix for that here:
https://github.com/software-mansion/react-native-reanimated/pull/4669

So either use react-reanimated 1 or use my fork:
`"react-native-reanimated": "git+https://github.com/hsjoberg/react-native-reanimated.git#e998c740a083f075e6845a9ed1c81d5df1c220fc",`