### PR TITLE
fix: ensure latest values are used when `preventRemove` is triggered in `usePreventRemove` hook

### DIFF
--- a/packages/core/src/usePreventRemove.tsx
+++ b/packages/core/src/usePreventRemove.tsx
@@ -32,16 +32,26 @@ export function UNSTABLE_usePreventRemove(
     };
   }, [setPreventRemove, id, routeKey, preventRemove]);
 
+  const preventRemoveRef = React.useRef(preventRemove);
+  React.useEffect(() => {
+    preventRemoveRef.current = preventRemove;
+  });
+
+  const callbackRef = React.useRef(callback);
+  React.useEffect(() => {
+    callbackRef.current = callback;
+  });
+
   const beforeRemoveListener = useLatestCallback<
     EventListenerCallback<EventMapCore<any>, 'beforeRemove'>
   >((e) => {
-    if (!preventRemove) {
+    if (!preventRemoveRef.current) {
       return;
     }
 
     e.preventDefault();
 
-    callback({ data: e.data });
+    callbackRef.current({ data: e.data });
   });
 
   React.useEffect(


### PR DESCRIPTION
**Motivation**

In `react-navigation/native@6.1.7` with `@react-navigation/core@6.4.9` `UNSTABLE_usePreventRemove`, when  `beforeRemove` listener is triggered it, it uses old value of `preventRemove` parameter that's passed into the hook. By using a reference to `preventRemove` (and `callback`) we can ensure the latest value is always used.

**Test plan**

Describe the **steps to test this change** so that a reviewer can verify it. Provide screenshots or videos if the change affects UI.

The change must pass lint, typescript and tests.
