### PR TITLE
fix: incorrect url parsing (isssue: #10924)

### DIFF
--- a/packages/native/src/__tests__/extractPathFromURL.test.tsx
+++ b/packages/native/src/__tests__/extractPathFromURL.test.tsx
@@ -324,3 +324,12 @@ it('returns undefined for non-matching host with wildcard', () => {
     )
   ).toBeUndefined();
 });
+
+it('returns a valid search query when it has a url as param', () => {
+  expect(
+    extractPathFromURL(
+      ['https://mysite.com'],
+      'https://mysite.com/readPolicy?url=https://test.com'
+    )
+  ).toBe('/readPolicy?url=https://test.com');
+});

--- a/packages/native/src/extractPathFromURL.tsx
+++ b/packages/native/src/extractPathFromURL.tsx
@@ -15,7 +15,10 @@ export function extractPathFromURL(prefixes: string[], url: string) {
         .join('\\.')}`
     );
 
-    const normalizedURL = url.replace(/\/+/g, '/');
+    const [originAndPath, searchParams] = url.split('?');
+    const normalizedURL = originAndPath
+      .replace(/\/+/g, '/')
+      .concat(searchParams ? `?${searchParams}` : '');
 
     if (prefixRegex.test(normalizedURL)) {
       return normalizedURL.replace(prefixRegex, '');


### PR DESCRIPTION

**Motivation**

fix: https://github.com/react-navigation/react-navigation/issues/10924


**Test plan**

```tsx
import extractPathFromURL from '@react-navigation/native/src/extractPathFromURL';

test('extractPathFromURL', () => {
  expect(extractPathFromURL(['https://mysite.com'], 'https://mysite.com/readPolicy?url=https://test.com')).toBe(
    '/readPolicy?url=https://test.com',
  );
});
// test fail ^^^ because `extractPathFromURL` removed all double slashes
// Expected: "/readPolicy?url=https://test.com"
// Received: "/readPolicy?url=https:/test.com"
```