### PR TITLE
fix: optimize route cache

### DIFF
--- a/example/src/Screens/BottomTabs.tsx
+++ b/example/src/Screens/BottomTabs.tsx
@@ -5,7 +5,6 @@ import {
 } from '@react-navigation/bottom-tabs';
 import { HeaderBackButton, useHeaderHeight } from '@react-navigation/elements';
 import {
-  getFocusedRouteNameFromRoute,
   NavigatorScreenParams,
   ParamListBase,
   useIsFocused,
@@ -56,16 +55,12 @@ const Tab = createBottomTabNavigator<BottomTabParams>();
 
 export function BottomTabs({
   navigation,
-  route,
 }: StackScreenProps<ParamListBase, string>) {
-  const routeName = getFocusedRouteNameFromRoute(route) ?? 'Article';
-
   React.useLayoutEffect(() => {
     navigation.setOptions({
       headerShown: false,
-      title: routeName,
     });
-  }, [navigation, routeName]);
+  }, [navigation]);
 
   return (
     <Tab.Navigator

--- a/packages/core/src/useRouteCache.tsx
+++ b/packages/core/src/useRouteCache.tsx
@@ -30,19 +30,24 @@ export function useRouteCache<State extends NavigationState>(
 
   cache.current = routes.reduce((acc, route) => {
     const previous = cache.current.get(route.key);
-    const { state, ...proxy } = route;
+    const { state, ...routeWithoutState } = route;
 
-    if (previous && isRecordEqual(previous, proxy)) {
+    let proxy;
+
+    if (previous && isRecordEqual(previous, routeWithoutState)) {
       // If a cached route object already exists, reuse it
-      acc.set(route.key, previous);
+      proxy = previous;
     } else {
-      Object.defineProperty(proxy, CHILD_STATE, {
-        enumerable: false,
-        value: state,
-      });
-
-      acc.set(route.key, proxy);
+      proxy = routeWithoutState;
     }
+
+    Object.defineProperty(proxy, CHILD_STATE, {
+      enumerable: false,
+      configurable: true,
+      value: state,
+    });
+
+    acc.set(route.key, proxy);
 
     return acc;
   }, new Map() as RouteCache);

--- a/packages/core/src/useRouteCache.tsx
+++ b/packages/core/src/useRouteCache.tsx
@@ -1,13 +1,10 @@
-import type {
-  NavigationState,
-  ParamListBase,
-  Route,
-} from '@react-navigation/routers';
+import type { NavigationState, ParamListBase } from '@react-navigation/routers';
 import * as React from 'react';
 
+import { isRecordEqual } from './isRecordEqual';
 import type { RouteProp } from './types';
 
-type RouteCache = Map<Route<string>, RouteProp<ParamListBase>>;
+type RouteCache = Map<string, RouteProp<ParamListBase>>;
 
 /**
  * Utilites such as `getFocusedRouteNameFromRoute` need to access state.
@@ -32,20 +29,19 @@ export function useRouteCache<State extends NavigationState>(
   }
 
   cache.current = routes.reduce((acc, route) => {
-    const previous = cache.current.get(route);
+    const previous = cache.current.get(route.key);
+    const { state, ...proxy } = route;
 
-    if (previous) {
+    if (previous && isRecordEqual(previous, proxy)) {
       // If a cached route object already exists, reuse it
-      acc.set(route, previous);
+      acc.set(route.key, previous);
     } else {
-      const { state, ...proxy } = route;
-
       Object.defineProperty(proxy, CHILD_STATE, {
         enumerable: false,
         value: state,
       });
 
-      acc.set(route, proxy);
+      acc.set(route.key, proxy);
     }
 
     return acc;


### PR DESCRIPTION
Optimize route cache to prevent re-rendering.
 
**Motivation**

Routes shouldn't re-render, we are now using route key as the cache key 
