### PR TITLE
feat: add children prop to tab bar indicator component

### DIFF
--- a/packages/react-native-tab-view/src/TabBarIndicator.tsx
+++ b/packages/react-native-tab-view/src/TabBarIndicator.tsx
@@ -20,6 +20,7 @@ export type Props<T extends Route> = SceneRendererProps & {
   style?: StyleProp<ViewStyle>;
   getTabWidth: GetTabWidth;
   gap?: number;
+  children?: React.ReactNode;
 };
 
 const getTranslateX = (
@@ -53,6 +54,7 @@ export function TabBarIndicator<T extends Route>({
   width,
   gap,
   style,
+  children,
 }: Props<T>) {
   const isIndicatorShown = React.useRef(false);
   const isWidthDynamic = width === 'auto';
@@ -136,7 +138,9 @@ export function TabBarIndicator<T extends Route>({
         width === 'auto' ? { opacity: opacity } : null,
         style,
       ]}
-    />
+    >
+      {children}
+    </Animated.View>
   );
 }
 


### PR DESCRIPTION
**Motivation**

I want to be able to display a `<LinearGradient/>` component inside the `<TabBarIndicator/>`. While you can use the `renderIndicator` prop on `TabBar`, you cannot render a wrapper or child of the indicator and have it inherit the animation the library already provides. By providing a `children` option to `TabBarIndicator`, this problem is easily solved.

**Test plan**

Tests all still pass and to test this specific change, try something like this:

```
<TabBar
  renderIndicator={(props) => {
    return (
      <TabBarIndicator {...props}>
        {someChildComponent}
      </TabBarIndicator>
    )
  }}
/>
```

This allows more complex components to be animated and accurately denote the active tab. I have some screenshots of an example where I'm using a `<LinearGradient/>` container to display a gradient indicator - something not possible with just a style object.

<img width="442" alt="Screenshot 2023-08-28 at 4 16 24 PM" src="https://github.com/react-navigation/react-navigation/assets/10537858/d90422c5-e22a-4b81-863c-a976d6e35c88">
<img width="447" alt="Screenshot 2023-08-28 at 4 16 46 PM" src="https://github.com/react-navigation/react-navigation/assets/10537858/a53d21d5-a2f6-49bd-8327-9af05f946688">

