### PR TITLE
fix: bottom bar animation tied with a screen

### DIFF
--- a/example/src/Screens/BottomTabs.tsx
+++ b/example/src/Screens/BottomTabs.tsx
@@ -15,6 +15,7 @@ import type { StackScreenProps } from '@react-navigation/stack';
 import { BlurView } from 'expo-blur';
 import * as React from 'react';
 import { ScrollView, StatusBar, StyleSheet } from 'react-native';
+import { Button } from 'react-native-paper';
 
 import { Albums } from '../Shared/Albums';
 import { Chat } from '../Shared/Chat';
@@ -68,12 +69,23 @@ export function BottomTabs({
     });
   }, [navigation, routeName]);
 
+  const [animationEnabled, setAnimationEnabled] = React.useState(false);
   return (
     <Tab.Navigator
       screenOptions={{
         headerLeft: (props) => (
           <HeaderBackButton {...props} onPress={navigation.goBack} />
         ),
+        headerRight: () => (
+          <Button
+            style={styles.leftButton}
+            onPress={() => setAnimationEnabled((prev) => !prev)}
+            icon={animationEnabled ? 'heart' : 'heart-outline'}
+          >
+            Fade {animationEnabled ? 'off' : 'on'}
+          </Button>
+        ),
+        ...(animationEnabled && TransitionPresets.FadeTransition),
       }}
     >
       <Tab.Screen
@@ -91,7 +103,6 @@ export function BottomTabs({
           tabBarLabel: 'Chat (Animated)',
           tabBarIcon: getTabBarIcon('message-reply'),
           tabBarBadge: 2,
-          ...TransitionPresets.FadeTransition,
         }}
       />
       <Tab.Screen
@@ -135,3 +146,9 @@ export function BottomTabs({
     </Tab.Navigator>
   );
 }
+
+const styles = StyleSheet.create({
+  leftButton: {
+    paddingRight: 8,
+  },
+});

--- a/packages/bottom-tabs/src/views/BottomTabView.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabView.tsx
@@ -71,7 +71,7 @@ export function BottomTabView(props: Props) {
           .map((route) => {
             const { animationEnabled, transitionSpec } =
               descriptors[route.key].options;
-            if (!animationEnabled) {
+            if (!animationEnabled || !transitionSpec) {
               return false;
             }
             return Animated[transitionSpec?.animation || 'timing'](

--- a/packages/bottom-tabs/src/views/BottomTabView.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabView.tsx
@@ -25,6 +25,7 @@ import { BottomTabBarHeightContext } from '../utils/BottomTabBarHeightContext';
 import { useAnimatedHashMap } from '../utils/useAnimatedHashMap';
 import { BottomTabBar, getTabBarHeight } from './BottomTabBar';
 import { MaybeScreen, MaybeScreenContainer } from './ScreenFallback';
+import CompositeAnimation = Animated.CompositeAnimation;
 
 type Props = BottomTabNavigationConfig & {
   state: TabNavigationState<ParamListBase>;
@@ -51,9 +52,6 @@ export function BottomTabView(props: Props) {
   } = props;
   const focusedRouteKey = state.routes[state.index].key;
 
-  const { animationEnabled, sceneStyleInterpolator, transitionSpec } =
-    descriptors[focusedRouteKey].options;
-
   /**
    * List of loaded tabs, tabs will be loaded when navigated to.
    */
@@ -68,35 +66,29 @@ export function BottomTabView(props: Props) {
 
   React.useEffect(() => {
     const animateToIndex = () => {
-      if (!animationEnabled) {
-        for (const route of routes) {
-          tabAnims[route.key].setValue(route.key === focusedRouteKey ? 0 : 1);
-        }
-        return;
-      }
       Animated.parallel(
-        state.routes.map((route) => {
-          return Animated[transitionSpec?.animation || 'timing'](
-            tabAnims[route.key],
-            {
-              ...transitionSpec?.config,
-              toValue: route.key === focusedRouteKey ? 0 : 1,
-              useNativeDriver: true,
+        state.routes
+          .map((route) => {
+            const { animationEnabled, transitionSpec } =
+              descriptors[route.key].options;
+            if (!animationEnabled) {
+              return false;
             }
-          );
-        })
+            return Animated[transitionSpec?.animation || 'timing'](
+              tabAnims[route.key],
+              {
+                ...transitionSpec?.config,
+                toValue: route.key === focusedRouteKey ? 0 : 1,
+                useNativeDriver: true,
+              }
+            );
+          })
+          .filter(Boolean) as CompositeAnimation[]
       ).start();
     };
 
     animateToIndex();
-  }, [
-    transitionSpec?.animation,
-    transitionSpec?.config,
-    state.routes,
-    tabAnims,
-    focusedRouteKey,
-    animationEnabled,
-  ]);
+  }, [state.routes, tabAnims, focusedRouteKey, descriptors]);
 
   const dimensions = SafeAreaProviderCompat.initialMetrics.frame;
   const [tabBarHeight, setTabBarHeight] = React.useState(() =>
@@ -149,7 +141,12 @@ export function BottomTabView(props: Props) {
       >
         {routes.map((route, index) => {
           const descriptor = descriptors[route.key];
-          const { lazy = true, unmountOnBlur } = descriptor.options;
+          const {
+            lazy = true,
+            unmountOnBlur,
+            animationEnabled,
+            sceneStyleInterpolator,
+          } = descriptor.options;
           const isFocused = state.index === index;
 
           if (unmountOnBlur && !isFocused) {


### PR DESCRIPTION
**Motivation**

Follow-up after the previous PR, when we used only the upper-most descriptor. Also, example has been adjusted to use either fully turned on or off animation., 

**Test plan**

press the button
![image](https://github.com/react-navigation/react-navigation/assets/25709300/6b084701-a2a0-4960-a72d-e1743c378d1d)
