### PR TITLE
feat: add option to show tabs on the side

### DIFF
--- a/example/src/Screens/BottomTabs.tsx
+++ b/example/src/Screens/BottomTabs.tsx
@@ -14,8 +14,14 @@ import {
 import type { StackScreenProps } from '@react-navigation/stack';
 import { BlurView } from 'expo-blur';
 import * as React from 'react';
-import { ScrollView, StatusBar, StyleSheet } from 'react-native';
-import { Appbar } from 'react-native-paper';
+import {
+  Image,
+  ScrollView,
+  StatusBar,
+  StyleSheet,
+  useWindowDimensions,
+} from 'react-native';
+import { Appbar, IconButton } from 'react-native-paper';
 
 import { Albums } from '../Shared/Albums';
 import { Chat } from '../Shared/Chat';
@@ -71,103 +77,144 @@ export function BottomTabs({
     });
   }, [navigation]);
 
-  const [animation, setAnimation] =
-    React.useState<keyof typeof animations>('none');
-
   const { showActionSheetWithOptions } = useActionSheet();
 
+  const dimensions = useWindowDimensions();
+
+  const [animation, setAnimation] =
+    React.useState<keyof typeof animations>('none');
+  const [isCompact, setIsCompact] = React.useState(false);
+
+  const isLargeScreen = dimensions.width >= 1024;
+
   return (
-    <Tab.Navigator
-      screenOptions={{
-        headerLeft: (props) => (
-          <HeaderBackButton {...props} onPress={navigation.goBack} />
-        ),
-        headerRight: ({ tintColor }) => (
-          <Appbar.Action
-            icon={animation === 'none' ? 'heart-outline' : 'heart'}
-            color={tintColor}
-            onPress={() => {
-              const options = Object.keys(
-                animations
-              ) as (keyof typeof animations)[];
+    <>
+      <Tab.Navigator
+        screenOptions={{
+          headerLeft: (props) => (
+            <HeaderBackButton {...props} onPress={navigation.goBack} />
+          ),
+          headerRight: ({ tintColor }) => (
+            <Appbar.Action
+              icon={animation === 'none' ? 'heart-outline' : 'heart'}
+              color={tintColor}
+              onPress={() => {
+                const options = Object.keys(
+                  animations
+                ) as (keyof typeof animations)[];
 
-              showActionSheetWithOptions(
-                {
-                  options: options.map((option) => {
-                    if (option === animation) {
-                      return `${option} (current)`;
+                showActionSheetWithOptions(
+                  {
+                    options: options.map((option) => {
+                      if (option === animation) {
+                        return `${option} (current)`;
+                      }
+
+                      return option;
+                    }),
+                  },
+                  (index) => {
+                    if (index != null) {
+                      setAnimation(options[index]);
                     }
-
-                    return option;
-                  }),
-                },
-                (index) => {
-                  if (index != null) {
-                    setAnimation(options[index]);
                   }
-                }
-              );
-            }}
-          />
-        ),
-        ...animations[animation],
-      }}
-    >
-      <Tab.Screen
-        name="TabStack"
-        component={SimpleStack}
-        options={{
-          title: 'Article',
-          tabBarIcon: getTabBarIcon('file-document'),
-        }}
-      />
-      <Tab.Screen
-        name="TabChat"
-        component={Chat}
-        options={{
-          tabBarLabel: 'Chat',
-          tabBarIcon: getTabBarIcon('message-reply'),
-          tabBarBadge: 2,
-        }}
-      />
-      <Tab.Screen
-        name="TabContacts"
-        component={Contacts}
-        options={{
-          title: 'Contacts',
-          tabBarIcon: getTabBarIcon('contacts'),
-        }}
-      />
-      <Tab.Screen
-        name="TabAlbums"
-        component={AlbumsScreen}
-        options={{
-          title: 'Albums',
-          headerTintColor: '#fff',
-          headerTransparent: true,
-          headerBackground: () => (
-            <BlurView
-              tint="dark"
-              intensity={100}
-              style={StyleSheet.absoluteFill}
+                );
+              }}
             />
           ),
-          tabBarIcon: getTabBarIcon('image-album'),
-          tabBarInactiveTintColor: 'rgba(255, 255, 255, 0.5)',
-          tabBarActiveTintColor: '#fff',
-          tabBarStyle: {
+          tabBarPosition: isLargeScreen ? 'left' : 'bottom',
+          tabBarLabelPosition:
+            isLargeScreen && isCompact ? 'below-icon' : undefined,
+          ...animations[animation],
+        }}
+      >
+        <Tab.Screen
+          name="TabStack"
+          component={SimpleStack}
+          options={{
+            title: 'Article',
+            tabBarIcon: getTabBarIcon('file-document'),
+          }}
+        />
+        <Tab.Screen
+          name="TabChat"
+          component={Chat}
+          options={{
+            tabBarLabel: 'Chat',
+            tabBarIcon: getTabBarIcon('message-reply'),
+            tabBarBadge: 2,
+          }}
+        />
+        <Tab.Screen
+          name="TabContacts"
+          component={Contacts}
+          options={{
+            title: 'Contacts',
+            tabBarIcon: getTabBarIcon('contacts'),
+          }}
+        />
+        <Tab.Screen
+          name="TabAlbums"
+          component={AlbumsScreen}
+          options={{
+            title: 'Albums',
+            headerTintColor: '#fff',
+            headerTransparent: true,
+            headerBackground: () => (
+              <BlurView
+                tint="dark"
+                intensity={100}
+                style={StyleSheet.absoluteFill}
+              />
+            ),
+            tabBarIcon: getTabBarIcon('image-album'),
+            tabBarInactiveTintColor: 'rgba(255, 255, 255, 0.5)',
+            tabBarActiveTintColor: '#fff',
+            tabBarStyle: {
+              position: isLargeScreen ? undefined : 'absolute',
+              borderColor: 'rgba(0, 0, 0, .2)',
+            },
+            tabBarBackground: () => (
+              <>
+                {isLargeScreen && (
+                  <Image
+                    source={require('../../assets/album-art-03.jpg')}
+                    style={{
+                      ...StyleSheet.absoluteFillObject,
+                      // Override default size of the image
+                      height: undefined,
+                      width: undefined,
+                      resizeMode: 'cover',
+                    }}
+                  />
+                )}
+                <BlurView
+                  tint="dark"
+                  intensity={100}
+                  style={{
+                    ...StyleSheet.absoluteFillObject,
+                    right: isLargeScreen
+                      ? // Offset for right border of the sidebar
+                        -StyleSheet.hairlineWidth
+                      : 0,
+                  }}
+                />
+              </>
+            ),
+          }}
+        />
+      </Tab.Navigator>
+      {isLargeScreen ? (
+        <IconButton
+          icon={isCompact ? 'chevron-double-right' : 'chevron-double-left'}
+          onPress={() => setIsCompact(!isCompact)}
+          style={{
             position: 'absolute',
-            borderTopColor: 'rgba(0, 0, 0, .2)',
-          },
-          tabBarBackground: () => (
-            <BlurView
-              tint="dark"
-              intensity={100}
-              style={StyleSheet.absoluteFill}
-            />
-          ),
-        }}
-      />
-    </Tab.Navigator>
+            bottom: 0,
+            left: 0,
+          }}
+        />
+      ) : null}
+    </>
   );
 }

--- a/packages/bottom-tabs/src/types.tsx
+++ b/packages/bottom-tabs/src/types.tsx
@@ -224,6 +224,11 @@ export type BottomTabNavigationOptions = HeaderOptions & {
   tabBarBackground?: () => React.ReactNode;
 
   /**
+   * Position of the tab bar on the screen. Defaults to `bottom`.
+   */
+  tabBarPosition?: 'bottom' | 'left' | 'right';
+
+  /**
    * Whether this screens should render the first time it's accessed. Defaults to `true`.
    * Set it to `false` if you want to render the screen on initial render.
    */

--- a/packages/bottom-tabs/src/views/BottomTabBar.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabBar.tsx
@@ -1,4 +1,7 @@
-import { MissingIcon } from '@react-navigation/elements';
+import {
+  getDefaultSidebarWidth,
+  MissingIcon,
+} from '@react-navigation/elements';
 import {
   CommonActions,
   NavigationContext,
@@ -8,6 +11,7 @@ import {
   useLinkTools,
   useTheme,
 } from '@react-navigation/native';
+import Color from 'color';
 import React from 'react';
 import {
   Animated,
@@ -15,10 +19,11 @@ import {
   Platform,
   StyleProp,
   StyleSheet,
+  useWindowDimensions,
   View,
   ViewStyle,
 } from 'react-native';
-import { EdgeInsets, useSafeAreaFrame } from 'react-native-safe-area-context';
+import type { EdgeInsets } from 'react-native-safe-area-context';
 
 import type { BottomTabBarProps, BottomTabDescriptorMap } from '../types';
 import { BottomTabBarHeightCallbackContext } from '../utils/BottomTabBarHeightCallbackContext';
@@ -32,6 +37,7 @@ type Props = BottomTabBarProps & {
 const DEFAULT_TABBAR_HEIGHT = 49;
 const COMPACT_TABBAR_HEIGHT = 32;
 const DEFAULT_MAX_TAB_ITEM_WIDTH = 125;
+const SPACING = 5;
 
 const useNativeDriver = Platform.OS !== 'web';
 
@@ -140,6 +146,7 @@ export function BottomTabBar({
   const focusedOptions = focusedDescriptor.options;
 
   const {
+    tabBarPosition = 'bottom',
     tabBarShowLabel,
     tabBarHideOnKeyboard = false,
     tabBarVisibilityAnimationConfig,
@@ -147,11 +154,17 @@ export function BottomTabBar({
     tabBarBackground,
     tabBarActiveTintColor,
     tabBarInactiveTintColor,
-    tabBarActiveBackgroundColor,
+    tabBarActiveBackgroundColor = tabBarPosition !== 'bottom'
+      ? Color(tabBarActiveTintColor ?? colors.primary)
+          .alpha(0.12)
+          .rgb()
+          .string()
+      : undefined,
     tabBarInactiveBackgroundColor,
   } = focusedOptions;
 
-  const dimensions = useSafeAreaFrame();
+  // FIXME: useSafeAreaFrame doesn't update values when window is resized on Web
+  const dimensions = useWindowDimensions();
   const isKeyboardShown = useIsKeyboardShown();
 
   const onHeightChange = React.useContext(BottomTabBarHeightCallbackContext);
@@ -256,42 +269,67 @@ export function BottomTabBar({
   return (
     <Animated.View
       style={[
-        styles.tabBar,
+        tabBarPosition === 'left'
+          ? styles.left
+          : tabBarPosition === 'right'
+          ? styles.right
+          : styles.bottom,
         {
           backgroundColor:
             tabBarBackgroundElement != null ? 'transparent' : colors.card,
-          borderTopColor: colors.border,
+          borderColor: colors.border,
         },
-        {
-          transform: [
-            {
-              translateY: visible.interpolate({
-                inputRange: [0, 1],
-                outputRange: [
-                  layout.height + paddingBottom + StyleSheet.hairlineWidth,
-                  0,
+        tabBarPosition === 'bottom'
+          ? [
+              {
+                transform: [
+                  {
+                    translateY: visible.interpolate({
+                      inputRange: [0, 1],
+                      outputRange: [
+                        layout.height +
+                          paddingBottom +
+                          StyleSheet.hairlineWidth,
+                        0,
+                      ],
+                    }),
+                  },
                 ],
-              }),
+                // Absolutely position the tab bar so that the content is below it
+                // This is needed to avoid gap at bottom when the tab bar is hidden
+                position: isTabBarHidden ? 'absolute' : (null as any),
+              },
+              {
+                height: tabBarHeight,
+                paddingBottom,
+                paddingHorizontal: Math.max(insets.left, insets.right),
+              },
+            ]
+          : {
+              paddingTop: insets.top,
+              paddingBottom: insets.bottom,
+              paddingLeft: tabBarPosition === 'left' ? insets.left : 0,
+              paddingRight: tabBarPosition === 'right' ? insets.right : 0,
+              minWidth: hasHorizontalLabels
+                ? getDefaultSidebarWidth(dimensions)
+                : 0,
             },
-          ],
-          // Absolutely position the tab bar so that the content is below it
-          // This is needed to avoid gap at bottom when the tab bar is hidden
-          position: isTabBarHidden ? 'absolute' : (null as any),
-        },
-        {
-          height: tabBarHeight,
-          paddingBottom,
-          paddingHorizontal: Math.max(insets.left, insets.right),
-        },
         tabBarStyle,
       ]}
       pointerEvents={isTabBarHidden ? 'none' : 'auto'}
-      onLayout={handleLayout}
+      onLayout={tabBarPosition === 'bottom' ? handleLayout : undefined}
     >
       <View pointerEvents="none" style={StyleSheet.absoluteFill}>
         {tabBarBackgroundElement}
       </View>
-      <View accessibilityRole="tablist" style={styles.content}>
+      <View
+        accessibilityRole="tablist"
+        style={
+          tabBarPosition === 'bottom'
+            ? styles.bottomContent
+            : styles.sideContent
+        }
+      >
         {routes.map((route, index) => {
           const focused = index === state.index;
           const { options } = descriptors[route.key];
@@ -366,7 +404,17 @@ export function BottomTabBar({
                   showLabel={tabBarShowLabel}
                   labelStyle={options.tabBarLabelStyle}
                   iconStyle={options.tabBarIconStyle}
-                  style={options.tabBarItemStyle}
+                  style={[
+                    tabBarPosition === 'bottom'
+                      ? styles.bottomItem
+                      : [
+                          styles.sideItem,
+                          hasHorizontalLabels
+                            ? { justifyContent: 'flex-start' }
+                            : null,
+                        ],
+                    options.tabBarItemStyle,
+                  ]}
                 />
               </NavigationRouteContext.Provider>
             </NavigationContext.Provider>
@@ -378,15 +426,40 @@ export function BottomTabBar({
 }
 
 const styles = StyleSheet.create({
-  tabBar: {
+  left: {
+    top: 0,
+    bottom: 0,
+    left: 0,
+    borderRightWidth: StyleSheet.hairlineWidth,
+  },
+  right: {
+    top: 0,
+    bottom: 0,
+    right: 0,
+    borderLeftWidth: StyleSheet.hairlineWidth,
+  },
+  bottom: {
     left: 0,
     right: 0,
     bottom: 0,
     borderTopWidth: StyleSheet.hairlineWidth,
     elevation: 8,
   },
-  content: {
+  bottomContent: {
     flex: 1,
     flexDirection: 'row',
+  },
+  sideContent: {
+    flex: 1,
+    flexDirection: 'column',
+    padding: SPACING,
+  },
+  bottomItem: {
+    flex: 1,
+  },
+  sideItem: {
+    margin: SPACING,
+    padding: SPACING * 2,
+    borderRadius: 4,
   },
 });

--- a/packages/bottom-tabs/src/views/BottomTabBar.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabBar.tsx
@@ -298,7 +298,7 @@ export function BottomTabBar({
                 ],
                 // Absolutely position the tab bar so that the content is below it
                 // This is needed to avoid gap at bottom when the tab bar is hidden
-                position: isTabBarHidden ? 'absolute' : (null as any),
+                position: isTabBarHidden ? 'absolute' : undefined,
               },
               {
                 height: tabBarHeight,

--- a/packages/bottom-tabs/src/views/BottomTabItem.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabItem.tsx
@@ -306,7 +306,6 @@ export function BottomTabItem({
 
 const styles = StyleSheet.create({
   tab: {
-    flex: 1,
     alignItems: 'center',
   },
   tabPortrait: {
@@ -327,7 +326,6 @@ const styles = StyleSheet.create({
   labelBeside: {
     fontSize: 13,
     marginLeft: 20,
-    marginTop: 3,
   },
   button: {
     display: 'flex',

--- a/packages/bottom-tabs/src/views/BottomTabView.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabView.tsx
@@ -151,12 +151,22 @@ export function BottomTabView(props: Props) {
     hasAnimation(descriptors[route.key].options)
   );
 
+  const { tabBarPosition = 'bottom' } = descriptors[focusedRouteKey].options;
+
   return (
-    <SafeAreaProviderCompat>
+    <SafeAreaProviderCompat
+      style={
+        tabBarPosition === 'left'
+          ? styles.left
+          : tabBarPosition === 'right'
+          ? styles.right
+          : null
+      }
+    >
       <MaybeScreenContainer
         enabled={detachInactiveScreens}
         hasTwoStates={hasTwoStates}
-        style={styles.container}
+        style={styles.screens}
       >
         {routes.map((route, index) => {
           const descriptor = descriptors[route.key];
@@ -218,7 +228,9 @@ export function BottomTabView(props: Props) {
               enabled={detachInactiveScreens}
               freezeOnBlur={freezeOnBlur}
             >
-              <BottomTabBarHeightContext.Provider value={tabBarHeight}>
+              <BottomTabBarHeightContext.Provider
+                value={tabBarPosition === 'bottom' ? tabBarHeight : 0}
+              >
                 <Screen
                   focused={isFocused}
                   route={descriptor.route}
@@ -250,7 +262,13 @@ export function BottomTabView(props: Props) {
 }
 
 const styles = StyleSheet.create({
-  container: {
+  left: {
+    flexDirection: 'row-reverse',
+  },
+  right: {
+    flexDirection: 'row',
+  },
+  screens: {
     flex: 1,
     overflow: 'hidden',
   },

--- a/packages/bottom-tabs/src/views/TabBarIcon.tsx
+++ b/packages/bottom-tabs/src/views/TabBarIcon.tsx
@@ -64,7 +64,7 @@ export function TabBarIcon({
       <Badge
         visible={badge != null}
         style={[styles.badge, badgeStyle]}
-        size={(ICON_SIZE * 3) / 4}
+        size={ICON_SIZE * 0.75}
       >
         {badge}
       </Badge>

--- a/packages/bottom-tabs/src/views/TabBarIcon.tsx
+++ b/packages/bottom-tabs/src/views/TabBarIcon.tsx
@@ -27,6 +27,8 @@ type Props = {
   style: StyleProp<ViewStyle>;
 };
 
+const ICON_SIZE = 25;
+
 export function TabBarIcon({
   route: _,
   horizontal,
@@ -39,8 +41,6 @@ export function TabBarIcon({
   renderIcon,
   style,
 }: Props) {
-  const size = 25;
-
   // We render the icon twice at the same position on top of each other:
   // active and inactive one, so we can fade between them.
   return (
@@ -50,25 +50,21 @@ export function TabBarIcon({
       <View style={[styles.icon, { opacity: activeOpacity }]}>
         {renderIcon({
           focused: true,
-          size,
+          size: ICON_SIZE,
           color: activeTintColor,
         })}
       </View>
       <View style={[styles.icon, { opacity: inactiveOpacity }]}>
         {renderIcon({
           focused: false,
-          size,
+          size: ICON_SIZE,
           color: inactiveTintColor,
         })}
       </View>
       <Badge
         visible={badge != null}
-        style={[
-          styles.badge,
-          horizontal ? styles.badgeHorizontal : styles.badgeVertical,
-          badgeStyle,
-        ]}
-        size={(size * 3) / 4}
+        style={[styles.badge, badgeStyle]}
+        size={(ICON_SIZE * 3) / 4}
       >
         {badge}
       </Badge>
@@ -88,23 +84,19 @@ const styles = StyleSheet.create({
     height: '100%',
     width: '100%',
     // Workaround for react-native >= 0.54 layout bug
-    minWidth: 25,
+    minWidth: ICON_SIZE,
   },
   iconVertical: {
-    flex: 1,
+    width: ICON_SIZE,
+    height: ICON_SIZE,
   },
   iconHorizontal: {
-    height: '100%',
-    marginTop: 3,
+    width: ICON_SIZE,
+    height: ICON_SIZE,
   },
   badge: {
     position: 'absolute',
-    left: 3,
-  },
-  badgeVertical: {
-    top: 3,
-  },
-  badgeHorizontal: {
-    top: 7,
+    right: -5,
+    top: -5,
   },
 });

--- a/packages/drawer/src/views/DrawerView.tsx
+++ b/packages/drawer/src/views/DrawerView.tsx
@@ -1,4 +1,5 @@
 import {
+  getDefaultSidebarWidth,
   getHeaderTitle,
   Header,
   SafeAreaProviderCompat,
@@ -297,7 +298,10 @@ function DrawerViewBase({
         overlayAccessibilityLabel={overlayAccessibilityLabel}
         drawerPosition={drawerPosition}
         drawerStyle={[
-          { backgroundColor: colors.card },
+          {
+            backgroundColor: colors.card,
+            width: getDefaultSidebarWidth(dimensions),
+          },
           drawerType === 'permanent' &&
             (drawerPosition === 'left'
               ? {

--- a/packages/elements/src/getDefaultSidebarWidth.tsx
+++ b/packages/elements/src/getDefaultSidebarWidth.tsx
@@ -1,0 +1,22 @@
+import { Platform } from 'react-native';
+
+export const getDefaultSidebarWidth = ({
+  height,
+  width,
+}: {
+  height: number;
+  width: number;
+}) => {
+  /*
+   * Default sidebar width is screen width - header height
+   * with a max width of 280 on mobile and 320 on tablet
+   * https://material.io/components/navigation-drawer
+   */
+  const smallerAxisSize = Math.min(height, width);
+  const isLandscape = width > height;
+  const isTablet = smallerAxisSize >= 600;
+  const appBarHeight = Platform.OS === 'ios' ? (isLandscape ? 32 : 44) : 56;
+  const maxWidth = isTablet ? 320 : 280;
+
+  return Math.min(smallerAxisSize - appBarHeight, maxWidth);
+};

--- a/packages/elements/src/index.tsx
+++ b/packages/elements/src/index.tsx
@@ -1,4 +1,5 @@
 export { Background } from './Background';
+export { getDefaultSidebarWidth } from './getDefaultSidebarWidth';
 export { getDefaultHeaderHeight } from './Header/getDefaultHeaderHeight';
 export { getHeaderTitle } from './Header/getHeaderTitle';
 export { Header } from './Header/Header';


### PR DESCRIPTION
**Motivation**

This adds ability to render the tab bar on left/right as a sidebar. It useful on larger screens where we may want to take advantage of the available horizontal screen and show a sidebar instead of a bottom tab bar.

**Test plan**

Open the "Bottom Tabs" example and resize the screen to see the different modes of the tab bar. Tap on the "<<" button on the bottom left to switch between a smaller and larger sidebar.

**Video**

https://github.com/react-navigation/react-navigation/assets/1174278/224beaa9-8e26-4d94-a70d-11e54c37d944