### PR TITLE
fix(HeaderSegment): handle headerRight/Left as a component/JSX element

### DIFF
--- a/packages/elements/src/Header/Header.tsx
+++ b/packages/elements/src/Header/Header.tsx
@@ -185,22 +185,37 @@ export function Header(props: Props) {
     },
   ];
 
-  const leftButton = headerLeft
-    ? headerLeft({
-        tintColor: headerTintColor,
-        pressColor: headerPressColor,
-        pressOpacity: headerPressOpacity,
-        labelVisible: headerLeftLabelVisible,
-      })
-    : null;
+  const leftButton =
+    typeof headerLeft === 'function'
+      ? headerLeft({
+          tintColor: headerTintColor,
+          pressColor: headerPressColor,
+          pressOpacity: headerPressOpacity,
+          labelVisible: headerLeftLabelVisible,
+        })
+      : React.isValidElement(headerLeft)
+      ? React.cloneElement(headerLeft, {
+          tintColor: headerTintColor,
+          pressColor: headerPressColor,
+          pressOpacity: headerPressOpacity,
+          labelVisible: headerLeftLabelVisible,
+        })
+      : null;
 
-  const rightButton = headerRight
-    ? headerRight({
-        tintColor: headerTintColor,
-        pressColor: headerPressColor,
-        pressOpacity: headerPressOpacity,
-      })
-    : null;
+  const rightButton =
+    typeof headerRight === 'function'
+      ? headerRight({
+          tintColor: headerTintColor,
+          pressColor: headerPressColor,
+          pressOpacity: headerPressOpacity,
+        })
+      : React.isValidElement(headerRight)
+      ? React.cloneElement(headerRight, {
+          tintColor: headerTintColor,
+          pressColor: headerPressColor,
+          pressOpacity: headerPressOpacity,
+        })
+      : null;
 
   const headerTitle =
     typeof customTitle !== 'function'

--- a/packages/elements/src/types.tsx
+++ b/packages/elements/src/types.tsx
@@ -35,14 +35,21 @@ export type HeaderOptions = {
    */
   headerTitleAllowFontScaling?: boolean;
   /**
-   * Function which returns a React Element to display on the left side of the header.
+   * React Element or function which returns a React Element to display on the left side of the header.
    */
-  headerLeft?: (props: {
-    tintColor?: string;
-    pressColor?: string;
-    pressOpacity?: number;
-    labelVisible?: boolean;
-  }) => React.ReactNode;
+  headerLeft?:
+    | React.ReactElement<{
+        tintColor?: string;
+        pressColor?: string;
+        pressOpacity?: number;
+        labelVisible?: boolean;
+      }>
+    | ((props: {
+        tintColor?: string;
+        pressColor?: string;
+        pressOpacity?: number;
+        labelVisible?: boolean;
+      }) => React.ReactNode);
   /**
    * Whether a label is visible in the left button. Used to add extra padding.
    */
@@ -52,13 +59,19 @@ export type HeaderOptions = {
    */
   headerLeftContainerStyle?: Animated.WithAnimatedValue<StyleProp<ViewStyle>>;
   /**
-   * Function which returns a React Element to display on the right side of the header.
+   * React Element or function which returns a React Element to display on the right side of the header.
    */
-  headerRight?: (props: {
-    tintColor?: string;
-    pressColor?: string;
-    pressOpacity?: number;
-  }) => React.ReactNode;
+  headerRight?:
+    | React.ReactElement<{
+        tintColor?: string;
+        pressColor?: string;
+        pressOpacity?: number;
+      }>
+    | ((props: {
+        tintColor?: string;
+        pressColor?: string;
+        pressOpacity?: number;
+      }) => React.ReactNode);
   /**
    * Style object for the container of the `headerRight` element.
    */

--- a/packages/stack/src/__tests__/index.test.tsx
+++ b/packages/stack/src/__tests__/index.test.tsx
@@ -32,3 +32,63 @@ it('renders a stack navigator with screens', async () => {
 
   expect(queryByText('Screen B')).not.toBeNull();
 });
+
+it("renders header segment's left/right with either functions or jsx elements", async () => {
+  const Stack = createStackNavigator();
+
+  const TestScreen = () => (
+    <View>
+      <Text>Test Screen</Text>
+    </View>
+  );
+
+  let resultWithElems = render(
+    <NavigationContainer>
+      <Stack.Navigator initialRouteName="ScreenWithElements">
+        <Stack.Screen
+          name="ScreenWithElements"
+          component={TestScreen}
+          options={{
+            headerLeft: (
+              <View>
+                <Text>Left</Text>
+              </View>
+            ),
+            headerRight: (
+              <View>
+                <Text>Right</Text>
+              </View>
+            ),
+          }}
+        />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+
+  let resultWithFuncs = render(
+    <NavigationContainer>
+      <Stack.Navigator initialRouteName="ScreenWithFunctions">
+        <Stack.Screen
+          name="ScreenWithFunctions"
+          component={TestScreen}
+          options={{
+            headerLeft: () => (
+              <View>
+                <Text>Left</Text>
+              </View>
+            ),
+            headerRight: () => (
+              <View>
+                <Text>Right</Text>
+              </View>
+            ),
+          }}
+        />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+  expect(resultWithElems.queryByText('Left')).not.toBeNull();
+  expect(resultWithElems.queryByText('Right')).not.toBeNull();
+  expect(resultWithFuncs.queryByText('Left')).not.toBeNull();
+  expect(resultWithFuncs.queryByText('Right')).not.toBeNull();
+});

--- a/packages/stack/src/types.tsx
+++ b/packages/stack/src/types.tsx
@@ -138,13 +138,17 @@ export type StackHeaderOptions = Omit<
    */
   headerTitle?: string | ((props: HeaderTitleProps) => React.ReactNode);
   /**
-   * Function which returns a React Element to display on the left side of the header.
+   * React Element or function which returns a React Element to display on the left side of the header.
    */
-  headerLeft?: (props: HeaderBackButtonProps) => React.ReactNode;
+  headerLeft?:
+    | React.ReactElement<HeaderBackButtonProps>
+    | ((props: HeaderBackButtonProps) => React.ReactNode);
   /**
-   * Function which returns a React Element to display on the right side of the header.
+   * React Element or function which returns React Element to display on the right side of the header.
    */
-  headerRight?: (props: HeaderButtonProps) => React.ReactNode;
+  headerRight?:
+    | React.ReactElement<HeaderButtonProps>
+    | ((props: HeaderButtonProps) => React.ReactNode);
   /**
    * Whether back button title font should scale to respect Text Size accessibility settings. Defaults to `false`.
    */

--- a/packages/stack/src/views/Header/HeaderSegment.tsx
+++ b/packages/stack/src/views/Header/HeaderSegment.tsx
@@ -154,32 +154,57 @@ export function HeaderSegment(props: Props) {
     typeof height === 'number' ? height : defaultHeight
   );
 
-  const headerLeft: StackHeaderOptions['headerLeft'] = left
-    ? (props) =>
-        left({
-          ...props,
-          backImage: headerBackImage,
-          accessibilityLabel: headerBackAccessibilityLabel,
-          testID: headerBackTestID,
-          allowFontScaling: headerBackAllowFontScaling,
-          onPress: onGoBack,
-          label: headerBackTitle,
-          truncatedLabel: headerTruncatedBackTitle,
-          labelStyle: [leftLabelStyle, headerBackTitleStyle],
-          onLabelLayout: handleLeftLabelLayout,
-          screenLayout: layout,
-          titleLayout,
-          canGoBack: Boolean(onGoBack),
-        })
-    : undefined;
+  let headerLeft: StackHeaderOptions['headerLeft'];
+  if (typeof left === 'function') {
+    headerLeft = (props) =>
+      left({
+        ...props,
+        backImage: headerBackImage,
+        accessibilityLabel: headerBackAccessibilityLabel,
+        testID: headerBackTestID,
+        allowFontScaling: headerBackAllowFontScaling,
+        onPress: onGoBack,
+        label: headerBackTitle,
+        truncatedLabel: headerTruncatedBackTitle,
+        labelStyle: [leftLabelStyle, headerBackTitleStyle],
+        onLabelLayout: handleLeftLabelLayout,
+        screenLayout: layout,
+        titleLayout,
+        canGoBack: Boolean(onGoBack),
+      });
+  } else if (React.isValidElement(left)) {
+    headerLeft = (props) =>
+      React.cloneElement(left, {
+        ...props,
+        backImage: headerBackImage,
+        accessibilityLabel: headerBackAccessibilityLabel,
+        testID: headerBackTestID,
+        allowFontScaling: headerBackAllowFontScaling,
+        onPress: onGoBack,
+        label: headerBackTitle,
+        truncatedLabel: headerTruncatedBackTitle,
+        labelStyle: [leftLabelStyle, headerBackTitleStyle],
+        onLabelLayout: handleLeftLabelLayout,
+        screenLayout: layout,
+        titleLayout,
+        canGoBack: Boolean(onGoBack),
+      });
+  }
 
-  const headerRight: StackHeaderOptions['headerRight'] = right
-    ? (props) =>
-        right({
-          ...props,
-          canGoBack: Boolean(onGoBack),
-        })
-    : undefined;
+  let headerRight: StackHeaderOptions['headerRight'];
+  if (typeof right === 'function') {
+    headerRight = (props) =>
+      right({
+        ...props,
+        canGoBack: Boolean(onGoBack),
+      });
+  } else if (React.isValidElement(right)) {
+    headerRight = (props) =>
+      React.cloneElement(right, {
+        ...props,
+        canGoBack: Boolean(onGoBack),
+      });
+  }
 
   const headerTitle: StackHeaderOptions['headerTitle'] =
     typeof title !== 'function'

--- a/packages/stack/src/views/Header/HeaderSegment.tsx
+++ b/packages/stack/src/views/Header/HeaderSegment.tsx
@@ -173,22 +173,21 @@ export function HeaderSegment(props: Props) {
         canGoBack: Boolean(onGoBack),
       });
   } else if (React.isValidElement(left)) {
-    headerLeft = (props) =>
-      React.cloneElement(left, {
-        ...props,
-        backImage: headerBackImage,
-        accessibilityLabel: headerBackAccessibilityLabel,
-        testID: headerBackTestID,
-        allowFontScaling: headerBackAllowFontScaling,
-        onPress: onGoBack,
-        label: headerBackTitle,
-        truncatedLabel: headerTruncatedBackTitle,
-        labelStyle: [leftLabelStyle, headerBackTitleStyle],
-        onLabelLayout: handleLeftLabelLayout,
-        screenLayout: layout,
-        titleLayout,
-        canGoBack: Boolean(onGoBack),
-      });
+    headerLeft = React.cloneElement(left, {
+      ...props,
+      backImage: headerBackImage,
+      accessibilityLabel: headerBackAccessibilityLabel,
+      testID: headerBackTestID,
+      allowFontScaling: headerBackAllowFontScaling,
+      onPress: onGoBack,
+      label: headerBackTitle,
+      truncatedLabel: headerTruncatedBackTitle,
+      labelStyle: [leftLabelStyle, headerBackTitleStyle],
+      onLabelLayout: handleLeftLabelLayout,
+      screenLayout: layout,
+      titleLayout,
+      canGoBack: Boolean(onGoBack),
+    });
   }
 
   let headerRight: StackHeaderOptions['headerRight'];
@@ -199,11 +198,9 @@ export function HeaderSegment(props: Props) {
         canGoBack: Boolean(onGoBack),
       });
   } else if (React.isValidElement(right)) {
-    headerRight = (props) =>
-      React.cloneElement(right, {
-        ...props,
-        canGoBack: Boolean(onGoBack),
-      });
+    headerRight = React.cloneElement(right, {
+      canGoBack: Boolean(onGoBack),
+    });
   }
 
   const headerTitle: StackHeaderOptions['headerTitle'] =


### PR DESCRIPTION
Motivation

Solves this issue: https://github.com/react-navigation/react-navigation/issues/8709

The headerRight and headerLeft properties can only be functions and not components/JSX elements. Reasons we'd want to fix this:
- It caused an error that was a little tricky to track down when I wrote code that dynamically updated the button in the top right with a JSX element. This previously worked in older versions of react navigation and broke when I upgraded. So this fix can make upgrades slightly smoother for people
- As [mcsky suggested in the ticket](https://github.com/react-navigation/react-navigation/issues/8709#issuecomment-1246925899), some may prefer to pass a component/element directly to avoid recreating DOM of the right header on render

Test plan

In `/react-navigation/packages/stack/src/__tests__/index.test.tsx` I've added a test case now that renders two screens: one with headerLeft/headerRight passed as functions and the other with elements. The test verifies that they are both rendered on each screen.

UPDATE: Apologies, I initially forgot to update types in some places and circled back to do that. I have fixed my test coverage as well. Please let me know what else I can do to improve this PR.