### PR TITLE
feat: add a layout prop for navigators

### DIFF
--- a/example/src/Screens/CustomLayout.tsx
+++ b/example/src/Screens/CustomLayout.tsx
@@ -1,0 +1,253 @@
+import {
+  getDefaultHeaderHeight,
+  getHeaderTitle,
+} from '@react-navigation/elements';
+import {
+  CommonActions,
+  ParamListBase,
+  useTheme,
+} from '@react-navigation/native';
+import {
+  createStackNavigator,
+  StackNavigationOptions,
+  StackScreenProps,
+} from '@react-navigation/stack';
+import * as React from 'react';
+import {
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { Button } from 'react-native-paper';
+import {
+  useSafeAreaFrame,
+  useSafeAreaInsets,
+} from 'react-native-safe-area-context';
+
+import { Albums } from '../Shared/Albums';
+import { Article } from '../Shared/Article';
+import { NewsFeed } from '../Shared/NewsFeed';
+
+export type SimpleStackParams = {
+  Article: { author: string } | undefined;
+  NewsFeed: { date: number };
+  Albums: undefined;
+};
+
+const scrollEnabled = Platform.select({ web: true, default: false });
+
+const ArticleScreen = ({
+  navigation,
+  route,
+}: StackScreenProps<SimpleStackParams, 'Article'>) => {
+  return (
+    <ScrollView>
+      <View style={styles.buttons}>
+        <Button
+          mode="contained"
+          onPress={() => navigation.navigate('NewsFeed', { date: Date.now() })}
+          style={styles.button}
+        >
+          Navigate to feed
+        </Button>
+        <Button
+          mode="outlined"
+          onPress={() => navigation.goBack()}
+          style={styles.button}
+        >
+          Go back
+        </Button>
+      </View>
+      <Article
+        author={{ name: route.params?.author ?? 'Unknown' }}
+        scrollEnabled={scrollEnabled}
+      />
+    </ScrollView>
+  );
+};
+
+const NewsFeedScreen = ({
+  route,
+  navigation,
+}: StackScreenProps<SimpleStackParams, 'NewsFeed'>) => {
+  return (
+    <ScrollView>
+      <View style={styles.buttons}>
+        <Button
+          mode="contained"
+          onPress={() => navigation.navigate('Albums')}
+          style={styles.button}
+        >
+          Navigate to album
+        </Button>
+        <Button
+          mode="outlined"
+          onPress={() => navigation.goBack()}
+          style={styles.button}
+        >
+          Go back
+        </Button>
+      </View>
+      <NewsFeed scrollEnabled={scrollEnabled} date={route.params.date} />
+    </ScrollView>
+  );
+};
+
+const AlbumsScreen = ({
+  navigation,
+}: StackScreenProps<SimpleStackParams, 'Albums'>) => {
+  return (
+    <ScrollView>
+      <View style={styles.buttons}>
+        <Button
+          mode="contained"
+          onPress={() =>
+            navigation.navigate('Article', { author: 'Babel fish' })
+          }
+          style={styles.button}
+        >
+          Navigate to article
+        </Button>
+        <Button
+          mode="outlined"
+          onPress={() => navigation.goBack()}
+          style={styles.button}
+        >
+          Go back
+        </Button>
+      </View>
+      <Albums scrollEnabled={scrollEnabled} />
+    </ScrollView>
+  );
+};
+
+const Stack = createStackNavigator<SimpleStackParams>();
+
+export function CustomLayout({
+  navigation,
+  screenOptions,
+}: StackScreenProps<ParamListBase> & {
+  screenOptions?: StackNavigationOptions;
+}) {
+  React.useLayoutEffect(() => {
+    navigation.setOptions({
+      headerShown: false,
+    });
+  }, [navigation]);
+
+  const { colors } = useTheme();
+
+  const frame = useSafeAreaFrame();
+  const insets = useSafeAreaInsets();
+
+  return (
+    <Stack.Navigator
+      layout={({ children, state, descriptors, navigation }) => {
+        return (
+          <View style={styles.container}>
+            <ScrollView
+              horizontal
+              style={{
+                backgroundColor: colors.card,
+                borderBottomColor: colors.border,
+                borderBottomWidth: StyleSheet.hairlineWidth,
+                maxHeight: getDefaultHeaderHeight(frame, false, insets.top),
+              }}
+              contentContainerStyle={[
+                styles.breadcrumbs,
+                { paddingTop: insets.top },
+              ]}
+            >
+              {state.routes.map((route, i, self) => {
+                return (
+                  <React.Fragment key={route.key}>
+                    <Pressable
+                      onPress={() => {
+                        navigation.dispatch((state) => {
+                          return CommonActions.reset({
+                            ...state,
+                            index: i,
+                            routes: state.routes.slice(0, i + 1),
+                          });
+                        });
+                      }}
+                    >
+                      <Text style={[styles.title, { color: colors.text }]}>
+                        {getHeaderTitle(
+                          descriptors[route.key].options,
+                          route.name
+                        )}
+                      </Text>
+                    </Pressable>
+                    {self.length - 1 !== i ? (
+                      <Text style={[styles.arrow, { color: colors.text }]}>
+                        ❯
+                      </Text>
+                    ) : null}
+                  </React.Fragment>
+                );
+              })}
+            </ScrollView>
+            {children}
+          </View>
+        );
+      }}
+      screenOptions={{
+        ...screenOptions,
+        headerShown: false,
+      }}
+    >
+      <Stack.Screen
+        name="Article"
+        component={ArticleScreen}
+        options={({ route }) => ({
+          title: `Article by ${route.params?.author ?? 'Unknown'}`,
+        })}
+        initialParams={{ author: 'Gandalf' }}
+      />
+      <Stack.Screen
+        name="NewsFeed"
+        component={NewsFeedScreen}
+        options={{ title: 'Feed' }}
+      />
+      <Stack.Screen
+        name="Albums"
+        component={AlbumsScreen}
+        options={{ title: 'Albums' }}
+      />
+    </Stack.Navigator>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  buttons: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    padding: 8,
+  },
+  button: {
+    margin: 8,
+  },
+  breadcrumbs: {
+    alignItems: 'center',
+    paddingHorizontal: 8,
+  },
+  title: {
+    fontSize: 16,
+    lineHeight: 16,
+    fontWeight: 'bold',
+    paddingVertical: 16,
+    paddingHorizontal: 8,
+  },
+  arrow: {
+    fontSize: 14,
+    lineHeight: 14,
+    opacity: 0.3,
+  },
+});

--- a/example/src/screens.tsx
+++ b/example/src/screens.tsx
@@ -2,6 +2,7 @@ import type { NavigatorScreenParams } from '@react-navigation/native';
 
 import { AuthFlow } from './Screens/AuthFlow';
 import { BottomTabs } from './Screens/BottomTabs';
+import { CustomLayout } from './Screens/CustomLayout';
 import { DrawerView } from './Screens/DrawerView';
 import { DynamicTabs } from './Screens/DynamicTabs';
 import { LinkComponent } from './Screens/LinkComponent';
@@ -89,6 +90,10 @@ export const SCREENS = {
   NativeStackPreventRemove: {
     title: 'Prevent removing screen in Native Stack',
     component: NativeStackPreventRemove,
+  },
+  CustomLayout: {
+    title: 'Custom Layout',
+    component: CustomLayout,
   },
   LinkComponent: {
     title: '<Link />',

--- a/packages/bottom-tabs/src/navigators/createBottomTabNavigator.tsx
+++ b/packages/bottom-tabs/src/navigators/createBottomTabNavigator.tsx
@@ -31,6 +31,7 @@ function BottomTabNavigator({
   initialRouteName,
   backBehavior,
   children,
+  layout,
   screenListeners,
   screenOptions,
   sceneContainerStyle,
@@ -48,6 +49,7 @@ function BottomTabNavigator({
       initialRouteName,
       backBehavior,
       children,
+      layout,
       screenListeners,
       screenOptions,
     });

--- a/packages/core/src/types.tsx
+++ b/packages/core/src/types.tsx
@@ -35,6 +35,30 @@ export type DefaultNavigatorOptions<
    */
   children: React.ReactNode;
   /**
+   * Layout component for the navigator.
+   * Useful for wrapping with a component with access to navigator's state and options.
+   */
+  layout?: (props: {
+    state: State;
+    navigation: NavigationHelpers<ParamList>;
+    descriptors: Record<
+      string,
+      Descriptor<
+        ScreenOptions,
+        NavigationProp<
+          ParamList,
+          keyof ParamList,
+          string | undefined,
+          State,
+          ScreenOptions,
+          EventMap
+        >,
+        RouteProp<ParamList>
+      >
+    >;
+    children: React.ReactNode;
+  }) => React.ReactElement;
+  /**
    * Event listeners for all the screens in the navigator.
    */
   screenListeners?:

--- a/packages/core/src/useNavigationBuilder.tsx
+++ b/packages/core/src/useNavigationBuilder.tsx
@@ -259,7 +259,7 @@ export function useNavigationBuilder<
     | NavigatorRoute
     | undefined;
 
-  const { children, screenListeners, ...rest } = options;
+  const { children, layout, screenOptions, screenListeners, ...rest } = options;
   const { current: router } = React.useRef<Router<State, any>>(
     createRouter({
       ...(rest as unknown as RouterOptions),
@@ -678,7 +678,7 @@ export function useNavigationBuilder<
     state,
     screens,
     navigation,
-    screenOptions: options.screenOptions,
+    screenOptions,
     onAction,
     getState,
     setState,
@@ -696,11 +696,23 @@ export function useNavigationBuilder<
     descriptors,
   });
 
-  const NavigationContent = useComponent((children: React.ReactNode) => (
-    <NavigationHelpersContext.Provider value={navigation}>
-      <PreventRemoveProvider>{children}</PreventRemoveProvider>
-    </NavigationHelpersContext.Provider>
-  ));
+  const NavigationContent = useComponent((children: React.ReactNode) => {
+    const element =
+      layout != null
+        ? layout({
+            state,
+            descriptors,
+            navigation,
+            children,
+          })
+        : children;
+
+    return (
+      <NavigationHelpersContext.Provider value={navigation}>
+        <PreventRemoveProvider>{element}</PreventRemoveProvider>
+      </NavigationHelpersContext.Provider>
+    );
+  });
 
   return {
     state,

--- a/packages/drawer/src/navigators/createDrawerNavigator.tsx
+++ b/packages/drawer/src/navigators/createDrawerNavigator.tsx
@@ -32,6 +32,7 @@ function DrawerNavigator({
   defaultStatus = 'closed',
   backBehavior,
   children,
+  layout,
   screenListeners,
   screenOptions,
   ...rest
@@ -49,6 +50,7 @@ function DrawerNavigator({
       defaultStatus,
       backBehavior,
       children,
+      layout,
       screenListeners,
       screenOptions,
     });

--- a/packages/material-top-tabs/src/navigators/createMaterialTopTabNavigator.tsx
+++ b/packages/material-top-tabs/src/navigators/createMaterialTopTabNavigator.tsx
@@ -31,6 +31,7 @@ function MaterialTopTabNavigator({
   initialRouteName,
   backBehavior,
   children,
+  layout,
   screenListeners,
   screenOptions,
   ...rest
@@ -47,6 +48,7 @@ function MaterialTopTabNavigator({
       initialRouteName,
       backBehavior,
       children,
+      layout,
       screenListeners,
       screenOptions,
     });

--- a/packages/native-stack/src/navigators/createNativeStackNavigator.tsx
+++ b/packages/native-stack/src/navigators/createNativeStackNavigator.tsx
@@ -22,6 +22,7 @@ function NativeStackNavigator({
   id,
   initialRouteName,
   children,
+  layout,
   screenListeners,
   screenOptions,
   ...rest
@@ -37,6 +38,7 @@ function NativeStackNavigator({
       id,
       initialRouteName,
       children,
+      layout,
       screenListeners,
       screenOptions,
     });

--- a/packages/stack/src/navigators/createStackNavigator.tsx
+++ b/packages/stack/src/navigators/createStackNavigator.tsx
@@ -33,6 +33,7 @@ function StackNavigator({
   id,
   initialRouteName,
   children,
+  layout,
   screenListeners,
   screenOptions,
   ...rest
@@ -49,6 +50,7 @@ function StackNavigator({
       id,
       initialRouteName,
       children,
+      layout,
       screenListeners,
       screenOptions,
     });


### PR DESCRIPTION
**Motivation**

This adds a new `layout` prop to navigators. It can be useful for augmenting the navigators with additional UI with a wrapper. The difference from adding a regular wrapper is that the code in `layout` callback has access to the navigator's state, options etc.

**Test plan**

Tested by implementing a breadcrumb UI in stack navigator in the example app.

https://github.com/react-navigation/react-navigation/assets/1174278/5ee2b7f5-f000-4d43-a147-33a1e1562b4c


