### PR TITLE
fix: pass `tintColor` to `Label`

### DIFF
--- a/packages/bottom-tabs/src/views/BottomTabItem.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabItem.tsx
@@ -242,6 +242,7 @@ export function BottomTabItem({
           labelStyle,
         ]}
         allowFontScaling={allowFontScaling}
+        tintColor={color}
       >
         {label}
       </Label>


### PR DESCRIPTION
**Motivation**

#11246 refactored the usage of the label, during which the `tintColor` was not forwarded to the new `Label` component. This PR forwards the `tintColor` derived from `options` using `tabBarActiveTintColor` and `tabBarActiveTintColor` to the `Label` component reverting the UI with the previously expected colors.

**Test plan**

There are some visible changes and the following are the steps to see the change

- Run the app
- Go to `Bottom Tabs`
- Before this PR, the color of the label for the active tab was based on `tintColor` from the theme and not the `tintColor` from options passed to the screen (`tabBarActiveTintColor` and `tabBarActiveTintColor`).
- In this PR, notice the color of the label changes according to the `tintColor` from screen options.

> Note: The color difference is not visible until seen carefully.

**Demo**
| Before | After |
| -- | -- |
| <video src="https://github.com/react-navigation/react-navigation/assets/43173341/614b45f3-67af-4458-9ae1-2c9dd91e7de2" />  |  <video src="https://github.com/react-navigation/react-navigation/assets/43173341/caaadeef-643d-4b53-a5f8-2da722148308" /> |










