### PR TITLE
fix: onReady not getting called on native

### DIFF
--- a/packages/core/src/BaseNavigationContainer.tsx
+++ b/packages/core/src/BaseNavigationContainer.tsx
@@ -301,13 +301,14 @@ export const BaseNavigationContainer = React.forwardRef(
       stateRef.current = state;
     });
 
-    const isNavigationReady = isReady();
+    const onReadyCalledRef = React.useRef(false);
 
     React.useEffect(() => {
-      if (isNavigationReady) {
+      if (!onReadyCalledRef.current && isReady()) {
+        onReadyCalledRef.current = true;
         onReadyRef.current?.();
       }
-    }, [isNavigationReady]);
+    }, [state, isReady]);
 
     React.useEffect(() => {
       const hydratedState = getRootState();


### PR DESCRIPTION
Before, we observed that `onReady` was not called as the component was re-rendered (hence, `isReady() not called`. 


**Test plan**
Add a console.log to `<NavigationContainer onReady={cosole.log} />`
