### PR TITLE
fix: [Drawer] fix iOS wrong detected frame dimensions

### DIFF
--- a/packages/drawer/src/views/DrawerView.tsx
+++ b/packages/drawer/src/views/DrawerView.tsx
@@ -14,9 +14,8 @@ import {
   useTheme,
 } from '@react-navigation/native';
 import * as React from 'react';
-import { Platform, StyleSheet } from 'react-native';
+import { Platform, StyleSheet, useWindowDimensions } from 'react-native';
 import { Drawer } from 'react-native-drawer-layout';
-import { useSafeAreaFrame } from 'react-native-safe-area-context';
 import useLatestCallback from 'use-latest-callback';
 
 import type {
@@ -80,7 +79,7 @@ function DrawerViewBase({
     setLoaded([...loaded, focusedRouteKey]);
   }
 
-  const dimensions = useSafeAreaFrame();
+  const dimensions = useWindowDimensions();
 
   const { colors } = useTheme();
 


### PR DESCRIPTION
**Motivation**

It seems that under certain scenarios on iOS, the useSafeAreaFrame hook is returning incorrect dimensions. The issue may lie in the native implementation of methods responsible for layout (`layoutSubviews`, `layoutIfNeeded`, etc). However, we only require the `height` and `width` of the main window, as the Drawer is hidden behind the root View and we do not need the x and y coordinates of the top frame as SafeArea `Rect` provides.

**Test plan**

- Open Drawer
- Open iOS Modal
dimensions values are correct and event is broadcasting properly
- Rotate screen landscape
- Rotate screen portrait
dimensions values broken and are no longer broadcast
- Close modal

- [x] The change must pass lint, typescript and tests.


https://github.com/react-navigation/react-navigation/assets/12899080/0145a065-11af-4eb3-9775-6f216546523a


https://github.com/react-navigation/react-navigation/assets/12899080/94288f31-8d3b-488e-8194-42f7d36aaade



<details>
<summary>RN info</summary>

```shell
alexandrkozhevnikov@Alexandrs-MacBook-Pro AwesomeProject % npx react-native info
info Fetching system and libraries information...
System:
  OS: macOS 14.0
  CPU: (10) arm64 Apple M1 Pro
  Memory: 101.14 MB / 16.00 GB
  Shell:
    version: "5.9"
    path: /bin/zsh
Binaries:
  Node:
    version: 18.17.1
    path: ~/.nvm/versions/node/v18.17.1/bin/node
  Yarn:
    version: 1.22.19
    path: ~/.nvm/versions/node/v18.17.1/bin/yarn
  npm:
    version: 9.6.7
    path: ~/.nvm/versions/node/v18.17.1/bin/npm
  Watchman:
    version: 2023.09.25.00
    path: /opt/homebrew/bin/watchman
Managers:
  CocoaPods:
    version: 1.12.1
    path: /Users/alexandrkozhevnikov/.rvm/gems/ruby-2.7.6/bin/pod
SDKs:
  iOS SDK:
    Platforms:
      - DriverKit 23.0
      - iOS 17.0
      - macOS 14.0
      - tvOS 17.0
      - watchOS 10.0
  Android SDK:
    Android NDK: 22.1.7171670
IDEs:
  Android Studio: Not Found
  Xcode:
    version: 15.0/15A240d
    path: /usr/bin/xcodebuild
Languages:
  Java:
    version: 11.0.20.1
    path: /usr/bin/javac
  Ruby:
    version: 2.7.6
    path: /Users/alexandrkozhevnikov/.rvm/rubies/ruby-2.7.6/bin/ruby
npmPackages:
  "@react-native-community/cli": Not Found
  react:
    installed: 18.2.0
    wanted: 18.2.0
  react-native:
    installed: 0.72.5
    wanted: 0.72.5
  react-native-macos: Not Found
npmGlobalPackages:
  "*react-native*": Not Found
Android:
  hermesEnabled: true
  newArchEnabled: false
iOS:
  hermesEnabled: true
  newArchEnabled: false
```

</details>

<details>
  <summary>Navigator snippet to reproduce</summary>
  
  ```javascript
const Drawer = createDrawerNavigator();
const RootStack = createNativeStackNavigator<RootStackParamList>();

const DrawerStackNavigator = memo(() => {
  return (
    <Drawer.Navigator
      drawerContent={DrawerContent}
      screenOptions={{
        headerShown: false,
        headerTransparent: true,
        drawerPosition: 'right',
        drawerType: 'front',
        drawerStyle: {
          width: 220,
        },
        freezeOnBlur: true,
        sceneContainerStyle: {flex: 1},
      }}>
      <Drawer.Screen
        options={{
          headerShown: false,
          title: 'App',
        }}
        name="Main"
        component={TabNavigator}
      />
    </Drawer.Navigator>
  );
});

export const MainStackNavigator = () => {
  return (
    <RootStack.Navigator
      screenOptions={{
        freezeOnBlur: true,
        headerBackground: undefined,
      }}>
      <RootStack.Screen
        options={{
          headerShown: false,
        }}
        name="TabStack"
        component={DrawerStackNavigator}
      />
      <RootStack.Screen
        options={{
          presentation: 'modal',
          headerShown: false,
        }}
        name="Modal1"
        component={Modal1}
      />
    </RootStack.Navigator>
  );
};
  ```
  
</details>
