### PR TITLE
fix: forShifting bottom-tabs animation

### DIFF
--- a/packages/bottom-tabs/src/TransitionConfigs/SceneStyleInterpolators.tsx
+++ b/packages/bottom-tabs/src/TransitionConfigs/SceneStyleInterpolators.tsx
@@ -35,7 +35,7 @@ export function forShifting({
         {
           translateX: current.interpolate({
             inputRange: [-1, 0, 1],
-            outputRange: [-50, 1, 50],
+            outputRange: [-50, 0, 50],
           }),
         },
       ],


### PR DESCRIPTION
**Motivation**

Noticed tabs were 1px off to the right when I was testing the new bottom-tab animations, the ShiftingTransition Present in the alpha.

**Test plan**

install:
`"@react-navigation/bottom-tabs": "^7.0.0-alpha.4",`
`"@react-navigation/core": "^7.0.0-alpha.3",`
`"@react-navigation/elements": "^2.0.0-alpha.1",`
`"@react-navigation/native": "^7.0.0-alpha.3",`
`"@react-navigation/native-stack": "^7.0.0-alpha.4",`
`"@react-navigation/stack": "^7.0.0-alpha.4",`

create Tab Navigator with these screen options:
```
const Tab = createBottomTabNavigator<TabsNavigatorStack>();

const animation = TransitionPresets.ShiftingTransition;

const screenOptions = {
    headerShown: false,

    animationEnabled: true,
    ...animation,
};
....
  <Tab.Navigator
                initialRouteName={...}
                screenOptions={screenOptions}
            >
....
```

then you can create two tabs and shift between them. if you have a background colour, you can better see the white pixel line. 

Here is an example of our Profile Page. if you look to the left of the banner, you can see the pixel offset.

Before:
![Simulator Screenshot - iPhone 14 - 2023-10-10 at 18 57 00](https://github.com/react-navigation/react-navigation/assets/61589377/de0a5080-3c76-492f-aa80-11915eddfc83)
After:
![Simulator Screenshot - iPhone 14 - 2023-10-10 at 18 57 10](https://github.com/react-navigation/react-navigation/assets/61589377/f64bb061-57ab-4bf3-ab1e-98210f133234)



