### PR TITLE
feat: add overlayEnable option in drawer layout

### DIFF
--- a/packages/react-native-drawer-layout/src/types.tsx
+++ b/packages/react-native-drawer-layout/src/types.tsx
@@ -79,6 +79,13 @@ export type DrawerProps = {
   drawerStyle?: StyleProp<ViewStyle>;
 
   /**
+   * Whether the overlay is enabled.
+   * If false, interaction is possible with the drawer content while drawer is open.
+   * Defaults to `true`.
+   */
+  overlayEnabled?: boolean;
+
+  /**
    * Style object for the drawer overlay.
    */
   overlayStyle?: StyleProp<ViewStyle>;

--- a/packages/react-native-drawer-layout/src/views/Drawer.tsx
+++ b/packages/react-native-drawer-layout/src/views/Drawer.tsx
@@ -67,6 +67,7 @@ export function Drawer({
   keyboardDismissMode = 'on-drag',
   hideStatusBarOnOpen = false,
   statusBarAnimation = 'slide',
+  overlayEnabled = true,
   style,
   ...rest
 }: Props) {
@@ -107,6 +108,7 @@ export function Drawer({
         keyboardDismissMode={keyboardDismissMode}
         hideStatusBarOnOpen={hideStatusBarOnOpen}
         statusBarAnimation={statusBarAnimation}
+        overlayEnabled={overlayEnabled}
       />
     </GestureHandlerRootView>
   );

--- a/packages/react-native-drawer-layout/src/views/legacy/Drawer.tsx
+++ b/packages/react-native-drawer-layout/src/views/legacy/Drawer.tsx
@@ -523,6 +523,7 @@ export class Drawer extends React.Component<Props> {
       children,
       gestureHandlerProps,
       overlayAccessibilityLabel,
+      overlayEnabled,
     } = this.props;
 
     const isOpen = drawerType === 'permanent' ? true : open;
@@ -596,8 +597,8 @@ export class Drawer extends React.Component<Props> {
                 {children}
               </View>
               {
-                // Disable overlay if sidebar is permanent
-                drawerType === 'permanent' ? null : (
+                // Disable overlay if sidebar is permanent or not overlayEnabled
+                drawerType === 'permanent' || !overlayEnabled ? null : (
                   <Overlay
                     progress={progress}
                     onPress={() => this.toggleDrawer(false)}

--- a/packages/react-native-drawer-layout/src/views/modern/Drawer.tsx
+++ b/packages/react-native-drawer-layout/src/views/modern/Drawer.tsx
@@ -59,6 +59,7 @@ export function Drawer({
   onTransitionStart,
   onTransitionEnd,
   open,
+  overlayEnabled,
   overlayStyle,
   overlayAccessibilityLabel,
   statusBarAnimation,
@@ -395,7 +396,7 @@ export function Drawer({
             >
               {children}
             </View>
-            {drawerType !== 'permanent' ? (
+            {drawerType !== 'permanent' && overlayEnabled ? (
               <Overlay
                 progress={progress}
                 onPress={() => toggleDrawer(false)}


### PR DESCRIPTION
Please provide enough information so that others can review your pull request.

**Motivation**

I like the react-native-drawer-layout and want to use it to host some settings that will pull out in a drawer. In my case, the requirements are that the drawer open and close but the content remain interactive. Currently, when using `drawerType="front"`, `drawerType="slide"`, and `drawerType="back"` and the drawer is open the content in the drawer is covered in an overlay that close the drawer when one attempts to interact with the content (children). This works well for use in a navigation but in my case I need to be able to interact with the content like `drawerType="permanent"` but open and close like `drawerType="front"`. 

I added a boolean option available on Drawer props following the naming conventions called `overlayEnabled` to allow the overlay to be turned off. It defaults to true to maintain the original functionality but can be set to false to allow the users to interact with the drawer content and leave the drawer open. 

**Test plan**

1. Use the repo example project. 
2. In the DrawerView.tsx set the Drawer prop `overlayEnabled={false}` and notice that you can click on the button to close the drawer in the screen (from the Drawer children). 
3. In the DrawerView.tsx set the Drawer prop `overlayEnabled={true}` the overlay appears over the content (children). Clicking any part of the will close the drawer.
4. In the DrawerView.tsx omit the Drawer prop `overlayEnabled` the overlay appears over the content (children). Clicking any part of the will close the drawer.