### PR TITLE
feat: add a button element to elements package 

### DIFF
--- a/example/src/Screens/AuthFlow.tsx
+++ b/example/src/Screens/AuthFlow.tsx
@@ -1,3 +1,4 @@
+import { Button } from '@react-navigation/elements';
 import { type ParamListBase, useTheme } from '@react-navigation/native';
 import {
   createStackNavigator,
@@ -5,7 +6,7 @@ import {
 } from '@react-navigation/stack';
 import * as React from 'react';
 import { ActivityIndicator, StyleSheet, TextInput, View } from 'react-native';
-import { Button, Title } from 'react-native-paper';
+import { Title } from 'react-native-paper';
 
 type AuthStackParams = {
   Home: undefined;
@@ -63,7 +64,7 @@ const SignInScreen = ({
           { backgroundColor: colors.card, color: colors.text },
         ]}
       />
-      <Button mode="contained" onPress={signIn} style={styles.button}>
+      <Button variant="filled" onPress={signIn} style={styles.button}>
         Sign in
       </Button>
       <Button onPress={() => navigation.navigate('Chat')} style={styles.button}>

--- a/example/src/Screens/CustomLayout.tsx
+++ b/example/src/Screens/CustomLayout.tsx
@@ -1,4 +1,5 @@
 import {
+  Button,
   getDefaultHeaderHeight,
   getHeaderTitle,
 } from '@react-navigation/elements';
@@ -21,7 +22,6 @@ import {
   Text,
   View,
 } from 'react-native';
-import { Button } from 'react-native-paper';
 import {
   useSafeAreaFrame,
   useSafeAreaInsets,
@@ -47,17 +47,12 @@ const ArticleScreen = ({
     <ScrollView>
       <View style={styles.buttons}>
         <Button
-          mode="contained"
+          variant="filled"
           onPress={() => navigation.navigate('NewsFeed', { date: Date.now() })}
-          style={styles.button}
         >
           Navigate to feed
         </Button>
-        <Button
-          mode="outlined"
-          onPress={() => navigation.goBack()}
-          style={styles.button}
-        >
+        <Button variant="tinted" onPress={() => navigation.goBack()}>
           Go back
         </Button>
       </View>
@@ -76,18 +71,10 @@ const NewsFeedScreen = ({
   return (
     <ScrollView>
       <View style={styles.buttons}>
-        <Button
-          mode="contained"
-          onPress={() => navigation.navigate('Albums')}
-          style={styles.button}
-        >
+        <Button variant="filled" onPress={() => navigation.navigate('Albums')}>
           Navigate to album
         </Button>
-        <Button
-          mode="outlined"
-          onPress={() => navigation.goBack()}
-          style={styles.button}
-        >
+        <Button variant="tinted" onPress={() => navigation.goBack()}>
           Go back
         </Button>
       </View>
@@ -103,19 +90,14 @@ const AlbumsScreen = ({
     <ScrollView>
       <View style={styles.buttons}>
         <Button
-          mode="contained"
+          variant="filled"
           onPress={() =>
             navigation.navigate('Article', { author: 'Babel fish' })
           }
-          style={styles.button}
         >
           Navigate to article
         </Button>
-        <Button
-          mode="outlined"
-          onPress={() => navigation.goBack()}
-          style={styles.button}
-        >
+        <Button variant="tinted" onPress={() => navigation.goBack()}>
           Go back
         </Button>
       </View>
@@ -229,10 +211,8 @@ const styles = StyleSheet.create({
   buttons: {
     flexDirection: 'row',
     flexWrap: 'wrap',
-    padding: 8,
-  },
-  button: {
-    margin: 8,
+    gap: 12,
+    padding: 12,
   },
   breadcrumbs: {
     alignItems: 'center',

--- a/example/src/Screens/DrawerView.tsx
+++ b/example/src/Screens/DrawerView.tsx
@@ -1,7 +1,7 @@
+import { Button } from '@react-navigation/elements';
 import * as React from 'react';
 import { StyleSheet, View } from 'react-native';
 import { Drawer, useDrawerProgress } from 'react-native-drawer-layout';
-import { Button } from 'react-native-paper';
 import Animated, {
   interpolate,
   type SharedValue,

--- a/example/src/Screens/DynamicTabs.tsx
+++ b/example/src/Screens/DynamicTabs.tsx
@@ -1,8 +1,9 @@
 import Feather from '@expo/vector-icons/Feather';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import { Button } from '@react-navigation/elements';
 import * as React from 'react';
 import { StyleSheet, View } from 'react-native';
-import { Button, Title } from 'react-native-paper';
+import { Title } from 'react-native-paper';
 
 type BottomTabParams = {
   [key: string]: undefined;
@@ -54,5 +55,6 @@ const styles = StyleSheet.create({
     flex: 1,
     alignItems: 'center',
     justifyContent: 'center',
+    gap: 8,
   },
 });

--- a/example/src/Screens/LinkComponent.tsx
+++ b/example/src/Screens/LinkComponent.tsx
@@ -1,8 +1,9 @@
+import { Button } from '@react-navigation/elements';
 import {
+  CommonActions,
   Link,
   type ParamListBase,
   StackActions,
-  useLinkProps,
 } from '@react-navigation/native';
 import {
   createStackNavigator,
@@ -10,7 +11,6 @@ import {
 } from '@react-navigation/stack';
 import * as React from 'react';
 import { Platform, ScrollView, StyleSheet, View } from 'react-native';
-import { Button } from 'react-native-paper';
 
 import type { LinkComponentDemoParamList } from '../screens';
 import { Albums } from '../Shared/Albums';
@@ -18,50 +18,26 @@ import { Article } from '../Shared/Article';
 
 const scrollEnabled = Platform.select({ web: true, default: false });
 
-const LinkButton = ({
-  screen,
-  params,
-  action,
-  href,
-  ...rest
-}: React.ComponentProps<typeof Button> &
-  Parameters<typeof useLinkProps>[0]) => {
-  // @ts-expect-error: This is already type-checked by the prop types
-  const props = useLinkProps({ screen, params, action, href });
-
-  return <Button {...props} {...rest} />;
-};
-
 const ArticleScreen = ({
-  navigation,
   route,
 }: StackScreenProps<LinkComponentDemoParamList, 'Article'>) => {
   return (
     <ScrollView>
       <View style={styles.buttons}>
-        <Link
-          screen="LinkComponent"
-          params={{ screen: 'Albums' }}
-          style={[styles.button, { padding: 8 }]}
-        >
+        <Link screen="LinkComponent" params={{ screen: 'Albums' }}>
           Go to LinkComponent &gt; Albums
         </Link>
         <Link
           screen="LinkComponent"
           params={{ screen: 'Albums' }}
           action={StackActions.replace('Albums')}
-          style={[styles.button, { padding: 8 }]}
         >
           Replace with LinkComponent &gt; Albums
         </Link>
-        <LinkButton screen="Home" mode="contained" style={styles.button}>
+        <Button screen="Home" variant="filled">
           Go to Home
-        </LinkButton>
-        <Button
-          mode="outlined"
-          onPress={() => navigation.goBack()}
-          style={styles.button}
-        >
+        </Button>
+        <Button variant="tinted" action={CommonActions.goBack()}>
           Go back
         </Button>
       </View>
@@ -82,23 +58,17 @@ const AlbumsScreen = ({
         <Link
           screen="LinkComponent"
           params={{ screen: 'Article', params: { author: 'Babel' } }}
-          style={[styles.button, { padding: 8 }]}
         >
-          Go to /link-component/article
+          Go to Article
         </Link>
-        <LinkButton
+        <Button
           screen="LinkComponent"
           params={{ screen: 'Article', params: { author: 'Babel' } }}
-          mode="contained"
-          style={styles.button}
+          variant="filled"
         >
-          Go to /link-component/article
-        </LinkButton>
-        <Button
-          mode="outlined"
-          onPress={() => navigation.goBack()}
-          style={styles.button}
-        >
+          Go to Article
+        </Button>
+        <Button variant="tinted" onPress={() => navigation.goBack()}>
           Go back
         </Button>
       </View>
@@ -140,9 +110,7 @@ export function LinkComponent({ navigation, ...rest }: Props) {
 
 const styles = StyleSheet.create({
   buttons: {
-    padding: 8,
-  },
-  button: {
-    margin: 8,
+    gap: 12,
+    padding: 12,
   },
 });

--- a/example/src/Screens/LinkingScreen.tsx
+++ b/example/src/Screens/LinkingScreen.tsx
@@ -1,10 +1,11 @@
+import { Button } from '@react-navigation/elements';
 import { useUnhandledLinking } from '@react-navigation/native';
 import {
   createStackNavigator,
   type StackScreenProps,
 } from '@react-navigation/stack';
 import React, { useContext } from 'react';
-import { Button, Platform, StyleSheet, Text, View } from 'react-native';
+import { Platform, StyleSheet, Text, View } from 'react-native';
 
 const info = `
 \u2022 xcrun simctl openurl booted exp://127.0.0.1:19000/--/linking/profile
@@ -32,11 +33,8 @@ const ProfileScreen = ({
       <Text style={{ ...styles.text, ...{ color: 'teal' } }}>
         Profile Screen
       </Text>
-      <Button
-        onPress={() => navigation.popTo('Home')}
-        title="Go back to home"
-      />
-      <Button onPress={signOut} title="Sign out" />
+      <Button onPress={() => navigation.popTo('Home')}>Go back to home</Button>
+      <Button onPress={signOut}>Sign out</Button>
     </View>
   );
 };
@@ -50,11 +48,8 @@ const HomeScreen = ({
       <Text style={{ ...styles.text, ...{ color: 'indianred' } }}>
         Home Screen
       </Text>
-      <Button
-        onPress={() => navigation.popTo('Profile')}
-        title="Go to profile"
-      />
-      <Button onPress={signOut} title="Sign out" />
+      <Button onPress={() => navigation.popTo('Profile')}>Go to profile</Button>
+      <Button onPress={signOut}>Sign out</Button>
     </View>
   );
 };
@@ -73,8 +68,9 @@ const SignInScreen = () => {
           scheduleNext();
           signIn();
         }}
-        title="Sign In"
-      />
+      >
+        Sign in
+      </Button>
     </View>
   );
 };

--- a/example/src/Screens/MixedHeaderMode.tsx
+++ b/example/src/Screens/MixedHeaderMode.tsx
@@ -1,3 +1,4 @@
+import { Button } from '@react-navigation/elements';
 import type { ParamListBase } from '@react-navigation/native';
 import {
   createStackNavigator,
@@ -7,7 +8,6 @@ import {
 } from '@react-navigation/stack';
 import * as React from 'react';
 import { Platform, ScrollView, StyleSheet, View } from 'react-native';
-import { Button } from 'react-native-paper';
 
 import { Albums } from '../Shared/Albums';
 import { Article } from '../Shared/Article';
@@ -29,17 +29,12 @@ const ArticleScreen = ({
     <ScrollView>
       <View style={styles.buttons}>
         <Button
-          mode="contained"
+          variant="filled"
           onPress={() => navigation.push('NewsFeed', { date: Date.now() })}
-          style={styles.button}
         >
           Push feed
         </Button>
-        <Button
-          mode="outlined"
-          onPress={() => navigation.pop()}
-          style={styles.button}
-        >
+        <Button variant="tinted" onPress={() => navigation.pop()}>
           Pop screen
         </Button>
       </View>
@@ -58,18 +53,10 @@ const NewsFeedScreen = ({
   return (
     <ScrollView>
       <View style={styles.buttons}>
-        <Button
-          mode="contained"
-          onPress={() => navigation.push('Albums')}
-          style={styles.button}
-        >
+        <Button variant="filled" onPress={() => navigation.push('Albums')}>
           Navigate to album
         </Button>
-        <Button
-          mode="outlined"
-          onPress={() => navigation.pop()}
-          style={styles.button}
-        >
+        <Button variant="tinted" onPress={() => navigation.pop()}>
           Pop screen
         </Button>
       </View>
@@ -85,17 +72,12 @@ const AlbumsScreen = ({
     <ScrollView>
       <View style={styles.buttons}>
         <Button
-          mode="contained"
+          variant="filled"
           onPress={() => navigation.push('Article', { author: 'Babel fish' })}
-          style={styles.button}
         >
           Push article
         </Button>
-        <Button
-          mode="outlined"
-          onPress={() => navigation.pop()}
-          style={styles.button}
-        >
+        <Button variant="tinted" onPress={() => navigation.pop()}>
           Pop screen
         </Button>
       </View>
@@ -158,9 +140,7 @@ const styles = StyleSheet.create({
   buttons: {
     flexDirection: 'row',
     flexWrap: 'wrap',
-    padding: 8,
-  },
-  button: {
-    margin: 8,
+    gap: 12,
+    padding: 12,
   },
 });

--- a/example/src/Screens/MixedStack.tsx
+++ b/example/src/Screens/MixedStack.tsx
@@ -1,3 +1,4 @@
+import { Button } from '@react-navigation/elements';
 import type { ParamListBase } from '@react-navigation/native';
 import {
   createStackNavigator,
@@ -5,7 +6,6 @@ import {
 } from '@react-navigation/stack';
 import * as React from 'react';
 import { Platform, ScrollView, StyleSheet, View } from 'react-native';
-import { Button } from 'react-native-paper';
 
 import { Albums } from '../Shared/Albums';
 import { Article } from '../Shared/Article';
@@ -24,31 +24,18 @@ const ArticleScreen = ({
   return (
     <ScrollView>
       <View style={styles.buttons}>
-        <View>
-          <Button
-            mode="contained"
-            onPress={() => navigation.push('Article', { author: 'Dalek' })}
-            style={styles.button}
-          >
-            Push article
-          </Button>
-          <Button
-            mode="outlined"
-            onPress={() => navigation.goBack()}
-            style={styles.button}
-          >
-            Go back
-          </Button>
-        </View>
-        <View>
-          <Button
-            mode="contained"
-            onPress={() => navigation.push('Albums')}
-            style={styles.button}
-          >
-            Push album
-          </Button>
-        </View>
+        <Button
+          variant="filled"
+          onPress={() => navigation.push('Article', { author: 'Dalek' })}
+        >
+          Push article
+        </Button>
+        <Button variant="tinted" onPress={() => navigation.goBack()}>
+          Go back
+        </Button>
+        <Button variant="filled" onPress={() => navigation.push('Albums')}>
+          Push album
+        </Button>
       </View>
       <Article
         author={{ name: route.params.author }}
@@ -62,31 +49,18 @@ const AlbumsScreen = ({ navigation }: StackScreenProps<MixedStackParams>) => {
   return (
     <ScrollView>
       <View style={styles.buttons}>
-        <View>
-          <Button
-            mode="contained"
-            onPress={() => navigation.push('Albums')}
-            style={styles.button}
-          >
-            Push album
-          </Button>
-          <Button
-            mode="outlined"
-            onPress={() => navigation.goBack()}
-            style={styles.button}
-          >
-            Go back
-          </Button>
-        </View>
-        <View>
-          <Button
-            mode="contained"
-            onPress={() => navigation.push('Article', { author: 'The Doctor' })}
-            style={styles.button}
-          >
-            Push article
-          </Button>
-        </View>
+        <Button variant="filled" onPress={() => navigation.push('Albums')}>
+          Push album
+        </Button>
+        <Button variant="tinted" onPress={() => navigation.goBack()}>
+          Go back
+        </Button>
+        <Button
+          variant="filled"
+          onPress={() => navigation.push('Article', { author: 'The Doctor' })}
+        >
+          Push article
+        </Button>
       </View>
       <Albums scrollEnabled={scrollEnabled} />
     </ScrollView>
@@ -130,9 +104,7 @@ const styles = StyleSheet.create({
   buttons: {
     flexDirection: 'row',
     flexWrap: 'wrap',
-    padding: 8,
-  },
-  button: {
-    margin: 8,
+    gap: 12,
+    padding: 12,
   },
 });

--- a/example/src/Screens/ModalStack.tsx
+++ b/example/src/Screens/ModalStack.tsx
@@ -1,3 +1,4 @@
+import { Button } from '@react-navigation/elements';
 import type { ParamListBase } from '@react-navigation/native';
 import {
   createStackNavigator,
@@ -5,7 +6,6 @@ import {
 } from '@react-navigation/stack';
 import * as React from 'react';
 import { Platform, ScrollView, StyleSheet, View } from 'react-native';
-import { Button } from 'react-native-paper';
 
 import { Albums } from '../Shared/Albums';
 import { Article } from '../Shared/Article';
@@ -24,18 +24,10 @@ const ArticleScreen = ({
   return (
     <ScrollView>
       <View style={styles.buttons}>
-        <Button
-          mode="contained"
-          onPress={() => navigation.push('Albums')}
-          style={styles.button}
-        >
+        <Button variant="filled" onPress={() => navigation.push('Albums')}>
           Push album
         </Button>
-        <Button
-          mode="outlined"
-          onPress={() => navigation.goBack()}
-          style={styles.button}
-        >
+        <Button variant="tinted" onPress={() => navigation.goBack()}>
           Go back
         </Button>
       </View>
@@ -52,17 +44,12 @@ const AlbumsScreen = ({ navigation }: StackScreenProps<ModalStackParams>) => {
     <ScrollView>
       <View style={styles.buttons}>
         <Button
-          mode="contained"
+          variant="filled"
           onPress={() => navigation.push('Article', { author: 'Babel fish' })}
-          style={styles.button}
         >
           Push article
         </Button>
-        <Button
-          mode="outlined"
-          onPress={() => navigation.goBack()}
-          style={styles.button}
-        >
+        <Button variant="tinted" onPress={() => navigation.goBack()}>
           Go back
         </Button>
       </View>
@@ -105,9 +92,7 @@ const styles = StyleSheet.create({
   buttons: {
     flexDirection: 'row',
     flexWrap: 'wrap',
-    padding: 8,
-  },
-  button: {
-    margin: 8,
+    gap: 12,
+    padding: 12,
   },
 });

--- a/example/src/Screens/NativeStack.tsx
+++ b/example/src/Screens/NativeStack.tsx
@@ -1,4 +1,4 @@
-import { useHeaderHeight } from '@react-navigation/elements';
+import { Button, useHeaderHeight } from '@react-navigation/elements';
 import type { ParamListBase } from '@react-navigation/native';
 import {
   createNativeStackNavigator,
@@ -6,7 +6,6 @@ import {
 } from '@react-navigation/native-stack';
 import * as React from 'react';
 import { Platform, ScrollView, StyleSheet, View } from 'react-native';
-import { Button } from 'react-native-paper';
 
 import { Albums } from '../Shared/Albums';
 import { Article } from '../Shared/Article';
@@ -28,31 +27,21 @@ const ArticleScreen = ({
     <ScrollView contentInsetAdjustmentBehavior="automatic">
       <View style={styles.buttons}>
         <Button
-          mode="contained"
+          variant="filled"
           onPress={() => navigation.push('NewsFeed', { date: Date.now() })}
-          style={styles.button}
         >
           Push feed
         </Button>
         <Button
-          mode="contained"
+          variant="filled"
           onPress={() => navigation.replace('NewsFeed', { date: Date.now() })}
-          style={styles.button}
         >
           Replace with feed
         </Button>
-        <Button
-          mode="contained"
-          onPress={() => navigation.popTo('Albums')}
-          style={styles.button}
-        >
+        <Button variant="filled" onPress={() => navigation.popTo('Albums')}>
           Pop to Albums
         </Button>
-        <Button
-          mode="outlined"
-          onPress={() => navigation.pop()}
-          style={styles.button}
-        >
+        <Button variant="tinted" onPress={() => navigation.pop()}>
           Pop screen
         </Button>
       </View>
@@ -79,18 +68,10 @@ const NewsFeedScreen = ({
   return (
     <ScrollView contentInsetAdjustmentBehavior="automatic">
       <View style={styles.buttons}>
-        <Button
-          mode="contained"
-          onPress={() => navigation.push('Albums')}
-          style={styles.button}
-        >
+        <Button variant="filled" onPress={() => navigation.push('Albums')}>
           Push Albums
         </Button>
-        <Button
-          mode="outlined"
-          onPress={() => navigation.goBack()}
-          style={styles.button}
-        >
+        <Button variant="tinted" onPress={() => navigation.goBack()}>
           Go back
         </Button>
       </View>
@@ -108,19 +89,14 @@ const AlbumsScreen = ({
     <ScrollView contentContainerStyle={{ paddingTop: headerHeight }}>
       <View style={styles.buttons}>
         <Button
-          mode="contained"
+          variant="filled"
           onPress={() =>
             navigation.navigate('Article', { author: 'Babel fish' })
           }
-          style={styles.button}
         >
           Navigate to article
         </Button>
-        <Button
-          mode="outlined"
-          onPress={() => navigation.pop(2)}
-          style={styles.button}
-        >
+        <Button variant="tinted" onPress={() => navigation.pop(2)}>
           Pop by 2
         </Button>
       </View>
@@ -179,9 +155,7 @@ const styles = StyleSheet.create({
   buttons: {
     flexDirection: 'row',
     flexWrap: 'wrap',
-    padding: 8,
-  },
-  button: {
-    margin: 8,
+    gap: 12,
+    padding: 12,
   },
 });

--- a/example/src/Screens/NativeStackHeaderCustomization.tsx
+++ b/example/src/Screens/NativeStackHeaderCustomization.tsx
@@ -1,3 +1,4 @@
+import { Button } from '@react-navigation/elements';
 import type { ParamListBase } from '@react-navigation/native';
 import {
   createNativeStackNavigator,
@@ -12,7 +13,7 @@ import {
   StyleSheet,
   View,
 } from 'react-native';
-import { Appbar, Button } from 'react-native-paper';
+import { Appbar } from 'react-native-paper';
 
 import { Albums } from '../Shared/Albums';
 import { Article } from '../Shared/Article';
@@ -34,17 +35,12 @@ const ArticleScreen = ({
     <ScrollView>
       <View style={styles.buttons}>
         <Button
-          mode="contained"
+          variant="filled"
           onPress={() => navigation.push('NewsFeed', { date: Date.now() })}
-          style={styles.button}
         >
           Push feed
         </Button>
-        <Button
-          mode="outlined"
-          onPress={() => navigation.pop()}
-          style={styles.button}
-        >
+        <Button variant="tinted" onPress={() => navigation.pop()}>
           Pop screen
         </Button>
       </View>
@@ -63,18 +59,10 @@ const NewsFeedScreen = ({
   return (
     <ScrollView>
       <View style={styles.buttons}>
-        <Button
-          mode="contained"
-          onPress={() => navigation.push('Albums')}
-          style={styles.button}
-        >
+        <Button variant="filled" onPress={() => navigation.push('Albums')}>
           Push Albums
         </Button>
-        <Button
-          mode="outlined"
-          onPress={() => navigation.goBack()}
-          style={styles.button}
-        >
+        <Button variant="tinted" onPress={() => navigation.goBack()}>
           Go back
         </Button>
       </View>
@@ -90,19 +78,14 @@ const AlbumsScreen = ({
     <ScrollView>
       <View style={styles.buttons}>
         <Button
-          mode="contained"
+          variant="filled"
           onPress={() =>
             navigation.navigate('Article', { author: 'Babel fish' })
           }
-          style={styles.button}
         >
           Navigate to article
         </Button>
-        <Button
-          mode="outlined"
-          onPress={() => navigation.pop(2)}
-          style={styles.button}
-        >
+        <Button variant="tinted" onPress={() => navigation.pop(2)}>
           Pop by 2
         </Button>
       </View>
@@ -197,10 +180,8 @@ const styles = StyleSheet.create({
   buttons: {
     flexDirection: 'row',
     flexWrap: 'wrap',
-    padding: 8,
-  },
-  button: {
-    margin: 8,
+    gap: 12,
+    padding: 12,
   },
   headerBackground: {
     height: undefined,

--- a/example/src/Screens/NativeStackPreventRemove.tsx
+++ b/example/src/Screens/NativeStackPreventRemove.tsx
@@ -1,4 +1,5 @@
 import { UNSTABLE_usePreventRemove } from '@react-navigation/core';
+import { Button } from '@react-navigation/elements';
 import {
   CommonActions,
   type ParamListBase,
@@ -17,7 +18,6 @@ import {
   TextInput,
   View,
 } from 'react-native';
-import { Button } from 'react-native-paper';
 
 import { Article } from '../Shared/Article';
 
@@ -35,18 +35,10 @@ const ArticleScreen = ({
   return (
     <ScrollView>
       <View style={styles.buttons}>
-        <Button
-          mode="contained"
-          onPress={() => navigation.push('Input')}
-          style={styles.button}
-        >
+        <Button variant="filled" onPress={() => navigation.push('Input')}>
           Push Input
         </Button>
-        <Button
-          mode="outlined"
-          onPress={() => navigation.popToTop()}
-          style={styles.button}
-        >
+        <Button variant="tinted" onPress={() => navigation.popToTop()}>
           Pop to top
         </Button>
       </View>
@@ -103,7 +95,7 @@ const InputScreen = ({
         onChangeText={setText}
       />
       <Button
-        mode="outlined"
+        variant="tinted"
         color="tomato"
         onPress={() =>
           navigation.dispatch({
@@ -111,14 +103,12 @@ const InputScreen = ({
             payload: { confirmed: true },
           })
         }
-        style={styles.button}
       >
         Discard and go back
       </Button>
       <Button
-        mode="outlined"
+        variant="tinted"
         onPress={() => navigation.push('Article', { author: text })}
-        style={styles.button}
       >
         Push Article
       </Button>
@@ -154,11 +144,11 @@ export function NativeStackPreventRemove({ navigation }: Props) {
 const styles = StyleSheet.create({
   content: {
     flex: 1,
-    padding: 16,
+    gap: 12,
+    padding: 12,
   },
   input: {
-    margin: 8,
-    padding: 10,
+    padding: 12,
     borderRadius: 3,
     borderWidth: StyleSheet.hairlineWidth,
     borderColor: 'rgba(0, 0, 0, 0.08)',
@@ -166,9 +156,7 @@ const styles = StyleSheet.create({
   buttons: {
     flexDirection: 'row',
     flexWrap: 'wrap',
-    padding: 8,
-  },
-  button: {
-    margin: 8,
+    gap: 12,
+    padding: 12,
   },
 });

--- a/example/src/Screens/NotFound.tsx
+++ b/example/src/Screens/NotFound.tsx
@@ -1,7 +1,7 @@
+import { Button } from '@react-navigation/elements';
 import type { StackScreenProps } from '@react-navigation/stack';
 import * as React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
-import { Button } from 'react-native-paper';
 
 import type { RootStackParamList } from '../screens';
 
@@ -13,7 +13,7 @@ export const NotFound = ({
     <View style={styles.container}>
       <Text style={styles.title}>404 Not Found ({route.path})</Text>
       <Button
-        mode="contained"
+        variant="filled"
         onPress={() => navigation.navigate('Home')}
         style={styles.button}
       >

--- a/example/src/Screens/SimpleStack.tsx
+++ b/example/src/Screens/SimpleStack.tsx
@@ -1,3 +1,4 @@
+import { Button } from '@react-navigation/elements';
 import type { ParamListBase } from '@react-navigation/native';
 import {
   createStackNavigator,
@@ -7,7 +8,6 @@ import {
 } from '@react-navigation/stack';
 import * as React from 'react';
 import { Platform, ScrollView, StyleSheet, View } from 'react-native';
-import { Button } from 'react-native-paper';
 
 import { Albums } from '../Shared/Albums';
 import { Article } from '../Shared/Article';
@@ -29,36 +29,26 @@ const ArticleScreen = ({
     <ScrollView>
       <View style={styles.buttons}>
         <Button
-          mode="contained"
+          variant="filled"
           onPress={() => navigation.replace('NewsFeed', { date: Date.now() })}
-          style={styles.button}
         >
           Replace with feed
         </Button>
-        <Button
-          mode="contained"
-          onPress={() => navigation.popTo('Albums')}
-          style={styles.button}
-        >
+        <Button variant="filled" onPress={() => navigation.popTo('Albums')}>
           Pop to Albums
         </Button>
         <Button
-          mode="outlined"
+          variant="tinted"
           onPress={() =>
             navigation.setParams({
               author:
                 route.params?.author === 'Gandalf' ? 'Babel fish' : 'Gandalf',
             })
           }
-          style={styles.button}
         >
           Update params
         </Button>
-        <Button
-          mode="outlined"
-          onPress={() => navigation.pop()}
-          style={styles.button}
-        >
+        <Button variant="tinted" onPress={() => navigation.pop()}>
           Pop screen
         </Button>
       </View>
@@ -77,18 +67,10 @@ const NewsFeedScreen = ({
   return (
     <ScrollView>
       <View style={styles.buttons}>
-        <Button
-          mode="contained"
-          onPress={() => navigation.navigate('Albums')}
-          style={styles.button}
-        >
+        <Button variant="filled" onPress={() => navigation.navigate('Albums')}>
           Navigate to album
         </Button>
-        <Button
-          mode="outlined"
-          onPress={() => navigation.goBack()}
-          style={styles.button}
-        >
+        <Button variant="tinted" onPress={() => navigation.goBack()}>
           Go back
         </Button>
       </View>
@@ -104,17 +86,12 @@ const AlbumsScreen = ({
     <ScrollView>
       <View style={styles.buttons}>
         <Button
-          mode="contained"
+          variant="filled"
           onPress={() => navigation.push('Article', { author: 'Babel fish' })}
-          style={styles.button}
         >
           Push article
         </Button>
-        <Button
-          mode="outlined"
-          onPress={() => navigation.pop(2)}
-          style={styles.button}
-        >
+        <Button variant="tinted" onPress={() => navigation.pop(2)}>
           Pop by 2
         </Button>
       </View>
@@ -170,9 +147,7 @@ const styles = StyleSheet.create({
   buttons: {
     flexDirection: 'row',
     flexWrap: 'wrap',
-    padding: 8,
-  },
-  button: {
-    margin: 8,
+    gap: 12,
+    margin: 12,
   },
 });

--- a/example/src/Screens/StackHeaderCustomization.tsx
+++ b/example/src/Screens/StackHeaderCustomization.tsx
@@ -1,5 +1,9 @@
 import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
-import { HeaderBackground, useHeaderHeight } from '@react-navigation/elements';
+import {
+  Button,
+  HeaderBackground,
+  useHeaderHeight,
+} from '@react-navigation/elements';
 import { type ParamListBase, useTheme } from '@react-navigation/native';
 import {
   createStackNavigator,
@@ -16,7 +20,7 @@ import {
   StyleSheet,
   View,
 } from 'react-native';
-import { Appbar, Button } from 'react-native-paper';
+import { Appbar } from 'react-native-paper';
 
 import { Albums } from '../Shared/Albums';
 import { Article } from '../Shared/Article';
@@ -36,18 +40,10 @@ const ArticleScreen = ({
   return (
     <ScrollView>
       <View style={styles.buttons}>
-        <Button
-          mode="contained"
-          onPress={() => navigation.push('Albums')}
-          style={styles.button}
-        >
+        <Button variant="filled" onPress={() => navigation.push('Albums')}>
           Push album
         </Button>
-        <Button
-          mode="outlined"
-          onPress={() => navigation.goBack()}
-          style={styles.button}
-        >
+        <Button variant="tinted" onPress={() => navigation.goBack()}>
           Go back
         </Button>
       </View>
@@ -66,17 +62,12 @@ const AlbumsScreen = ({ navigation }: StackScreenProps<SimpleStackParams>) => {
     <ScrollView contentContainerStyle={{ paddingTop: headerHeight }}>
       <View style={styles.buttons}>
         <Button
-          mode="contained"
+          variant="filled"
           onPress={() => navigation.push('Article', { author: 'Babel fish' })}
-          style={styles.button}
         >
           Push article
         </Button>
-        <Button
-          mode="outlined"
-          onPress={() => navigation.goBack()}
-          style={styles.button}
-        >
+        <Button variant="tinted" onPress={() => navigation.goBack()}>
           Go back
         </Button>
       </View>
@@ -186,10 +177,8 @@ const styles = StyleSheet.create({
   buttons: {
     flexDirection: 'row',
     flexWrap: 'wrap',
-    padding: 8,
-  },
-  button: {
-    margin: 8,
+    gap: 12,
+    padding: 12,
   },
   banner: {
     textAlign: 'center',

--- a/example/src/Screens/StackPreventRemove.tsx
+++ b/example/src/Screens/StackPreventRemove.tsx
@@ -1,3 +1,4 @@
+import { Button } from '@react-navigation/elements';
 import {
   CommonActions,
   type ParamListBase,
@@ -16,7 +17,6 @@ import {
   TextInput,
   View,
 } from 'react-native';
-import { Button } from 'react-native-paper';
 
 import { Article } from '../Shared/Article';
 
@@ -34,18 +34,10 @@ const ArticleScreen = ({
   return (
     <ScrollView>
       <View style={styles.buttons}>
-        <Button
-          mode="contained"
-          onPress={() => navigation.push('Input')}
-          style={styles.button}
-        >
+        <Button variant="filled" onPress={() => navigation.push('Input')}>
           Push Input
         </Button>
-        <Button
-          mode="outlined"
-          onPress={() => navigation.popToTop()}
-          style={styles.button}
-        >
+        <Button variant="tinted" onPress={() => navigation.popToTop()}>
           Pop to top
         </Button>
       </View>
@@ -113,7 +105,7 @@ const InputScreen = ({
         onChangeText={setText}
       />
       <Button
-        mode="outlined"
+        variant="tinted"
         color="tomato"
         onPress={() =>
           navigation.dispatch({
@@ -121,14 +113,12 @@ const InputScreen = ({
             payload: { confirmed: true },
           })
         }
-        style={styles.button}
       >
         Discard and go back
       </Button>
       <Button
-        mode="outlined"
+        variant="tinted"
         onPress={() => navigation.push('Article', { author: text })}
-        style={styles.button}
       >
         Push Article
       </Button>
@@ -158,11 +148,11 @@ export function StackPreventRemove({ navigation }: Props) {
 const styles = StyleSheet.create({
   content: {
     flex: 1,
-    padding: 16,
+    gap: 12,
+    padding: 12,
   },
   input: {
-    margin: 8,
-    padding: 10,
+    padding: 12,
     borderRadius: 3,
     borderWidth: StyleSheet.hairlineWidth,
     borderColor: 'rgba(0, 0, 0, 0.08)',
@@ -170,9 +160,7 @@ const styles = StyleSheet.create({
   buttons: {
     flexDirection: 'row',
     flexWrap: 'wrap',
-    padding: 8,
-  },
-  button: {
-    margin: 8,
+    gap: 12,
+    padding: 12,
   },
 });

--- a/example/src/Screens/StackTransparent.tsx
+++ b/example/src/Screens/StackTransparent.tsx
@@ -1,3 +1,4 @@
+import { Button } from '@react-navigation/elements';
 import { type ParamListBase, useTheme } from '@react-navigation/native';
 import {
   createStackNavigator,
@@ -13,7 +14,7 @@ import {
   StyleSheet,
   View,
 } from 'react-native';
-import { Button, Paragraph } from 'react-native-paper';
+import { Paragraph } from 'react-native-paper';
 
 import { Article } from '../Shared/Article';
 import { NewsFeed } from '../Shared/NewsFeed';
@@ -33,25 +34,13 @@ const ArticleScreen = ({
   return (
     <ScrollView>
       <View style={styles.buttons}>
-        <Button
-          mode="contained"
-          onPress={() => navigation.push('Dialog')}
-          style={styles.button}
-        >
+        <Button variant="filled" onPress={() => navigation.push('Dialog')}>
           Show Dialog
         </Button>
-        <Button
-          mode="contained"
-          onPress={() => navigation.push('NewsFeed')}
-          style={styles.button}
-        >
+        <Button variant="filled" onPress={() => navigation.push('NewsFeed')}>
           Push NewsFeed
         </Button>
-        <Button
-          mode="outlined"
-          onPress={() => navigation.goBack()}
-          style={styles.button}
-        >
+        <Button variant="tinted" onPress={() => navigation.goBack()}>
           Go back
         </Button>
       </View>
@@ -69,18 +58,10 @@ const NewsFeedScreen = ({
   return (
     <ScrollView>
       <View style={styles.buttons}>
-        <Button
-          mode="contained"
-          onPress={() => navigation.push('Dialog')}
-          style={styles.button}
-        >
+        <Button variant="filled" onPress={() => navigation.push('Dialog')}>
           Show Dialog
         </Button>
-        <Button
-          mode="outlined"
-          onPress={() => navigation.goBack()}
-          style={styles.button}
-        >
+        <Button variant="tinted" onPress={() => navigation.goBack()}>
           Go back
         </Button>
       </View>
@@ -115,7 +96,7 @@ const DialogScreen = ({
           },
         ]}
       >
-        <Paragraph>
+        <Paragraph style={styles.paragraph}>
           Mise en place is a French term that literally means “put in place.” It
           also refers to a way cooks in professional kitchens and restaurants
           set up their work stations—first by gathering all ingredients for a
@@ -126,7 +107,11 @@ const DialogScreen = ({
           ingredient and save you time from running back and forth from the
           pantry ten times.
         </Paragraph>
-        <Button style={styles.close} compact onPress={navigation.goBack}>
+        <Button
+          variant="plain"
+          style={styles.close}
+          onPress={navigation.goBack}
+        >
           Okay
         </Button>
       </Animated.View>
@@ -173,10 +158,8 @@ const styles = StyleSheet.create({
   buttons: {
     flexDirection: 'row',
     flexWrap: 'wrap',
-    padding: 8,
-  },
-  button: {
-    margin: 8,
+    gap: 12,
+    padding: 12,
   },
   container: {
     flex: 1,
@@ -184,7 +167,7 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   dialog: {
-    padding: 16,
+    padding: 8,
     width: '90%',
     maxWidth: 400,
     borderRadius: 3,
@@ -192,6 +175,9 @@ const styles = StyleSheet.create({
   backdrop: {
     ...StyleSheet.absoluteFillObject,
     backgroundColor: 'rgba(0, 0, 0, 0.6)',
+  },
+  paragraph: {
+    padding: 16,
   },
   close: {
     alignSelf: 'flex-end',

--- a/example/src/Screens/Static.tsx
+++ b/example/src/Screens/Static.tsx
@@ -1,5 +1,6 @@
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import { Button } from '@react-navigation/elements';
 import {
   createStaticNavigation,
   NavigationIndependentTree,
@@ -7,7 +8,6 @@ import {
 import { createStackNavigator } from '@react-navigation/stack';
 import * as React from 'react';
 import { Platform, ScrollView, StyleSheet, View } from 'react-native';
-import { Button } from 'react-native-paper';
 
 import { Albums } from '../Shared/Albums';
 import { Chat } from '../Shared/Chat';
@@ -38,7 +38,7 @@ const AlbumsScreen = () => {
   return (
     <ScrollView>
       <View style={styles.buttons}>
-        <Button mode="contained" onPress={() => setIsChatShown(!isChatShown)}>
+        <Button variant="filled" onPress={() => setIsChatShown(!isChatShown)}>
           {isChatShown ? 'Hide' : 'Show'} Chat
         </Button>
       </View>
@@ -97,6 +97,7 @@ const styles = StyleSheet.create({
   buttons: {
     flexDirection: 'row',
     flexWrap: 'wrap',
-    padding: 16,
+    gap: 12,
+    padding: 12,
   },
 });

--- a/package.json
+++ b/package.json
@@ -55,13 +55,14 @@
       "<rootDir>/jest/setup.js"
     ],
     "transformIgnorePatterns": [
-      "node_modules/(?!(@react-native|react-native|react-native-reanimated|nanoid)/)"
+      "node_modules/(?!(@react-native|react-native|react-native-reanimated)/)"
     ],
     "moduleNameMapper": {
       "@react-navigation/([^/]+)": "<rootDir>/packages/$1/src",
       "react-native-tab-view": "<rootDir>/packages/react-native-tab-view/src",
       "react-native-drawer-layout": "<rootDir>/packages/react-native-drawer-layout/src"
     },
+    "prettierPath": null,
     "preset": "react-native"
   },
   "prettier": {

--- a/packages/drawer/src/views/DrawerItem.tsx
+++ b/packages/drawer/src/views/DrawerItem.tsx
@@ -1,11 +1,10 @@
-import { PlatformPressable } from '@react-navigation/elements';
+import { PlatformPressable, Text } from '@react-navigation/elements';
 import { type Route, useTheme } from '@react-navigation/native';
 import Color from 'color';
 import * as React from 'react';
 import {
   type StyleProp,
   StyleSheet,
-  Text,
   type TextStyle,
   View,
   type ViewStyle,

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -36,6 +36,9 @@
     "prepack": "bob build",
     "clean": "del lib"
   },
+  "dependencies": {
+    "color": "^4.2.3"
+  },
   "devDependencies": {
     "@react-native-masked-view/masked-view": "0.2.9",
     "@react-navigation/native": "workspace:^",

--- a/packages/elements/src/Button.tsx
+++ b/packages/elements/src/Button.tsx
@@ -4,8 +4,8 @@ import * as React from 'react';
 import { StyleSheet } from 'react-native';
 
 import {
-  type Props as PlatformPressableProps,
   PlatformPressable,
+  type Props as PlatformPressableProps,
 } from './PlatformPressable';
 import { Text } from './Text';
 

--- a/packages/elements/src/Button.tsx
+++ b/packages/elements/src/Button.tsx
@@ -1,0 +1,97 @@
+import { useLinkProps, useTheme } from '@react-navigation/native';
+import Color from 'color';
+import * as React from 'react';
+import { StyleSheet } from 'react-native';
+
+import {
+  type Props as PlatformPressableProps,
+  PlatformPressable,
+} from './PlatformPressable';
+import { Text } from './Text';
+
+type BaseProps = Omit<PlatformPressableProps, 'children'> & {
+  variant?: 'plain' | 'tinted' | 'filled';
+  color?: string;
+  children: string | string[];
+};
+
+type LinkProps = Omit<BaseProps, 'onPress'> &
+  Parameters<typeof useLinkProps>[0];
+
+const BUTTON_RADIUS = 40;
+
+export function Button(props: BaseProps | LinkProps) {
+  if ('screen' in props || 'action' in props) {
+    return <ButtonLink {...props} />;
+  } else {
+    return <ButtonBase {...props} />;
+  }
+}
+
+function ButtonLink({ screen, params, action, href, ...rest }: LinkProps) {
+  // @ts-expect-error: This is already type-checked by the prop types
+  const props = useLinkProps({ screen, params, action, href });
+
+  return <ButtonBase {...rest} {...props} />;
+}
+
+function ButtonBase({
+  variant = 'tinted',
+  color: customColor,
+  android_ripple,
+  style,
+  children,
+  ...rest
+}: BaseProps) {
+  const { colors, fonts } = useTheme();
+
+  const color = customColor ?? colors.primary;
+
+  let backgroundColor;
+  let textColor;
+
+  switch (variant) {
+    case 'plain':
+      backgroundColor = 'transparent';
+      textColor = color;
+      break;
+    case 'tinted':
+      backgroundColor = Color(color).fade(0.85).string();
+      textColor = color;
+      break;
+    case 'filled':
+      backgroundColor = color;
+      textColor = Color(color).isDark() ? 'white' : 'black';
+      break;
+  }
+
+  return (
+    <PlatformPressable
+      {...rest}
+      style={[{ backgroundColor }, styles.button, style]}
+      android_ripple={{
+        radius: BUTTON_RADIUS,
+        color: Color(textColor).fade(0.85).string(),
+        ...android_ripple,
+      }}
+    >
+      <Text style={[{ color: textColor }, fonts.regular, styles.text]}>
+        {children}
+      </Text>
+    </PlatformPressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  button: {
+    paddingHorizontal: 24,
+    paddingVertical: 10,
+    borderRadius: BUTTON_RADIUS,
+  },
+  text: {
+    fontSize: 14,
+    lineHeight: 20,
+    letterSpacing: 0.1,
+    textAlign: 'center',
+  },
+});

--- a/packages/elements/src/Label/Label.tsx
+++ b/packages/elements/src/Label/Label.tsx
@@ -1,12 +1,12 @@
-import { useTheme } from '@react-navigation/native';
 import * as React from 'react';
 import {
   type StyleProp,
   StyleSheet,
-  Text,
   type TextProps,
   type TextStyle,
 } from 'react-native';
+
+import { Text } from '../Text';
 
 type Props = Omit<TextProps, 'style'> & {
   tintColor?: string;
@@ -15,18 +15,11 @@ type Props = Omit<TextProps, 'style'> & {
 };
 
 export function Label({ tintColor, style, ...rest }: Props) {
-  const { colors, fonts } = useTheme();
-
   return (
     <Text
       numberOfLines={1}
       {...rest}
-      style={[
-        fonts.regular,
-        styles.label,
-        { color: tintColor === undefined ? colors.text : tintColor },
-        style,
-      ]}
+      style={[styles.label, tintColor != null && { color: tintColor }, style]}
     />
   );
 }

--- a/packages/elements/src/Text.tsx
+++ b/packages/elements/src/Text.tsx
@@ -1,0 +1,14 @@
+import { useTheme } from '@react-navigation/native';
+import * as React from 'react';
+import { Text as NativeText, type TextProps } from 'react-native';
+
+export function Text({ style, ...rest }: TextProps) {
+  const { colors, fonts } = useTheme();
+
+  return (
+    <NativeText
+      {...rest}
+      style={[{ color: colors.text }, fonts.regular, style]}
+    />
+  );
+}

--- a/packages/elements/src/index.tsx
+++ b/packages/elements/src/index.tsx
@@ -1,4 +1,5 @@
 export { Background } from './Background';
+export { Button } from './Button';
 export { getDefaultSidebarWidth } from './getDefaultSidebarWidth';
 export { getDefaultHeaderHeight } from './Header/getDefaultHeaderHeight';
 export { getHeaderTitle } from './Header/getHeaderTitle';
@@ -17,6 +18,7 @@ export { PlatformPressable } from './PlatformPressable';
 export { ResourceSavingView } from './ResourceSavingView';
 export { SafeAreaProviderCompat } from './SafeAreaProviderCompat';
 export { Screen } from './Screen';
+export { Text } from './Text';
 
 export const Assets = [
   // eslint-disable-next-line import/no-commonjs

--- a/packages/elements/tsconfig.json
+++ b/packages/elements/tsconfig.json
@@ -3,7 +3,8 @@
   "references": [
     { "path": "../core" },
     { "path": "../routers" },
-    { "path": "../native" }
+    { "path": "../native" },
+    { "path": "../elements" },
   ],
   "compilerOptions": {
     "rootDir": ".",

--- a/packages/material-top-tabs/package.json
+++ b/packages/material-top-tabs/package.json
@@ -41,6 +41,7 @@
     "clean": "del lib"
   },
   "dependencies": {
+    "@react-navigation/elements": "^2.0.0-alpha.2",
     "color": "^4.2.3",
     "react-native-tab-view": "^4.0.0-alpha.0"
   },

--- a/packages/material-top-tabs/src/views/MaterialTopTabBar.tsx
+++ b/packages/material-top-tabs/src/views/MaterialTopTabBar.tsx
@@ -1,3 +1,4 @@
+import { Text } from '@react-navigation/elements';
 import {
   type ParamListBase,
   type Route,
@@ -7,7 +8,7 @@ import {
 } from '@react-navigation/native';
 import Color from 'color';
 import * as React from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import { TabBar, TabBarIndicator } from 'react-native-tab-view';
 
 import type { MaterialTopTabBarProps } from '../types';
@@ -18,7 +19,7 @@ export function MaterialTopTabBar({
   descriptors,
   ...rest
 }: MaterialTopTabBarProps) {
-  const { colors, fonts } = useTheme();
+  const { colors } = useTheme();
   const { direction } = useLocale();
 
   const focusedOptions = descriptors[state.routes[state.index].key].options;
@@ -106,12 +107,7 @@ export function MaterialTopTabBar({
         if (typeof label === 'string') {
           return (
             <Text
-              style={[
-                { color },
-                fonts.regular,
-                styles.label,
-                options.tabBarLabelStyle,
-              ]}
+              style={[{ color }, styles.label, options.tabBarLabelStyle]}
               allowFontScaling={options.tabBarAllowFontScaling}
             >
               {label}

--- a/packages/native/src/Link.tsx
+++ b/packages/native/src/Link.tsx
@@ -6,6 +6,7 @@ import {
   type TextProps,
 } from 'react-native';
 
+import { useTheme } from './theming/useTheme';
 import { type Props as LinkProps, useLinkProps } from './useLinkProps';
 
 type Props<ParamList extends ReactNavigation.RootParamList> =
@@ -36,8 +37,10 @@ export function Link<ParamList extends ReactNavigation.RootParamList>({
   params,
   action,
   href,
+  style,
   ...rest
 }: Props<ParamList>) {
+  const { colors, fonts } = useTheme();
   // @ts-expect-error: This is already type-checked by the prop types
   const props = useLinkProps<ParamList>({ screen, params, action, href });
 
@@ -61,5 +64,6 @@ export function Link<ParamList extends ReactNavigation.RootParamList>({
       web: { onClick: onPress } as any,
       default: { onPress },
     }),
+    style: [{ color: colors.primary }, fonts.regular, style],
   });
 }

--- a/packages/native/src/__tests__/Link.test.tsx
+++ b/packages/native/src/__tests__/Link.test.tsx
@@ -50,14 +50,26 @@ it('renders link with href on web', () => {
   );
 
   expect(toJSON()).toMatchInlineSnapshot(`
-    <Text
-      accessibilityRole="link"
-      href="/bar/42"
-      onPress={[Function]}
-    >
-      Go to Bar
-    </Text>
-  `);
+<Text
+  accessibilityRole="link"
+  href="/bar/42"
+  onPress={[Function]}
+  style={
+    [
+      {
+        "color": "rgb(0, 122, 255)",
+      },
+      {
+        "fontFamily": "System",
+        "fontWeight": "400",
+      },
+      undefined,
+    ]
+  }
+>
+  Go to Bar
+</Text>
+`);
 
   const event = {
     defaultPrevented: false,
@@ -69,14 +81,26 @@ it('renders link with href on web', () => {
   fireEvent.press(getByText('Go to Bar'), event);
 
   expect(toJSON()).toMatchInlineSnapshot(`
-    <Text
-      accessibilityRole="link"
-      href="/foo"
-      onPress={[Function]}
-    >
-      Go to Foo
-    </Text>
-  `);
+<Text
+  accessibilityRole="link"
+  href="/foo"
+  onPress={[Function]}
+  style={
+    [
+      {
+        "color": "rgb(0, 122, 255)",
+      },
+      {
+        "fontFamily": "System",
+        "fontWeight": "400",
+      },
+      undefined,
+    ]
+  }
+>
+  Go to Foo
+</Text>
+`);
 });
 
 it("doesn't navigate if default was prevented", () => {
@@ -121,14 +145,26 @@ it("doesn't navigate if default was prevented", () => {
   );
 
   expect(toJSON()).toMatchInlineSnapshot(`
-    <Text
-      accessibilityRole="link"
-      href="/bar/42"
-      onPress={[Function]}
-    >
-      Go to Bar
-    </Text>
-  `);
+<Text
+  accessibilityRole="link"
+  href="/bar/42"
+  onPress={[Function]}
+  style={
+    [
+      {
+        "color": "rgb(0, 122, 255)",
+      },
+      {
+        "fontFamily": "System",
+        "fontWeight": "400",
+      },
+      undefined,
+    ]
+  }
+>
+  Go to Bar
+</Text>
+`);
 
   const event = {
     defaultPrevented: false,
@@ -140,12 +176,24 @@ it("doesn't navigate if default was prevented", () => {
   fireEvent.press(getByText('Go to Bar'), event);
 
   expect(toJSON()).toMatchInlineSnapshot(`
-    <Text
-      accessibilityRole="link"
-      href="/bar/42"
-      onPress={[Function]}
-    >
-      Go to Bar
-    </Text>
-  `);
+<Text
+  accessibilityRole="link"
+  href="/bar/42"
+  onPress={[Function]}
+  style={
+    [
+      {
+        "color": "rgb(0, 122, 255)",
+      },
+      {
+        "fontFamily": "System",
+        "fontWeight": "400",
+      },
+      undefined,
+    ]
+  }
+>
+  Go to Bar
+</Text>
+`);
 });

--- a/packages/native/src/useLinkProps.tsx
+++ b/packages/native/src/useLinkProps.tsx
@@ -92,13 +92,8 @@ export function useLinkProps<ParamList extends ReactNavigation.RootParamList>({
     let shouldHandle = false;
 
     if (Platform.OS !== 'web' || !e) {
-      shouldHandle = e ? !e.defaultPrevented : true;
-    } else if (
-      !e.defaultPrevented && // onPress prevented default
-      !hasModifierKey &&
-      isLeftClick &&
-      isSelfTarget
-    ) {
+      shouldHandle = true;
+    } else if (!hasModifierKey && isLeftClick && isSelfTarget) {
       e.preventDefault();
       shouldHandle = true;
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3489,6 +3489,7 @@ __metadata:
     "@react-navigation/native": "workspace:^"
     "@testing-library/react-native": ^12.3.1
     "@types/react": ~18.2.33
+    color: ^4.2.3
     del-cli: ^5.1.0
     react: 18.2.0
     react-native: 0.72.6
@@ -3559,6 +3560,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@react-navigation/material-top-tabs@workspace:packages/material-top-tabs"
   dependencies:
+    "@react-navigation/elements": ^2.0.0-alpha.2
     "@react-navigation/native": "workspace:^"
     "@testing-library/react-native": ^12.3.1
     "@types/react": ~18.2.33


### PR DESCRIPTION
This adds a simple `Button` component to make it easier for quick demos, examples and learning material etc.

It implements part of the material design guidelines: https://m3.material.io/components/buttons/overview

There are 3 variants implemented:

- `'plain'`
- `'tinted'`
- `'filled'`

These variants also exist in iOS design guidelines, so it makes the buttons somewhat platform agnostic. Though exact measurements will slightly differ.

Since the `Button` is part of React Navigation, it has built-in support for navigating to screens, and renders an anchor tag on the Web when used for navigation:

```js
<Button screen="Profile" params={{ userId: 'jane' }}>
  View Jane's Profile
<Button>
```

It can also be used as a regular button:

```js
<Button onPress={() => { /* do something */ }}>
  Do something
</Button>
```

<img width="271" alt="image" src="https://github.com/react-navigation/react-navigation/assets/1174278/45d9e00d-5269-440b-b3f5-801148870b97">


https://github.com/react-navigation/react-navigation/assets/1174278/71b08c8f-8542-48b7-880f-aeb34eb3f814


