### PR TITLE
fix!: don't use screen from params as initialRouteName

### DIFF
--- a/packages/core/src/__tests__/index.test.tsx
+++ b/packages/core/src/__tests__/index.test.tsx
@@ -789,18 +789,16 @@ it('navigates to nested child in a navigator', () => {
     `"[bar-a, {"lol":"why","whoa":"test"}]"`
   );
 
-  act(() => navigation.navigate('bar', { screen: 'bar-b' }));
-
   act(() => navigation.goBack());
 
   expect(element).toMatchInlineSnapshot(
-    `"[bar-a, {"lol":"why","whoa":"test"}]"`
+    `"[bar-b, {"some":"stuff","test":42}]"`
   );
 
-  act(() => navigation.navigate('bar', { screen: 'bar-b' }));
+  act(() => navigation.navigate('bar', { screen: 'bar-a' }));
 
   expect(element).toMatchInlineSnapshot(
-    `"[bar-b, {"some":"stuff","test":42,"whoa":"test"}]"`
+    `"[bar-a, {"lol":"why","whoa":"test"}]"`
   );
 });
 
@@ -939,17 +937,12 @@ it('navigates to nested child in a navigator with initial: false', () => {
         name: 'bar',
         params: { params: { test: 42 }, screen: 'bar-b' },
         state: {
-          index: 1,
-          key: '3',
+          index: 0,
+          key: '4',
           routeNames: ['bar-a', 'bar-b'],
           routes: [
             {
-              key: 'bar-a',
-              name: 'bar-a',
-              params: { lol: 'why' },
-            },
-            {
-              key: 'bar-b',
+              key: 'bar-b-3',
               name: 'bar-b',
               params: { some: 'stuff', test: 42 },
             },
@@ -997,7 +990,7 @@ it('navigates to nested child in a navigator with initial: false', () => {
   expect(second).toMatchInlineSnapshot(`"[foo-a, undefined]"`);
   expect(navigation.getRootState()).toEqual({
     index: 0,
-    key: '4',
+    key: '5',
     routeNames: ['foo', 'bar'],
     routes: [
       {
@@ -1005,7 +998,7 @@ it('navigates to nested child in a navigator with initial: false', () => {
         name: 'foo',
         state: {
           index: 0,
-          key: '5',
+          key: '6',
           routeNames: ['foo-a', 'foo-b'],
           routes: [
             { key: 'foo-a', name: 'foo-a' },
@@ -1033,18 +1026,18 @@ it('navigates to nested child in a navigator with initial: false', () => {
 
   expect(navigation.getRootState()).toEqual({
     index: 2,
-    key: '4',
+    key: '5',
     routeNames: ['foo', 'bar'],
     routes: [
       { key: 'foo', name: 'foo' },
       { key: 'bar', name: 'bar' },
       {
-        key: '6',
+        key: '7',
         name: 'bar',
         params: { initial: false, params: { test: 42 }, screen: 'bar-b' },
         state: {
           index: 2,
-          key: '7',
+          key: '8',
           routeNames: ['bar-a', 'bar-b'],
           routes: [
             {
@@ -1057,7 +1050,7 @@ it('navigates to nested child in a navigator with initial: false', () => {
               name: 'bar-b',
               params: { some: 'stuff' },
             },
-            { key: '8', name: 'bar-b', params: { test: 42 } },
+            { key: '9', name: 'bar-b', params: { test: 42 } },
           ],
           stale: false,
           type: 'test',
@@ -1124,26 +1117,26 @@ it('navigates to nested child in a navigator with initial: false', () => {
 
   expect(navigation.getRootState()).toEqual({
     index: 1,
-    key: '11',
+    key: '12',
     routeNames: ['foo', 'bar'],
     routes: [
-      { key: 'foo-9', name: 'foo' },
+      { key: 'foo-10', name: 'foo' },
       {
-        key: 'bar-10',
+        key: 'bar-11',
         name: 'bar',
         params: { initial: false, params: { test: 42 }, screen: 'bar-b' },
         state: {
           index: 1,
-          key: '14',
+          key: '15',
           routeNames: ['bar-a', 'bar-b'],
           routes: [
             {
-              key: 'bar-a-12',
+              key: 'bar-a-13',
               name: 'bar-a',
               params: { lol: 'why' },
             },
             {
-              key: 'bar-b-13',
+              key: 'bar-b-14',
               name: 'bar-b',
               params: { some: 'stuff' },
             },

--- a/packages/core/src/useNavigationBuilder.tsx
+++ b/packages/core/src/useNavigationBuilder.tsx
@@ -262,15 +262,7 @@ export function useNavigationBuilder<
 
   const { children, layout, screenOptions, screenListeners, ...rest } = options;
   const { current: router } = React.useRef<Router<State, any>>(
-    createRouter({
-      ...(rest as unknown as RouterOptions),
-      ...(route?.params &&
-      route.params.state == null &&
-      route.params.initial !== false &&
-      typeof route.params.screen === 'string'
-        ? { initialRouteName: route.params.screen }
-        : null),
-    })
+    createRouter(rest as unknown as RouterOptions)
   );
 
   const routeConfigs = getRouteConfigsFromChildren<
@@ -394,7 +386,11 @@ export function useNavigationBuilder<
     // So we need to rehydrate it to make it usable
     if (
       (currentState === undefined || !isStateValid(currentState)) &&
-      route?.params?.state == null
+      route?.params?.state == null &&
+      !(
+        typeof route?.params?.screen === 'string' &&
+        route?.params?.initial !== false
+      )
     ) {
       return [
         router.getInitialState({
@@ -405,9 +401,29 @@ export function useNavigationBuilder<
         true,
       ];
     } else {
+      let stateFromParams;
+
+      if (route?.params?.state != null) {
+        stateFromParams = route.params.state;
+      } else if (
+        typeof route?.params?.screen === 'string' &&
+        route?.params?.initial !== false
+      ) {
+        stateFromParams = {
+          index: 0,
+          routes: [
+            {
+              name: route.params.screen,
+              params: route.params.params,
+              path: route.params.path,
+            },
+          ],
+        };
+      }
+
       return [
         router.getRehydratedState(
-          (route?.params?.state ?? currentState) as PartialState<State>,
+          (stateFromParams ?? currentState) as PartialState<State>,
           {
             routeNames,
             routeParamList: initialRouteParamList,


### PR DESCRIPTION
BREAKING CHANGE:

Previously when using nested navigation API, we used that screen as `initialRouteName`.

e.g.

```js
navigation.navigate('MyScreen', { screen: 'NestedScreen' });
```

Here, the `'NestedScreen'` will be set as `initialRouteName`.

It has the result of rendering the navigator with that screen as focused screen. While this behaviour is expected, that screen was also used as the `initialRouteName` for every other operation ignoring the `initialRouteName` prop - which is not expected.

This change refactors the way the focused screen for initial render is set to avoid this behavior.