### PR TITLE
fix: cannot resolve use-latest-callback

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,7 +40,7 @@
     "nanoid": "3.3.6",
     "query-string": "^7.1.3",
     "react-is": "^18.2.0",
-    "use-latest-callback": "^0.1.7"
+    "use-latest-callback": "^0.1.9"
   },
   "devDependencies": {
     "@testing-library/react-native": "^12.3.1",

--- a/packages/drawer/package.json
+++ b/packages/drawer/package.json
@@ -44,7 +44,7 @@
     "@react-navigation/elements": "^2.0.0-alpha.2",
     "color": "^4.2.3",
     "react-native-drawer-layout": "workspace:^",
-    "use-latest-callback": "^0.1.7"
+    "use-latest-callback": "^0.1.9"
   },
   "devDependencies": {
     "@react-navigation/native": "workspace:^",

--- a/packages/native/package.json
+++ b/packages/native/package.json
@@ -41,7 +41,7 @@
     "escape-string-regexp": "^4.0.0",
     "fast-deep-equal": "^3.1.3",
     "nanoid": "3.3.6",
-    "use-latest-callback": "^0.1.7"
+    "use-latest-callback": "^0.1.9"
   },
   "devDependencies": {
     "@testing-library/react-native": "^12.3.1",

--- a/packages/react-native-drawer-layout/package.json
+++ b/packages/react-native-drawer-layout/package.json
@@ -37,7 +37,7 @@
     "clean": "del lib"
   },
   "dependencies": {
-    "use-latest-callback": "^0.1.7"
+    "use-latest-callback": "^0.1.9"
   },
   "devDependencies": {
     "del-cli": "^5.1.0",

--- a/packages/react-native-tab-view/package.json
+++ b/packages/react-native-tab-view/package.json
@@ -39,7 +39,7 @@
     "clean": "del lib"
   },
   "dependencies": {
-    "use-latest-callback": "^0.1.7"
+    "use-latest-callback": "^0.1.9"
   },
   "devDependencies": {
     "del-cli": "^5.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3424,7 +3424,7 @@ __metadata:
     react-native-builder-bob: ^0.23.1
     react-test-renderer: 18.2.0
     typescript: ^5.2.2
-    use-latest-callback: ^0.1.7
+    use-latest-callback: ^0.1.9
   peerDependencies:
     react: "*"
   languageName: unknown
@@ -3469,7 +3469,7 @@ __metadata:
     react-native-safe-area-context: 4.6.3
     react-native-screens: ~3.22.0
     typescript: ^5.2.2
-    use-latest-callback: ^0.1.7
+    use-latest-callback: ^0.1.9
   peerDependencies:
     "@react-navigation/native": ^6.0.0
     react: "*"
@@ -3621,7 +3621,7 @@ __metadata:
     react-native: 0.72.6
     react-native-builder-bob: ^0.23.1
     typescript: ^5.2.2
-    use-latest-callback: ^0.1.7
+    use-latest-callback: ^0.1.9
   peerDependencies:
     react: "*"
     react-native: 0.72.6
@@ -15533,7 +15533,7 @@ __metadata:
     react-native: 0.72.6
     react-native-builder-bob: ^0.23.1
     typescript: ^5.2.2
-    use-latest-callback: ^0.1.7
+    use-latest-callback: ^0.1.9
   peerDependencies:
     react: "*"
     react-native: 0.72.6
@@ -15646,7 +15646,7 @@ __metadata:
     react-native-builder-bob: ^0.23.1
     react-native-pager-view: 6.2.0
     typescript: ^5.2.2
-    use-latest-callback: ^0.1.7
+    use-latest-callback: ^0.1.9
   peerDependencies:
     react: "*"
     react-native: 0.72.6
@@ -18379,12 +18379,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"use-latest-callback@npm:^0.1.7":
-  version: 0.1.7
-  resolution: "use-latest-callback@npm:0.1.7"
+"use-latest-callback@npm:^0.1.9":
+  version: 0.1.9
+  resolution: "use-latest-callback@npm:0.1.9"
   peerDependencies:
     react: ">=16.8"
-  checksum: 0da07610ed8aa5274a2d1e258a034ca591d7508b5d9f04c3f56cc750d5f6c68f2bb430c346f0a344a46a4a942de21d942e8c175b170c1ea640558bb25071f7fb
+  checksum: 620969d85763b65aca5f9b601c31eb476a8f7602cfccfb3c0f9dc60ff3b863e04dd64360ada255e15606771513de33b25e4631607d702605b26630f61381b3d4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
upgrade version of use-latest-callback which contains the fix issue not able to locate the main file



Please provide enough information so that others can review your pull request.

**Motivation**

I encounter the issue below after install latest version of @react-navigation/core and it is the same with this issue https://github.com/react-navigation/react-navigation/issues/11690

@satya164 already fixed the issue in this pr: 
https://github.com/satya164/use-latest-callback/pull/5


```bash
iOS Bundling failed 1448ms
Unable to resolve "use-latest-callback" from "node_modules/@react-navigation/core/src/PreventRemoveProvider.tsx"
```

```bash
Metro has encountered an error: While trying to resolve module `use-latest-callback` from file `../node_modules/@react-navigation/core/src/PreventRemoveProvider.tsx`, the package `../node_modules/@react-navigation/core/node_modules/use-latest-callback/package.json` was successfully found. However, this package itself specifies a `main` module field that could not be resolved (`../node_modules/@react-navigation/core/node_modules/use-latest-callback/lib/index.js`. Indeed, none of these files exist:

  * ../node_modules/@react-navigation/core/node_modules/use-latest-callback/lib/index.js(.native|.ios.ts|.native.ts|.ts|.ios.tsx|.native.tsx|.tsx|.ios.js|.native.js|.js|.ios.jsx|.native.jsx|.jsx|.ios.json|.native.json|.json|.ios.cjs|.native.cjs|.cjs)
  * ../node_modules/@react-navigation/core/node_modules/use-latest-callback/lib/index.js/index(.native|.ios.ts|.native.ts|.ts|.ios.tsx|.native.tsx|.tsx|.ios.js|.native.js|.js|.ios.jsx|.native.jsx|.jsx|.ios.json|.native.json|.json|.ios.cjs|.native.cjs|.cjs): ../node_modules/metro/src/node-haste/DependencyGraph.js (289:17)

```


**Test plan**

* I ran typecheck, lint and e2s test
