### PR TITLE
fix: unref router so that it can be updated with changing options

### DIFF
--- a/packages/core/src/useNavigationBuilder.tsx
+++ b/packages/core/src/useNavigationBuilder.tsx
@@ -6,7 +6,6 @@ import {
   ParamListBase,
   PartialState,
   Route,
-  Router,
   RouterConfigOptions,
   RouterFactory,
 } from '@react-navigation/routers';
@@ -276,17 +275,15 @@ export default function useNavigationBuilder<
     | undefined;
 
   const { children, screenListeners, ...rest } = options;
-  const { current: router } = React.useRef<Router<State, any>>(
-    createRouter({
-      ...(rest as unknown as RouterOptions),
-      ...(route?.params &&
-      route.params.state == null &&
-      route.params.initial !== false &&
-      typeof route.params.screen === 'string'
-        ? { initialRouteName: route.params.screen }
-        : null),
-    })
-  );
+  const router = createRouter({
+    ...(rest as unknown as RouterOptions),
+    ...(route?.params &&
+    route.params.state == null &&
+    route.params.initial !== false &&
+    typeof route.params.screen === 'string'
+      ? { initialRouteName: route.params.screen }
+      : null),
+  });
 
   const routeConfigs = getRouteConfigsFromChildren<
     State,


### PR DESCRIPTION
**Motivation**
The documentation for CustomRouter (https://reactnavigation.org/docs/custom-routers) suggests that you can pass options to the CustomRouter/createCustomRouter function. Whenever the CustomNavigator is re-rendered, the options are passed again to the `useNavigationBuilder` function, suggesting that they are then passed further to the `createRouter` function. However, as the result of `createRouter` is saved as a ref, the new options are never passed again to the router. 

There is already a small discussion with a Snack here:
https://github.com/react-navigation/react-navigation/discussions/11488

This PR is simply removing the ref and makes the intended behaviour works. However I wonder why the router needed to be referenced in the first place. Is the performance greatly affected?
