### PR TITLE
Fix focus and blur callbacks' order when using useFocusEffect() hook

### DIFF
--- a/packages/core/src/useFocusEffect.tsx
+++ b/packages/core/src/useFocusEffect.tsx
@@ -72,10 +72,15 @@ export function useFocusEffect(effect: EffectCallback) {
     };
 
     // We need to run the effect on intial render/dep changes if the screen is focused
-    if (navigation.isFocused()) {
-      cleanup = callback();
-      isFocused = true;
-    }
+    let immediateId: NodeJS.Immediate | undefined = setImmediate(() => {
+      immediateId = undefined;
+
+      if (!isFocused && navigation.isFocused())
+      {
+        cleanup = callback();
+        isFocused = true;
+      }
+    });
 
     const unsubscribeFocus = navigation.addListener('focus', () => {
       // If callback was already called for focus, avoid calling it again
@@ -102,6 +107,8 @@ export function useFocusEffect(effect: EffectCallback) {
     });
 
     return () => {
+      if (immediateId !== undefined) clearImmediate(immediateId);
+      
       if (cleanup !== undefined) {
         cleanup();
       }

--- a/packages/core/src/useFocusEffect.tsx
+++ b/packages/core/src/useFocusEffect.tsx
@@ -75,8 +75,7 @@ export function useFocusEffect(effect: EffectCallback) {
     let immediateId: NodeJS.Immediate | undefined = setImmediate(() => {
       immediateId = undefined;
 
-      if (!isFocused && navigation.isFocused())
-      {
+      if (!isFocused && navigation.isFocused()) {
         cleanup = callback();
         isFocused = true;
       }
@@ -108,7 +107,7 @@ export function useFocusEffect(effect: EffectCallback) {
 
     return () => {
       if (immediateId !== undefined) clearImmediate(immediateId);
-      
+
       if (cleanup !== undefined) {
         cleanup();
       }


### PR DESCRIPTION
**Motivation**

I noticed when using useFocusEffect() hook, the focus callback of a just mounted component runs before blur/cleanup callback of a previously or already mounted component. This caused issues with screens requiring transactional behavior.

For example, imagine you have three screens. Two screens are in full screen mode, one is not. The two screens in full screen mode use useFocusEffect() hook - entering full screen mode on focus and exiting it on blur. Now, say I'm currently in one of the two screens requiring full screen mode, and I navigate to the other screen in full screen mode, then, this happens: focus callback (second screen), blur callback (first screen). By the time I'm in the second screen, I won't be in full screen mode due to the error in the order of execution of focus/blur callbacks.

This issue is similar to #7963 which has been resolved, but it fixed only the execution order of navigation focus/blur events (i.e., `navigation.addListener`), not useFocusEffect() hook.

**Test plan**

Use useFocusEffect() hook in two screens and observe the order of execution of the focus/blur callbacks.