### PR TITLE
chore: update transform style for web

### DIFF
--- a/packages/elements/src/Header/HeaderBackButton.tsx
+++ b/packages/elements/src/Header/HeaderBackButton.tsx
@@ -251,6 +251,6 @@ const styles = StyleSheet.create({
     alignSelf: 'center',
   },
   flip: {
-    transform: [{ scaleX: -1 }],
+    transform: 'scaleX(-1)',
   },
 });


### PR DESCRIPTION


**Motivation**

This API is "deprecated" according to `react-native-web` so we get the following warning whenever anyone attempts to render React Navigation: `Warning: "transform" style array value is deprecated. Use space-separated string functions, e.g., "scaleX(2) rotateX(15deg)".`

**Test plan**

Describe the **steps to test this change** so that a reviewer can verify it. Provide screenshots or videos if the change affects UI.

The change must pass lint, typescript and tests.
