### PR TITLE
`tabBarBadge` also accepts a bool (or more specifically true)

### DIFF
--- a/example/src/Screens/BottomTabs.tsx
+++ b/example/src/Screens/BottomTabs.tsx
@@ -138,6 +138,7 @@ export function BottomTabs({
           options={{
             title: 'Article',
             tabBarIcon: getTabBarIcon('file-document'),
+            tabBarBadge: true,
           }}
         />
         <Tab.Screen

--- a/packages/bottom-tabs/src/types.tsx
+++ b/packages/bottom-tabs/src/types.tsx
@@ -148,7 +148,7 @@ export type BottomTabNavigationOptions = HeaderOptions & {
   /**
    * Text to show in a badge on the tab icon.
    */
-  tabBarBadge?: number | string | true;
+  tabBarBadge?: number | string | boolean;
 
   /**
    * Custom style for the tab bar badge.

--- a/packages/bottom-tabs/src/types.tsx
+++ b/packages/bottom-tabs/src/types.tsx
@@ -148,7 +148,7 @@ export type BottomTabNavigationOptions = HeaderOptions & {
   /**
    * Text to show in a badge on the tab icon.
    */
-  tabBarBadge?: number | string | boolean;
+  tabBarBadge?: number | string | true;
 
   /**
    * Custom style for the tab bar badge.

--- a/packages/bottom-tabs/src/types.tsx
+++ b/packages/bottom-tabs/src/types.tsx
@@ -148,7 +148,7 @@ export type BottomTabNavigationOptions = HeaderOptions & {
   /**
    * Text to show in a badge on the tab icon.
    */
-  tabBarBadge?: number | string;
+  tabBarBadge?: number | string | true;
 
   /**
    * Custom style for the tab bar badge.

--- a/packages/bottom-tabs/src/views/BottomTabItem.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabItem.tsx
@@ -57,7 +57,7 @@ type Props = {
   /**
    * Text to show in a badge on the tab icon.
    */
-  badge?: number | string;
+  badge?: number | string | boolean;
   /**
    * Custom style for the badge.
    */


### PR DESCRIPTION
**Motivation**

The docs state that `tabBarBadge` accepts a boolean: https://reactnavigation.org/docs/material-bottom-tab-navigator/#tabbarbadge

If you want to display badge without a number in, this is how it's done. However the current code does not allow this and so there's currently not a supported method of displaying a badge with no value. 

**Test plan**

We've added a badge with no value to the `BottomTabs.tsx` in the example project.
<img width="310" alt="image" src="https://github.com/react-navigation/react-navigation/assets/422196/cf95e818-4134-4a7c-9f4a-5f90c8d98eb4">
