### PR TITLE
fix: run focus effects after navigation transition

### DIFF
--- a/packages/core/src/__tests__/useFocusEffect.test.tsx
+++ b/packages/core/src/__tests__/useFocusEffect.test.tsx
@@ -9,6 +9,7 @@ import { useNavigationBuilder } from '../useNavigationBuilder';
 import { MockRouter, MockRouterKey } from './__fixtures__/MockRouter';
 
 beforeEach(() => {
+  jest.useFakeTimers();
   MockRouterKey.current = 0;
 });
 
@@ -48,21 +49,25 @@ test('runs focus effect on focus change', () => {
 
   render(element);
 
+  jest.runAllTimers();
   expect(focusEffect).not.toHaveBeenCalled();
   expect(focusEffectCleanup).not.toHaveBeenCalled();
 
   act(() => navigation.current.navigate('second'));
 
+  jest.runAllTimers();
   expect(focusEffect).toHaveBeenCalledTimes(1);
   expect(focusEffectCleanup).not.toHaveBeenCalled();
 
   act(() => navigation.current.navigate('third'));
 
+  jest.runAllTimers();
   expect(focusEffect).toHaveBeenCalledTimes(1);
   expect(focusEffectCleanup).toHaveBeenCalledTimes(1);
 
   act(() => navigation.current.navigate('second'));
 
+  jest.runAllTimers();
   expect(focusEffect).toHaveBeenCalledTimes(2);
   expect(focusEffectCleanup).toHaveBeenCalledTimes(1);
 });
@@ -157,6 +162,7 @@ test('runs focus effect when initial state is given', () => {
 
   act(() => navigation.current.navigate('first'));
 
+  jest.runAllTimers();
   expect(focusEffect).toHaveBeenCalledTimes(1);
   expect(focusEffectCleanup).toHaveBeenCalledTimes(1);
 });
@@ -200,6 +206,7 @@ test('runs focus effect when only focused route is rendered', () => {
 
   act(() => navigation.current.navigate('second'));
 
+  jest.runAllTimers();
   expect(focusEffect).toHaveBeenCalledTimes(1);
   expect(focusEffectCleanup).toHaveBeenCalledTimes(1);
 });
@@ -242,6 +249,7 @@ test('runs cleanup when component is unmounted', () => {
 
   root.update(<App mounted={false} />);
 
+  jest.runAllTimers();
   expect(focusEffect).toHaveBeenCalledTimes(1);
   expect(focusEffectCleanup).toHaveBeenCalledTimes(1);
 });

--- a/packages/core/src/useFocusEffect.tsx
+++ b/packages/core/src/useFocusEffect.tsx
@@ -88,7 +88,11 @@ export function useFocusEffect(effect: EffectCallback) {
         cleanup();
       }
 
-      cleanup = callback();
+      const timer = setTimeout(() => {
+        cleanup = callback();
+      }, 1);
+      cleanup = () => clearTimeout(timer);
+
       isFocused = true;
     });
 

--- a/packages/stack/src/__tests__/index.test.tsx
+++ b/packages/stack/src/__tests__/index.test.tsx
@@ -223,6 +223,8 @@ test('runs focus effect on focus change on preloaded route', () => {
 
   act(() => navigation.navigate('B'));
 
+  act(() => jest.runAllTimers());
+
   expect(focusEffect).toHaveBeenCalledTimes(1);
   expect(focusEffectCleanup).not.toHaveBeenCalled();
 


### PR DESCRIPTION
**Motivation**

I've been investigating why our app had turned slow and less responsive esp on older Android devices. Seemingly a navigation between two already mounted tabs should be near instant. I found that it only happened where we were doing side effects in `useFocusEffect` and I attribute it to both the introduction of automatic batching in React 18 and that the effects themselves might be taxing on the CPU and/or bridge. 

In this PR I change the behaviour of the hook when being _reactivated_ (mount behaviour remains the same) to run just after the render update being committed by wrapping it inside a `setTimeout`. I had originally used `requestIdleCallback` which seemed more correct, however it seems that function has had issues historically and might break on iOS for users on older versions of React Native, see https://github.com/facebook/react-native/issues/28602. Using `setImmediate` does not avoid the batching behaviour as IIRC the implementation on RN side will then not involve a native timer. 

Fixes https://github.com/react-navigation/react-navigation/issues/11613

**Test plan**

Verified on an enterprise app and updated unit tests to reflect the change. 