### PR TITLE
feat: add option to set tab bar width

### DIFF
--- a/example/src/Screens/BottomTabs.tsx
+++ b/example/src/Screens/BottomTabs.tsx
@@ -20,9 +20,18 @@ import {
   ScrollView,
   StatusBar,
   StyleSheet,
+  Text,
   useWindowDimensions,
+  View,
 } from 'react-native';
-import { Appbar, IconButton } from 'react-native-paper';
+import {
+  Appbar,
+  Button,
+  Checkbox,
+  FAB,
+  IconButton,
+  RadioButton,
+} from 'react-native-paper';
 
 import { Albums } from '../Shared/Albums';
 import { Chat } from '../Shared/Chat';
@@ -72,6 +81,110 @@ const animations = {
   none: null,
 } as const;
 
+const SettingsContext = React.createContext({
+  openSettingsModal: false,
+  tabBarWidth: 100,
+  useTabBarWidthProps: false,
+  setOpenSettingModal: (_isOpen: boolean) => {},
+  setTabBarWidth: (_width: number) => {},
+  setUseTabBarWidthProps: (_useProps: boolean) => {},
+});
+
+const SettingsFab = () => {
+  const { setOpenSettingModal } = React.useContext(SettingsContext);
+
+  return (
+    // eslint-disable-next-line react/jsx-pascal-case
+    <FAB
+      style={styles.fab}
+      small
+      icon="cog"
+      onPress={() => setOpenSettingModal(true)}
+    />
+  );
+};
+
+const SettingsModal = () => {
+  const tabBarWidthOptions = [100, 150, 200];
+  const {
+    useTabBarWidthProps,
+    setUseTabBarWidthProps,
+    openSettingsModal,
+    setOpenSettingModal,
+    tabBarWidth,
+    setTabBarWidth,
+  } = React.useContext(SettingsContext);
+  if (!openSettingsModal) {
+    return <></>;
+  }
+  return (
+    <View style={styles.settingsModal}>
+      <View style={styles.settingsModalSurface}>
+        <Button onPress={() => setOpenSettingModal(false)}>
+          Close Settings Modal
+        </Button>
+        <View style={styles.settingsModalSurfaceRow}>
+          <Text style={{ fontSize: 18 }}>
+            use tabBarWidth Props to set the tab bar width with callback
+          </Text>
+          <Checkbox
+            status={useTabBarWidthProps ? 'checked' : 'unchecked'}
+            onPress={() => {
+              setUseTabBarWidthProps(!useTabBarWidthProps);
+            }}
+          />
+        </View>
+        <View>
+          {tabBarWidthOptions.map((number) => {
+            return (
+              <View key={number} style={styles.settingsModalSurfaceRow}>
+                <Text>{number}</Text>
+                <RadioButton
+                  disabled={!useTabBarWidthProps}
+                  value={number.toString()}
+                  status={tabBarWidth === number ? 'checked' : 'unchecked'}
+                  onPress={() => setTabBarWidth(number)}
+                />
+              </View>
+            );
+          })}
+        </View>
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  fab: {
+    position: 'absolute',
+    margin: 16,
+    right: 0,
+    bottom: 0,
+  },
+  settingsModal: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    width: '100%',
+    height: '100%',
+    backgroundColor: 'rgba(0,0,0,0.8)',
+    zIndex: 999,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  settingsModalSurface: {
+    width: '50%',
+    height: '50%',
+    backgroundColor: 'white',
+  },
+  settingsModalSurfaceRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    padding: 10,
+  },
+});
+
 export function BottomTabs({
   navigation,
 }: StackScreenProps<ParamListBase, string>) {
@@ -91,8 +204,21 @@ export function BottomTabs({
 
   const isLargeScreen = dimensions.width >= 1024;
 
+  const [openSettingsModal, setOpenSettingModal] = React.useState(false);
+  const [tabBarWidth, setTabBarWidth] = React.useState(100);
+  const [useTabBarWidthProps, setUseTabBarWidthProps] = React.useState(false);
+
   return (
-    <>
+    <SettingsContext.Provider
+      value={{
+        openSettingsModal,
+        setOpenSettingModal,
+        tabBarWidth,
+        setTabBarWidth,
+        useTabBarWidthProps,
+        setUseTabBarWidthProps,
+      }}
+    >
       <Tab.Navigator
         screenOptions={{
           headerLeft: (props) => (
@@ -126,6 +252,7 @@ export function BottomTabs({
               }}
             />
           ),
+          tabBarWidth: useTabBarWidthProps ? () => tabBarWidth : undefined,
           tabBarPosition: isLargeScreen ? 'left' : 'bottom',
           tabBarLabelPosition:
             isLargeScreen && isCompact ? 'below-icon' : undefined,
@@ -219,6 +346,8 @@ export function BottomTabs({
           }}
         />
       ) : null}
-    </>
+      <SettingsFab />
+      <SettingsModal />
+    </SettingsContext.Provider>
   );
 }

--- a/packages/bottom-tabs/src/types.tsx
+++ b/packages/bottom-tabs/src/types.tsx
@@ -15,6 +15,7 @@ import type * as React from 'react';
 import type {
   Animated,
   GestureResponderEvent,
+  ScaledSize,
   StyleProp,
   TextStyle,
   ViewStyle,
@@ -229,6 +230,11 @@ export type BottomTabNavigationOptions = HeaderOptions & {
    * Position of the tab bar on the screen. Defaults to `bottom`.
    */
   tabBarPosition?: 'bottom' | 'left' | 'right';
+
+  /**
+   * Function which returns the width of the tab bar on the screen.
+   */
+  tabBarWidth?: (dimensions: ScaledSize) => number;
 
   /**
    * Whether this screens should render the first time it's accessed. Defaults to `true`.

--- a/packages/bottom-tabs/src/views/BottomTabBar.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabBar.tsx
@@ -165,6 +165,7 @@ export function BottomTabBar({
           .string()
       : undefined,
     tabBarInactiveBackgroundColor,
+    tabBarWidth,
   } = focusedOptions;
 
   // FIXME: useSafeAreaFrame doesn't update values when window is resized on Web
@@ -270,6 +271,12 @@ export function BottomTabBar({
 
   const tabBarBackgroundElement = tabBarBackground?.();
 
+  const sideBarWidth = tabBarWidth
+    ? tabBarWidth(dimensions)
+    : hasHorizontalLabels
+    ? getDefaultSidebarWidth(dimensions)
+    : 0;
+
   return (
     <Animated.View
       style={[
@@ -314,9 +321,7 @@ export function BottomTabBar({
               paddingBottom: insets.bottom,
               paddingLeft: tabBarPosition === 'left' ? insets.left : 0,
               paddingRight: tabBarPosition === 'right' ? insets.right : 0,
-              minWidth: hasHorizontalLabels
-                ? getDefaultSidebarWidth(dimensions)
-                : 0,
+              minWidth: sideBarWidth,
             },
         tabBarStyle,
       ]}


### PR DESCRIPTION
Please provide enough information so that others can review your pull request.

**Motivation**

Pull Request #11578 https://github.com/react-navigation/react-navigation/pull/11578 added an option to show the tab bar on the left or the right.

This PR adds ability to set the tab bar width. It useful on larger screens where tab bar is set to the side and allows customisation of tab bar width according to the ux ui need

**Test plan**

Open the "Bottom Tabs" example and resize the screen to show to tab bar on the left. 
Press the FAB on the bottom right to open the setting modal
Check the checkbox and select different tab bar width to show the effect

**Video**

https://github.com/react-navigation/react-navigation/assets/146067776/1dc09cde-0ea5-41aa-b4ed-04c189a42e00


