### PR TITLE
feat: [bottom-tabs] allow position = top

### DIFF
--- a/packages/bottom-tabs/src/types.tsx
+++ b/packages/bottom-tabs/src/types.tsx
@@ -228,7 +228,7 @@ export type BottomTabNavigationOptions = HeaderOptions & {
   /**
    * Position of the tab bar on the screen. Defaults to `bottom`.
    */
-  tabBarPosition?: 'bottom' | 'left' | 'right';
+  tabBarPosition?: 'bottom' | 'left' | 'right' | 'top';
 
   /**
    * Whether this screens should render the first time it's accessed. Defaults to `true`.

--- a/packages/bottom-tabs/src/views/BottomTabBar.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabBar.tsx
@@ -158,7 +158,8 @@ export function BottomTabBar({
     tabBarBackground,
     tabBarActiveTintColor,
     tabBarInactiveTintColor,
-    tabBarActiveBackgroundColor = tabBarPosition !== 'bottom'
+    tabBarActiveBackgroundColor = tabBarPosition !== 'bottom' &&
+    tabBarPosition !== 'top'
       ? Color(tabBarActiveTintColor ?? colors.primary)
           .alpha(0.12)
           .rgb()
@@ -270,6 +271,9 @@ export function BottomTabBar({
 
   const tabBarBackgroundElement = tabBarBackground?.();
 
+  const tabBarIsHorizontal =
+    tabBarPosition === 'bottom' || tabBarPosition === 'top';
+
   return (
     <Animated.View
       style={[
@@ -283,7 +287,7 @@ export function BottomTabBar({
             tabBarBackgroundElement != null ? 'transparent' : colors.card,
           borderColor: colors.border,
         },
-        tabBarPosition === 'bottom'
+        tabBarIsHorizontal
           ? [
               {
                 transform: [
@@ -321,18 +325,14 @@ export function BottomTabBar({
         tabBarStyle,
       ]}
       pointerEvents={isTabBarHidden ? 'none' : 'auto'}
-      onLayout={tabBarPosition === 'bottom' ? handleLayout : undefined}
+      onLayout={tabBarIsHorizontal ? handleLayout : undefined}
     >
       <View pointerEvents="none" style={StyleSheet.absoluteFill}>
         {tabBarBackgroundElement}
       </View>
       <View
         accessibilityRole="tablist"
-        style={
-          tabBarPosition === 'bottom'
-            ? styles.bottomContent
-            : styles.sideContent
-        }
+        style={tabBarIsHorizontal ? styles.bottomContent : styles.sideContent}
       >
         {routes.map((route, index) => {
           const focused = index === state.index;
@@ -410,7 +410,7 @@ export function BottomTabBar({
                   labelStyle={options.tabBarLabelStyle}
                   iconStyle={options.tabBarIconStyle}
                   style={[
-                    tabBarPosition === 'bottom'
+                    tabBarIsHorizontal
                       ? styles.bottomItem
                       : [
                           styles.sideItem,

--- a/packages/bottom-tabs/src/views/BottomTabView.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabView.tsx
@@ -163,6 +163,11 @@ export function BottomTabView(props: Props) {
           : null
       }
     >
+      {tabBarPosition === 'top' ? (
+        <BottomTabBarHeightCallbackContext.Provider value={setTabBarHeight}>
+          {renderTabBar()}
+        </BottomTabBarHeightCallbackContext.Provider>
+      ) : null}
       <MaybeScreenContainer
         enabled={detachInactiveScreens}
         hasTwoStates={hasTwoStates}
@@ -259,9 +264,11 @@ export function BottomTabView(props: Props) {
           );
         })}
       </MaybeScreenContainer>
-      <BottomTabBarHeightCallbackContext.Provider value={setTabBarHeight}>
-        {renderTabBar()}
-      </BottomTabBarHeightCallbackContext.Provider>
+      {tabBarPosition !== 'top' ? (
+        <BottomTabBarHeightCallbackContext.Provider value={setTabBarHeight}>
+          {renderTabBar()}
+        </BottomTabBarHeightCallbackContext.Provider>
+      ) : null}
     </SafeAreaProviderCompat>
   );
 }


### PR DESCRIPTION
Please provide enough information so that others can review your pull request.

**Motivation**

Currently in `bottom-tabs`, the `tabBarPosition` prop can only have `bottom`, `left`, or `right` values.

For Apple TV and Android TV, it is helpful to allow `top` as well, so that there can be a top nav bar without absolute positioning (which causes problems for TV focus navigation).

**Test plan**

Test app that works correctly with this change: https://github.com/douglowder/IgniteTV/tree/top-navigation