### PR TITLE
fix: fix tabBarShowLabel not working when specified per screen

### DIFF
--- a/packages/bottom-tabs/src/views/BottomTabBar.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabBar.tsx
@@ -151,7 +151,6 @@ export function BottomTabBar({
 
   const {
     tabBarPosition = 'bottom',
-    tabBarShowLabel,
     tabBarHideOnKeyboard = false,
     tabBarVisibilityAnimationConfig,
     tabBarStyle,
@@ -406,7 +405,7 @@ export function BottomTabBar({
                   badge={options.tabBarBadge}
                   badgeStyle={options.tabBarBadgeStyle}
                   label={label}
-                  showLabel={tabBarShowLabel}
+                  showLabel={options.tabBarShowLabel}
                   labelStyle={options.tabBarLabelStyle}
                   iconStyle={options.tabBarIconStyle}
                   style={[


### PR DESCRIPTION
**Motivation**

This pull request addresses an issue where the `tabBarShowLabel` property was not functioning as expected when specified individually for each screen in the React Navigation Bottom Tab.

When specifying `tabBarShowLabel` as `false` for one of the screens, the label remained visible while the screen was not focused. Upon focusing on the screen, all labels disappeared, creating an inconsistency in the display of tab bar labels.

**Test plan**

1. Create a bottom tab navigator with multiple screens.
2. Set `tabBarShowLabel` to `false` for one specific screen.
3. Observe the behavior:
a. The label for the specified screen remains visible when it is not focused.
b. Upon focusing on the screen, all bottom tab bar labels disappear.
