### PR TITLE
docs: corrected ts check script name in CONTRIBUTING file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ yarn example start
 Make sure your code passes TypeScript and ESLint. Run the following to verify:
 
 ```sh
-yarn typescript
+yarn typecheck
 yarn lint
 ```
 


### PR DESCRIPTION
**Motivation**

This pull request updates the contributing file to correct a command inconsistency. The previous command `yarn typescript` has been replaced with the accurate `yarn typecheck`. This change ensures alignment with the correct command for TypeScript type-checking.
