### PR TITLE
fix: make params property optional in the return type of useRoute

### DIFF
--- a/packages/core/src/useRoute.tsx
+++ b/packages/core/src/useRoute.tsx
@@ -9,7 +9,10 @@ import type { RouteProp } from './types';
  *
  * @returns Route prop of the parent screen.
  */
-export function useRoute<T extends RouteProp<ParamListBase>>(): T {
+export function useRoute<T extends RouteProp<ParamListBase>>(): Omit<
+  T,
+  'params'
+> & { params?: T['params'] } {
   const route = React.useContext(NavigationRouteContext);
 
   if (route === undefined) {
@@ -18,5 +21,5 @@ export function useRoute<T extends RouteProp<ParamListBase>>(): T {
     );
   }
 
-  return route as T;
+  return route as Omit<T, 'params'> & { params?: T['params'] };
 }


### PR DESCRIPTION
**Motivation**

The return type of useRoute includes `params` as non-optional, but in fact `params` is optional. Therefore, the return type has been modified to match.

cf. https://github.com/react-navigation/react-navigation/issues/6851

**Test plan**

Describe the **steps to test this change** so that a reviewer can verify it. Provide screenshots or videos if the change affects UI.

The change must pass lint, typescript and tests.
