### PR TITLE
fix: White flash transitions with DarkTheme

### DIFF
--- a/packages/native-stack/src/views/NativeStackView.native.tsx
+++ b/packages/native-stack/src/views/NativeStackView.native.tsx
@@ -445,10 +445,14 @@ type Props = {
 function NativeStackViewInner({ state, navigation, descriptors }: Props) {
   const { setNextDismissedKey } = useDismissedRouteError(state);
 
+  const { colors } = useTheme();
+
   useInvalidPreventRemoveError(descriptors);
 
   return (
-    <ScreenStack style={styles.container}>
+    <ScreenStack
+      style={[styles.container, { backgroundColor: colors.background }]}
+    >
       {state.routes.map((route, index) => {
         const descriptor = descriptors[route.key];
         const isFocused = state.index === index;

--- a/packages/native-stack/src/views/NativeStackView.tsx
+++ b/packages/native-stack/src/views/NativeStackView.tsx
@@ -10,6 +10,7 @@ import {
   type ParamListBase,
   type StackNavigationState,
   useLinkBuilder,
+  useTheme,
 } from '@react-navigation/native';
 import * as React from 'react';
 import { Image, StyleSheet, View } from 'react-native';
@@ -35,6 +36,7 @@ const TRANSPARENT_PRESENTATIONS = [
 export function NativeStackView({ state, descriptors }: Props) {
   const parentHeaderBack = React.useContext(HeaderBackContext);
   const { buildHref } = useLinkBuilder();
+  const { colors } = useTheme();
 
   if (state.preloadedRoutes.length !== 0) {
     throw new Error(
@@ -44,7 +46,7 @@ export function NativeStackView({ state, descriptors }: Props) {
 
   return (
     <SafeAreaProviderCompat>
-      <View style={styles.container}>
+      <View style={[styles.container, { backgroundColor: colors.background }]}>
         {state.routes.map((route, i) => {
           const isFocused = state.index === i;
           const previousKey = state.routes[i - 1]?.key;


### PR DESCRIPTION
This PR fixes the issue #11797

Even with the DarkTheme during the transition ScreenStack comes up with a white background. I solved it by setting the backgroundColor as the theme color