### PR TITLE
feat: introduce missing props from native-stack v5

### DIFF
--- a/packages/native-stack/src/types.tsx
+++ b/packages/native-stack/src/types.tsx
@@ -20,6 +20,7 @@ import type {
   ScreenProps,
   ScreenStackHeaderConfigProps,
   SearchBarProps,
+  SheetDetentTypes,
 } from 'react-native-screens';
 
 export type NativeStackNavigationEventMap = {
@@ -31,6 +32,10 @@ export type NativeStackNavigationEventMap = {
    * Event which fires when a transition animation ends.
    */
   transitionEnd: { data: { closing: boolean } };
+  /**
+   * Event which fires when a swipe back is canceled on iOS.
+   */
+  gestureCancel: { data: undefined };
 };
 
 export type NativeStackNavigationProp<
@@ -331,6 +336,12 @@ export type NativeStackNavigationOptions = {
    */
   autoHideHomeIndicator?: boolean;
   /**
+   * Whether the keyboard should hide when swiping to the previous screen. Defaults to `false`.
+   *
+   * @platform ios
+   */
+  hideKeyboardOnSwipe?: boolean;
+  /**
    * Sets the navigation bar color. Defaults to initial navigation bar color.
    *
    * @platform android
@@ -423,6 +434,12 @@ export type NativeStackNavigationOptions = {
    */
   gestureEnabled?: boolean;
   /**
+   * Use it to restrict the distance from the edges of screen in which the gesture should be recognized. To be used alongside `fullScreenGestureEnabled`.
+   *
+   * @platform ios
+   */
+  gestureResponseDistance?: ScreenProps['gestureResponseDistance'];
+  /**
    * The type of animation to use when this screen replaces another screen. Defaults to `pop`.
    *
    * Supported values:
@@ -470,6 +487,62 @@ export type NativeStackNavigationOptions = {
    * Only supported on iOS and Android.
    */
   presentation?: Exclude<ScreenProps['stackPresentation'], 'push'> | 'card';
+  /**
+   * Describes heights where a sheet can rest.
+   * Works only when `stackPresentation` is set to `formSheet`.
+   * Defaults to `large`.
+   *
+   * Available values:
+   *
+   * - `large` - only large detent level will be allowed
+   * - `medium` - only medium detent level will be allowed
+   * - `all` - all detent levels will be allowed
+   *
+   * @platform ios
+   */
+  sheetAllowedDetents?: SheetDetentTypes;
+  /**
+   * Whether the sheet should expand to larger detent when scrolling.
+   * Works only when `stackPresentation` is set to `formSheet`.
+   * Defaults to `true`.
+   *
+   * @platform ios
+   */
+  sheetExpandsWhenScrolledToEdge?: boolean;
+  /**
+   * The corner radius that the sheet will try to render with.
+   * Works only when `stackPresentation` is set to `formSheet`.
+   *
+   * If set to non-negative value it will try to render sheet with provided radius, else it will apply system default.
+   *
+   * If left unset system default is used.
+   *
+   * @platform ios
+   */
+  sheetCornerRadius?: number;
+  /**
+   * Boolean indicating whether the sheet shows a grabber at the top.
+   * Works only when `stackPresentation` is set to `formSheet`.
+   * Defaults to `false`.
+   *
+   * @platform ios
+   */
+  sheetGrabberVisible?: boolean;
+  /**
+   * The largest sheet detent for which a view underneath won't be dimmed.
+   * Works only when `stackPresentation` is se tto `formSheet`.
+   *
+   * If this prop is set to:
+   *
+   * - `large` - the view underneath won't be dimmed at any detent level
+   * - `medium` - the view underneath will be dimmed only when detent level is `large`
+   * - `all` - the view underneath will be dimmed for any detent level
+   *
+   * Defaults to `all`.
+   *
+   * @platform ios
+   */
+  sheetLargestUndimmedDetent?: SheetDetentTypes;
   /**
    * The display orientation to use for the screen.
    *

--- a/packages/native-stack/src/types.tsx
+++ b/packages/native-stack/src/types.tsx
@@ -489,7 +489,7 @@ export type NativeStackNavigationOptions = {
   presentation?: Exclude<ScreenProps['stackPresentation'], 'push'> | 'card';
   /**
    * Describes heights where a sheet can rest.
-   * Works only when `stackPresentation` is set to `formSheet`.
+   * Works only when `presentation` is set to `formSheet`.
    * Defaults to `large`.
    *
    * Available values:
@@ -503,7 +503,7 @@ export type NativeStackNavigationOptions = {
   sheetAllowedDetents?: SheetDetentTypes;
   /**
    * Whether the sheet should expand to larger detent when scrolling.
-   * Works only when `stackPresentation` is set to `formSheet`.
+   * Works only when `presentation` is set to `formSheet`.
    * Defaults to `true`.
    *
    * @platform ios
@@ -511,7 +511,7 @@ export type NativeStackNavigationOptions = {
   sheetExpandsWhenScrolledToEdge?: boolean;
   /**
    * The corner radius that the sheet will try to render with.
-   * Works only when `stackPresentation` is set to `formSheet`.
+   * Works only when `presentation` is set to `formSheet`.
    *
    * If set to non-negative value it will try to render sheet with provided radius, else it will apply system default.
    *
@@ -522,7 +522,7 @@ export type NativeStackNavigationOptions = {
   sheetCornerRadius?: number;
   /**
    * Boolean indicating whether the sheet shows a grabber at the top.
-   * Works only when `stackPresentation` is set to `formSheet`.
+   * Works only when `presentation` is set to `formSheet`.
    * Defaults to `false`.
    *
    * @platform ios
@@ -530,7 +530,7 @@ export type NativeStackNavigationOptions = {
   sheetGrabberVisible?: boolean;
   /**
    * The largest sheet detent for which a view underneath won't be dimmed.
-   * Works only when `stackPresentation` is se tto `formSheet`.
+   * Works only when `presentation` is se tto `formSheet`.
    *
    * If this prop is set to:
    *

--- a/packages/native-stack/src/types.tsx
+++ b/packages/native-stack/src/types.tsx
@@ -340,7 +340,7 @@ export type NativeStackNavigationOptions = {
    *
    * @platform ios
    */
-  hideKeyboardOnSwipe?: boolean;
+  keyboardHandlingEnabled?: boolean;
   /**
    * Sets the navigation bar color. Defaults to initial navigation bar color.
    *

--- a/packages/native-stack/src/views/NativeStackView.native.tsx
+++ b/packages/native-stack/src/views/NativeStackView.native.tsx
@@ -104,7 +104,12 @@ const MaybeNestedStack = ({
   if (isHeaderInModal) {
     return (
       <ScreenStack style={styles.container}>
-        <Screen enabled style={StyleSheet.absoluteFill}>
+        <Screen
+          enabled
+          isNativeStack
+          hasLargeHeader={options.headerLargeTitle ?? false}
+          style={StyleSheet.absoluteFill}
+        >
           {content}
           <HeaderConfig
             {...options}
@@ -128,11 +133,13 @@ type SceneViewProps = {
   previousDescriptor?: NativeStackDescriptor;
   nextDescriptor?: NativeStackDescriptor;
   onWillDisappear: () => void;
+  onWillAppear: () => void;
   onAppear: () => void;
   onDisappear: () => void;
   onDismissed: ScreenProps['onDismissed'];
   onHeaderBackButtonClicked: ScreenProps['onHeaderBackButtonClicked'];
   onNativeDismissCancelled: ScreenProps['onDismissed'];
+  onGestureCancel: ScreenProps['onGestureCancel'];
 };
 
 const SceneView = ({
@@ -142,11 +149,13 @@ const SceneView = ({
   previousDescriptor,
   nextDescriptor,
   onWillDisappear,
+  onWillAppear,
   onAppear,
   onDisappear,
   onDismissed,
   onHeaderBackButtonClicked,
   onNativeDismissCancelled,
+  onGestureCancel,
 }: SceneViewProps) => {
   const { route, navigation, options, render } = descriptor;
 
@@ -162,15 +171,22 @@ const SceneView = ({
     animationTypeForReplace = 'push',
     gestureEnabled,
     gestureDirection = presentation === 'card' ? 'horizontal' : 'vertical',
+    gestureResponseDistance,
     header,
     headerBackButtonMenuEnabled,
     headerShown,
     headerBackground,
     headerTransparent,
     autoHideHomeIndicator,
+    hideKeyboardOnSwipe,
     navigationBarColor,
     navigationBarHidden,
     orientation,
+    sheetAllowedDetents = 'large',
+    sheetLargestUndimmedDetent = 'all',
+    sheetGrabberVisible = false,
+    sheetCornerRadius = -1.0,
+    sheetExpandsWhenScrolledToEdge = true,
     statusBarAnimation,
     statusBarHidden,
     statusBarStyle,
@@ -270,7 +286,9 @@ const SceneView = ({
     <Screen
       key={route.key}
       enabled
+      isNativeStack
       style={StyleSheet.absoluteFill}
+      hasLargeHeader={options.headerLargeTitle ?? false}
       customAnimationOnSwipe={animationMatchesGesture}
       fullScreenSwipeEnabled={fullScreenGestureEnabled}
       gestureEnabled={
@@ -281,12 +299,18 @@ const SceneView = ({
           : gestureEnabled
       }
       homeIndicatorHidden={autoHideHomeIndicator}
+      hideKeyboardOnSwipe={hideKeyboardOnSwipe}
       navigationBarColor={navigationBarColor}
       navigationBarHidden={navigationBarHidden}
       replaceAnimation={animationTypeForReplace}
       stackPresentation={presentation === 'card' ? 'push' : presentation}
       stackAnimation={animation}
       screenOrientation={orientation}
+      sheetAllowedDetents={sheetAllowedDetents}
+      sheetLargestUndimmedDetent={sheetLargestUndimmedDetent}
+      sheetGrabberVisible={sheetGrabberVisible}
+      sheetCornerRadius={sheetCornerRadius}
+      sheetExpandsWhenScrolledToEdge={sheetExpandsWhenScrolledToEdge}
       statusBarAnimation={statusBarAnimation}
       statusBarHidden={statusBarHidden}
       statusBarStyle={statusBarStyle}
@@ -294,11 +318,13 @@ const SceneView = ({
       statusBarTranslucent={statusBarTranslucent}
       swipeDirection={gestureDirectionOverride}
       transitionDuration={animationDuration}
+      onWillAppear={onWillAppear}
       onWillDisappear={onWillDisappear}
       onAppear={onAppear}
       onDisappear={onDisappear}
       onDismissed={onDismissed}
-      isNativeStack
+      onGestureCancel={onGestureCancel}
+      gestureResponseDistance={gestureResponseDistance}
       nativeBackButtonDismissalEnabled={false} // on Android
       onHeaderBackButtonClicked={onHeaderBackButtonClicked}
       preventNativeDismiss={isRemovePrevented} // on iOS
@@ -456,6 +482,13 @@ function NativeStackViewInner({ state, navigation, descriptors }: Props) {
                 target: route.key,
               });
             }}
+            onWillAppear={() => {
+              navigation.emit({
+                type: 'transitionStart',
+                data: { closing: false },
+                target: route.key,
+              });
+            }}
             onAppear={() => {
               navigation.emit({
                 type: 'transitionEnd',
@@ -491,6 +524,12 @@ function NativeStackViewInner({ state, navigation, descriptors }: Props) {
                 ...StackActions.pop(event.nativeEvent.dismissCount),
                 source: route.key,
                 target: state.key,
+              });
+            }}
+            onGestureCancel={() => {
+              navigation.emit({
+                type: 'gestureCancel',
+                target: route.key,
               });
             }}
           />

--- a/packages/native-stack/src/views/NativeStackView.native.tsx
+++ b/packages/native-stack/src/views/NativeStackView.native.tsx
@@ -178,7 +178,7 @@ const SceneView = ({
     headerBackground,
     headerTransparent,
     autoHideHomeIndicator,
-    hideKeyboardOnSwipe,
+    keyboardHandlingEnabled,
     navigationBarColor,
     navigationBarHidden,
     orientation,
@@ -299,7 +299,7 @@ const SceneView = ({
           : gestureEnabled
       }
       homeIndicatorHidden={autoHideHomeIndicator}
-      hideKeyboardOnSwipe={hideKeyboardOnSwipe}
+      hideKeyboardOnSwipe={keyboardHandlingEnabled}
       navigationBarColor={navigationBarColor}
       navigationBarHidden={navigationBarHidden}
       replaceAnimation={animationTypeForReplace}


### PR DESCRIPTION
**Motivation**

For some time now, people are complaining that current native stack does not have some props that are included in v5, but not in v6.
I've deeply investigated the `props.tsx` file and I can make a conclusion some of the things that are missing include:
- no `hideKeyboardOnSwipe` `gestureResponseDistance` property,
- no props for managing the form sheet - `sheetX` properties,
- missing support for `onWillAppear` (is it intentional?) and `onGestureCancel` events.

This PR fixes all those things by adding them to `props.tsx` and their support in `NativeStackView.native.tsx` file.
One thing I also wanted to mention is that some of the events from the event map in `types.tsx` like `dismiss`, `appear` or `headerHeightChange` were not included in changes. That's because I think these ones should not be emitted directly from `navigation#emit` and/or they might lose the support in future react-native-screens versions. For example, `appear` event (which is currently deprecated) should not be used and you should replace it with `transitionEnd` event instead.

**Test plan**

You can test these props by checking how they affect screens after adjusting them in Native Stack example. Remember about setting `presentation` to `formSheet` while using `sheetX` props.

Some of the examples I've already prepared:

<details>
<summary>Using GestureResponseDistance on NewsFeed</summary>

This will enable changing the area of the gesture with a rectangle starting from the ~middle of the screen down to bottom.

`NativeStack.tsx:139`
```tsx
      <Stack.Screen
        name="NewsFeed"
        component={NewsFeedScreen}
        options={{
          title: 'Feed',
          fullScreenGestureEnabled: true,
          gestureResponseDistance: {
            start: 40,
            end: 353,
            top: 400,
            bottom: 852,
          },
        }}
      />
```
</details>

<details>
<summary>Using sheet props on NewsFeed</summary>

This will change the NewsFeed screen to the form sheet with rounded corners and maximum height to the middle.

`NativeStack.tsx:139`
```tsx
      <Stack.Screen
        name="NewsFeed"
        component={NewsFeedScreen}
        options={{
          title: 'Feed',
          presentation: 'formSheet',
          sheetAllowedDetents: 'medium',
          sheetCornerRadius: 32,
        }}
      />
```
</details>