### PR TITLE
fix(Android): don't remount components during navigation on the new architecture

### DIFF
--- a/packages/stack/src/views/Stack/Card.tsx
+++ b/packages/stack/src/views/Stack/Card.tsx
@@ -539,6 +539,7 @@ export class Card extends React.Component<Props> {
           // Make sure that this view isn't removed. If this view is removed, our style with animated value won't apply
           collapsable={false}
         />
+        {/* Make sure this view is not removed on the new architecture, as it causes focus loss during navigation on Android. */}
         <View pointerEvents="box-none" collapsable={false} {...rest}>
           {overlayEnabled ? (
             <View pointerEvents="box-none" style={StyleSheet.absoluteFill}>

--- a/packages/stack/src/views/Stack/Card.tsx
+++ b/packages/stack/src/views/Stack/Card.tsx
@@ -539,8 +539,13 @@ export class Card extends React.Component<Props> {
           // Make sure that this view isn't removed. If this view is removed, our style with animated value won't apply
           collapsable={false}
         />
-        {/* Make sure this view is not removed on the new architecture, as it causes focus loss during navigation on Android. */}
-        <View pointerEvents="box-none" collapsable={false} {...rest}>
+        <View
+          pointerEvents="box-none"
+          // Make sure this view is not removed on the new architecture, as it causes focus loss during navigation on Android.
+          // This can happen when the view flattening results in different trees - due to `overflow` style changing in a parent.
+          collapsable={false}
+          {...rest}
+        >
           {overlayEnabled ? (
             <View pointerEvents="box-none" style={StyleSheet.absoluteFill}>
               {overlay({ style: overlayStyle })}

--- a/packages/stack/src/views/Stack/Card.tsx
+++ b/packages/stack/src/views/Stack/Card.tsx
@@ -539,7 +539,7 @@ export class Card extends React.Component<Props> {
           // Make sure that this view isn't removed. If this view is removed, our style with animated value won't apply
           collapsable={false}
         />
-        <View pointerEvents="box-none" {...rest}>
+        <View pointerEvents="box-none" collapsable={false} {...rest}>
           {overlayEnabled ? (
             <View pointerEvents="box-none" style={StyleSheet.absoluteFill}>
               {overlay({ style: overlayStyle })}


### PR DESCRIPTION
**Motivation**

This PR prevents the native view hierarchy built by `Stack` from re-mounting to prevent blurring focus - when a view is removed from the hierarchy it's blurred on Android, but it's not focused back when added again. Due to one of the views in the `Card` component being flattened, children of `Card` were removed from the hierarchy and attached under a different parent.

<details>
<summary>Before the change</summary>

https://github.com/react-navigation/react-navigation/assets/21055725/38ce6cbe-a717-4ca4-be04-0fdfe6e2e796

Native hierarchy on the first screen:
![Screenshot 2024-02-01 at 11 46 27](https://github.com/react-navigation/react-navigation/assets/21055725/9950f07c-ef6b-4cd7-9632-37c75638e35a)

Native hierarchy on the second screen:
![Screenshot 2024-02-01 at 11 46 46](https://github.com/react-navigation/react-navigation/assets/21055725/27e2d3c6-b3d6-4053-912e-5cde932305c3)

Notice the different nesting levels between the two - one of the views got collapsed during navigation.
</details>

<details>
<summary>After the change</summary>

https://github.com/react-navigation/react-navigation/assets/21055725/fd0b4623-1033-4ec8-aedd-0a66ae9adc19

Native hierarchy on the first screen:
![Screenshot 2024-02-01 at 11 47 29](https://github.com/react-navigation/react-navigation/assets/21055725/761885b1-357b-4be9-ab57-78b1fe8db3c1)

Native hierarchy on the second screen:
![Screenshot 2024-02-01 at 11 47 36](https://github.com/react-navigation/react-navigation/assets/21055725/bd46ef18-c2c9-49a1-b77c-e8203ef32e1b)

Notice the same nesting levels between the two.
</details>

**Test plan**

<details>
<summary>I've tested the change on the following code</summary>

```jsx
import 'react-native-gesture-handler';
import {NavigationContainer, useFocusEffect} from '@react-navigation/native';
import React, {useRef} from 'react';
import {createStackNavigator} from '@react-navigation/stack';
import {Button, TextInput, View} from 'react-native';

const Stack = createStackNavigator();

function Thing({navigation}: any) {
  const ref = useRef(null);

  useFocusEffect(() => {
    setTimeout(() => {
      ref.current?.focus();
    }, 300);
  });

  return (
    <View style={{flex: 1, backgroundColor: 'wheat'}}>
      <TextInput
        ref={ref}
        style={{backgroundColor: 'white', borderWidth: 1, borderColor: 'black'}}
      />
      <Button
        title="navigate"
        onPress={() => {
          navigation.navigate('Second');
        }}
      />
    </View>
  );
}

function Second() {
  return <View style={{flex: 1, backgroundColor: 'red'}} />;
}

function App() {
  return (
    <NavigationContainer>
      <Stack.Navigator
        screenOptions={{headerShown: false}}
        detachInactiveScreens={false}>
        <Stack.Screen name="Home" component={Thing} />
        <Stack.Screen name="Second" component={Second} />
      </Stack.Navigator>
    </NavigationContainer>
  );
}

export default App;

```

</details>
