### PR TITLE
fix: type errors when getState used outside of a screen

### DIFF
--- a/packages/core/src/BaseNavigationContainer.tsx
+++ b/packages/core/src/BaseNavigationContainer.tsx
@@ -209,6 +209,12 @@ export const BaseNavigationContainer = React.forwardRef(
         getCurrentRoute,
         getCurrentOptions,
         isReady,
+        setParams: () => {
+          throw new Error('Cannot call setParams when not inside a screen');
+        },
+        setOptions: () => {
+          throw new Error('Cannot call setOptions when not inside a screen');
+        },
       }),
       [
         canGoBack,

--- a/packages/core/src/BaseNavigationContainer.tsx
+++ b/packages/core/src/BaseNavigationContainer.tsx
@@ -213,7 +213,7 @@ export const BaseNavigationContainer = React.forwardRef(
           throw new Error('Cannot call setParams outside a screen');
         },
         setOptions: () => {
-          throw new Error('Cannot call setOptions when not inside a screen');
+          throw new Error('Cannot call setOptions outside a screen');
         },
       }),
       [

--- a/packages/core/src/BaseNavigationContainer.tsx
+++ b/packages/core/src/BaseNavigationContainer.tsx
@@ -210,7 +210,7 @@ export const BaseNavigationContainer = React.forwardRef(
         getCurrentOptions,
         isReady,
         setParams: () => {
-          throw new Error('Cannot call setParams when not inside a screen');
+          throw new Error('Cannot call setParams outside a screen');
         },
         setOptions: () => {
           throw new Error('Cannot call setOptions when not inside a screen');

--- a/packages/core/src/types.tsx
+++ b/packages/core/src/types.tsx
@@ -775,6 +775,18 @@ export type NavigationContainerRef<ParamList extends {}> =
        * Whether the navigation container is ready to handle actions.
        */
       isReady(): boolean;
+      /**
+       * Stub function for setOptions on navigation object for use with useNavigation.
+       */
+      setOptions(): never;
+      /**
+       * Stub function for setParams on navigation object for use with useNavigation.
+       */
+      setParams(): never;
+      /**
+       * Stub function for getParent on navigation object for use with useNavigation.
+       */
+      getParent(): undefined;
     };
 
 export type NavigationContainerRefWithCurrent<ParamList extends {}> =

--- a/packages/core/src/useNavigation.tsx
+++ b/packages/core/src/useNavigation.tsx
@@ -1,3 +1,4 @@
+import { type NavigationState } from '@react-navigation/routers';
 import * as React from 'react';
 
 import { NavigationContainerRefContext } from './NavigationContainerRefContext';
@@ -10,7 +11,9 @@ import type { NavigationProp } from './types';
  * @returns Navigation prop of the parent screen.
  */
 export function useNavigation<
-  T = NavigationProp<ReactNavigation.RootParamList>,
+  T = Omit<NavigationProp<ReactNavigation.RootParamList>, 'getState'> & {
+    getState(): NavigationState | undefined;
+  },
 >(): T {
   const root = React.useContext(NavigationContainerRefContext);
   const navigation = React.useContext(NavigationContext);

--- a/packages/native/src/useScrollToTop.tsx
+++ b/packages/native/src/useScrollToTop.tsx
@@ -1,7 +1,8 @@
 import {
   type EventArg,
+  NavigationContext,
   type NavigationProp,
-  useNavigation,
+  type ParamListBase,
   useRoute,
 } from '@react-navigation/core';
 import * as React from 'react';
@@ -49,13 +50,18 @@ function getScrollableNode(ref: React.RefObject<ScrollableWrapper>) {
 }
 
 export function useScrollToTop(ref: React.RefObject<ScrollableWrapper>) {
-  const navigation = useNavigation();
+  const navigation = React.useContext(NavigationContext);
   const route = useRoute();
 
-  React.useEffect(() => {
-    const tabNavigations: NavigationProp<ReactNavigation.RootParamList>[] = [];
-    let currentNavigation = navigation;
+  if (navigation === undefined) {
+    throw new Error(
+      "Couldn't find a navigation object. Is your component inside NavigationContainer?"
+    );
+  }
 
+  React.useEffect(() => {
+    const tabNavigations: NavigationProp<ParamListBase>[] = [];
+    let currentNavigation = navigation;
     // If the screen is nested inside multiple tab navigators, we should scroll to top for any of them
     // So we need to find all the parent tab navigators and add the listeners there
     while (currentNavigation) {


### PR DESCRIPTION
This PR addresses the issue: [11701](https://github.com/react-navigation/react-navigation/issues/11701)
