### PR TITLE
fix: browser navigating out after using back feature and going home

### DIFF
--- a/packages/native/src/useLinking.tsx
+++ b/packages/native/src/useLinking.tsx
@@ -359,7 +359,12 @@ export default function useLinking(
           const currentIndex = history.index;
 
           try {
-            if (nextIndex !== -1 && nextIndex < currentIndex) {
+            if (
+              nextIndex !== -1 &&
+              nextIndex < currentIndex &&
+              // We should only go back if the entry exists and it's less than current index
+              history.get(nextIndex - currentIndex)
+            ) {
               // An existing entry for this path exists and it's less than current index, go back to that
               await history.go(nextIndex - currentIndex);
             } else {


### PR DESCRIPTION
**Motivation**

Fix for #11832

Before going to negative history index check if the history will return anything for that index. If that's not the case the previous behavior would open previously opened page from that tab.

**Test plan**

From my testing project you can test it by

To replicate the issue in my example open the app and do:

    1. Open new tab and go to any page. After that manually put the app address to the address bar and navigate to it.
    2. Navigate with menu to PageA
    3. Navigate with menu to PageB
    4. Use browser go back (can be button, keyboard shortcut or mouse button)
    5. Navigate with menu to PageB again
    6. Try navigating Home with menu
    7. You will no longer get redirected to a previous page from step 0 but to the home page instead
