### PR TITLE
fix: conflicting nested path params in state for linking

### DIFF
--- a/packages/core/src/__tests__/getStateFromPath.test.tsx
+++ b/packages/core/src/__tests__/getStateFromPath.test.tsx
@@ -2687,3 +2687,41 @@ it('encoding params correctly', () => {
     getPathFromState<object>(getStateFromPath<object>(path, config)!, config)
   ).toEqual(path);
 });
+
+it('resolves nested path params with same name to correct screen', () => {
+  const path = '/foo/42/bar/43';
+
+  const config = {
+    initialRouteName: 'Foo',
+    screens: {
+      Foo: {
+        path: 'foo/:id',
+        screens: {
+          Bar: {
+            path: 'bar/:id',
+          },
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: 'Foo',
+        params: { id: '42' },
+        state: {
+          routes: [
+            {
+              name: 'Bar',
+              params: { id: '43' },
+              path,
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getStateFromPath<object>(path, config)).toEqual(state);
+});

--- a/packages/core/src/getStateFromPath.tsx
+++ b/packages/core/src/getStateFromPath.tsx
@@ -331,28 +331,30 @@ const matchAgainstConfigs = (remaining: string, configs: RouteConfig[]) => {
         );
         const prefixPartsLength = prefix?.split('/').length;
 
-        const params = routeConfig?.normalizedPath
-          ?.split('/')
-          .map((p, index) => [p, index] as const)
-          .filter(([p]) => p.startsWith(':'))
-          .reduce(
-            (acc, [p, index]) => {
-              // Get the position of the param in the matched params based on the parent path segments count
-              index = prefixPartsLength ? index + prefixPartsLength - 1 : index;
-
-              const value = matchedParams[p]?.[index];
-
-              if (value) {
-                const key = p.replace(/^:/, '').replace(/\?$/, '');
-                acc[key] = routeConfig.parse?.[key]
-                  ? routeConfig.parse[key](value)
-                  : value;
-              }
-
+        const params = routeConfig?.normalizedPath?.split('/').reduce(
+          (acc, p, index) => {
+            if (!p.startsWith(':')) {
               return acc;
-            },
-            {} as Record<string, unknown>
-          );
+            }
+
+            // Get the position of the param in the matched params based on the parent path segments count
+            const pos = prefixPartsLength
+              ? index + prefixPartsLength - 1
+              : index;
+
+            const value = matchedParams[p]?.[pos];
+
+            if (value) {
+              const key = p.replace(/^:/, '').replace(/\?$/, '');
+              acc[key] = routeConfig.parse?.[key]
+                ? routeConfig.parse[key](value)
+                : value;
+            }
+
+            return acc;
+          },
+          {} as Record<string, unknown>
+        );
 
         if (params && Object.keys(params).length) {
           return { name, params };

--- a/packages/core/src/getStateFromPath.tsx
+++ b/packages/core/src/getStateFromPath.tsx
@@ -325,11 +325,10 @@ const matchAgainstConfigs = (remaining: string, configs: RouteConfig[]) => {
         });
 
         // Get the number of segments in the initial pattern
-        const pathPrefix = routeConfig?.pattern.replace(
-          new RegExp(`${escape(routeConfig.normalizedPath)}$`),
-          ''
-        );
-        const numPrefixParts = pathPrefix?.split('/').length;
+        const numInitialSegments = routeConfig?.pattern
+          // Extract the prefix from the pattern by removing the ending path pattern (e.g pattern=`a/b/c/d` and normalizedPath=`c/d` becomes `a/b`)
+          .replace(new RegExp(`${escape(routeConfig.normalizedPath)}$`), '')
+          ?.split('/').length;
 
         const params = routeConfig?.normalizedPath
           ?.split('/')
@@ -340,7 +339,7 @@ const matchAgainstConfigs = (remaining: string, configs: RouteConfig[]) => {
 
             // Get the real index of the path parameter in the matched path
             // by offsetting by the number of segments in the initial pattern
-            const offset = numPrefixParts ? numPrefixParts - 1 : 0;
+            const offset = numInitialSegments ? numInitialSegments - 1 : 0;
             const _index = index + offset;
 
             const value = matchedParams[p]?.[_index];


### PR DESCRIPTION
**Motivation**
When a path configuration contains multiple path parameters with the same name, the last path parameter value wins when constructing the navigation state.

For example consider the following scenario:

```ts
const path = '/foo/42/bar/43';

  const config = {
    initialRouteName: 'Foo',
    screens: {
      Foo: {
        path: 'foo/:id',
        screens: {
          Bar: {
            path: 'bar/:id',
          },
        },
      },
    },
  };

  const state = {
    routes: [
      {
        name: 'Foo',
        params: { id: '43' }, // PROBLEM: This should be 42
        state: {
          routes: [
            {
              name: 'Bar',
              params: { id: '43' },
              path,
            },
          ],
        },
      },
    ],
  }
```

This PR updates the resolution logic to assign positions to each of the path segments, so that we can assign the correct values to the screen in the navigation state based on the position which it appears in the path, and not just the name.


**Test plan**
* Copy the test in this PR, checkout to main and run the tests
* You will notice that the test fails to resolve the right params to the route `'Foo'`
* Now checkout to this PR's branch and run all tests and notice that they pass


**Considerations**
* Another approach could be to include validation logic that prevents this scenario from happening by validating that there are no repeated path params with the same name.
  * This however, could be a breaking change, and might call for additional functionality as "aliasing" to be able to name path params in the config, and then translate them to a different name before being passed to the screen.
  * Alternatively, in the implementing screen, the developer could update the route param name to match what is in the new path parameter
  * OR, in the implementing screen, accept either the original param name or deep link param name and pick whichever one is available

Happy to adjust this PR to the validation approach if desired, or close in favor of the user-land mitigations. Thanks!
