### PR TITLE
fix: Make all screens after presentation: 'modal' as modal unless specified

### DIFF
--- a/example/src/Screens/MixedNativeStack.tsx
+++ b/example/src/Screens/MixedNativeStack.tsx
@@ -1,0 +1,113 @@
+import { Button } from '@react-navigation/elements';
+import type { PathConfigMap } from '@react-navigation/native';
+import {
+  createNativeStackNavigator,
+  type NativeStackScreenProps,
+} from '@react-navigation/native-stack';
+import * as React from 'react';
+import { Platform, ScrollView, StyleSheet, View } from 'react-native';
+
+import { COMMON_LINKING_CONFIG } from '../constants';
+import { Albums } from '../Shared/Albums';
+import { Article } from '../Shared/Article';
+
+export type MixedNativeStackParams = {
+  Article: { author: string };
+  Albums: undefined;
+};
+
+const linking: PathConfigMap<MixedNativeStackParams> = {
+  Article: COMMON_LINKING_CONFIG.Article,
+  Albums: 'albums',
+};
+
+const scrollEnabled = Platform.select({ web: true, default: false });
+
+const ArticleScreen = ({
+  navigation,
+  route,
+}: NativeStackScreenProps<MixedNativeStackParams, 'Article'>) => {
+  return (
+    <ScrollView>
+      <View style={styles.buttons}>
+        <Button
+          variant="filled"
+          onPress={() => navigation.push('Article', { author: 'Dalek' })}
+        >
+          Push article
+        </Button>
+        <Button variant="tinted" onPress={() => navigation.goBack()}>
+          Go back
+        </Button>
+        <Button variant="filled" onPress={() => navigation.push('Albums')}>
+          Push album
+        </Button>
+      </View>
+      <Article
+        author={{ name: route.params.author }}
+        scrollEnabled={scrollEnabled}
+      />
+    </ScrollView>
+  );
+};
+
+const AlbumsScreen = ({
+  navigation,
+}: NativeStackScreenProps<MixedNativeStackParams>) => {
+  return (
+    <ScrollView>
+      <View style={styles.buttons}>
+        <Button variant="filled" onPress={() => navigation.push('Albums')}>
+          Push album
+        </Button>
+        <Button variant="tinted" onPress={() => navigation.goBack()}>
+          Go back
+        </Button>
+        <Button
+          variant="filled"
+          onPress={() => navigation.push('Article', { author: 'The Doctor' })}
+        >
+          Push article
+        </Button>
+      </View>
+      <Albums scrollEnabled={scrollEnabled} />
+    </ScrollView>
+  );
+};
+
+const Stack = createNativeStackNavigator<MixedNativeStackParams>();
+
+export function MixedNativeStack() {
+  return (
+    <Stack.Navigator>
+      <Stack.Screen
+        name="Article"
+        component={ArticleScreen}
+        options={({ route }) => ({
+          title: `Article by ${route.params.author}`,
+        })}
+        initialParams={{ author: 'Gandalf' }}
+      />
+      <Stack.Screen
+        name="Albums"
+        component={AlbumsScreen}
+        options={{
+          title: 'Albums',
+          presentation: 'modal',
+        }}
+      />
+    </Stack.Navigator>
+  );
+}
+
+MixedNativeStack.title = 'Native + Modal Stack';
+MixedNativeStack.linking = linking;
+
+const styles = StyleSheet.create({
+  buttons: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 12,
+    padding: 12,
+  },
+});

--- a/example/src/screens.tsx
+++ b/example/src/screens.tsx
@@ -14,6 +14,7 @@ import { LinkingScreen } from './Screens/LinkingScreen';
 import { MasterDetail } from './Screens/MasterDetail';
 import { MaterialTopTabsScreen } from './Screens/MaterialTopTabs';
 import { MixedHeaderMode } from './Screens/MixedHeaderMode';
+import { MixedNativeStack } from './Screens/MixedNativeStack';
 import { MixedStack } from './Screens/MixedStack';
 import { ModalStack } from './Screens/ModalStack';
 import { NativeStack } from './Screens/NativeStack';
@@ -33,6 +34,7 @@ export const SCREENS = {
   SimpleStack,
   ModalStack,
   MixedStack,
+  MixedNativeStack,
   MixedHeaderMode,
   StackTransparent,
   StackHeaderCustomization,

--- a/packages/native-stack/src/utils/getModalRoutesKeys.ts
+++ b/packages/native-stack/src/utils/getModalRoutesKeys.ts
@@ -4,15 +4,15 @@ import type { NativeStackDescriptorMap } from '../types';
 
 export const getModalRouteKeys = (
   routes: Route<string>[],
-  descriptors: NativeStackDescriptorMap,
-  modalTypes: string[] = ['modal']
+  descriptors: NativeStackDescriptorMap
 ) =>
   routes.reduce<string[]>((acc, route) => {
     const { presentation } = descriptors[route.key]?.options ?? {};
 
     if (
       (acc.length && !presentation) ||
-      modalTypes.includes(presentation ?? '')
+      presentation === 'modal' ||
+      presentation === 'transparentModal'
     ) {
       acc.push(route.key);
     }

--- a/packages/native-stack/src/utils/getModalRoutesKeys.ts
+++ b/packages/native-stack/src/utils/getModalRoutesKeys.ts
@@ -1,0 +1,21 @@
+import type { Route } from '@react-navigation/native';
+
+import type { NativeStackDescriptorMap } from '../types';
+
+export const getModalRouteKeys = (
+  routes: Route<string>[],
+  descriptors: NativeStackDescriptorMap,
+  modalTypes: string[] = ['modal']
+) =>
+  routes.reduce<string[]>((acc, route) => {
+    const { presentation } = descriptors[route.key]?.options ?? {};
+
+    if (
+      (acc.length && !presentation) ||
+      modalTypes.includes(presentation ?? '')
+    ) {
+      acc.push(route.key);
+    }
+
+    return acc;
+  }, []);

--- a/packages/native-stack/src/views/NativeStackView.native.tsx
+++ b/packages/native-stack/src/views/NativeStackView.native.tsx
@@ -42,6 +42,7 @@ import type {
   NativeStackNavigationHelpers,
   NativeStackNavigationOptions,
 } from '../types';
+import { getModalRouteKeys } from '../utils/getModalRoutesKeys';
 import { AnimatedHeaderHeightContext } from '../utils/useAnimatedHeaderHeight';
 import { useDismissedRouteError } from '../utils/useDismissedRouteError';
 import { useInvalidPreventRemoveError } from '../utils/useInvalidPreventRemoveError';
@@ -132,7 +133,7 @@ type SceneViewProps = {
   descriptor: NativeStackDescriptor;
   previousDescriptor?: NativeStackDescriptor;
   nextDescriptor?: NativeStackDescriptor;
-  isForsedModalStack?: boolean;
+  isPresentationModal?: boolean;
   onWillDisappear: () => void;
   onWillAppear: () => void;
   onAppear: () => void;
@@ -149,7 +150,7 @@ const SceneView = ({
   descriptor,
   previousDescriptor,
   nextDescriptor,
-  isForsedModalStack,
+  isPresentationModal,
   onWillDisappear,
   onWillAppear,
   onAppear,
@@ -164,7 +165,7 @@ const SceneView = ({
   let {
     animation,
     animationMatchesGesture,
-    presentation = isForsedModalStack ? 'modal' : 'card',
+    presentation = isPresentationModal ? 'modal' : 'card',
     fullScreenGestureEnabled,
   } = options;
 
@@ -451,10 +452,6 @@ export function NativeStackView({ state, navigation, descriptors }: Props) {
 
   useInvalidPreventRemoveError(descriptors);
 
-  // if the is a one screen with modal 'presentation'
-  // then all next screens also should be with the same presentation
-  let isForsedModalStack = false;
-
   return (
     <SafeAreaProviderCompat style={{ backgroundColor: colors.background }}>
       <ScreenStack style={styles.container}>
@@ -467,12 +464,9 @@ export function NativeStackView({ state, navigation, descriptors }: Props) {
             ? descriptors[previousKey]
             : undefined;
           const nextDescriptor = nextKey ? descriptors[nextKey] : undefined;
-          if (
-            !descriptor.options.presentation &&
-            previousDescriptor?.options.presentation === 'modal'
-          ) {
-            isForsedModalStack = true;
-          }
+          const isModal = getModalRouteKeys(state.routes, descriptors).includes(
+            route.key
+          );
 
           return (
             <SceneView
@@ -482,7 +476,7 @@ export function NativeStackView({ state, navigation, descriptors }: Props) {
               descriptor={descriptor}
               previousDescriptor={previousDescriptor}
               nextDescriptor={nextDescriptor}
-              isForsedModalStack={isForsedModalStack}
+              isPresentationModal={isModal}
               onWillDisappear={() => {
                 navigation.emit({
                   type: 'transitionStart',

--- a/packages/native-stack/src/views/NativeStackView.native.tsx
+++ b/packages/native-stack/src/views/NativeStackView.native.tsx
@@ -452,6 +452,8 @@ export function NativeStackView({ state, navigation, descriptors }: Props) {
 
   useInvalidPreventRemoveError(descriptors);
 
+  const modalRouteKeys = getModalRouteKeys(state.routes, descriptors);
+
   return (
     <SafeAreaProviderCompat style={{ backgroundColor: colors.background }}>
       <ScreenStack style={styles.container}>
@@ -464,10 +466,8 @@ export function NativeStackView({ state, navigation, descriptors }: Props) {
             ? descriptors[previousKey]
             : undefined;
           const nextDescriptor = nextKey ? descriptors[nextKey] : undefined;
-          const isModal = getModalRouteKeys(state.routes, descriptors, [
-            'modal',
-            'transparentModal',
-          ]).includes(route.key);
+
+          const isModal = modalRouteKeys.includes(route.key);
 
           return (
             <SceneView

--- a/packages/native-stack/src/views/NativeStackView.native.tsx
+++ b/packages/native-stack/src/views/NativeStackView.native.tsx
@@ -464,9 +464,10 @@ export function NativeStackView({ state, navigation, descriptors }: Props) {
             ? descriptors[previousKey]
             : undefined;
           const nextDescriptor = nextKey ? descriptors[nextKey] : undefined;
-          const isModal = getModalRouteKeys(state.routes, descriptors).includes(
-            route.key
-          );
+          const isModal = getModalRouteKeys(state.routes, descriptors, [
+            'modal',
+            'transparentModal',
+          ]).includes(route.key);
 
           return (
             <SceneView

--- a/packages/native-stack/src/views/NativeStackView.native.tsx
+++ b/packages/native-stack/src/views/NativeStackView.native.tsx
@@ -166,6 +166,13 @@ const SceneView = ({
     presentation = 'card',
   } = options;
 
+  if (
+    !options.presentation &&
+    previousDescriptor?.options.presentation === 'modal'
+  ) {
+    presentation = 'modal';
+  }
+
   const {
     animationDuration,
     animationTypeForReplace = 'push',

--- a/packages/native-stack/src/views/NativeStackView.native.tsx
+++ b/packages/native-stack/src/views/NativeStackView.native.tsx
@@ -159,19 +159,17 @@ const SceneView = ({
 }: SceneViewProps) => {
   const { route, navigation, options, render } = descriptor;
 
-  let {
-    animation,
-    animationMatchesGesture,
-    fullScreenGestureEnabled,
-    presentation = 'card',
-  } = options;
+  let { animation, animationMatchesGesture, fullScreenGestureEnabled } =
+    options;
 
   if (
     !options.presentation &&
     previousDescriptor?.options.presentation === 'modal'
   ) {
-    presentation = 'modal';
+    options.presentation = 'modal';
   }
+
+  let presentation = options.presentation ?? 'card';
 
   const {
     animationDuration,

--- a/packages/stack/src/utils/getModalRoutesKeys.ts
+++ b/packages/stack/src/utils/getModalRoutesKeys.ts
@@ -1,0 +1,21 @@
+import type { Route } from '@react-navigation/native';
+
+import type { StackDescriptorMap } from '../types';
+
+export const getModalRouteKeys = (
+  routes: Route<string>[],
+  descriptors: StackDescriptorMap,
+  modalTypes: string[] = ['modal']
+) =>
+  routes.reduce<string[]>((acc, route) => {
+    const { presentation } = descriptors[route.key]?.options ?? {};
+
+    if (
+      (acc.length && !presentation) ||
+      modalTypes.includes(presentation ?? '')
+    ) {
+      acc.push(route.key);
+    }
+
+    return acc;
+  }, []);

--- a/packages/stack/src/utils/getModalRoutesKeys.ts
+++ b/packages/stack/src/utils/getModalRoutesKeys.ts
@@ -4,15 +4,15 @@ import type { StackDescriptorMap } from '../types';
 
 export const getModalRouteKeys = (
   routes: Route<string>[],
-  descriptors: StackDescriptorMap,
-  modalTypes: string[] = ['modal']
+  descriptors: StackDescriptorMap
 ) =>
   routes.reduce<string[]>((acc, route) => {
     const { presentation } = descriptors[route.key]?.options ?? {};
 
     if (
       (acc.length && !presentation) ||
-      modalTypes.includes(presentation ?? '')
+      presentation === 'modal' ||
+      presentation === 'transparentModal'
     ) {
       acc.push(route.key);
     }

--- a/packages/stack/src/views/Stack/CardStack.tsx
+++ b/packages/stack/src/views/Stack/CardStack.tsx
@@ -303,10 +303,10 @@ export class CardStack extends React.Component<Props, State> {
 
         // Assume modal if there are already modal screens in the stack
         // or current screen is a modal when no presentation is specified
-        const isModal = getModalRouteKeys(
-          props.routes,
-          props.descriptors
-        ).includes(route.key);
+        const isModal = getModalRouteKeys(props.routes, props.descriptors, [
+          'modal',
+          'transparentModal',
+        ]).includes(route.key);
 
         const defaultTransitionPreset =
           isModal || optionsForTransitionConfig.presentation === 'modal'

--- a/packages/stack/src/views/Stack/CardStack.tsx
+++ b/packages/stack/src/views/Stack/CardStack.tsx
@@ -255,6 +255,10 @@ export class CardStack extends React.Component<Props, State> {
       return acc;
     }, {});
 
+    // if the is a one screen with modal 'presentation'
+    // then all next screens also should be with the same presentation
+    let isForcedModalStack = false;
+
     const scenes = [...props.routes, ...props.state.preloadedRoutes].map(
       (route, index, self) => {
         // For preloaded screens, we don't care about the previous and the next screen
@@ -304,10 +308,11 @@ export class CardStack extends React.Component<Props, State> {
           previousDescriptor?.options.presentation === 'modal' ||
           descriptor?.options.presentation === 'modal'
         ) {
-          optionsForTransitionConfig.presentation = 'modal';
+          isForcedModalStack = true;
         }
 
         const defaultTransitionPreset =
+          isForcedModalStack ||
           optionsForTransitionConfig.presentation === 'modal'
             ? ModalTransition
             : optionsForTransitionConfig.presentation === 'transparentModal'

--- a/packages/stack/src/views/Stack/CardStack.tsx
+++ b/packages/stack/src/views/Stack/CardStack.tsx
@@ -288,6 +288,14 @@ export class CardStack extends React.Component<Props, State> {
       return acc;
     }, {});
 
+    const modalRouteKeys = getModalRouteKeys(
+      [...props.routes, ...props.state.preloadedRoutes],
+      {
+        ...props.descriptors,
+        ...props.preloadedDescriptors,
+      }
+    );
+
     const scenes = [...props.routes, ...props.state.preloadedRoutes].map(
       (route, index, self) => {
         // For preloaded screens, we don't care about the previous and the next screen
@@ -335,10 +343,7 @@ export class CardStack extends React.Component<Props, State> {
 
         // Assume modal if there are already modal screens in the stack
         // or current screen is a modal when no presentation is specified
-        const isModal = getModalRouteKeys(props.routes, props.descriptors, [
-          'modal',
-          'transparentModal',
-        ]).includes(route.key);
+        const isModal = modalRouteKeys.includes(route.key);
 
         // Disable screen transition animation by default on web, windows and macos to match the native behavior
         const excludedPlatforms =

--- a/packages/stack/src/views/Stack/CardStack.tsx
+++ b/packages/stack/src/views/Stack/CardStack.tsx
@@ -300,6 +300,13 @@ export class CardStack extends React.Component<Props, State> {
             ? nextDescriptor.options
             : descriptor.options;
 
+        if (
+          previousDescriptor?.options.presentation === 'modal' ||
+          descriptor?.options.presentation === 'modal'
+        ) {
+          optionsForTransitionConfig.presentation = 'modal';
+        }
+
         const defaultTransitionPreset =
           optionsForTransitionConfig.presentation === 'modal'
             ? ModalTransition

--- a/packages/stack/src/views/Stack/CardStack.tsx
+++ b/packages/stack/src/views/Stack/CardStack.tsx
@@ -38,6 +38,7 @@ import type {
 } from '../../types';
 import { findLastIndex } from '../../utils/findLastIndex';
 import { getDistanceForDirection } from '../../utils/getDistanceForDirection';
+import { getModalRouteKeys } from '../../utils/getModalRoutesKeys';
 import type { Props as HeaderContainerProps } from '../Header/HeaderContainer';
 import { MaybeScreen, MaybeScreenContainer } from '../Screens';
 import { CardContainer } from './CardContainer';
@@ -255,10 +256,6 @@ export class CardStack extends React.Component<Props, State> {
       return acc;
     }, {});
 
-    // if the is a one screen with modal 'presentation'
-    // then all next screens also should be with the same presentation
-    let isForcedModalStack = false;
-
     const scenes = [...props.routes, ...props.state.preloadedRoutes].map(
       (route, index, self) => {
         // For preloaded screens, we don't care about the previous and the next screen
@@ -304,16 +301,15 @@ export class CardStack extends React.Component<Props, State> {
             ? nextDescriptor.options
             : descriptor.options;
 
-        if (
-          previousDescriptor?.options.presentation === 'modal' ||
-          descriptor?.options.presentation === 'modal'
-        ) {
-          isForcedModalStack = true;
-        }
+        // Assume modal if there are already modal screens in the stack
+        // or current screen is a modal when no presentation is specified
+        const isModal = getModalRouteKeys(
+          props.routes,
+          props.descriptors
+        ).includes(route.key);
 
         const defaultTransitionPreset =
-          isForcedModalStack ||
-          optionsForTransitionConfig.presentation === 'modal'
+          isModal || optionsForTransitionConfig.presentation === 'modal'
             ? ModalTransition
             : optionsForTransitionConfig.presentation === 'transparentModal'
               ? ModalFadeTransition


### PR DESCRIPTION

Make all screens after presentation: 'modal' as modal unless specified

