### PR TITLE
Remove throwing error from useBottomTabBarHeight

### DIFF
--- a/packages/bottom-tabs/src/utils/useBottomTabBarHeight.tsx
+++ b/packages/bottom-tabs/src/utils/useBottomTabBarHeight.tsx
@@ -6,7 +6,9 @@ export function useBottomTabBarHeight() {
   const height = React.useContext(BottomTabBarHeightContext);
 
   if (height === undefined) {
-    console.warn("Couldn't find the bottom tab bar height. Are you inside a screen in Bottom Tab Navigator?");
+    console.warn(
+      "Couldn't find the bottom tab bar height. Are you inside a screen in Bottom Tab Navigator?"
+    );
     return 0;
   }
 

--- a/packages/bottom-tabs/src/utils/useBottomTabBarHeight.tsx
+++ b/packages/bottom-tabs/src/utils/useBottomTabBarHeight.tsx
@@ -6,9 +6,8 @@ export function useBottomTabBarHeight() {
   const height = React.useContext(BottomTabBarHeightContext);
 
   if (height === undefined) {
-    throw new Error(
-      "Couldn't find the bottom tab bar height. Are you inside a screen in Bottom Tab Navigator?"
-    );
+    console.warn("Couldn't find the bottom tab bar height. Are you inside a screen in Bottom Tab Navigator?");
+    return 0;
   }
 
   return height;


### PR DESCRIPTION
**Motivation**

Motivation of this PR is described on [this issue](https://github.com/react-navigation/react-navigation/issues/11861)
