### PR TITLE
fix: Adjust URL encoding to avoid encoding unnecessarily

### DIFF
--- a/packages/core/src/__tests__/getStateFromPath.test.tsx
+++ b/packages/core/src/__tests__/getStateFromPath.test.tsx
@@ -2606,14 +2606,23 @@ it('throws when invalid properties are specified in the config', () => {
   );
 });
 
+// Valid characters according to
+// https://datatracker.ietf.org/doc/html/rfc3986#section-3.3 (see pchar definition)
+// A–Z, a–z, 0–9, -, ., _, ~, !, $, &, ', (, ), *, +, ,, ;, =, :, @
+// User09-A_Z~!$&'()*+,;=:@__#?# - should encode only last ones #?#
+// query params after '?' should be encoded fully with encodeURIComponent
 it('encoding params correctly', () => {
-  const path = 'users/mail/user_%23_email@gmail.com';
+  const paramWithValidSymbols = `User09-A_Z~!$&'()*+,;=:@__`;
+  const invalidSymbols = '#?[]{}%<>||';
+  const queryString = 'user#email@gmail.com=2&4';
+
+  const path = `users/id/${paramWithValidSymbols}${encodeURIComponent(invalidSymbols)}?query=${encodeURIComponent(queryString)}`;
   const config = {
     path: 'users',
     screens: {
       Users: {
         screens: {
-          Mail: 'mail/:email',
+          User: 'id/:id',
         },
       },
     },
@@ -2626,8 +2635,11 @@ it('encoding params correctly', () => {
         state: {
           routes: [
             {
-              name: 'Mail',
-              params: { email: 'user_#_email@gmail.com' },
+              name: 'User',
+              params: {
+                id: `${paramWithValidSymbols}${invalidSymbols}`,
+                query: queryString,
+              },
             },
           ],
         },

--- a/packages/core/src/__tests__/getStateFromPath.test.tsx
+++ b/packages/core/src/__tests__/getStateFromPath.test.tsx
@@ -2605,3 +2605,38 @@ it('throws when invalid properties are specified in the config', () => {
     `"Found invalid path 'foo/:id'. The 'path' in the top-level configuration cannot contain patterns for params."`
   );
 });
+
+it('encoding params correctly', () => {
+  const path = 'users/mail/user_%23_email@gmail.com';
+  const config = {
+    path: 'users',
+    screens: {
+      Users: {
+        screens: {
+          Mail: 'mail/:email',
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: 'Users',
+        state: {
+          routes: [
+            {
+              name: 'Mail',
+              params: { email: 'user_#_email@gmail.com' },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getPathFromState<object>(state, config)).toEqual(path);
+  expect(
+    getPathFromState<object>(getStateFromPath<object>(path, config)!, config)
+  ).toEqual(path);
+});

--- a/packages/core/src/getPathFromState.tsx
+++ b/packages/core/src/getPathFromState.tsx
@@ -5,7 +5,6 @@ import type {
 } from '@react-navigation/routers';
 import * as queryString from 'query-string';
 
-import { encodeParams } from '../utils/encodeParams';
 import type { PathConfig, PathConfigMap } from './types';
 import { validatePathConfig } from './validatePathConfig';
 
@@ -197,7 +196,12 @@ export function getPathFromState<ParamList extends {}>(
               return '';
             }
 
-            return encodeParams(value);
+            // Valid characters according to
+            // https://datatracker.ietf.org/doc/html/rfc3986#section-3.3 (see pchar definition)
+            return String(value).replace(
+              /[^A-Za-z0-9\-._~!$&'()*+,;=:@]/g,
+              (char) => encodeURIComponent(char)
+            );
           }
 
           return encodeURIComponent(p);

--- a/packages/core/src/getPathFromState.tsx
+++ b/packages/core/src/getPathFromState.tsx
@@ -5,6 +5,7 @@ import type {
 } from '@react-navigation/routers';
 import * as queryString from 'query-string';
 
+import { encodeParams } from '../utils/encodeParams';
 import type { PathConfig, PathConfigMap } from './types';
 import { validatePathConfig } from './validatePathConfig';
 
@@ -196,7 +197,7 @@ export function getPathFromState<ParamList extends {}>(
               return '';
             }
 
-            return encodeURIComponent(value);
+            return encodeParams(value);
           }
 
           return encodeURIComponent(p);

--- a/packages/core/src/getStateFromPath.tsx
+++ b/packages/core/src/getStateFromPath.tsx
@@ -291,11 +291,14 @@ const matchAgainstConfigs = (remaining: string, configs: RouteConfig[]) => {
         ?.split('/')
         .filter((p) => p.startsWith(':'))
         .reduce<Record<string, any>>(
-          (acc, p, i) =>
-            Object.assign(acc, {
+          (acc, p, i) => {
+            const decodedParamSegment = decodeURIComponent(match![(i + 1) * 2]);
+            return Object.assign(acc, {
               // The param segments appear every second item starting from 2 in the regex match result
-              [p]: match![(i + 1) * 2].replace(/\//, ''),
-            }),
+              [p]: decodedParamSegment.replace(/\//, ''),
+            });
+          },
+
           {}
         );
 

--- a/packages/core/utils/encodeParams.ts
+++ b/packages/core/utils/encodeParams.ts
@@ -1,0 +1,7 @@
+export const encodeParams = (param: string) =>
+  String(param).replace(
+    /[^A-Za-z0-9\-._~!$&'()*+,;=:@]/g,
+    function (char: string) {
+      return '%' + char.charCodeAt(0).toString(16).toUpperCase();
+    }
+  );

--- a/packages/core/utils/encodeParams.ts
+++ b/packages/core/utils/encodeParams.ts
@@ -1,7 +1,0 @@
-export const encodeParams = (param: string) =>
-  String(param).replace(
-    /[^A-Za-z0-9\-._~!$&'()*+,;=:@]/g,
-    function (char: string) {
-      return '%' + char.charCodeAt(0).toString(16).toUpperCase();
-    }
-  );


### PR DESCRIPTION

**Motivation**

sometimes encodes characters unnecessarily, e.g. @ is converted to %40 even though it's valid in a URL.
valid characters - A–Z, a–z, 0–9, -, ., _, ~, !, $, &, ', (, ), *, +, ,, ;, =, :, @
