### PR TITLE
fix: [6.x] - decode params for state creation 

### DIFF
--- a/packages/core/src/__tests__/getStateFromPath.test.tsx
+++ b/packages/core/src/__tests__/getStateFromPath.test.tsx
@@ -48,7 +48,7 @@ it('converts path string to initial state', () => {
   );
 });
 
-it('decode path params correctly', () => {
+it('decodes encoded params in path', () => {
   const path = '/foo/bar/bar_%23_foo';
   const config = {
     screens: {

--- a/packages/core/src/__tests__/getStateFromPath.test.tsx
+++ b/packages/core/src/__tests__/getStateFromPath.test.tsx
@@ -48,6 +48,44 @@ it('converts path string to initial state', () => {
   );
 });
 
+it('decode path params correctly', () => {
+  const path = '/foo/bar/bar_%23_foo';
+  const config = {
+    screens: {
+      Foo: {
+        path: 'foo',
+        screens: {
+          Bar: {
+            path: '/bar/:id',
+          },
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: 'Foo',
+        state: {
+          routes: [
+            {
+              name: 'Bar',
+              params: { id: 'bar_#_foo' },
+              path,
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getStateFromPath<object>(path, config)).toEqual(state);
+  expect(
+    getPathFromState<object>(getStateFromPath<object>(path, config)!, config)
+  ).toEqual(path);
+});
+
 it('converts path string to initial state with config', () => {
   const path = '/foo/bar/sweet/apple/baz/jane?count=10&answer=42&valid=true';
   const config = {

--- a/packages/core/src/getStateFromPath.tsx
+++ b/packages/core/src/getStateFromPath.tsx
@@ -275,11 +275,14 @@ const matchAgainstConfigs = (remaining: string, configs: RouteConfig[]) => {
         ?.split('/')
         .filter((p) => p.startsWith(':'))
         .reduce<Record<string, any>>(
-          (acc, p, i) =>
-            Object.assign(acc, {
-              // The param segments appear every second item starting from 2 in the regex match result
-              [p]: match![(i + 1) * 2].replace(/\//, ''),
-            }),
+          (acc, p, i) => {
+            // The param segments appear every second item starting from 2 in the regex match result
+            const decodedParamSegment = decodeURIComponent(match![(i + 1) * 2]);
+            return Object.assign(acc, {
+              [p]: decodedParamSegment.replace(/\//, ''),
+            });
+          },
+
           {}
         );
 


### PR DESCRIPTION
**Motivation**

params was not decoded before put to the state - it can lead to different path
