### PR TITLE
fix: add links href to material top tabs

### DIFF
--- a/packages/material-top-tabs/src/views/MaterialTopTabBar.tsx
+++ b/packages/material-top-tabs/src/views/MaterialTopTabBar.tsx
@@ -2,6 +2,7 @@ import { Text } from '@react-navigation/elements';
 import {
   type ParamListBase,
   type TabNavigationState,
+  useLinkBuilder,
   useLocale,
   useTheme,
 } from '@react-navigation/native';
@@ -47,6 +48,7 @@ export function MaterialTopTabBar({
 }: MaterialTopTabBarProps) {
   const { colors } = useTheme();
   const { direction } = useLocale();
+  const { buildHref } = useLinkBuilder();
 
   const focusedOptions = descriptors[state.routes[state.index].key].options;
 
@@ -62,6 +64,7 @@ export function MaterialTopTabBar({
       return [
         route.key,
         {
+          href: buildHref(route.name, route.params),
           testID: options.tabBarButtonTestID,
           accessibilityLabel: options.tabBarAccessibilityLabel,
           badge: options.tabBarBadge,

--- a/packages/react-native-tab-view/src/TabBar.tsx
+++ b/packages/react-native-tab-view/src/TabBar.tsx
@@ -448,6 +448,7 @@ export function TabBar<T extends Route>({
         labelText = getLabelTextDefault({ route }),
         accessible = getAccessibleDefault({ route }),
         accessibilityLabel = getAccessibilityLabelDefault({ route }),
+        href,
       } = {
         ...commonOptions,
         ...options?.[route.key],
@@ -518,6 +519,7 @@ export function TabBar<T extends Route>({
         : undefined;
 
       const props = {
+        href,
         key: route.key,
         position,
         route,

--- a/packages/react-native-tab-view/src/TabBarItem.tsx
+++ b/packages/react-native-tab-view/src/TabBarItem.tsx
@@ -104,6 +104,7 @@ const TabBarItemInternal = <T extends Route>({
   defaultTabWidth,
   icon: customIcon,
   badge: customBadge,
+  href,
   labelText,
   routesLength,
   android_ripple = { borderless: true },
@@ -223,6 +224,7 @@ const TabBarItemInternal = <T extends Route>({
       onLayout={onLayout}
       onPress={onPress}
       onLongPress={onLongPress}
+      href={href}
       style={[styles.pressable, tabContainerStyle]}
     >
       <View pointerEvents="none" style={[styles.item, tabStyle]}>

--- a/packages/react-native-tab-view/src/types.tsx
+++ b/packages/react-native-tab-view/src/types.tsx
@@ -8,6 +8,7 @@ export type TabDescriptor<T extends Route> = {
   testID?: string;
   labelText?: string;
   labelAllowFontScaling?: boolean;
+  href?: string;
   label?: (props: {
     focused: boolean;
     color: string;


### PR DESCRIPTION
**Motivation**

Material tabs on web had no links for better UX

