### PR TITLE
fix: preserve # in the URL if the screen hasn't changed - partially done

### DIFF
--- a/example/e2e/config/setup-server.ts
+++ b/example/e2e/config/setup-server.ts
@@ -4,7 +4,8 @@ export default async function () {
   // @ts-expect-error this is specific to jest-dev-server
   globalThis.servers = await setup([
     {
-      command: 'yarn serve -l 3579 web-build',
+      command:
+        'yarn serve --no-port-switching --single --listen 3579 web-build',
       launchTimeout: 50000,
       port: 3579,
     },

--- a/example/e2e/tests/Link.test.ts
+++ b/example/e2e/tests/Link.test.ts
@@ -83,39 +83,26 @@ test('replaces article with the album screen', async ({ page }) => {
   await page.waitForURL('**/');
 });
 
-test('correct hash for navigation', async ({ page }) => {
+test('preserves hash for navigation', async ({ page }) => {
   await page.waitForURL('**/link-component/article/gandalf');
 
-  await expect(page).toHaveTitle(
-    'Article by Gandalf - React Navigation Example'
-  );
-
-  const addHashText = page.getByText('Add hash to current URL');
-  expect(addHashText).toBeVisible();
-
-  await addHashText.click();
+  await page.getByText('Add hash to URL').click();
 
   await page.waitForURL('**/link-component/article/gandalf#frodo');
 
-  const updateParamsButton = page.getByRole('button', {
-    name: 'Update author param',
-  });
-  expect(updateParamsButton).toBeVisible();
+  await page.getByRole('button', { name: 'Update params' }).click();
 
-  updateParamsButton.click();
+  await page.waitForURL('**/link-component/article/babel-fish#frodo');
 
-  await page.waitForURL('**/link-component/article/bilbo-baggins#frodo');
+  await page.reload();
+
+  await page.waitForURL('**/link-component/article/babel-fish#frodo');
+
   await expect(page).toHaveTitle(
-    'Article by Bilbo Baggins - React Navigation Example'
+    'Article by Babel fish - React Navigation Example'
   );
 
-  const link = page.getByRole('link', {
-    name: 'Replace with Albums',
-  });
-
-  await expect(link).toHaveAttribute('href', '/link-component/albums');
-
-  await link.click();
+  await page.getByRole('link', { name: 'Replace with Albums' }).click();
 
   await page.waitForURL('**/link-component/albums');
 });

--- a/example/e2e/tests/Link.test.ts
+++ b/example/e2e/tests/Link.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 
 test.beforeEach(async ({ page }) => {
-  await page.goto('http://localhost:3579');
+  await page.goto('http://localhost:19006');
   await page.getByText('<Link />').click();
 });
 
@@ -81,4 +81,41 @@ test('replaces article with the album screen', async ({ page }) => {
   await page.getByLabel('Home, back').click();
 
   await page.waitForURL('**/');
+});
+
+test('correct hash for navigation', async ({ page }) => {
+  await page.waitForURL('**/link-component/article/gandalf');
+
+  await expect(page).toHaveTitle(
+    'Article by Gandalf - React Navigation Example'
+  );
+
+  const addHashText = page.getByText('Add hash to current URL');
+  expect(addHashText).toBeVisible();
+
+  await addHashText.click();
+
+  await page.waitForURL('**/link-component/article/gandalf#frodo');
+
+  const updateParamsButton = page.getByRole('button', {
+    name: 'Update author param',
+  });
+  expect(updateParamsButton).toBeVisible();
+
+  updateParamsButton.click();
+
+  await page.waitForURL('**/link-component/article/bilbo-baggins#frodo');
+  await expect(page).toHaveTitle(
+    'Article by Bilbo Baggins - React Navigation Example'
+  );
+
+  const link = page.getByRole('link', {
+    name: 'Replace with Albums',
+  });
+
+  await expect(link).toHaveAttribute('href', '/link-component/albums');
+
+  await link.click();
+
+  await page.waitForURL('**/link-component/albums');
 });

--- a/example/e2e/tests/Link.test.ts
+++ b/example/e2e/tests/Link.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 
 test.beforeEach(async ({ page }) => {
-  await page.goto('http://localhost:19006');
+  await page.goto('http://localhost:3579');
   await page.getByText('<Link />').click();
 });
 

--- a/example/src/Screens/LinkComponent.tsx
+++ b/example/src/Screens/LinkComponent.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@react-navigation/elements';
+import { Button, Text } from '@react-navigation/elements';
 import {
   CommonActions,
   Link,
@@ -31,6 +31,7 @@ export const linkComponentDemoLinking: PathConfigMap<LinkComponentDemoParamList>
 const scrollEnabled = Platform.select({ web: true, default: false });
 
 const ArticleScreen = ({
+  navigation,
   route,
 }: StackScreenProps<LinkComponentDemoParamList, 'Article'>) => {
   return (
@@ -46,6 +47,27 @@ const ArticleScreen = ({
         >
           Replace with Albums
         </Link>
+        {Platform.OS === 'web' && (
+          <Text
+            onPress={() => {
+              location.hash = 'frodo';
+            }}
+          >
+            Add hash to current URL
+          </Text>
+        )}
+
+        <Button
+          variant="filled"
+          testID="update-author-param"
+          onPress={() => {
+            navigation?.setParams({
+              author: 'Bilbo Baggins',
+            });
+          }}
+        >
+          Update author param
+        </Button>
         <Button screen="Home" variant="filled">
           Go to Home
         </Button>

--- a/example/src/Screens/LinkComponent.tsx
+++ b/example/src/Screens/LinkComponent.tsx
@@ -1,4 +1,4 @@
-import { Button, Text } from '@react-navigation/elements';
+import { Button } from '@react-navigation/elements';
 import {
   CommonActions,
   Link,
@@ -47,33 +47,35 @@ const ArticleScreen = ({
         >
           Replace with Albums
         </Link>
-        {Platform.OS === 'web' && (
-          <Text
-            onPress={() => {
-              location.hash = 'frodo';
-            }}
-          >
-            Add hash to current URL
-          </Text>
-        )}
 
-        <Button
-          variant="filled"
-          testID="update-author-param"
-          onPress={() => {
-            navigation?.setParams({
-              author: 'Bilbo Baggins',
-            });
-          }}
-        >
-          Update author param
-        </Button>
         <Button screen="Home" variant="filled">
           Go to Home
         </Button>
         <Button variant="tinted" action={CommonActions.goBack()}>
           Go back
         </Button>
+
+        <Button
+          variant="tinted"
+          onPress={() =>
+            navigation.setParams({
+              author:
+                route.params?.author === 'Gandalf' ? 'Babel fish' : 'Gandalf',
+            })
+          }
+        >
+          Update params
+        </Button>
+
+        {Platform.OS === 'web' && (
+          <Button
+            onPress={() => {
+              location.hash = 'frodo';
+            }}
+          >
+            Add hash to URL
+          </Button>
+        )}
       </View>
       <Article
         author={{ name: route.params.author }}

--- a/packages/native/src/createMemoryHistory.tsx
+++ b/packages/native/src/createMemoryHistory.tsx
@@ -87,6 +87,7 @@ export function createMemoryHistory() {
       // Need to keep the hash part of the path if there was no previous history entry
       // or the previous history entry had the same path
       let pathWithHash = path;
+      const hash = pathWithHash.includes('#') ? '' : location.hash;
 
       if (!items.length || items.findIndex((item) => item.id === id) < 0) {
         // There are two scenarios for creating an array with only one history record:
@@ -95,12 +96,13 @@ export function createMemoryHistory() {
         //   the page when navigating forward in history.
         // - This is the first time any state modifications are done
         //   So we need to push the entry as there's nothing to replace
-        pathWithHash = pathWithHash + location.hash;
+
+        pathWithHash = pathWithHash + hash;
         items = [{ path: pathWithHash, state, id }];
         index = 0;
       } else {
         if (items[index].path === path) {
-          pathWithHash = pathWithHash + location.hash;
+          pathWithHash = pathWithHash + hash;
         }
         items[index] = { path, state, id };
       }

--- a/packages/native/src/useLinking.tsx
+++ b/packages/native/src/useLinking.tsx
@@ -300,8 +300,19 @@ export function useLinking(
           }
         }
       }
+
+      const [previousFocusedState] = findMatchingState(
+        previousStateRef.current,
+        state
+      );
+
+      const lastScreen =
+        previousFocusedState?.routes?.[
+          previousFocusedState?.routes?.length - 1
+        ];
+      // @ts-expect-error key is ommited for focused route
+      const isSameScreen = lastScreen?.key === route?.key;
       const path = getPathFromStateRef.current(state, configRef.current);
-      const isSameScreen = path.split('?')[0] === route?.path?.split('?')?.[0];
 
       return isSameScreen ? path + location.hash : path;
     };

--- a/packages/native/src/useLinking.tsx
+++ b/packages/native/src/useLinking.tsx
@@ -296,12 +296,14 @@ export function useLinking(
             focusedRoute.name === route.name &&
             isEqual(focusedRoute.params, route.params)
           ) {
-            return route.path;
+            return route.path + location.hash;
           }
         }
       }
+      const path = getPathFromStateRef.current(state, configRef.current);
+      const isSameScreen = path.split('?')[0] === route?.path?.split('?')?.[0];
 
-      return getPathFromStateRef.current(state, configRef.current);
+      return isSameScreen ? path + location.hash : path;
     };
 
     if (ref.current) {


### PR DESCRIPTION

**Motivation**

when updating some params on the page, the hash shouldn’t be removed
