### PR TITLE
fix: support custom fontFamily configurations in headerTitleStyle

### DIFF
--- a/packages/native-stack/src/views/HeaderConfig.tsx
+++ b/packages/native-stack/src/views/HeaderConfig.tsx
@@ -58,16 +58,16 @@ export function HeaderConfig({
     headerTintColor ?? (Platform.OS === 'ios' ? colors.primary : colors.text);
 
   const headerBackTitleStyleFlattened =
-    StyleSheet.flatten([headerBackTitleStyle, fonts.regular]) || {};
+    StyleSheet.flatten([fonts.regular,headerBackTitleStyle]) || {};
   const headerLargeTitleStyleFlattened =
     StyleSheet.flatten([
-      headerLargeTitleStyle,
       Platform.select({ ios: fonts.heavy, default: fonts.medium }),
+      headerLargeTitleStyle
     ]) || {};
   const headerTitleStyleFlattened =
     StyleSheet.flatten([
-      headerTitleStyle,
       Platform.select({ ios: fonts.bold, default: fonts.medium }),
+      headerTitleStyle
     ]) || {};
   const headerStyleFlattened = StyleSheet.flatten(headerStyle) || {};
   const headerLargeStyleFlattened = StyleSheet.flatten(headerLargeStyle) || {};

--- a/packages/native-stack/src/views/HeaderConfig.tsx
+++ b/packages/native-stack/src/views/HeaderConfig.tsx
@@ -58,16 +58,16 @@ export function HeaderConfig({
     headerTintColor ?? (Platform.OS === 'ios' ? colors.primary : colors.text);
 
   const headerBackTitleStyleFlattened =
-    StyleSheet.flatten([fonts.regular,headerBackTitleStyle]) || {};
+    StyleSheet.flatten([fonts.regular, headerBackTitleStyle]) || {};
   const headerLargeTitleStyleFlattened =
     StyleSheet.flatten([
       Platform.select({ ios: fonts.heavy, default: fonts.medium }),
-      headerLargeTitleStyle
+      headerLargeTitleStyle,
     ]) || {};
   const headerTitleStyleFlattened =
     StyleSheet.flatten([
       Platform.select({ ios: fonts.bold, default: fonts.medium }),
-      headerTitleStyle
+      headerTitleStyle,
     ]) || {};
   const headerStyleFlattened = StyleSheet.flatten(headerStyle) || {};
   const headerLargeStyleFlattened = StyleSheet.flatten(headerLargeStyle) || {};


### PR DESCRIPTION
Passing a custom font for the `headerTitleStyle` configuration is ignored because the user set values always get overridden by the `fonts` values from the `useTheme()` hook. 

By changing the order of the values passed to `Stylesheet.flatten()`, any user passed `fontFamily` configurations then get retained.

I believe this fixes the issue raised in #11429. It's not just iOS specific; it cuts across all platforms. 