### PR TITLE
refactor: implement drawer on Web with CSS transitions

### DIFF
--- a/packages/react-native-drawer-layout/src/types.tsx
+++ b/packages/react-native-drawer-layout/src/types.tsx
@@ -1,5 +1,7 @@
-import type { StyleProp, ViewStyle } from 'react-native';
+import * as React from 'react';
+import type { StyleProp, View, ViewStyle } from 'react-native';
 import type { PanGestureHandler } from 'react-native-gesture-handler';
+import type { SharedValue } from 'react-native-reanimated';
 
 export type Layout = { width: number; height: number };
 
@@ -149,4 +151,11 @@ export type DrawerProps = {
    * Content that the drawer should wrap.
    */
   children: React.ReactNode;
+};
+
+export type OverlayProps = React.ComponentProps<typeof View> & {
+  open: boolean;
+  progress: SharedValue<number>;
+  onPress: () => void;
+  accessibilityLabel?: string;
 };

--- a/packages/react-native-drawer-layout/src/utils/getDrawerWidth.tsx
+++ b/packages/react-native-drawer-layout/src/utils/getDrawerWidth.tsx
@@ -1,0 +1,49 @@
+import {
+  Platform,
+  type StyleProp,
+  StyleSheet,
+  type ViewStyle,
+} from 'react-native';
+
+const getDefaultDrawerWidth = ({
+  height,
+  width,
+}: {
+  height: number;
+  width: number;
+}) => {
+  /**
+   * Default drawer width is screen width - header height
+   * with a max width of 280 on mobile and 320 on tablet
+   * https://material.io/components/navigation-drawer
+   */
+  const smallerAxisSize = Math.min(height, width);
+  const isLandscape = width > height;
+  const isTablet = smallerAxisSize >= 600;
+  const appBarHeight = Platform.OS === 'ios' ? (isLandscape ? 32 : 44) : 56;
+  const maxWidth = isTablet ? 320 : 280;
+
+  return Math.min(smallerAxisSize - appBarHeight, maxWidth);
+};
+
+export function getDrawerWidth({
+  layout,
+  drawerStyle,
+}: {
+  layout: { width: number; height: number };
+  drawerStyle?: StyleProp<ViewStyle>;
+}) {
+  const { width = getDefaultDrawerWidth(layout) } =
+    StyleSheet.flatten(drawerStyle) || {};
+
+  if (typeof width === 'string' && width.endsWith('%')) {
+    // Try to calculate width if a percentage is given
+    const percentage = Number(width.replace(/%$/, ''));
+
+    if (Number.isFinite(percentage)) {
+      return layout.width * (percentage / 100);
+    }
+  }
+
+  return typeof width === 'number' ? width : 0;
+}

--- a/packages/react-native-drawer-layout/src/utils/useFakeSharedValue.tsx
+++ b/packages/react-native-drawer-layout/src/utils/useFakeSharedValue.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+
+class FakeSharedValue {
+  _listeners = new Map<number, (value: number) => void>();
+  _value: number;
+
+  constructor(value: number) {
+    this._value = value;
+  }
+
+  addListener(id: number, listener: (value: number) => void) {
+    this._listeners.set(id, listener);
+  }
+
+  removeListener(id: number) {
+    this._listeners.delete(id);
+  }
+
+  modify(modifier?: (value: number) => number) {
+    this.value = modifier !== undefined ? modifier(this.value) : this.value;
+  }
+
+  set value(value: number) {
+    this._value = value;
+
+    for (const listener of this._listeners.values()) {
+      listener(value);
+    }
+  }
+
+  get value() {
+    return this._value;
+  }
+
+  _isReanimatedSharedValue = true;
+}
+
+/**
+ * Compatibility layer for `useDrawerProgress` with `react-native-reanimated`
+ */
+export function useFakeSharedValue(value: number): FakeSharedValue {
+  const sharedValue = React.useRef<FakeSharedValue | null>(null);
+
+  if (sharedValue.current === null) {
+    sharedValue.current = new FakeSharedValue(value);
+  }
+
+  return sharedValue.current;
+}

--- a/packages/react-native-drawer-layout/src/views/Drawer.native.tsx
+++ b/packages/react-native-drawer-layout/src/views/Drawer.native.tsx
@@ -1,0 +1,466 @@
+import * as React from 'react';
+import {
+  I18nManager,
+  InteractionManager,
+  Keyboard,
+  Platform,
+  StatusBar,
+  StyleSheet,
+  useWindowDimensions,
+  View,
+} from 'react-native';
+import Animated, {
+  interpolate,
+  runOnJS,
+  useAnimatedGestureHandler,
+  useAnimatedStyle,
+  useDerivedValue,
+  useSharedValue,
+  withSpring,
+} from 'react-native-reanimated';
+import useLatestCallback from 'use-latest-callback';
+
+import type { DrawerProps } from '../types';
+import { DrawerProgressContext } from '../utils/DrawerProgressContext';
+import { getDrawerWidth } from '../utils/getDrawerWidth';
+import {
+  GestureHandlerRootView,
+  GestureState,
+  PanGestureHandler,
+  type PanGestureHandlerGestureEvent,
+} from './GestureHandler';
+import { Overlay } from './Overlay';
+
+const SWIPE_EDGE_WIDTH = 32;
+const SWIPE_MIN_OFFSET = 5;
+const SWIPE_MIN_DISTANCE = 60;
+const SWIPE_MIN_VELOCITY = 500;
+
+const DRAWER_BORDER_RADIUS = 16;
+
+const minmax = (value: number, start: number, end: number) => {
+  'worklet';
+
+  return Math.min(Math.max(value, start), end);
+};
+
+export function Drawer({
+  layout: customLayout,
+  drawerPosition = I18nManager.getConstants().isRTL ? 'right' : 'left',
+  drawerStyle,
+  drawerType = Platform.select({ ios: 'slide', default: 'front' }),
+  gestureHandlerProps,
+  hideStatusBarOnOpen = false,
+  keyboardDismissMode = 'on-drag',
+  onClose,
+  onOpen,
+  onGestureStart,
+  onGestureCancel,
+  onGestureEnd,
+  onTransitionStart,
+  onTransitionEnd,
+  open,
+  overlayStyle,
+  overlayAccessibilityLabel,
+  statusBarAnimation = 'slide',
+  swipeEnabled = Platform.OS !== 'web' &&
+    Platform.OS !== 'windows' &&
+    Platform.OS !== 'macos',
+  swipeEdgeWidth = SWIPE_EDGE_WIDTH,
+  swipeMinDistance = SWIPE_MIN_DISTANCE,
+  swipeMinVelocity = SWIPE_MIN_VELOCITY,
+  renderDrawerContent,
+  children,
+  style,
+}: DrawerProps) {
+  const windowDimensions = useWindowDimensions();
+
+  const layout = customLayout ?? windowDimensions;
+  const drawerWidth = getDrawerWidth({ layout, drawerStyle });
+
+  const isOpen = drawerType === 'permanent' ? true : open;
+  const isRight = drawerPosition === 'right';
+
+  const getDrawerTranslationX = React.useCallback(
+    (open: boolean) => {
+      'worklet';
+
+      if (drawerPosition === 'left') {
+        return open ? 0 : -drawerWidth;
+      }
+
+      return open ? 0 : drawerWidth;
+    },
+    [drawerPosition, drawerWidth]
+  );
+
+  const hideStatusBar = React.useCallback(
+    (hide: boolean) => {
+      if (hideStatusBarOnOpen) {
+        StatusBar.setHidden(hide, statusBarAnimation);
+      }
+    },
+    [hideStatusBarOnOpen, statusBarAnimation]
+  );
+
+  React.useEffect(() => {
+    hideStatusBar(isOpen);
+
+    return () => hideStatusBar(false);
+  }, [isOpen, hideStatusBarOnOpen, statusBarAnimation, hideStatusBar]);
+
+  const interactionHandleRef = React.useRef<number | null>(null);
+
+  const startInteraction = () => {
+    interactionHandleRef.current = InteractionManager.createInteractionHandle();
+  };
+
+  const endInteraction = () => {
+    if (interactionHandleRef.current != null) {
+      InteractionManager.clearInteractionHandle(interactionHandleRef.current);
+      interactionHandleRef.current = null;
+    }
+  };
+
+  const hideKeyboard = () => {
+    if (keyboardDismissMode === 'on-drag') {
+      Keyboard.dismiss();
+    }
+  };
+
+  const onGestureBegin = () => {
+    onGestureStart?.();
+    startInteraction();
+    hideKeyboard();
+    hideStatusBar(true);
+  };
+
+  const onGestureFinish = () => {
+    onGestureEnd?.();
+    endInteraction();
+  };
+
+  const onGestureAbort = () => {
+    onGestureCancel?.();
+    endInteraction();
+  };
+
+  // FIXME: Currently hitSlop is broken when on Android when drawer is on right
+  // https://github.com/software-mansion/react-native-gesture-handler/issues/569
+  const hitSlop = isRight
+    ? // Extend hitSlop to the side of the screen when drawer is closed
+      // This lets the user drag the drawer from the side of the screen
+      { right: 0, width: isOpen ? undefined : swipeEdgeWidth }
+    : { left: 0, width: isOpen ? undefined : swipeEdgeWidth };
+
+  const borderRadiiStyle =
+    drawerType !== 'permanent'
+      ? isRight
+        ? {
+            borderTopLeftRadius: DRAWER_BORDER_RADIUS,
+            borderBottomLeftRadius: DRAWER_BORDER_RADIUS,
+          }
+        : {
+            borderTopRightRadius: DRAWER_BORDER_RADIUS,
+            borderBottomRightRadius: DRAWER_BORDER_RADIUS,
+          }
+      : null;
+
+  const touchStartX = useSharedValue(0);
+  const touchX = useSharedValue(0);
+  const translationX = useSharedValue(getDrawerTranslationX(open));
+  const gestureState = useSharedValue<GestureState>(GestureState.UNDETERMINED);
+
+  const handleAnimationStart = useLatestCallback((open: boolean) => {
+    onTransitionStart?.(!open);
+  });
+
+  const handleAnimationEnd = useLatestCallback(
+    (open: boolean, finished?: boolean) => {
+      if (!finished) return;
+      onTransitionEnd?.(!open);
+    }
+  );
+
+  const toggleDrawer = React.useCallback(
+    (open: boolean, velocity?: number) => {
+      'worklet';
+
+      const translateX = getDrawerTranslationX(open);
+
+      if (velocity === undefined) {
+        runOnJS(handleAnimationStart)(open);
+      }
+
+      touchStartX.value = 0;
+      touchX.value = 0;
+      translationX.value = withSpring(
+        translateX,
+        {
+          velocity,
+          stiffness: 1000,
+          damping: 500,
+          mass: 3,
+          overshootClamping: true,
+          restDisplacementThreshold: 0.01,
+          restSpeedThreshold: 0.01,
+        },
+        (finished) => runOnJS(handleAnimationEnd)(open, finished)
+      );
+
+      if (open) {
+        runOnJS(onOpen)();
+      } else {
+        runOnJS(onClose)();
+      }
+    },
+    [
+      getDrawerTranslationX,
+      handleAnimationEnd,
+      handleAnimationStart,
+      onClose,
+      onOpen,
+      touchStartX,
+      touchX,
+      translationX,
+    ]
+  );
+
+  React.useEffect(() => toggleDrawer(open), [open, toggleDrawer]);
+
+  const onGestureEvent = useAnimatedGestureHandler<
+    PanGestureHandlerGestureEvent,
+    { startX: number; hasCalledOnStart: boolean }
+  >({
+    onStart: (event, ctx) => {
+      ctx.hasCalledOnStart = false;
+      ctx.startX = translationX.value;
+      gestureState.value = event.state;
+      touchStartX.value = event.x;
+    },
+    onCancel: () => {
+      runOnJS(onGestureAbort)();
+    },
+    onActive: (event, ctx) => {
+      touchX.value = event.x;
+      translationX.value = ctx.startX + event.translationX;
+      gestureState.value = event.state;
+
+      // onStart will _always_ be called, even when the activation
+      // criteria isn't met yet. This makes sure onGestureBegin is only
+      // called when the criteria is really met.
+      if (!ctx.hasCalledOnStart) {
+        ctx.hasCalledOnStart = true;
+        runOnJS(onGestureBegin)();
+      }
+    },
+    onEnd: (event) => {
+      gestureState.value = event.state;
+
+      const nextOpen =
+        (Math.abs(event.translationX) > SWIPE_MIN_OFFSET &&
+          Math.abs(event.translationX) > swipeMinVelocity) ||
+        Math.abs(event.translationX) > swipeMinDistance
+          ? drawerPosition === 'left'
+            ? // If swiped to right, open the drawer, otherwise close it
+              (event.velocityX === 0 ? event.translationX : event.velocityX) > 0
+            : // If swiped to left, open the drawer, otherwise close it
+              (event.velocityX === 0 ? event.translationX : event.velocityX) < 0
+          : open;
+
+      toggleDrawer(nextOpen, event.velocityX);
+    },
+    onFinish: () => {
+      runOnJS(onGestureFinish)();
+    },
+  });
+
+  const translateX = useDerivedValue(() => {
+    // Comment stolen from react-native-gesture-handler/DrawerLayout
+    //
+    // While closing the drawer when user starts gesture outside of its area (in greyed
+    // out part of the window), we want the drawer to follow only once finger reaches the
+    // edge of the drawer.
+    // E.g. on the diagram below drawer is illustrate by X signs and the greyed out area by
+    // dots. The touch gesture starts at '*' and moves left, touch path is indicated by
+    // an arrow pointing left
+    // 1) +---------------+ 2) +---------------+ 3) +---------------+ 4) +---------------+
+    //    |XXXXXXXX|......|    |XXXXXXXX|......|    |XXXXXXXX|......|    |XXXXX|.........|
+    //    |XXXXXXXX|......|    |XXXXXXXX|......|    |XXXXXXXX|......|    |XXXXX|.........|
+    //    |XXXXXXXX|......|    |XXXXXXXX|......|    |XXXXXXXX|......|    |XXXXX|.........|
+    //    |XXXXXXXX|......|    |XXXXXXXX|.<-*..|    |XXXXXXXX|<--*..|    |XXXXX|<-----*..|
+    //    |XXXXXXXX|......|    |XXXXXXXX|......|    |XXXXXXXX|......|    |XXXXX|.........|
+    //    |XXXXXXXX|......|    |XXXXXXXX|......|    |XXXXXXXX|......|    |XXXXX|.........|
+    //    |XXXXXXXX|......|    |XXXXXXXX|......|    |XXXXXXXX|......|    |XXXXX|.........|
+    //    +---------------+    +---------------+    +---------------+    +---------------+
+    //
+    // For the above to work properly we define animated value that will keep start position
+    // of the gesture. Then we use that value to calculate how much we need to subtract from
+    // the translationX. If the gesture started on the greyed out area we take the distance from the
+    // edge of the drawer to the start position. Otherwise we don't subtract at all and the
+    // drawer be pulled back as soon as you start the pan.
+    //
+    // This is used only when drawerType is "front"
+    const touchDistance =
+      drawerType === 'front' && gestureState.value === GestureState.ACTIVE
+        ? minmax(
+            drawerPosition === 'left'
+              ? touchStartX.value - drawerWidth
+              : layout.width - drawerWidth - touchStartX.value,
+            0,
+            layout.width
+          )
+        : 0;
+
+    const translateX =
+      drawerPosition === 'left'
+        ? minmax(translationX.value + touchDistance, -drawerWidth, 0)
+        : minmax(translationX.value - touchDistance, 0, drawerWidth);
+
+    return translateX;
+  });
+
+  const drawerAnimatedStyle = useAnimatedStyle(() => {
+    const distanceFromEdge = layout.width - drawerWidth;
+
+    return {
+      transform:
+        drawerType === 'permanent'
+          ? // Reanimated needs the property to be present, but it results in Browser bug
+            // https://bugs.chromium.org/p/chromium/issues/detail?id=20574
+            []
+          : [
+              {
+                translateX:
+                  // The drawer stays in place when `drawerType` is `back`
+                  (drawerType === 'back' ? 0 : translateX.value) +
+                  (drawerPosition === 'left' ? 0 : distanceFromEdge),
+              },
+            ],
+    };
+  });
+
+  const contentAnimatedStyle = useAnimatedStyle(() => {
+    return {
+      transform:
+        drawerType === 'permanent'
+          ? // Reanimated needs the property to be present, but it results in Browser bug
+            // https://bugs.chromium.org/p/chromium/issues/detail?id=20574
+            []
+          : [
+              {
+                translateX:
+                  // The screen content stays in place when `drawerType` is `front`
+                  drawerType === 'front'
+                    ? 0
+                    : translateX.value +
+                      drawerWidth * (drawerPosition === 'left' ? 1 : -1),
+              },
+            ],
+    };
+  });
+
+  const progress = useDerivedValue(() => {
+    return drawerType === 'permanent'
+      ? 1
+      : interpolate(
+          translateX.value,
+          [getDrawerTranslationX(false), getDrawerTranslationX(true)],
+          [0, 1]
+        );
+  });
+
+  return (
+    <GestureHandlerRootView style={[styles.container, style]}>
+      <DrawerProgressContext.Provider value={progress}>
+        <PanGestureHandler
+          activeOffsetX={[-SWIPE_MIN_OFFSET, SWIPE_MIN_OFFSET]}
+          failOffsetY={[-SWIPE_MIN_OFFSET, SWIPE_MIN_OFFSET]}
+          hitSlop={hitSlop}
+          enabled={drawerType !== 'permanent' && swipeEnabled}
+          onGestureEvent={onGestureEvent}
+          {...gestureHandlerProps}
+        >
+          {/* Immediate child of gesture handler needs to be an Animated.View */}
+          <Animated.View
+            style={[
+              styles.main,
+              {
+                flexDirection:
+                  drawerType === 'permanent' && !isRight
+                    ? 'row-reverse'
+                    : 'row',
+              },
+            ]}
+          >
+            <Animated.View style={[styles.content, contentAnimatedStyle]}>
+              <View
+                accessibilityElementsHidden={
+                  isOpen && drawerType !== 'permanent'
+                }
+                importantForAccessibility={
+                  isOpen && drawerType !== 'permanent'
+                    ? 'no-hide-descendants'
+                    : 'auto'
+                }
+                style={styles.content}
+              >
+                {children}
+              </View>
+              {drawerType !== 'permanent' ? (
+                <Overlay
+                  open={open}
+                  progress={progress}
+                  onPress={() => toggleDrawer(false)}
+                  style={overlayStyle}
+                  accessibilityLabel={overlayAccessibilityLabel}
+                />
+              ) : null}
+            </Animated.View>
+            <Animated.View
+              removeClippedSubviews={Platform.OS !== 'ios'}
+              style={[
+                styles.drawer,
+                {
+                  width: drawerWidth,
+                  position:
+                    drawerType === 'permanent' ? 'relative' : 'absolute',
+                  zIndex: drawerType === 'back' ? -1 : 0,
+                },
+                borderRadiiStyle,
+                drawerAnimatedStyle,
+                drawerStyle,
+              ]}
+            >
+              {renderDrawerContent()}
+            </Animated.View>
+          </Animated.View>
+        </PanGestureHandler>
+      </DrawerProgressContext.Provider>
+    </GestureHandlerRootView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  drawer: {
+    top: 0,
+    bottom: 0,
+    maxWidth: '100%',
+    backgroundColor: 'white',
+  },
+  content: {
+    flex: 1,
+  },
+  main: {
+    flex: 1,
+    ...Platform.select({
+      // FIXME: We need to hide `overflowX` on Web so the translated content doesn't show offscreen.
+      // But adding `overflowX: 'hidden'` prevents content from collapsing the URL bar.
+      web: null,
+      default: { overflow: 'hidden' },
+    }),
+  },
+});

--- a/packages/react-native-drawer-layout/src/views/Drawer.tsx
+++ b/packages/react-native-drawer-layout/src/views/Drawer.tsx
@@ -1,476 +1,166 @@
 import * as React from 'react';
-import {
-  I18nManager,
-  InteractionManager,
-  Keyboard,
-  Platform,
-  StatusBar,
-  StyleSheet,
-  useWindowDimensions,
-  View,
-} from 'react-native';
-import Animated, {
-  interpolate,
-  runOnJS,
-  useAnimatedGestureHandler,
-  useAnimatedStyle,
-  useDerivedValue,
-  useSharedValue,
-  withSpring,
-} from 'react-native-reanimated';
+import { StyleSheet, useWindowDimensions, View } from 'react-native';
 import useLatestCallback from 'use-latest-callback';
 
 import type { DrawerProps } from '../types';
 import { DrawerProgressContext } from '../utils/DrawerProgressContext';
-import {
-  GestureHandlerRootView,
-  GestureState,
-  PanGestureHandler,
-  type PanGestureHandlerGestureEvent,
-} from './GestureHandler';
+import { getDrawerWidth } from '../utils/getDrawerWidth';
+import { useFakeSharedValue } from '../utils/useFakeSharedValue';
 import { Overlay } from './Overlay';
 
-export const SWIPE_EDGE_WIDTH = 32;
-export const SWIPE_MIN_OFFSET = 5;
-export const SWIPE_MIN_DISTANCE = 60;
-export const SWIPE_MIN_VELOCITY = 500;
-
-export const DRAWER_BORDER_RADIUS = 16;
-
-const minmax = (value: number, start: number, end: number) => {
-  'worklet';
-
-  return Math.min(Math.max(value, start), end);
-};
-
-const getDefaultDrawerWidth = ({
-  height,
-  width,
-}: {
-  height: number;
-  width: number;
-}) => {
-  /*
-   * Default drawer width is screen width - header height
-   * with a max width of 280 on mobile and 320 on tablet
-   * https://material.io/components/navigation-drawer
-   */
-  const smallerAxisSize = Math.min(height, width);
-  const isLandscape = width > height;
-  const isTablet = smallerAxisSize >= 600;
-  const appBarHeight = Platform.OS === 'ios' ? (isLandscape ? 32 : 44) : 56;
-  const maxWidth = isTablet ? 320 : 280;
-
-  return Math.min(smallerAxisSize - appBarHeight, maxWidth);
-};
+const DRAWER_BORDER_RADIUS = 16;
 
 export function Drawer({
   layout: customLayout,
-  drawerPosition = I18nManager.getConstants().isRTL ? 'right' : 'left',
+  drawerPosition = 'left',
   drawerStyle,
-  drawerType = Platform.select({ ios: 'slide', default: 'front' }),
-  gestureHandlerProps,
-  hideStatusBarOnOpen = false,
-  keyboardDismissMode = 'on-drag',
+  drawerType = 'front',
   onClose,
-  onOpen,
-  onGestureStart,
-  onGestureCancel,
-  onGestureEnd,
   onTransitionStart,
   onTransitionEnd,
   open,
   overlayStyle,
   overlayAccessibilityLabel,
-  statusBarAnimation = 'slide',
-  swipeEnabled = Platform.OS !== 'web' &&
-    Platform.OS !== 'windows' &&
-    Platform.OS !== 'macos',
-  swipeEdgeWidth = SWIPE_EDGE_WIDTH,
-  swipeMinDistance = SWIPE_MIN_DISTANCE,
-  swipeMinVelocity = SWIPE_MIN_VELOCITY,
   renderDrawerContent,
   children,
   style,
 }: DrawerProps) {
-  // FIXME: temporary workaround for useSafeAreaFrame not updating on Web
   const windowDimensions = useWindowDimensions();
+
   const layout = customLayout ?? windowDimensions;
+  const drawerWidth = getDrawerWidth({ layout, drawerStyle });
 
-  const getDrawerWidth = (): number => {
-    const { width = getDefaultDrawerWidth(layout) } =
-      StyleSheet.flatten(drawerStyle) || {};
+  const progress = useFakeSharedValue(open ? 1 : 0);
 
-    if (typeof width === 'string' && width.endsWith('%')) {
-      // Try to calculate width if a percentage is given
-      const percentage = Number(width.replace(/%$/, ''));
+  React.useEffect(() => {
+    progress.value = open ? 1 : 0;
+  }, [open, progress]);
 
-      if (Number.isFinite(percentage)) {
-        return layout.width * (percentage / 100);
-      }
+  const drawerRef = React.useRef<View>(null);
+
+  const onTransitionStartLatest = useLatestCallback(() => {
+    onTransitionStart?.(open === false);
+  });
+
+  const onTransitionEndLatest = useLatestCallback(() => {
+    onTransitionEnd?.(open === false);
+  });
+
+  React.useEffect(() => {
+    const element = drawerRef.current as HTMLDivElement | null;
+
+    if (element) {
+      element.addEventListener('transitionstart', onTransitionStartLatest);
+      element.addEventListener('transitionend', onTransitionEndLatest);
     }
-
-    return typeof width === 'number' ? width : 0;
-  };
-
-  const drawerWidth = getDrawerWidth();
+  }, [onTransitionEndLatest, onTransitionStartLatest]);
 
   const isOpen = drawerType === 'permanent' ? true : open;
   const isRight = drawerPosition === 'right';
 
-  const getDrawerTranslationX = React.useCallback(
-    (open: boolean) => {
-      'worklet';
+  const borderRadiiStyle =
+    drawerType !== 'permanent'
+      ? isRight
+        ? {
+            borderTopLeftRadius: DRAWER_BORDER_RADIUS,
+            borderBottomLeftRadius: DRAWER_BORDER_RADIUS,
+          }
+        : {
+            borderTopRightRadius: DRAWER_BORDER_RADIUS,
+            borderBottomRightRadius: DRAWER_BORDER_RADIUS,
+          }
+      : null;
 
-      if (drawerPosition === 'left') {
-        return open ? 0 : -drawerWidth;
-      }
-
-      return open ? 0 : drawerWidth;
-    },
-    [drawerPosition, drawerWidth]
-  );
-
-  const hideStatusBar = React.useCallback(
-    (hide: boolean) => {
-      if (hideStatusBarOnOpen) {
-        StatusBar.setHidden(hide, statusBarAnimation);
-      }
-    },
-    [hideStatusBarOnOpen, statusBarAnimation]
-  );
-
-  React.useEffect(() => {
-    hideStatusBar(isOpen);
-
-    return () => hideStatusBar(false);
-  }, [isOpen, hideStatusBarOnOpen, statusBarAnimation, hideStatusBar]);
-
-  const interactionHandleRef = React.useRef<number | null>(null);
-
-  const startInteraction = () => {
-    interactionHandleRef.current = InteractionManager.createInteractionHandle();
-  };
-
-  const endInteraction = () => {
-    if (interactionHandleRef.current != null) {
-      InteractionManager.clearInteractionHandle(interactionHandleRef.current);
-      interactionHandleRef.current = null;
-    }
-  };
-
-  const hideKeyboard = () => {
-    if (keyboardDismissMode === 'on-drag') {
-      Keyboard.dismiss();
-    }
-  };
-
-  const onGestureBegin = () => {
-    onGestureStart?.();
-    startInteraction();
-    hideKeyboard();
-    hideStatusBar(true);
-  };
-
-  const onGestureFinish = () => {
-    onGestureEnd?.();
-    endInteraction();
-  };
-
-  const onGestureAbort = () => {
-    onGestureCancel?.();
-    endInteraction();
-  };
-
-  // FIXME: Currently hitSlop is broken when on Android when drawer is on right
-  // https://github.com/software-mansion/react-native-gesture-handler/issues/569
-  const hitSlop = isRight
-    ? // Extend hitSlop to the side of the screen when drawer is closed
-      // This lets the user drag the drawer from the side of the screen
-      { right: 0, width: isOpen ? undefined : swipeEdgeWidth }
-    : { left: 0, width: isOpen ? undefined : swipeEdgeWidth };
-
-  const borderRadiiStyle = isRight
-    ? {
-        borderTopLeftRadius: DRAWER_BORDER_RADIUS,
-        borderBottomLeftRadius: DRAWER_BORDER_RADIUS,
-      }
-    : {
-        borderTopRightRadius: DRAWER_BORDER_RADIUS,
-        borderBottomRightRadius: DRAWER_BORDER_RADIUS,
-      };
-
-  const touchStartX = useSharedValue(0);
-  const touchX = useSharedValue(0);
-  const translationX = useSharedValue(getDrawerTranslationX(open));
-  const gestureState = useSharedValue<GestureState>(GestureState.UNDETERMINED);
-
-  const handleAnimationStart = useLatestCallback((open: boolean) => {
-    onTransitionStart?.(!open);
-  });
-
-  const handleAnimationEnd = useLatestCallback(
-    (open: boolean, finished?: boolean) => {
-      if (!finished) return;
-      onTransitionEnd?.(!open);
-    }
-  );
-
-  const toggleDrawer = React.useCallback(
-    (open: boolean, velocity?: number) => {
-      'worklet';
-
-      const translateX = getDrawerTranslationX(open);
-
-      if (velocity === undefined) {
-        runOnJS(handleAnimationStart)(open);
-      }
-
-      touchStartX.value = 0;
-      touchX.value = 0;
-      translationX.value = withSpring(
-        translateX,
-        {
-          velocity,
-          stiffness: 1000,
-          damping: 500,
-          mass: 3,
-          overshootClamping: true,
-          restDisplacementThreshold: 0.01,
-          restSpeedThreshold: 0.01,
-        },
-        (finished) => runOnJS(handleAnimationEnd)(open, finished)
-      );
-
-      if (open) {
-        runOnJS(onOpen)();
-      } else {
-        runOnJS(onClose)();
-      }
-    },
-    [
-      getDrawerTranslationX,
-      handleAnimationEnd,
-      handleAnimationStart,
-      onClose,
-      onOpen,
-      touchStartX,
-      touchX,
-      translationX,
-    ]
-  );
-
-  React.useEffect(() => toggleDrawer(open), [open, toggleDrawer]);
-
-  const onGestureEvent = useAnimatedGestureHandler<
-    PanGestureHandlerGestureEvent,
-    { startX: number; hasCalledOnStart: boolean }
-  >({
-    onStart: (event, ctx) => {
-      ctx.hasCalledOnStart = false;
-      ctx.startX = translationX.value;
-      gestureState.value = event.state;
-      touchStartX.value = event.x;
-    },
-    onCancel: () => {
-      runOnJS(onGestureAbort)();
-    },
-    onActive: (event, ctx) => {
-      touchX.value = event.x;
-      translationX.value = ctx.startX + event.translationX;
-      gestureState.value = event.state;
-
-      // onStart will _always_ be called, even when the activation
-      // criteria isn't met yet. This makes sure onGestureBegin is only
-      // called when the criteria is really met.
-      if (!ctx.hasCalledOnStart) {
-        ctx.hasCalledOnStart = true;
-        runOnJS(onGestureBegin)();
-      }
-    },
-    onEnd: (event) => {
-      gestureState.value = event.state;
-
-      const nextOpen =
-        (Math.abs(event.translationX) > SWIPE_MIN_OFFSET &&
-          Math.abs(event.translationX) > swipeMinVelocity) ||
-        Math.abs(event.translationX) > swipeMinDistance
-          ? drawerPosition === 'left'
-            ? // If swiped to right, open the drawer, otherwise close it
-              (event.velocityX === 0 ? event.translationX : event.velocityX) > 0
-            : // If swiped to left, open the drawer, otherwise close it
-              (event.velocityX === 0 ? event.translationX : event.velocityX) < 0
-          : open;
-
-      toggleDrawer(nextOpen, event.velocityX);
-    },
-    onFinish: () => {
-      runOnJS(onGestureFinish)();
-    },
-  });
-
-  const translateX = useDerivedValue(() => {
-    // Comment stolen from react-native-gesture-handler/DrawerLayout
-    //
-    // While closing the drawer when user starts gesture outside of its area (in greyed
-    // out part of the window), we want the drawer to follow only once finger reaches the
-    // edge of the drawer.
-    // E.g. on the diagram below drawer is illustrate by X signs and the greyed out area by
-    // dots. The touch gesture starts at '*' and moves left, touch path is indicated by
-    // an arrow pointing left
-    // 1) +---------------+ 2) +---------------+ 3) +---------------+ 4) +---------------+
-    //    |XXXXXXXX|......|    |XXXXXXXX|......|    |XXXXXXXX|......|    |XXXXX|.........|
-    //    |XXXXXXXX|......|    |XXXXXXXX|......|    |XXXXXXXX|......|    |XXXXX|.........|
-    //    |XXXXXXXX|......|    |XXXXXXXX|......|    |XXXXXXXX|......|    |XXXXX|.........|
-    //    |XXXXXXXX|......|    |XXXXXXXX|.<-*..|    |XXXXXXXX|<--*..|    |XXXXX|<-----*..|
-    //    |XXXXXXXX|......|    |XXXXXXXX|......|    |XXXXXXXX|......|    |XXXXX|.........|
-    //    |XXXXXXXX|......|    |XXXXXXXX|......|    |XXXXXXXX|......|    |XXXXX|.........|
-    //    |XXXXXXXX|......|    |XXXXXXXX|......|    |XXXXXXXX|......|    |XXXXX|.........|
-    //    +---------------+    +---------------+    +---------------+    +---------------+
-    //
-    // For the above to work properly we define animated value that will keep start position
-    // of the gesture. Then we use that value to calculate how much we need to subtract from
-    // the translationX. If the gesture started on the greyed out area we take the distance from the
-    // edge of the drawer to the start position. Otherwise we don't subtract at all and the
-    // drawer be pulled back as soon as you start the pan.
-    //
-    // This is used only when drawerType is "front"
-    const touchDistance =
-      drawerType === 'front' && gestureState.value === GestureState.ACTIVE
-        ? minmax(
-            drawerPosition === 'left'
-              ? touchStartX.value - drawerWidth
-              : layout.width - drawerWidth - touchStartX.value,
-            0,
-            layout.width
-          )
-        : 0;
-
-    const translateX =
-      drawerPosition === 'left'
-        ? minmax(translationX.value + touchDistance, -drawerWidth, 0)
-        : minmax(translationX.value - touchDistance, 0, drawerWidth);
-
-    return translateX;
-  });
-
-  const drawerAnimatedStyle = useAnimatedStyle(() => {
-    const distanceFromEdge = layout.width - drawerWidth;
-
-    return {
-      transform:
-        drawerType === 'permanent'
-          ? // Reanimated needs the property to be present, but it results in Browser bug
-            // https://bugs.chromium.org/p/chromium/issues/detail?id=20574
-            []
-          : [
-              {
-                translateX:
-                  // The drawer stays in place when `drawerType` is `back`
-                  (drawerType === 'back' ? 0 : translateX.value) +
-                  (drawerPosition === 'left' ? 0 : distanceFromEdge),
-              },
-            ],
-    };
-  });
-
-  const contentAnimatedStyle = useAnimatedStyle(() => {
-    return {
-      transform:
-        drawerType === 'permanent'
-          ? // Reanimated needs the property to be present, but it results in Browser bug
-            // https://bugs.chromium.org/p/chromium/issues/detail?id=20574
-            []
-          : [
-              {
-                translateX:
-                  // The screen content stays in place when `drawerType` is `front`
-                  drawerType === 'front'
+  const drawerAnimatedStyle =
+    drawerType !== 'permanent'
+      ? {
+          transition: 'transform 0.3s',
+          transform: [
+            {
+              // The drawer stays in place at open position when `drawerType` is `back`
+              translateX:
+                open || drawerType === 'back'
+                  ? drawerPosition === 'left'
                     ? 0
-                    : translateX.value +
-                      drawerWidth * (drawerPosition === 'left' ? 1 : -1),
-              },
-            ],
-    };
-  });
+                    : layout.width - drawerWidth
+                  : drawerPosition === 'left'
+                    ? -drawerWidth
+                    : layout.width,
+            },
+          ],
+        }
+      : null;
 
-  const progress = useDerivedValue(() => {
-    return drawerType === 'permanent'
-      ? 1
-      : interpolate(
-          translateX.value,
-          [getDrawerTranslationX(false), getDrawerTranslationX(true)],
-          [0, 1]
-        );
-  });
+  const contentAnimatedStyle =
+    drawerType !== 'permanent'
+      ? {
+          transition: 'transform 0.3s',
+          transform: [
+            {
+              translateX: open
+                ? // The screen content stays in place when `drawerType` is `front`
+                  drawerType === 'front'
+                  ? 0
+                  : drawerWidth * (drawerPosition === 'left' ? 1 : -1)
+                : 0,
+            },
+          ],
+        }
+      : null;
 
   return (
-    <GestureHandlerRootView style={[styles.container, style]}>
+    <View style={[styles.container, style]}>
       <DrawerProgressContext.Provider value={progress}>
-        <PanGestureHandler
-          activeOffsetX={[-SWIPE_MIN_OFFSET, SWIPE_MIN_OFFSET]}
-          failOffsetY={[-SWIPE_MIN_OFFSET, SWIPE_MIN_OFFSET]}
-          hitSlop={hitSlop}
-          enabled={drawerType !== 'permanent' && swipeEnabled}
-          onGestureEvent={onGestureEvent}
-          {...gestureHandlerProps}
+        <View
+          style={[
+            styles.main,
+            {
+              flexDirection:
+                drawerType === 'permanent' && !isRight ? 'row-reverse' : 'row',
+            },
+          ]}
         >
-          {/* Immediate child of gesture handler needs to be an Animated.View */}
-          <Animated.View
+          <View style={[styles.content, contentAnimatedStyle]}>
+            <View
+              accessibilityElementsHidden={isOpen && drawerType !== 'permanent'}
+              importantForAccessibility={
+                isOpen && drawerType !== 'permanent'
+                  ? 'no-hide-descendants'
+                  : 'auto'
+              }
+              style={styles.content}
+            >
+              {children}
+            </View>
+            {drawerType !== 'permanent' ? (
+              <Overlay
+                open={open}
+                progress={progress}
+                onPress={() => onClose()}
+                style={overlayStyle}
+                accessibilityLabel={overlayAccessibilityLabel}
+              />
+            ) : null}
+          </View>
+          <View
+            ref={drawerRef}
             style={[
-              styles.main,
+              styles.drawer,
               {
-                flexDirection:
-                  drawerType === 'permanent' && !isRight
-                    ? 'row-reverse'
-                    : 'row',
+                width: drawerWidth,
+                position: drawerType === 'permanent' ? 'relative' : 'absolute',
+                zIndex: drawerType === 'back' ? -1 : 0,
               },
+              borderRadiiStyle,
+              drawerAnimatedStyle,
+              drawerStyle,
             ]}
           >
-            <Animated.View style={[styles.content, contentAnimatedStyle]}>
-              <View
-                accessibilityElementsHidden={
-                  isOpen && drawerType !== 'permanent'
-                }
-                importantForAccessibility={
-                  isOpen && drawerType !== 'permanent'
-                    ? 'no-hide-descendants'
-                    : 'auto'
-                }
-                style={styles.content}
-              >
-                {children}
-              </View>
-              {drawerType !== 'permanent' ? (
-                <Overlay
-                  progress={progress}
-                  onPress={() => toggleDrawer(false)}
-                  style={overlayStyle}
-                  accessibilityLabel={overlayAccessibilityLabel}
-                />
-              ) : null}
-            </Animated.View>
-            <Animated.View
-              removeClippedSubviews={Platform.OS !== 'ios'}
-              style={[
-                styles.drawer,
-                {
-                  width: drawerWidth,
-                  position:
-                    drawerType === 'permanent' ? 'relative' : 'absolute',
-                  zIndex: drawerType === 'back' ? -1 : 0,
-                },
-                drawerType === 'permanent' ? null : borderRadiiStyle,
-                drawerAnimatedStyle,
-                drawerStyle,
-              ]}
-            >
-              {renderDrawerContent()}
-            </Animated.View>
-          </Animated.View>
-        </PanGestureHandler>
+            {renderDrawerContent()}
+          </View>
+        </View>
       </DrawerProgressContext.Provider>
-    </GestureHandlerRootView>
+    </View>
   );
 }
 
@@ -489,11 +179,5 @@ const styles = StyleSheet.create({
   },
   main: {
     flex: 1,
-    ...Platform.select({
-      // FIXME: We need to hide `overflowX` on Web so the translated content doesn't show offscreen.
-      // But adding `overflowX: 'hidden'` prevents content from collapsing the URL bar.
-      web: null,
-      default: { overflow: 'hidden' },
-    }),
   },
 });

--- a/packages/react-native-drawer-layout/src/views/Overlay.native.tsx
+++ b/packages/react-native-drawer-layout/src/views/Overlay.native.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react';
+import { Pressable, StyleSheet } from 'react-native';
+import Animated, {
+  useAnimatedProps,
+  useAnimatedStyle,
+} from 'react-native-reanimated';
+
+import type { OverlayProps } from '../types';
+
+const PROGRESS_EPSILON = 0.05;
+
+export function Overlay({
+  progress,
+  onPress,
+  style,
+  accessibilityLabel = 'Close drawer',
+  ...rest
+}: OverlayProps) {
+  const animatedStyle = useAnimatedStyle(() => {
+    return {
+      opacity: progress.value,
+      // We don't want the user to be able to press through the overlay when drawer is open
+      // We can send the overlay behind the screen to avoid it
+      zIndex: progress.value > PROGRESS_EPSILON ? 0 : -1,
+    };
+  });
+
+  const animatedProps = useAnimatedProps(() => {
+    const active = progress.value > PROGRESS_EPSILON;
+
+    return {
+      pointerEvents: active ? 'auto' : 'none',
+      accessibilityElementsHidden: !active,
+      importantForAccessibility: active ? 'auto' : 'no-hide-descendants',
+    } as const;
+  });
+
+  return (
+    <Animated.View
+      {...rest}
+      style={[styles.overlay, animatedStyle, style]}
+      animatedProps={animatedProps}
+    >
+      <Pressable
+        onPress={onPress}
+        style={styles.pressable}
+        accessibilityRole="button"
+        accessibilityLabel={accessibilityLabel}
+      />
+    </Animated.View>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+  },
+  pressable: {
+    flex: 1,
+    pointerEvents: 'auto',
+  },
+});

--- a/packages/react-native-drawer-layout/src/views/Overlay.tsx
+++ b/packages/react-native-drawer-layout/src/views/Overlay.tsx
@@ -1,81 +1,47 @@
 import * as React from 'react';
-import { Platform, Pressable, StyleSheet } from 'react-native';
-import Animated, {
-  type SharedValue,
-  useAnimatedProps,
-  useAnimatedStyle,
-} from 'react-native-reanimated';
+import { Pressable, StyleSheet, View } from 'react-native';
 
-const PROGRESS_EPSILON = 0.05;
+import type { OverlayProps } from '../types';
 
-type Props = React.ComponentProps<typeof Animated.View> & {
-  progress: SharedValue<number>;
-  onPress: () => void;
-  accessibilityLabel?: string;
-};
-
-export const Overlay = React.forwardRef(function Overlay(
-  {
-    progress,
-    onPress,
-    style,
-    accessibilityLabel = 'Close drawer',
-    ...rest
-  }: Props,
-  ref: React.Ref<Animated.View>
-) {
-  const animatedStyle = useAnimatedStyle(() => {
-    return {
-      opacity: progress.value,
-      // We don't want the user to be able to press through the overlay when drawer is open
-      // We can send the overlay behind the screen to avoid it
-      zIndex: progress.value > PROGRESS_EPSILON ? 0 : -1,
-    };
-  });
-
-  const animatedProps = useAnimatedProps(() => {
-    const active = progress.value > PROGRESS_EPSILON;
-
-    return {
-      pointerEvents: active ? 'auto' : 'none',
-      accessibilityElementsHidden: !active,
-      importantForAccessibility: active ? 'auto' : 'no-hide-descendants',
-    } as const;
-  });
-
+export function Overlay({
+  open,
+  onPress,
+  style,
+  accessibilityLabel = 'Close drawer',
+  ...rest
+}: OverlayProps) {
   return (
-    <Animated.View
+    <View
       {...rest}
-      ref={ref}
-      style={[styles.overlay, overlayStyle, animatedStyle, style]}
-      animatedProps={animatedProps}
+      style={[
+        styles.overlay,
+        { opacity: open ? 1 : 0, pointerEvents: open ? 'auto' : 'none' },
+        style,
+      ]}
+      accessibilityElementsHidden={!open}
+      importantForAccessibility={open ? 'auto' : 'no-hide-descendants'}
     >
       <Pressable
         onPress={onPress}
-        style={styles.pressable}
+        style={[styles.pressable, { pointerEvents: open ? 'auto' : 'none' }]}
         accessibilityRole="button"
         accessibilityLabel={accessibilityLabel}
       />
-    </Animated.View>
+    </View>
   );
-});
-
-const overlayStyle = Platform.select<Record<string, string>>({
-  web: {
-    // Disable touch highlight on mobile Safari.
-    // WebkitTapHighlightColor must be used outside of StyleSheet.create because react-native-web will omit the property.
-    WebkitTapHighlightColor: 'transparent',
-  },
-  default: {},
-});
+}
 
 const styles = StyleSheet.create({
   overlay: {
     ...StyleSheet.absoluteFillObject,
     backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    // Disable touch highlight on mobile Safari.
+    // WebkitTapHighlightColor must be used outside of StyleSheet.create because react-native-web will omit the property.
+    // @ts-expect-error: WebkitTapHighlightColor is web only
+    WebkitTapHighlightColor: 'transparent',
+    transition: 'opacity 0.3s',
   },
   pressable: {
     flex: 1,
-    pointerEvents: 'auto',
   },
 });


### PR DESCRIPTION
**Motivation**

Currently, the drawer doesn't use Gesture Handler on the Web, so there are no interactive animations. So including Reanimated unnecessarily increases the bundle size.

This re-implements the drawer on the Web using CSS transitions instead of Reanimated. 

**Test plan**

Open the "Drawer Layout" screen in the example app.

https://github.com/react-navigation/react-navigation/assets/1174278/8d46d9e3-0269-47b7-9931-be1019d95be0

