### PR TITLE
feat: added integration for `InteractionManager` with `native-stack`

### DIFF
--- a/packages/native-stack/src/views/NativeStackView.native.tsx
+++ b/packages/native-stack/src/views/NativeStackView.native.tsx
@@ -264,18 +264,24 @@ const SceneView = ({
         InteractionManager.createInteractionHandle();
     }
   }, [focused]);
+  const finishInteraction = React.useCallback(() => {
+    if (interactionHandleRef.current !== undefined) {
+      InteractionManager.clearInteractionHandle(interactionHandleRef.current);
+      interactionHandleRef.current = undefined;
+    }
+  }, []);
+  // in case if screen is unmounted faster than transition finishes, then `onAppear` will not be fired
+  // so we clean up an interaction here
+  React.useEffect(() => finishInteraction, [finishInteraction]);
   const onAppearCallback = React.useCallback<
     NonNullable<ScreenProps['onAppear']>
   >(
     (e) => {
       onAppear?.(e);
 
-      if (interactionHandleRef.current !== undefined) {
-        InteractionManager.clearInteractionHandle(interactionHandleRef.current);
-        interactionHandleRef.current = undefined;
-      }
+      finishInteraction();
     },
-    [onAppear]
+    [onAppear, finishInteraction]
   );
 
   const [customHeaderHeight, setCustomHeaderHeight] =


### PR DESCRIPTION
**Motivation**

The integration with `interactionManager` was added in react-navigation@5 I believe (https://reactnavigation.org/blog/2020/02/06/react-navigation-5.0/#other-improvements).

And since then it was a convenient way to run tasks when animation gets finished.

Since `react-navigation@6` it's recommended to use `native-stack` instead of `stack`. However it seems like `InteractionManager` doesn't take into consideration animations driven by `native-stack`. As a result all code that was relying on execution `InteractionManager.runAfterInteractions` callback after animation is broken when we switch to `native-stack`.

**Test plan**

The way to test the integration would be to add a code, like:

```tsx
const [color, setColor] = useState("#000000");

const goToNextScreen = () => {
  navigation.navigate("NextScreenInStack");

  InteractionManager.runAfterInteractions(() => {
    setColor("#ff0000");
  });
};
```

- Without these change the color would be changed immediately and you could see a change during the animation;
- With these changes the callback will be executed only when animation gets completed.
