### PR TITLE
refactor: drop unmountOnBlur in favor of popToTopOnBlur

### DIFF
--- a/example/src/Screens/BottomTabs.tsx
+++ b/example/src/Screens/BottomTabs.tsx
@@ -145,6 +145,7 @@ export function BottomTabs() {
           name="TabStack"
           component={SimpleStack}
           options={{
+            popToTopOnBlur: true,
             title: 'Article',
             headerShown: false,
             tabBarIcon: getTabBarIcon('file-document'),
@@ -154,7 +155,7 @@ export function BottomTabs() {
           name="TabChat"
           component={Chat}
           options={{
-            tabBarLabel: 'Chat',
+            title: 'Chat',
             tabBarIcon: getTabBarIcon('message-reply'),
             tabBarBadge: 2,
           }}

--- a/example/src/Screens/BottomTabs.tsx
+++ b/example/src/Screens/BottomTabs.tsx
@@ -184,10 +184,10 @@ export function BottomTabs() {
             tabBarIcon: getTabBarIcon('image-album'),
             tabBarInactiveTintColor: 'rgba(255, 255, 255, 0.5)',
             tabBarActiveTintColor: '#fff',
-            tabBarStyle: {
-              position: isLargeScreen ? undefined : 'absolute',
-              borderColor: 'rgba(0, 0, 0, .2)',
-            },
+            tabBarStyle: [
+              { borderWidth: 0 },
+              isLargeScreen ? null : { position: 'absolute' },
+            ],
             tabBarBackground: () => (
               <>
                 {isLargeScreen && (

--- a/packages/bottom-tabs/src/types.tsx
+++ b/packages/bottom-tabs/src/types.tsx
@@ -259,10 +259,10 @@ export type BottomTabNavigationOptions = HeaderOptions & {
   headerShown?: boolean;
 
   /**
-   * Whether this screen should be unmounted when navigating away from it.
+   * Whether any nested stack should be popped to top when navigating away from the tab.
    * Defaults to `false`.
    */
-  unmountOnBlur?: boolean;
+  popToTopOnBlur?: boolean;
 
   /**
    * Whether inactive screens should be suspended from re-rendering. Defaults to `false`.

--- a/packages/drawer/src/types.tsx
+++ b/packages/drawer/src/types.tsx
@@ -200,10 +200,10 @@ export type DrawerNavigationOptions = HeaderOptions & {
   keyboardDismissMode?: 'on-drag' | 'none';
 
   /**
-   * Whether this screen should be unmounted when navigating away from it.
+   * Whether any nested stack should be popped to top when navigating away from the tab.
    * Defaults to `false`.
    */
-  unmountOnBlur?: boolean;
+  popToTopOnBlur?: boolean;
 
   /**
    * Whether inactive screens should be suspended from re-rendering. Defaults to `false`.

--- a/packages/drawer/src/views/DrawerView.tsx
+++ b/packages/drawer/src/views/DrawerView.tsx
@@ -10,6 +10,7 @@ import {
   type DrawerNavigationState,
   type DrawerStatus,
   type ParamListBase,
+  StackActions,
   useLocale,
   useTheme,
 } from '@react-navigation/native';
@@ -81,6 +82,30 @@ function DrawerViewBase({
   if (!loaded.includes(focusedRouteKey)) {
     setLoaded([...loaded, focusedRouteKey]);
   }
+
+  const previousRouteKeyRef = React.useRef(focusedRouteKey);
+
+  React.useEffect(() => {
+    const previousRouteKey = previousRouteKeyRef.current;
+
+    if (
+      previousRouteKey !== focusedRouteKey &&
+      descriptors[previousRouteKey]?.options.popToTopOnBlur
+    ) {
+      const prevRoute = state.routes.find(
+        (route) => route.key === previousRouteKey
+      );
+
+      if (prevRoute?.state?.type === 'stack' && prevRoute.state.key) {
+        navigation.dispatch({
+          ...StackActions.popToTop(),
+          target: prevRoute.state.key,
+        });
+      }
+    }
+
+    previousRouteKeyRef.current = focusedRouteKey;
+  }, [descriptors, focusedRouteKey, navigation, state.routes]);
 
   const dimensions = useSafeAreaFrame();
 
@@ -194,12 +219,8 @@ function DrawerViewBase({
       >
         {state.routes.map((route, index) => {
           const descriptor = descriptors[route.key];
-          const { lazy = true, unmountOnBlur } = descriptor.options;
+          const { lazy = true } = descriptor.options;
           const isFocused = state.index === index;
-
-          if (unmountOnBlur && !isFocused) {
-            return null;
-          }
 
           if (
             lazy &&


### PR DESCRIPTION
This drops the `unmountOnBlur` option of bottom tabs and drawer in favor of a `popToTopOnBlur` option.

In many cases, the requirement is to return to the first screen of the stack nested in tabs. However using `unmountOnBlur` in those scenarios would also destroy any state of the screen. It's also slower to remount a nested navigator on tab navigation.

The `popToTopOnBlur` option provides an alternative approach - it pops the screens on a nested stack to go back to the first screen in the stack. It's much faster than remounting the nested navigator, and also doesn't destroy the state of the first screen in the stack.

It's still possible to achieve the old behavior of `unmountOnBlur` by using the `useIsFocused` hook in the screen:

```js
const isFocused = useIsFocused();

if (!isFocused) {
  return null;
}
```