### PR TITLE
fix: [6.x] - only replace trailing slash on decode

### DIFF
--- a/packages/core/src/__tests__/getStateFromPath.test.tsx
+++ b/packages/core/src/__tests__/getStateFromPath.test.tsx
@@ -86,6 +86,44 @@ it('decodes encoded params in path', () => {
   ).toEqual(path);
 });
 
+it('decodes encoded params in path that have encoded /', () => {
+  const path = '/foo/bar/bar_%2F_foo';
+  const config = {
+    screens: {
+      Foo: {
+        path: 'foo',
+        screens: {
+          Bar: {
+            path: '/bar/:id',
+          },
+        },
+      },
+    },
+  };
+
+  const state = {
+    routes: [
+      {
+        name: 'Foo',
+        state: {
+          routes: [
+            {
+              name: 'Bar',
+              params: { id: 'bar_/_foo' },
+              path,
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getStateFromPath<object>(path, config)).toEqual(state);
+  expect(
+    getPathFromState<object>(getStateFromPath<object>(path, config)!, config)
+  ).toEqual(path);
+});
+
 it('converts path string to initial state with config', () => {
   const path = '/foo/bar/sweet/apple/baz/jane?count=10&answer=42&valid=true';
   const config = {

--- a/packages/core/src/getStateFromPath.tsx
+++ b/packages/core/src/getStateFromPath.tsx
@@ -286,11 +286,13 @@ const matchAgainstConfigs = (remaining: string, configs: RouteConfig[]) => {
           const decodedParamSegment = decodeURIComponent(
             // The param segments appear every second item starting from 2 in the regex match result
             match![(acc.pos + 1) * 2]
+              // Remove trailing slash
+              .replace(/\/$/, '')
           );
 
           Object.assign(acc.matchedParams, {
             [p]: Object.assign(acc.matchedParams[p] || {}, {
-              [index]: decodedParamSegment.replace(/\//, ''),
+              [index]: decodedParamSegment,
             }),
           });
 


### PR DESCRIPTION
**Motivation**

I first noticed this in `@react-navigation/core@6.4.14`. I think it happened in  https://github.com/react-navigation/react-navigation/pull/11869

When you decode a path param that has an encoded `/` it removes the encoded param and leaves the trailing param in state.

**Test plan**
Create a route that have a path param with a`%2F` in it, verify that it comes out correctly decoded
