### PR TITLE
test: change queryByText to getByText in useUnhandledLinking.test.tsx

### DIFF
--- a/packages/native/src/__tests__/useUnhandledLinking.test.tsx
+++ b/packages/native/src/__tests__/useUnhandledLinking.test.tsx
@@ -119,22 +119,22 @@ it('schedules a state to be handled on conditional linking', async () => {
     );
   };
 
-  const { queryByText } = render(<App />);
+  const { queryByText, getByText } = render(<App />);
 
   expect(queryByText('SignIn')).not.toBeNull();
 
-  fireEvent.press(queryByText(/sign in/i));
+  fireEvent.press(getByText(/sign in/i));
 
   expect(queryByText('SignIn')).toBeNull();
 
   expect(queryByText('Profile')).not.toBeNull();
 
-  fireEvent.press(queryByText(/sign out/i));
+  fireEvent.press(getByText(/sign out/i));
 
   expect(queryByText('SignIn')).not.toBeNull();
   expect(queryByText('Home')).toBeNull();
   expect(queryByText('Profile')).toBeNull();
-  fireEvent.press(queryByText(/sign in/i));
+  fireEvent.press(getByText(/sign in/i));
   expect(queryByText('Home')).not.toBeNull();
 });
 
@@ -226,11 +226,11 @@ it('schedules a state to be handled on conditional linking under nested navigato
     );
   };
 
-  const { queryByText } = render(<App />);
+  const { queryByText, getByText } = render(<App />);
 
   expect(queryByText('SignIn')).not.toBeNull();
 
-  fireEvent.press(queryByText(/sign in/i));
+  fireEvent.press(getByText(/sign in/i));
 
   expect(queryByText('SignIn')).toBeNull();
 
@@ -326,22 +326,22 @@ it('schedules a state to be handled on conditional linking in nested stack', asy
     );
   };
 
-  const { queryByText } = await render(<App />);
+  const { queryByText, getByText } = await render(<App />);
 
   expect(queryByText('SignIn')).not.toBeNull();
 
-  fireEvent.press(queryByText(/sign in/i));
+  fireEvent.press(getByText(/sign in/i));
 
   expect(queryByText('SignIn')).toBeNull();
   expect(queryByText('Profile')).not.toBeNull();
 
-  fireEvent.press(queryByText(/sign out/i));
+  fireEvent.press(getByText(/sign out/i));
 
   expect(queryByText('SignIn')).not.toBeNull();
   expect(queryByText('Details')).toBeNull();
   expect(queryByText('Profile')).toBeNull();
 
-  fireEvent.press(queryByText(/sign in/i));
+  fireEvent.press(getByText(/sign in/i));
 
   expect(queryByText('Details')).not.toBeNull();
 });
@@ -442,11 +442,11 @@ it('clears lastUnhandledLink upon calling clearUnhandledLink', async () => {
     );
   };
 
-  const { queryByText } = render(<App />);
+  const { queryByText, getByText } = render(<App />);
 
   expect(queryByText('profile')).not.toBeNull();
 
-  fireEvent.press(queryByText(/clear/i));
+  fireEvent.press(getByText(/clear/i));
 
   expect(queryByText('profile')).toBeNull();
 });


### PR DESCRIPTION
**Motivation**

In `useUnhandledLinking.test.tsx` file, we're trying to query the element with given label and press it with `fireEvent.press`. Unfortunately, in my case Typescript prints several warnings about the wrong return type of passed argument. In fact, Typescript is correct there - we're trying to pass the argument of type `ReactTestInstance | null` to the function that accepts arguments of type `ReactTestInstance`. Because of that, I'm willing to change `queryByText` to `getByText` in places where the tests are trying to press the element with queried label.

I'm also leaving remains of the `queryByText` in the expect functions intentionally, since we're still expecting that some elements will be null there.

**Test plan**

Passing CI should be enough to check if that works! ✅
