### PR TITLE
chore: add `root` prop to .eslintrc

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,5 @@
 {
+  "root": true,
   "extends": "satya164",
   "plugins": ["simple-import-sort"],
   "settings": {
@@ -32,20 +33,24 @@
     "simple-import-sort/imports": "error",
     "simple-import-sort/exports": "error"
   },
-  "overrides": [{
-    "files":["example/e2e/tests/*.ts"],
-    "rules": {
-      "jest/*": "off"
+  "overrides": [
+    {
+      "files": ["example/e2e/tests/*.ts"],
+      "rules": {
+        "jest/*": "off"
+      }
+    },
+    {
+      "files": ["scripts/*.js", "netlify/functions/**/*.js"],
+      "rules": {
+        "import/no-commonjs": "off"
+      }
+    },
+    {
+      "files": ["**/config/*.{ts,js}", "*.config.{ts,js}"],
+      "rules": {
+        "import/no-default-export": "off"
+      }
     }
-  }, {
-    "files":["scripts/*.js", "netlify/functions/**/*.js"],
-    "rules": {
-      "import/no-commonjs": "off"
-    }
-  }, {
-    "files":["**/config/*.{ts,js}", "*.config.{ts,js}"],
-    "rules": {
-      "import/no-default-export": "off"
-    }
-  }]
+  ]
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -33,24 +33,20 @@
     "simple-import-sort/imports": "error",
     "simple-import-sort/exports": "error"
   },
-  "overrides": [
-    {
-      "files": ["example/e2e/tests/*.ts"],
-      "rules": {
-        "jest/*": "off"
-      }
-    },
-    {
-      "files": ["scripts/*.js", "netlify/functions/**/*.js"],
-      "rules": {
-        "import/no-commonjs": "off"
-      }
-    },
-    {
-      "files": ["**/config/*.{ts,js}", "*.config.{ts,js}"],
-      "rules": {
-        "import/no-default-export": "off"
-      }
+  "overrides": [{
+    "files":["example/e2e/tests/*.ts"],
+    "rules": {
+      "jest/*": "off"
     }
-  ]
+  }, {
+    "files":["scripts/*.js", "netlify/functions/**/*.js"],
+    "rules": {
+      "import/no-commonjs": "off"
+    }
+  }, {
+    "files":["**/config/*.{ts,js}", "*.config.{ts,js}"],
+    "rules": {
+      "import/no-default-export": "off"
+    }
+  }]
 }


### PR DESCRIPTION
**Motivation**

Currently, ESlint crashes when someone has bundled react-navigation as a submodule to the project (here, in react-native-screens we've got one 😁 ). Our goal is to mark react-navigation's ESlint RC file as a root configuration, to omit configuration mismatching.
