### PR TITLE
fix: use measured header height when exposing it

### DIFF
--- a/example/src/Screens/NativeStack.tsx
+++ b/example/src/Screens/NativeStack.tsx
@@ -1,11 +1,12 @@
-import { Button, useHeaderHeight } from '@react-navigation/elements';
-import type { PathConfigMap } from '@react-navigation/native';
+import { Button, Text, useHeaderHeight } from '@react-navigation/elements';
+import { type PathConfigMap, useTheme } from '@react-navigation/native';
 import {
   createNativeStackNavigator,
   type NativeStackScreenProps,
+  useAnimatedHeaderHeight,
 } from '@react-navigation/native-stack';
 import * as React from 'react';
-import { Platform, ScrollView, StyleSheet, View } from 'react-native';
+import { Animated, Platform, ScrollView, StyleSheet, View } from 'react-native';
 
 import { COMMON_LINKING_CONFIG } from '../constants';
 import { Albums } from '../Shared/Albums';
@@ -31,32 +32,35 @@ const ArticleScreen = ({
   route,
 }: NativeStackScreenProps<NativeStackParams, 'Article'>) => {
   return (
-    <ScrollView contentInsetAdjustmentBehavior="automatic">
-      <View style={styles.buttons}>
-        <Button
-          variant="filled"
-          onPress={() => navigation.push('NewsFeed', { date: Date.now() })}
-        >
-          Push feed
-        </Button>
-        <Button
-          variant="filled"
-          onPress={() => navigation.replace('NewsFeed', { date: Date.now() })}
-        >
-          Replace with feed
-        </Button>
-        <Button variant="filled" onPress={() => navigation.popTo('Albums')}>
-          Pop to Albums
-        </Button>
-        <Button variant="tinted" onPress={() => navigation.pop()}>
-          Pop screen
-        </Button>
-      </View>
-      <Article
-        author={{ name: route.params?.author ?? 'Unknown' }}
-        scrollEnabled={scrollEnabled}
-      />
-    </ScrollView>
+    <View>
+      <ScrollView contentInsetAdjustmentBehavior="automatic">
+        <View style={styles.buttons}>
+          <Button
+            variant="filled"
+            onPress={() => navigation.push('NewsFeed', { date: Date.now() })}
+          >
+            Push feed
+          </Button>
+          <Button
+            variant="filled"
+            onPress={() => navigation.replace('NewsFeed', { date: Date.now() })}
+          >
+            Replace with feed
+          </Button>
+          <Button variant="filled" onPress={() => navigation.popTo('Albums')}>
+            Pop to Albums
+          </Button>
+          <Button variant="tinted" onPress={() => navigation.pop()}>
+            Pop screen
+          </Button>
+        </View>
+        <Article
+          author={{ name: route.params?.author ?? 'Unknown' }}
+          scrollEnabled={scrollEnabled}
+        />
+      </ScrollView>
+      <HeaderHeightView />
+    </View>
   );
 };
 
@@ -73,17 +77,20 @@ const NewsFeedScreen = ({
   }, [navigation]);
 
   return (
-    <ScrollView contentInsetAdjustmentBehavior="automatic">
-      <View style={styles.buttons}>
-        <Button variant="filled" onPress={() => navigation.push('Albums')}>
-          Push Albums
-        </Button>
-        <Button variant="tinted" onPress={() => navigation.goBack()}>
-          Go back
-        </Button>
-      </View>
-      <NewsFeed scrollEnabled={scrollEnabled} date={route.params.date} />
-    </ScrollView>
+    <View>
+      <ScrollView contentInsetAdjustmentBehavior="automatic">
+        <View style={styles.buttons}>
+          <Button variant="filled" onPress={() => navigation.push('Albums')}>
+            Push Albums
+          </Button>
+          <Button variant="tinted" onPress={() => navigation.goBack()}>
+            Go back
+          </Button>
+        </View>
+        <NewsFeed scrollEnabled={scrollEnabled} date={route.params.date} />
+      </ScrollView>
+      <HeaderHeightView />
+    </View>
   );
 };
 
@@ -93,22 +100,50 @@ const AlbumsScreen = ({
   const headerHeight = useHeaderHeight();
 
   return (
-    <ScrollView contentContainerStyle={{ paddingTop: headerHeight }}>
-      <View style={styles.buttons}>
-        <Button
-          variant="filled"
-          onPress={() =>
-            navigation.navigate('Article', { author: 'Babel fish' })
-          }
-        >
-          Navigate to article
-        </Button>
-        <Button variant="tinted" onPress={() => navigation.pop(2)}>
-          Pop by 2
-        </Button>
-      </View>
-      <Albums scrollEnabled={scrollEnabled} />
-    </ScrollView>
+    <View>
+      <ScrollView contentContainerStyle={{ paddingTop: headerHeight }}>
+        <View style={styles.buttons}>
+          <Button
+            variant="filled"
+            onPress={() =>
+              navigation.navigate('Article', { author: 'Babel fish' })
+            }
+          >
+            Navigate to article
+          </Button>
+          <Button variant="tinted" onPress={() => navigation.pop(2)}>
+            Pop by 2
+          </Button>
+        </View>
+        <Albums scrollEnabled={scrollEnabled} />
+      </ScrollView>
+      <HeaderHeightView />
+    </View>
+  );
+};
+
+const HeaderHeightView = () => {
+  const { colors } = useTheme();
+
+  const animatedHeaderHeight = useAnimatedHeaderHeight();
+  const headerHeight = useHeaderHeight();
+
+  return (
+    <Animated.View
+      style={[
+        styles.headerHeight,
+        {
+          backgroundColor: colors.card,
+          borderColor: colors.border,
+          shadowColor: colors.border,
+        },
+        Platform.OS === 'ios' && {
+          transform: [{ translateY: animatedHeaderHeight }],
+        },
+      ]}
+    >
+      <Text>{headerHeight.toFixed(2)}</Text>
+    </Animated.View>
   );
 };
 
@@ -161,5 +196,15 @@ const styles = StyleSheet.create({
     flexWrap: 'wrap',
     gap: 12,
     padding: 12,
+  },
+  headerHeight: {
+    position: 'absolute',
+    top: 0,
+    right: 0,
+    padding: 12,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRightWidth: 0,
+    borderTopWidth: 0,
+    borderBottomLeftRadius: 3,
   },
 });

--- a/example/src/Screens/NativeStack.tsx
+++ b/example/src/Screens/NativeStack.tsx
@@ -117,12 +117,16 @@ const AlbumsScreen = ({
         </View>
         <Albums scrollEnabled={scrollEnabled} />
       </ScrollView>
-      <HeaderHeightView />
+      <HeaderHeightView hasOffset />
     </View>
   );
 };
 
-const HeaderHeightView = () => {
+const HeaderHeightView = ({
+  hasOffset = Platform.OS === 'ios',
+}: {
+  hasOffset?: boolean;
+}) => {
   const { colors } = useTheme();
 
   const animatedHeaderHeight = useAnimatedHeaderHeight();
@@ -137,7 +141,7 @@ const HeaderHeightView = () => {
           borderColor: colors.border,
           shadowColor: colors.border,
         },
-        Platform.OS === 'ios' && {
+        hasOffset && {
           transform: [{ translateY: animatedHeaderHeight }],
         },
       ]}
@@ -150,6 +154,8 @@ const HeaderHeightView = () => {
 const Stack = createNativeStackNavigator<NativeStackParams>();
 
 export function NativeStack() {
+  const { colors } = useTheme();
+
   return (
     <Stack.Navigator>
       <Stack.Screen
@@ -178,6 +184,10 @@ export function NativeStack() {
           presentation: 'modal',
           headerTransparent: true,
           headerBlurEffect: 'light',
+          headerStyle: {
+            // Add a background color since Android doesn't support blur effect
+            backgroundColor: colors.card,
+          },
         }}
       />
     </Stack.Navigator>

--- a/packages/native-stack/src/utils/debounce.tsx
+++ b/packages/native-stack/src/utils/debounce.tsx
@@ -1,0 +1,14 @@
+export function debounce<T extends (...args: any[]) => void>(
+  func: T,
+  duration: number
+): T {
+  let timeout: NodeJS.Timeout;
+
+  return function (this: unknown, ...args) {
+    clearTimeout(timeout);
+
+    timeout = setTimeout(() => {
+      func.apply(this, args);
+    }, duration);
+  } as T;
+}

--- a/packages/native-stack/src/utils/useAnimatedHeaderHeight.tsx
+++ b/packages/native-stack/src/utils/useAnimatedHeaderHeight.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import type { Animated } from 'react-native';
 
 export const AnimatedHeaderHeightContext = React.createContext<
-  Animated.Value | undefined
+  Animated.AnimatedInterpolation<number> | undefined
 >(undefined);
 
 export function useAnimatedHeaderHeight() {


### PR DESCRIPTION
**Motivation**

Currently the `useHeaderHeight` hook returns a hardcoded value since previously we didn't have a way to measure the header height. But now there's a `onHeaderHeightChange` listener that we can use to measure the accurate height.

This PR makes sure that we use this event when measuring header height.

**Test plan**

Tested in the example app:

https://github.com/react-navigation/react-navigation/assets/1174278/c6e415eb-3cba-4e65-8717-9fd2d03f8987

