### PR TITLE
feat: add ability to override bottom tab sideContent and bottomContent styles

### DIFF
--- a/packages/bottom-tabs/src/types.tsx
+++ b/packages/bottom-tabs/src/types.tsx
@@ -228,6 +228,11 @@ export type BottomTabNavigationOptions = HeaderOptions & {
   tabBarStyle?: Animated.WithAnimatedValue<StyleProp<ViewStyle>>;
 
   /**
+   * Style object for the tab bar content container.
+   */
+  tabBarContentStyle?: StyleProp<ViewStyle>;
+
+  /**
    * Function which returns a React Element to use as background for the tab bar.
    * You could render an image, a gradient, blur view etc.
    *

--- a/packages/bottom-tabs/src/views/BottomTabBar.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabBar.tsx
@@ -155,6 +155,7 @@ export function BottomTabBar({
     tabBarHideOnKeyboard = false,
     tabBarVisibilityAnimationConfig,
     tabBarStyle,
+    tabBarContentStyle,
     tabBarBackground,
     tabBarActiveTintColor,
     tabBarInactiveTintColor,
@@ -332,7 +333,10 @@ export function BottomTabBar({
       </View>
       <View
         accessibilityRole="tablist"
-        style={tabBarIsHorizontal ? styles.bottomContent : styles.sideContent}
+        style={[
+          tabBarIsHorizontal ? styles.bottomContent : styles.sideContent,
+          tabBarContentStyle,
+        ]}
       >
         {routes.map((route, index) => {
           const focused = index === state.index;


### PR DESCRIPTION
**Motivation**

This is an extension to #11578 

I'm using the alphas in a new project to create sidebar tabs but I am running into problems related to how the `sideContent` and `bottomContent` styles are being applied

1) Default padding of sidebar cannot be overriden as it's set as a constant
https://github.com/react-navigation/react-navigation/blob/a41d932198d1b48d84f410be1633fc5ddcb2df3f/packages/bottom-tabs/src/views/BottomTabBar.tsx#L41
https://github.com/react-navigation/react-navigation/blob/a41d932198d1b48d84f410be1633fc5ddcb2df3f/packages/bottom-tabs/src/views/BottomTabBar.tsx#L457-L461
https://github.com/react-navigation/react-navigation/blob/a41d932198d1b48d84f410be1633fc5ddcb2df3f/packages/bottom-tabs/src/views/BottomTabBar.tsx#L333-L336

2) Cannot make tabs be centred through `justifyContent`. There is not way to supply additional styles that merge with `sideContent` or `bottomContent`.

Both issues could be addressed by merging in another style option eg

```js
<View
  accessibilityRole="tablist"
  style={[
    tabBarIsHorizontal ? 
      styles.bottomContent 
      : styles.sideContent, 
    tabBarContentStyle
  ]}
>
```
Which is what this PR does

**Test plan**

Create sidebar tabs with these options

```ts
const screenOptions: BottomTabNavigationOptions = {
  headerShown: false,
  tabBarPosition: 'left',
  tabBarShowLabel: false,
  tabBarIconStyle: {
    width: 20,
    height: 20,
  },
  tabBarStyle: {
    backgroundColor: '#18082c',
    borderEndWidth: 0,
    minWidth: 0,
    padding: 0,
    paddingStart: 0,
    paddingEnd: 0,
    paddingTop: 0,
    paddingBottom: 0,
  },
  tabBarItemStyle: {
    marginHorizontal: 0,
    marginVertical: 0,
    borderRadius: 0,
    padding: 18,
  },
};
```

Tabs will be aligned at the top, add this option to center them and remove default padding

```ts
tabBarContentStyle: {
  padding: 0,
  justifyContent: 'center',
},
```

You should see this change from this
<img width="244" alt="image" src="https://github.com/react-navigation/react-navigation/assets/83799/05b3b3d8-ff5a-432f-a0b5-dcf58abb12bd">

to 

<img width="223" alt="image" src="https://github.com/react-navigation/react-navigation/assets/83799/a647cc33-dc47-40f1-bfb5-d9fb9341a51c">
