### PR TITLE
feat: introduce missing props from native-stack v5 (v6)

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -38,7 +38,7 @@
     "react-native-paper": "^4.12.1",
     "react-native-reanimated": "~2.14.4",
     "react-native-safe-area-context": "4.5.0",
-    "react-native-screens": "~3.20.0",
+    "react-native-screens": "~3.29.0",
     "react-native-tab-view": "workspace:^",
     "react-native-vector-icons": "^9.1.0",
     "react-native-web": "~0.18.7"

--- a/packages/bottom-tabs/package.json
+++ b/packages/bottom-tabs/package.json
@@ -51,7 +51,7 @@
     "react-native": "0.71.8",
     "react-native-builder-bob": "^0.20.4",
     "react-native-safe-area-context": "4.5.0",
-    "react-native-screens": "~3.20.0",
+    "react-native-screens": "~3.29.0",
     "typescript": "^4.9.4"
   },
   "peerDependencies": {

--- a/packages/drawer/package.json
+++ b/packages/drawer/package.json
@@ -57,7 +57,7 @@
     "react-native-gesture-handler": "~2.9.0",
     "react-native-reanimated": "~2.14.4",
     "react-native-safe-area-context": "4.5.0",
-    "react-native-screens": "~3.20.0",
+    "react-native-screens": "~3.29.0",
     "typescript": "^4.9.4"
   },
   "peerDependencies": {

--- a/packages/native-stack/package.json
+++ b/packages/native-stack/package.json
@@ -53,7 +53,7 @@
     "react": "18.2.0",
     "react-native": "0.71.8",
     "react-native-builder-bob": "^0.20.4",
-    "react-native-screens": "~3.30.1",
+    "react-native-screens": "~3.29.0",
     "typescript": "^4.9.4"
   },
   "peerDependencies": {

--- a/packages/native-stack/package.json
+++ b/packages/native-stack/package.json
@@ -53,7 +53,7 @@
     "react": "18.2.0",
     "react-native": "0.71.8",
     "react-native-builder-bob": "^0.20.4",
-    "react-native-screens": "~3.20.0",
+    "react-native-screens": "~3.30.1",
     "typescript": "^4.9.4"
   },
   "peerDependencies": {

--- a/packages/native-stack/src/types.tsx
+++ b/packages/native-stack/src/types.tsx
@@ -20,6 +20,7 @@ import type {
   ScreenProps,
   ScreenStackHeaderConfigProps,
   SearchBarProps,
+  SheetDetentTypes,
 } from 'react-native-screens';
 
 export type NativeStackNavigationEventMap = {
@@ -31,6 +32,10 @@ export type NativeStackNavigationEventMap = {
    * Event which fires when a transition animation ends.
    */
   transitionEnd: { data: { closing: boolean } };
+  /**
+   * Event which fires when a swipe back is canceled on iOS.
+   */
+  gestureCancel: { data: undefined };
 };
 
 export type NativeStackNavigationProp<
@@ -327,6 +332,12 @@ export type NativeStackNavigationOptions = {
    */
   autoHideHomeIndicator?: boolean;
   /**
+   * Whether the keyboard should hide when swiping to the previous screen. Defaults to `false`.
+   *
+   * @platform ios
+   */
+  keyboardHandlingEnabled?: boolean;
+  /**
    * Sets the navigation bar color. Defaults to initial navigation bar color.
    *
    * @platform android
@@ -419,6 +430,12 @@ export type NativeStackNavigationOptions = {
    */
   gestureEnabled?: boolean;
   /**
+   * Use it to restrict the distance from the edges of screen in which the gesture should be recognized. To be used alongside `fullScreenGestureEnabled`.
+   *
+   * @platform ios
+   */
+  gestureResponseDistance?: ScreenProps['gestureResponseDistance'];
+  /**
    * The type of animation to use when this screen replaces another screen. Defaults to `pop`.
    *
    * Supported values:
@@ -466,6 +483,62 @@ export type NativeStackNavigationOptions = {
    * Only supported on iOS and Android.
    */
   presentation?: Exclude<ScreenProps['stackPresentation'], 'push'> | 'card';
+  /**
+   * Describes heights where a sheet can rest.
+   * Works only when `presentation` is set to `formSheet`.
+   * Defaults to `large`.
+   *
+   * Available values:
+   *
+   * - `large` - only large detent level will be allowed
+   * - `medium` - only medium detent level will be allowed
+   * - `all` - all detent levels will be allowed
+   *
+   * @platform ios
+   */
+  sheetAllowedDetents?: SheetDetentTypes;
+  /**
+   * Whether the sheet should expand to larger detent when scrolling.
+   * Works only when `presentation` is set to `formSheet`.
+   * Defaults to `true`.
+   *
+   * @platform ios
+   */
+  sheetExpandsWhenScrolledToEdge?: boolean;
+  /**
+   * The corner radius that the sheet will try to render with.
+   * Works only when `presentation` is set to `formSheet`.
+   *
+   * If set to non-negative value it will try to render sheet with provided radius, else it will apply system default.
+   *
+   * If left unset system default is used.
+   *
+   * @platform ios
+   */
+  sheetCornerRadius?: number;
+  /**
+   * Boolean indicating whether the sheet shows a grabber at the top.
+   * Works only when `presentation` is set to `formSheet`.
+   * Defaults to `false`.
+   *
+   * @platform ios
+   */
+  sheetGrabberVisible?: boolean;
+  /**
+   * The largest sheet detent for which a view underneath won't be dimmed.
+   * Works only when `presentation` is se tto `formSheet`.
+   *
+   * If this prop is set to:
+   *
+   * - `large` - the view underneath won't be dimmed at any detent level
+   * - `medium` - the view underneath will be dimmed only when detent level is `large`
+   * - `all` - the view underneath will be dimmed for any detent level
+   *
+   * Defaults to `all`.
+   *
+   * @platform ios
+   */
+  sheetLargestUndimmedDetent?: SheetDetentTypes;
   /**
    * The display orientation to use for the screen.
    *

--- a/packages/native-stack/src/views/HeaderConfig.tsx
+++ b/packages/native-stack/src/views/HeaderConfig.tsx
@@ -253,7 +253,6 @@ export default function HeaderConfig({
       ) : null}
       {hasHeaderSearchBar ? (
         <ScreenStackHeaderSearchBarView>
-          {/* @ts-expect-error: it's not possible to retype `ref` for now. */}
           <SearchBar {...headerSearchBarOptions} />
         </ScreenStackHeaderSearchBarView>
       ) : null}

--- a/packages/native-stack/src/views/HeaderConfig.tsx
+++ b/packages/native-stack/src/views/HeaderConfig.tsx
@@ -9,7 +9,6 @@ import {
   View,
 } from 'react-native';
 import {
-  // @ts-expect-error: Available since react-native-screens v3.21
   isNewBackTitleImplementation,
   isSearchBarAvailableForCurrentPlatform,
   ScreenStackHeaderBackButtonImage,
@@ -162,7 +161,6 @@ export default function HeaderConfig({
           ? headerBackTitle
           : ' '
       }
-      // @ts-expect-error: Available since react-native-screens v3.21
       backTitleVisible={headerBackTitleVisible}
       backTitleFontFamily={backTitleFontFamily}
       backTitleFontSize={headerBackTitleStyleFlattened.fontSize}
@@ -255,6 +253,7 @@ export default function HeaderConfig({
       ) : null}
       {hasHeaderSearchBar ? (
         <ScreenStackHeaderSearchBarView>
+          {/* @ts-expect-error: it's not possible to retype `ref` for now. */}
           <SearchBar {...headerSearchBarOptions} />
         </ScreenStackHeaderSearchBarView>
       ) : null}

--- a/packages/native-stack/src/views/NativeStackView.native.tsx
+++ b/packages/native-stack/src/views/NativeStackView.native.tsx
@@ -97,7 +97,12 @@ const MaybeNestedStack = ({
   if (isHeaderInModal) {
     return (
       <ScreenStack style={styles.container}>
-        <Screen enabled style={StyleSheet.absoluteFill}>
+        <Screen
+          enabled
+          isNativeStack
+          hasLargeHeader={options.headerLargeTitle ?? false}
+          style={StyleSheet.absoluteFill}
+        >
           {content}
           <HeaderConfig
             {...options}
@@ -121,11 +126,13 @@ type SceneViewProps = {
   previousDescriptor?: NativeStackDescriptor;
   nextDescriptor?: NativeStackDescriptor;
   onWillDisappear: () => void;
+  onWillAppear: () => void;
   onAppear: () => void;
   onDisappear: () => void;
   onDismissed: ScreenProps['onDismissed'];
   onHeaderBackButtonClicked: ScreenProps['onHeaderBackButtonClicked'];
   onNativeDismissCancelled: ScreenProps['onDismissed'];
+  onGestureCancel: ScreenProps['onGestureCancel'];
 };
 
 const SceneView = ({
@@ -135,26 +142,35 @@ const SceneView = ({
   previousDescriptor,
   nextDescriptor,
   onWillDisappear,
+  onWillAppear,
   onAppear,
   onDisappear,
   onDismissed,
   onHeaderBackButtonClicked,
   onNativeDismissCancelled,
+  onGestureCancel,
 }: SceneViewProps) => {
   const { route, navigation, options, render } = descriptor;
   const {
     animationDuration,
     animationTypeForReplace = 'push',
     gestureEnabled,
+    gestureResponseDistance,
     header,
     headerBackButtonMenuEnabled,
     headerShown,
     headerBackground,
     headerTransparent,
     autoHideHomeIndicator,
+    keyboardHandlingEnabled,
     navigationBarColor,
     navigationBarHidden,
     orientation,
+    sheetAllowedDetents = 'large',
+    sheetLargestUndimmedDetent = 'all',
+    sheetGrabberVisible = false,
+    sheetCornerRadius = -1.0,
+    sheetExpandsWhenScrolledToEdge = true,
     statusBarAnimation,
     statusBarHidden,
     statusBarStyle,
@@ -253,7 +269,9 @@ const SceneView = ({
     <Screen
       key={route.key}
       enabled
+      isNativeStack
       style={StyleSheet.absoluteFill}
+      hasLargeHeader={options.headerLargeTitle ?? false}
       customAnimationOnSwipe={customAnimationOnGesture}
       fullScreenSwipeEnabled={fullScreenGestureEnabled}
       gestureEnabled={
@@ -264,12 +282,18 @@ const SceneView = ({
           : gestureEnabled
       }
       homeIndicatorHidden={autoHideHomeIndicator}
+      hideKeyboardOnSwipe={keyboardHandlingEnabled}
       navigationBarColor={navigationBarColor}
       navigationBarHidden={navigationBarHidden}
       replaceAnimation={animationTypeForReplace}
       stackPresentation={presentation === 'card' ? 'push' : presentation}
       stackAnimation={animation}
       screenOrientation={orientation}
+      sheetAllowedDetents={sheetAllowedDetents}
+      sheetLargestUndimmedDetent={sheetLargestUndimmedDetent}
+      sheetGrabberVisible={sheetGrabberVisible}
+      sheetCornerRadius={sheetCornerRadius}
+      sheetExpandsWhenScrolledToEdge={sheetExpandsWhenScrolledToEdge}
       statusBarAnimation={statusBarAnimation}
       statusBarHidden={statusBarHidden}
       statusBarStyle={statusBarStyle}
@@ -278,10 +302,12 @@ const SceneView = ({
       swipeDirection={gestureDirectionOverride}
       transitionDuration={animationDuration}
       onWillDisappear={onWillDisappear}
+      onWillAppear={onWillAppear}
       onAppear={onAppear}
       onDisappear={onDisappear}
       onDismissed={onDismissed}
-      isNativeStack
+      onGestureCancel={onGestureCancel}
+      gestureResponseDistance={gestureResponseDistance}
       nativeBackButtonDismissalEnabled={false} // on Android
       onHeaderBackButtonClicked={onHeaderBackButtonClicked}
       // @ts-ignore props not exported from rn-screens
@@ -424,6 +450,13 @@ function NativeStackViewInner({ state, navigation, descriptors }: Props) {
                 target: route.key,
               });
             }}
+            onWillAppear={() => {
+              navigation.emit({
+                type: 'transitionStart',
+                data: { closing: false },
+                target: route.key,
+              });
+            }}
             onAppear={() => {
               navigation.emit({
                 type: 'transitionEnd',
@@ -459,6 +492,12 @@ function NativeStackViewInner({ state, navigation, descriptors }: Props) {
                 ...StackActions.pop(event.nativeEvent.dismissCount),
                 source: route.key,
                 target: state.key,
+              });
+            }}
+            onGestureCancel={() => {
+              navigation.emit({
+                type: 'gestureCancel',
+                target: route.key,
               });
             }}
           />

--- a/packages/stack/package.json
+++ b/packages/stack/package.json
@@ -56,7 +56,7 @@
     "react-native-builder-bob": "^0.20.4",
     "react-native-gesture-handler": "~2.9.0",
     "react-native-safe-area-context": "4.5.0",
-    "react-native-screens": "~3.20.0",
+    "react-native-screens": "~3.29.0",
     "typescript": "^4.9.4"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5790,7 +5790,7 @@ __metadata:
     react: 18.2.0
     react-native: 0.71.8
     react-native-builder-bob: ^0.20.4
-    react-native-screens: ~3.20.0
+    react-native-screens: ~3.30.1
     typescript: ^4.9.4
     warn-once: ^0.1.0
   peerDependencies:
@@ -22020,6 +22020,19 @@ __metadata:
     react: "*"
     react-native: "*"
   checksum: 94ab21378ee82765d329ccb8c92f5ca7cb15df916496fac7ce9a03c45e22579715000dae9c16f0a7d734a8fc1c2d0569fd82ecb71119a0b56046b5ea7533e7c2
+  languageName: node
+  linkType: hard
+
+"react-native-screens@npm:~3.30.1":
+  version: 3.30.1
+  resolution: "react-native-screens@npm:3.30.1"
+  dependencies:
+    react-freeze: ^1.0.0
+    warn-once: ^0.1.0
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+  checksum: e6c9b69ec97a4e46dd335ed25312c3621546bf0959754338aabbd4a16cc9cfb259548c996d2d737ea772a7b2ce7f198ffcd2977673e74c141334ce94fa3861c6
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5554,7 +5554,7 @@ __metadata:
     react-native: 0.71.8
     react-native-builder-bob: ^0.20.4
     react-native-safe-area-context: 4.5.0
-    react-native-screens: ~3.20.0
+    react-native-screens: ~3.29.0
     typescript: ^4.9.4
     warn-once: ^0.1.0
   peerDependencies:
@@ -5628,7 +5628,7 @@ __metadata:
     react-native-gesture-handler: ~2.9.0
     react-native-reanimated: ~2.14.4
     react-native-safe-area-context: 4.5.0
-    react-native-screens: ~3.20.0
+    react-native-screens: ~3.29.0
     typescript: ^4.9.4
     warn-once: ^0.1.0
   peerDependencies:
@@ -5713,7 +5713,7 @@ __metadata:
     react-native-paper: ^4.12.1
     react-native-reanimated: ~2.14.4
     react-native-safe-area-context: 4.5.0
-    react-native-screens: ~3.20.0
+    react-native-screens: ~3.29.0
     react-native-tab-view: "workspace:^"
     react-native-vector-icons: ^9.1.0
     react-native-web: ~0.18.7
@@ -5790,7 +5790,7 @@ __metadata:
     react: 18.2.0
     react-native: 0.71.8
     react-native-builder-bob: ^0.20.4
-    react-native-screens: ~3.30.1
+    react-native-screens: ~3.29.0
     typescript: ^4.9.4
     warn-once: ^0.1.0
   peerDependencies:
@@ -5854,7 +5854,7 @@ __metadata:
     react-native-builder-bob: ^0.20.4
     react-native-gesture-handler: ~2.9.0
     react-native-safe-area-context: 4.5.0
-    react-native-screens: ~3.20.0
+    react-native-screens: ~3.29.0
     typescript: ^4.9.4
     warn-once: ^0.1.0
   peerDependencies:
@@ -22010,29 +22010,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-screens@npm:~3.20.0":
-  version: 3.20.0
-  resolution: "react-native-screens@npm:3.20.0"
+"react-native-screens@npm:~3.29.0":
+  version: 3.29.0
+  resolution: "react-native-screens@npm:3.29.0"
   dependencies:
     react-freeze: ^1.0.0
     warn-once: ^0.1.0
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 94ab21378ee82765d329ccb8c92f5ca7cb15df916496fac7ce9a03c45e22579715000dae9c16f0a7d734a8fc1c2d0569fd82ecb71119a0b56046b5ea7533e7c2
-  languageName: node
-  linkType: hard
-
-"react-native-screens@npm:~3.30.1":
-  version: 3.30.1
-  resolution: "react-native-screens@npm:3.30.1"
-  dependencies:
-    react-freeze: ^1.0.0
-    warn-once: ^0.1.0
-  peerDependencies:
-    react: "*"
-    react-native: "*"
-  checksum: e6c9b69ec97a4e46dd335ed25312c3621546bf0959754338aabbd4a16cc9cfb259548c996d2d737ea772a7b2ce7f198ffcd2977673e74c141334ce94fa3861c6
+  checksum: c1879eea8386f32c2655fedd79d41d8e25d2f4e7f883abbcad2c747ea7ac859f4a7f469475a519948e7c5ea317a7ebd8df92c6365627f6a5da1e4a208cece7e1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**Motivation**

Follow-up for PR #11803 that introduced props from native-stack v5 to v7. Here, I'm migrating missing props also to native-stack v6. Take a look in [original PR](https://github.com/react-navigation/react-navigation/pull/11803) for more information about this change.

**Test plan**

You can test these props by checking how they affect screens after adjusting them in Native Stack example. Remember about setting `presentation` to `formSheet` while using `sheetX` props.

Some of the examples I've already prepared:

<details>
<summary>Using GestureResponseDistance on NewsFeed</summary>

This will enable changing the area of the gesture with a rectangle starting from the ~middle of the screen down to bottom.

`NativeStack.tsx:139`
```tsx
      <Stack.Screen
        name="NewsFeed"
        component={NewsFeedScreen}
        options={{
          title: 'Feed',
          fullScreenGestureEnabled: true,
          gestureResponseDistance: {
            start: 40,
            end: 353,
            top: 400,
            bottom: 852,
          },
        }}
      />
```
</details>

<details>
<summary>Using sheet props on NewsFeed</summary>

This will change the NewsFeed screen to the form sheet with rounded corners and maximum height to the middle.

`NativeStack.tsx:139`
```tsx
      <Stack.Screen
        name="NewsFeed"
        component={NewsFeedScreen}
        options={{
          title: 'Feed',
          presentation: 'formSheet',
          sheetAllowedDetents: 'medium',
          sheetCornerRadius: 32,
        }}
      />
```
</details>