### PR TITLE
Bugs + (partial) Fixes: Non-responsiveness of "tabBarLabelStyle" and "tabBarLabel" in MaterialTopTabBar

### DIFF
--- a/packages/material-top-tabs/src/views/MaterialTopTabBar.tsx
+++ b/packages/material-top-tabs/src/views/MaterialTopTabBar.tsx
@@ -76,7 +76,9 @@ export function MaterialTopTabBar({
           labelText:
             options.tabBarShowLabel === false
               ? undefined
-              : options.title !== undefined
+              : options.tabBarLabel !== undefined && typeof options.tabBarLabel === "string"
+                ? options.tabBarLabel
+                : options.title !== undefined
                 ? options.title
                 : route.name,
         },

--- a/packages/material-top-tabs/src/views/MaterialTopTabBar.tsx
+++ b/packages/material-top-tabs/src/views/MaterialTopTabBar.tsx
@@ -16,19 +16,19 @@ import type { MaterialTopTabBarProps } from '../types';
 type MaterialLabelType = {
   color: string;
   label?: string;
-  labelStyle?: StyleProp<ViewStyle>;
+  style?: StyleProp<ViewStyle>;
   allowScaling?: boolean;
 };
 
 const MaterialLabel = ({
   color,
   label,
-  labelStyle,
+  style,
   allowScaling,
 }: MaterialLabelType) => {
   return (
     <Text
-      style={[{ color }, styles.label, labelStyle]}
+      style={[{ color }, styles.label, style]}
       allowFontScaling={allowScaling}
     >
       {label}

--- a/packages/material-top-tabs/src/views/MaterialTopTabBar.tsx
+++ b/packages/material-top-tabs/src/views/MaterialTopTabBar.tsx
@@ -76,11 +76,12 @@ export function MaterialTopTabBar({
           labelText:
             options.tabBarShowLabel === false
               ? undefined
-              : options.tabBarLabel !== undefined && typeof options.tabBarLabel === "string"
+              : options.tabBarLabel !== undefined &&
+                  typeof options.tabBarLabel === 'string'
                 ? options.tabBarLabel
                 : options.title !== undefined
-                ? options.title
-                : route.name,
+                  ? options.title
+                  : route.name,
         },
       ];
     })

--- a/packages/react-native-tab-view/src/TabBar.tsx
+++ b/packages/react-native-tab-view/src/TabBar.tsx
@@ -525,7 +525,6 @@ export function TabBar<T extends Route>({
         : undefined;
 
       const props = {
-        ...rest,
         key: route.key,
         position,
         route,
@@ -545,6 +544,7 @@ export function TabBar<T extends Route>({
         style: tabStyle,
         defaultTabWidth,
         android_ripple,
+        ...rest,
       } satisfies TabBarItemProps<T> & { key: string };
 
       return (


### PR DESCRIPTION
The props tabBarLabelStyle and tabBarLabel are ignored by MaterialTopTabBar. This pull requests solves the problem full for tabBarLabelStyle. For tabBarLabel this PR only fixes the problem for tabBarLabel(s) of type string.