### PR TITLE
feat(Android): added navigationBarTranslucent option

### DIFF
--- a/packages/native-stack/src/types.tsx
+++ b/packages/native-stack/src/types.tsx
@@ -361,6 +361,12 @@ export type NativeStackNavigationOptions = {
    */
   navigationBarColor?: string;
   /**
+   * Boolean indicating whether the content should be visible behind the navigation bar. Defaults to `false`.
+   *
+   * @platform android
+   */
+  navigationBarTranslucent?: boolean;
+  /**
    * Sets the visibility of the navigation bar. Defaults to `false`.
    *
    * @platform android

--- a/packages/native-stack/src/views/NativeStackView.native.tsx
+++ b/packages/native-stack/src/views/NativeStackView.native.tsx
@@ -332,6 +332,7 @@ const SceneView = ({
       homeIndicatorHidden={autoHideHomeIndicator}
       hideKeyboardOnSwipe={keyboardHandlingEnabled}
       navigationBarColor={navigationBarColor}
+      // @ts-expect-error prop supported from react-native-screens 3.32.0 onwards
       navigationBarTranslucent={navigationBarTranslucent}
       navigationBarHidden={navigationBarHidden}
       replaceAnimation={animationTypeForReplace}

--- a/packages/native-stack/src/views/NativeStackView.native.tsx
+++ b/packages/native-stack/src/views/NativeStackView.native.tsx
@@ -185,6 +185,7 @@ const SceneView = ({
     autoHideHomeIndicator,
     keyboardHandlingEnabled,
     navigationBarColor,
+    navigationBarTranslucent,
     navigationBarHidden,
     orientation,
     sheetAllowedDetents = 'large',
@@ -331,6 +332,7 @@ const SceneView = ({
       homeIndicatorHidden={autoHideHomeIndicator}
       hideKeyboardOnSwipe={keyboardHandlingEnabled}
       navigationBarColor={navigationBarColor}
+      navigationBarTranslucent={navigationBarTranslucent}
       navigationBarHidden={navigationBarHidden}
       replaceAnimation={animationTypeForReplace}
       stackPresentation={presentation === 'card' ? 'push' : presentation}


### PR DESCRIPTION
**Motivation**

This PR intents to enable navigation bar translucency control. You can find more about this feature [here](https://github.com/software-mansion/react-native-screens/pull/2152)

**Test plan**

Play around with following screen options:
```
  <Stack.Navigator
    screenOptions={{
      navigationBarColor: 'transparent',
      navigationBarTranslucent: true,
      navigationBarHidden: false,
    }}>
```
