### PR TITLE
Adjust sidebar styling in bottom tabs to match drawer

### DIFF
--- a/packages/bottom-tabs/src/views/BottomTabBar.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabBar.tsx
@@ -464,7 +464,6 @@ const styles = StyleSheet.create({
   },
   sideItem: {
     margin: SPACING,
-    padding: SPACING * 2,
-    borderRadius: 4,
+    borderRadius: 56,
   },
 });

--- a/packages/bottom-tabs/src/views/BottomTabBar.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabBar.tsx
@@ -387,6 +387,7 @@ export function BottomTabBar({
                   descriptor={descriptors[route.key]}
                   focused={focused}
                   horizontal={hasHorizontalLabels}
+                  variant={tabBarIsHorizontal ? 'OS' : 'Material'}
                   onPress={onPress}
                   onLongPress={onLongPress}
                   accessibilityLabel={accessibilityLabel}
@@ -464,6 +465,7 @@ const styles = StyleSheet.create({
   },
   sideItem: {
     margin: SPACING,
+    padding: SPACING * 2,
     borderRadius: 56,
   },
 });

--- a/packages/bottom-tabs/src/views/BottomTabBar.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabBar.tsx
@@ -269,10 +269,9 @@ export function BottomTabBar({
     layout,
   });
 
-  const tabBarBackgroundElement = tabBarBackground?.();
+  const isSidebar = tabBarPosition === 'left' || tabBarPosition === 'right';
 
-  const tabBarIsHorizontal =
-    tabBarPosition === 'bottom' || tabBarPosition === 'top';
+  const tabBarBackgroundElement = tabBarBackground?.();
 
   return (
     <Animated.View
@@ -287,8 +286,17 @@ export function BottomTabBar({
             tabBarBackgroundElement != null ? 'transparent' : colors.card,
           borderColor: colors.border,
         },
-        tabBarIsHorizontal
-          ? [
+        isSidebar
+          ? {
+              paddingTop: insets.top,
+              paddingBottom: insets.bottom,
+              paddingStart: tabBarPosition === 'left' ? insets.left : 0,
+              paddingEnd: tabBarPosition === 'right' ? insets.right : 0,
+              minWidth: hasHorizontalLabels
+                ? getDefaultSidebarWidth(dimensions)
+                : 0,
+            }
+          : [
               {
                 transform: [
                   {
@@ -312,27 +320,18 @@ export function BottomTabBar({
                 paddingBottom,
                 paddingHorizontal: Math.max(insets.left, insets.right),
               },
-            ]
-          : {
-              paddingTop: insets.top,
-              paddingBottom: insets.bottom,
-              paddingStart: tabBarPosition === 'left' ? insets.left : 0,
-              paddingEnd: tabBarPosition === 'right' ? insets.right : 0,
-              minWidth: hasHorizontalLabels
-                ? getDefaultSidebarWidth(dimensions)
-                : 0,
-            },
+            ],
         tabBarStyle,
       ]}
       pointerEvents={isTabBarHidden ? 'none' : 'auto'}
-      onLayout={tabBarIsHorizontal ? handleLayout : undefined}
+      onLayout={isSidebar ? undefined : handleLayout}
     >
       <View pointerEvents="none" style={StyleSheet.absoluteFill}>
         {tabBarBackgroundElement}
       </View>
       <View
         accessibilityRole="tablist"
-        style={tabBarIsHorizontal ? styles.bottomContent : styles.sideContent}
+        style={isSidebar ? styles.sideContent : styles.bottomContent}
       >
         {routes.map((route, index) => {
           const focused = index === state.index;
@@ -387,7 +386,7 @@ export function BottomTabBar({
                   descriptor={descriptors[route.key]}
                   focused={focused}
                   horizontal={hasHorizontalLabels}
-                  variant={tabBarIsHorizontal ? 'OS' : 'Material'}
+                  variant={isSidebar ? 'material' : 'uikit'}
                   onPress={onPress}
                   onLongPress={onLongPress}
                   accessibilityLabel={accessibilityLabel}
@@ -411,14 +410,14 @@ export function BottomTabBar({
                   labelStyle={options.tabBarLabelStyle}
                   iconStyle={options.tabBarIconStyle}
                   style={[
-                    tabBarIsHorizontal
-                      ? styles.bottomItem
-                      : [
+                    isSidebar
+                      ? [
                           styles.sideItem,
                           hasHorizontalLabels
-                            ? { justifyContent: 'flex-start' }
-                            : null,
-                        ],
+                            ? styles.sideItemHorizontal
+                            : styles.sideItemVertical,
+                        ]
+                      : styles.bottomItem,
                     options.tabBarItemStyle,
                   ]}
                 />
@@ -466,6 +465,12 @@ const styles = StyleSheet.create({
   sideItem: {
     margin: SPACING,
     padding: SPACING * 2,
+  },
+  sideItemHorizontal: {
     borderRadius: 56,
+    justifyContent: 'flex-start',
+  },
+  sideItemVertical: {
+    borderRadius: 16,
   },
 });

--- a/packages/bottom-tabs/src/views/BottomTabItem.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabItem.tsx
@@ -173,7 +173,7 @@ export function BottomTabItem({
   iconStyle,
   style,
 }: Props) {
-  const { colors } = useTheme();
+  const { colors, fonts } = useTheme();
 
   const activeTintColor =
     customActiveTintColor === undefined
@@ -216,8 +216,11 @@ export function BottomTabItem({
     return (
       <Label
         style={[
-          horizontal ? styles.labelBeside : styles.labelBeneath,
+          horizontal
+            ? [styles.labelBeside, { marginStart: icon !== undefined ? 16 : 0 }]
+            : styles.labelBeneath,
           labelStyle,
+          fonts.medium,
         ]}
         allowFontScaling={allowFontScaling}
         tintColor={color}
@@ -290,16 +293,22 @@ const styles = StyleSheet.create({
   tabPortrait: {
     justifyContent: 'flex-end',
     flexDirection: 'column',
+    padding: 12,
   },
   tabLandscape: {
     justifyContent: 'center',
     flexDirection: 'row',
+    paddingVertical: 12,
+    paddingStart: 16,
+    paddingEnd: 24,
   },
   labelBeneath: {
     fontSize: 10,
   },
   labelBeside: {
-    fontSize: 13,
+    marginEnd: 12,
+    marginVertical: 4,
+    lineHeight: 24,
     marginStart: 20,
   },
 });

--- a/packages/bottom-tabs/src/views/BottomTabItem.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabItem.tsx
@@ -90,9 +90,11 @@ type Props = {
    */
   horizontal: boolean;
   /**
-   * Variant of navigation bar styling ('OS' for mobile view or 'Material' for web view).
+   * Variant of navigation bar styling
+   * - `uikit`: iOS UIKit style
+   * - `material`: Material Design style
    */
-  variant: 'OS' | 'Material';
+  variant: 'uikit' | 'material';
   /**
    * Color for the icon and label when the item is active.
    */
@@ -225,10 +227,10 @@ export function BottomTabItem({
             ? [
                 styles.labelBeside,
                 { marginStart: icon !== undefined ? 16 : 0 },
-                variant === 'OS' && styles.labelBesideForOsVariant,
+                variant === 'uikit' && styles.labelBesideUikit,
               ]
             : styles.labelBeneath,
-          variant === 'Material' && fonts.medium,
+          variant === 'material' && fonts.medium,
           labelStyle,
         ]}
         allowFontScaling={allowFontScaling}
@@ -319,7 +321,7 @@ const styles = StyleSheet.create({
     lineHeight: 24,
     marginStart: 20,
   },
-  labelBesideForOsVariant: {
+  labelBesideUikit: {
     fontSize: 13,
   },
 });

--- a/packages/bottom-tabs/src/views/BottomTabItem.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabItem.tsx
@@ -90,6 +90,10 @@ type Props = {
    */
   horizontal: boolean;
   /**
+   * Variant of navigation bar styling ('OS' for mobile view or 'Material' for web view).
+   */
+  variant: 'OS' | 'Material';
+  /**
    * Color for the icon and label when the item is active.
    */
   activeTintColor?: string;
@@ -163,6 +167,7 @@ export function BottomTabItem({
   onPress,
   onLongPress,
   horizontal,
+  variant,
   activeTintColor: customActiveTintColor,
   inactiveTintColor: customInactiveTintColor,
   activeBackgroundColor = 'transparent',
@@ -217,10 +222,14 @@ export function BottomTabItem({
       <Label
         style={[
           horizontal
-            ? [styles.labelBeside, { marginStart: icon !== undefined ? 16 : 0 }]
+            ? [
+                styles.labelBeside,
+                { marginStart: icon !== undefined ? 16 : 0 },
+                variant === 'OS' && styles.labelBesideForOsVariant,
+              ]
             : styles.labelBeneath,
+          variant === 'Material' && fonts.medium,
           labelStyle,
-          fonts.medium,
         ]}
         allowFontScaling={allowFontScaling}
         tintColor={color}
@@ -293,7 +302,6 @@ const styles = StyleSheet.create({
   tabPortrait: {
     justifyContent: 'flex-end',
     flexDirection: 'column',
-    padding: 12,
   },
   tabLandscape: {
     justifyContent: 'center',
@@ -310,5 +318,8 @@ const styles = StyleSheet.create({
     marginVertical: 4,
     lineHeight: 24,
     marginStart: 20,
+  },
+  labelBesideForOsVariant: {
+    fontSize: 13,
   },
 });


### PR DESCRIPTION
Please provide enough information so that others can review your pull request.

**Motivation**

Motivation for this change comes from a task, named the same as the Title

**Test plan**

Describe the **steps to test this change** so that a reviewer can verify it. Provide screenshots or videos if the change affects UI.

Drawer:
<img width="351" alt="image" src="https://github.com/react-navigation/react-navigation/assets/41384305/0259e471-9358-4e9f-982b-0eee1cf5819d">

Bottom Tabs:
<img width="355" alt="image" src="https://github.com/react-navigation/react-navigation/assets/41384305/b6d0beea-6471-44e2-b2ad-f172056a0b48">

<img width="83" alt="image" src="https://github.com/react-navigation/react-navigation/assets/41384305/ecf2e1e9-043c-4da5-ab98-04c6c5940bf3">


The change must pass lint, typescript and tests.
