### PR TITLE
fix(native-stack, v6): set `headerTopInsetEnabled` to the same value as `statusBarTranslucent` to prevent header content jump

### DIFF
--- a/packages/native-stack/src/views/NativeStackView.native.tsx
+++ b/packages/native-stack/src/views/NativeStackView.native.tsx
@@ -236,7 +236,17 @@ const SceneView = ({
   const [customHeaderHeight, setCustomHeaderHeight] =
     React.useState(defaultHeaderHeight);
 
-  const headerTopInsetEnabled = topInset !== 0;
+  // During the very first render topInset is > 0 when running
+  // in non edge-to-edge mode on Android, while on every consecutive render
+  // topInset === 0, causing header content to jump, as we add padding on the first frame,
+  // just to remove it in next one. To prevent this, when statusBarTranslucent is set,
+  // we apply additional padding in header only if its true.
+  // For more details see: https://github.com/react-navigation/react-navigation/pull/12014
+  const headerTopInsetEnabled =
+    typeof statusBarTranslucent === 'boolean'
+      ? statusBarTranslucent
+      : topInset !== 0;
+
   const headerHeight = header ? customHeaderHeight : defaultHeaderHeight;
   const headerBack = previousDescriptor
     ? {


### PR DESCRIPTION
**Motivation**

Backporting #12014 to v6

**Test plan**

Same as in #12014

