### PR TITLE
fix: immediately update navigation state after tapping tabs on material top tabs

### DIFF
--- a/packages/material-top-tabs/src/views/MaterialTopTabView.tsx
+++ b/packages/material-top-tabs/src/views/MaterialTopTabView.tsx
@@ -38,6 +38,22 @@ export function MaterialTopTabView({
   const renderTabBar = (props: SceneRendererProps) => {
     return tabBar({
       ...props,
+      jumpTo: (key: string) => {
+        const route = state.routes.find((route) => route.key === key);
+
+        if (route) {
+          navigation.dispatch({
+            ...CommonActions.navigate({
+              name: route.name,
+              params: route.params,
+              path: route.path,
+            }),
+            target: state.key,
+          });
+        } else {
+          throw new Error(`Could not find the route with the key: ${key}`);
+        }
+      },
       state: state,
       navigation: navigation,
       descriptors: descriptors,


### PR DESCRIPTION
Please provide enough information so that others can review your pull request.

**Motivation**

Explain the **motivation** for making this change. What existing problem does the pull request solve?

If this pull request addresses an existing issue, link to the issue. If an issue is not present, describe the issue here.

The pr is due to https://github.com/orgs/react-navigation/projects/1/views/3?pane=issue&itemId=57472726

**Test plan**

Describe the **steps to test this change** so that a reviewer can verify it. Provide screenshots or videos if the change affects UI.

Go to material top tabs -> click on different pages -> url path should update immediately after clicking

The change must pass lint, typescript and tests.
