### PR TITLE
test: add maestro tests with playwright adapter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
 
-  integration-test:
+  e2e-test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -78,8 +78,8 @@ jobs:
       - name: Build example for web
         run: yarn example expo export --platform web
 
-      - name: Run integration tests
-        run: yarn example test
+      - name: Run e2e tests
+        run: yarn example e2e:web
 
   build:
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ npx playwright install
 Run the e2e tests by:
 
 ```sh
-yarn example test --ui
+yarn example e2e:web --ui
 ```
 
 By default, this will use the local dev server for the app. If you want to test a production build, first build the [example app](/example/) for web:
@@ -66,7 +66,19 @@ yarn example expo export --platform web
 Then run the tests with the `CI` environment variable:
 
 ```sh
-CI=1 yarn example test
+CI=1 yarn example e2e:web
+```
+
+Before running Maestro tests:
+
+- Install it following the instructions [here](https://maestro.mobile.dev/getting-started/installing-maestro).
+- Start the Emulator or Simulator and install the Expo Go app.
+- Start the Metro server with `yarn example start`.
+
+Then run the Maestro tests by:
+
+```sh
+yarn example e2e:native
 ```
 
 ### Commit message convention
@@ -77,7 +89,7 @@ We follow the [conventional commits specification](https://www.conventionalcommi
 - `feat`: new features, e.g. add new method to the module.
 - `refactor`: code refactor, e.g. migrate from class components to hooks.
 - `docs`: changes to documentation, e.g. add usage example for the module.
-- `test`: adding or updating tests, eg add integration tests using detox.
+- `test`: adding or updating tests, eg add e2e tests using maestro.
 - `chore`: tooling changes, e.g. change CI config.
 
 Our pre-commit hooks verify that your commit message matches this format when committing.

--- a/example/e2e/maestro/auth-flow.yml
+++ b/example/e2e/maestro/auth-flow.yml
@@ -1,0 +1,7 @@
+appId: ${APP_ID}
+name: Auth Flow
+---
+- openLink:
+    link: exp://127.0.0.1:8081/--/auth-flow
+- assertVisible:
+    text: 'Sign in'

--- a/example/e2e/maestro/bottom-tabs.yml
+++ b/example/e2e/maestro/bottom-tabs.yml
@@ -1,0 +1,7 @@
+appId: ${APP_ID}
+name: Bottom Tabs
+---
+- openLink:
+    link: exp://127.0.0.1:8081/--/bottom-tabs
+- assertVisible:
+    text: 'Article by Gandalf'

--- a/example/e2e/maestro/drawer-view.yml
+++ b/example/e2e/maestro/drawer-view.yml
@@ -1,0 +1,7 @@
+appId: ${APP_ID}
+name: Drawer View
+---
+- openLink:
+    link: exp://127.0.0.1:8081/--/drawer-view
+- assertVisible:
+    text: 'Drawer Layout'

--- a/example/e2e/maestro/dynamic-tabs.yml
+++ b/example/e2e/maestro/dynamic-tabs.yml
@@ -1,0 +1,7 @@
+appId: ${APP_ID}
+name: Dynamic Tabs
+---
+- openLink:
+    link: exp://127.0.0.1:8081/--/dynamic-tabs
+- assertVisible:
+    text: 'Tab 0'

--- a/example/e2e/maestro/link-component.yml
+++ b/example/e2e/maestro/link-component.yml
@@ -1,0 +1,7 @@
+appId: ${APP_ID}
+name: Link Component
+---
+- openLink:
+    link: exp://127.0.0.1:8081/--/link-component
+- assertVisible:
+    text: 'Article by Gandalf'

--- a/example/e2e/maestro/linking-screen.yml
+++ b/example/e2e/maestro/linking-screen.yml
@@ -1,0 +1,7 @@
+appId: ${APP_ID}
+name: Linking Screen
+---
+- openLink:
+    link: exp://127.0.0.1:8081/--/linking-screen
+- assertVisible:
+    text: 'Sign in'

--- a/example/e2e/maestro/master-detail.yml
+++ b/example/e2e/maestro/master-detail.yml
@@ -1,0 +1,7 @@
+appId: ${APP_ID}
+name: Master Detail
+---
+- openLink:
+    link: exp://127.0.0.1:8081/--/master-detail
+- assertVisible:
+    text: 'Pages'

--- a/example/e2e/maestro/material-top-tabs.yml
+++ b/example/e2e/maestro/material-top-tabs.yml
@@ -1,0 +1,7 @@
+appId: ${APP_ID}
+name: Material Top Tabs
+---
+- openLink:
+    link: exp://127.0.0.1:8081/--/material-top-tabs-screen
+- assertVisible:
+    text: 'Material Top Tabs'

--- a/example/e2e/maestro/mixed-header-mode.yml
+++ b/example/e2e/maestro/mixed-header-mode.yml
@@ -1,0 +1,7 @@
+appId: ${APP_ID}
+name: Mixed Header Mode
+---
+- openLink:
+    link: exp://127.0.0.1:8081/--/mixed-header-mode
+- assertVisible:
+    text: 'Article by Gandalf'

--- a/example/e2e/maestro/mixed-native-stack.yml
+++ b/example/e2e/maestro/mixed-native-stack.yml
@@ -1,0 +1,7 @@
+appId: ${APP_ID}
+name: Mixed Native Stack
+---
+- openLink:
+    link: exp://127.0.0.1:8081/--/mixed-native-stack
+- assertVisible:
+    text: 'Article by Gandalf'

--- a/example/e2e/maestro/mixed-stack.yml
+++ b/example/e2e/maestro/mixed-stack.yml
@@ -1,0 +1,7 @@
+appId: ${APP_ID}
+name: Mixed Stack
+---
+- openLink:
+    link: exp://127.0.0.1:8081/--/mixed-stack
+- assertVisible:
+    text: 'Article by Gandalf'

--- a/example/e2e/maestro/modal-stack.yml
+++ b/example/e2e/maestro/modal-stack.yml
@@ -1,0 +1,27 @@
+appId: ${APP_ID}
+name: Modal Stack
+---
+- openLink:
+    link: exp://127.0.0.1:8081/--/modal-stack
+- assertVisible:
+    text: 'Article by Gandalf'
+- tapOn:
+    text: 'Push albums'
+    retryTapIfNoChange: false
+- assertVisible:
+    text: 'Albums'
+- tapOn:
+    text: 'Push article'
+    retryTapIfNoChange: false
+- assertVisible:
+    text: 'Article by Babel fish'
+- tapOn:
+    text: 'Go back'
+    retryTapIfNoChange: false
+- assertVisible:
+    text: 'Albums'
+- tapOn:
+    text: 'Go back'
+    retryTapIfNoChange: false
+- assertVisible:
+    text: 'Article by Gandalf'

--- a/example/e2e/maestro/native-stack-header-customization.yml
+++ b/example/e2e/maestro/native-stack-header-customization.yml
@@ -1,0 +1,7 @@
+appId: ${APP_ID}
+name: Native Stack Header Customization
+---
+- openLink:
+    link: exp://127.0.0.1:8081/--/native-stack-header-customization
+- assertVisible:
+    text: 'What is Lorem Ipsum?'

--- a/example/e2e/maestro/native-stack-prevent-remove.yml
+++ b/example/e2e/maestro/native-stack-prevent-remove.yml
@@ -1,0 +1,7 @@
+appId: ${APP_ID}
+name: Native Stack Prevent Remove
+---
+- openLink:
+    link: exp://127.0.0.1:8081/--/native-stack-prevent-remove
+- assertVisible:
+    text: 'Input'

--- a/example/e2e/maestro/native-stack.yml
+++ b/example/e2e/maestro/native-stack.yml
@@ -1,0 +1,42 @@
+appId: ${APP_ID}
+name: Native Stack
+---
+- openLink:
+    link: exp://127.0.0.1:8081/--/native-stack
+- assertVisible:
+    text: 'Article by Gandalf'
+- tapOn:
+    text: 'Push feed'
+    retryTapIfNoChange: false
+- assertVisible:
+    text: 'Feed'
+- tapOn:
+    text: 'Push albums'
+    retryTapIfNoChange: false
+- assertVisible:
+    text: 'Albums'
+- tapOn:
+    text: 'Navigate to article'
+    retryTapIfNoChange: false
+- assertVisible:
+    text: 'Article by Babel fish'
+- tapOn:
+    text: 'Replace with feed'
+    retryTapIfNoChange: false
+- assertVisible:
+    text: 'Feed'
+- tapOn:
+    text: 'Go back'
+    retryTapIfNoChange: false
+- assertVisible:
+    text: 'Albums'
+- tapOn:
+    text: 'Pop by 2'
+    retryTapIfNoChange: false
+- assertVisible:
+    text: 'Article by Gandalf'
+- tapOn:
+    text: 'Pop to albums'
+    retryTapIfNoChange: false
+- assertVisible:
+    text: 'Albums'

--- a/example/e2e/maestro/navigator-layout.yml
+++ b/example/e2e/maestro/navigator-layout.yml
@@ -1,0 +1,7 @@
+appId: ${APP_ID}
+name: Navigator Layout
+---
+- openLink:
+    link: exp://127.0.0.1:8081/--/navigator-layout
+- assertVisible:
+    text: 'Article by Gandalf'

--- a/example/e2e/maestro/screen-layout.yml
+++ b/example/e2e/maestro/screen-layout.yml
@@ -1,0 +1,7 @@
+appId: ${APP_ID}
+name: Screen Layout
+---
+- openLink:
+    link: exp://127.0.0.1:8081/--/screen-layout
+- assertVisible:
+    text: 'Suspense & ErrorBoundary'

--- a/example/e2e/maestro/simple-stack.yml
+++ b/example/e2e/maestro/simple-stack.yml
@@ -1,0 +1,37 @@
+appId: ${APP_ID}
+name: Simple Stack
+---
+- openLink:
+    link: exp://127.0.0.1:8081/--/simple-stack
+- assertVisible:
+    text: 'Article by Gandalf'
+- tapOn:
+    text: 'Update params'
+    retryTapIfNoChange: false
+- assertVisible:
+    text: 'Article by Babel fish'
+- tapOn:
+    text: 'Replace with feed'
+    retryTapIfNoChange: false
+- assertVisible:
+    text: 'Feed'
+- tapOn:
+    text: 'Navigate to albums'
+    retryTapIfNoChange: false
+- assertVisible:
+    text: 'Albums'
+- tapOn:
+    text: 'Push article'
+    retryTapIfNoChange: false
+- assertVisible:
+    text: 'Article by Babel fish'
+- tapOn:
+    text: 'Pop to albums'
+    retryTapIfNoChange: false
+- assertVisible:
+    text: 'Albums'
+- tapOn:
+    text: 'Pop by 2'
+    retryTapIfNoChange: false
+- assertVisible:
+    text: 'Feed'

--- a/example/e2e/maestro/stack-header-customization.yml
+++ b/example/e2e/maestro/stack-header-customization.yml
@@ -1,0 +1,7 @@
+appId: ${APP_ID}
+name: Stack Header Customization
+---
+- openLink:
+    link: exp://127.0.0.1:8081/--/stack-header-customization
+- assertVisible:
+    text: 'Article by Gandalf'

--- a/example/e2e/maestro/stack-preload-flow.yml
+++ b/example/e2e/maestro/stack-preload-flow.yml
@@ -1,0 +1,7 @@
+appId: ${APP_ID}
+name: Stack Preload Flow
+---
+- openLink:
+    link: exp://127.0.0.1:8081/--/stack-preload-flow
+- assertVisible:
+    text: 'Home'

--- a/example/e2e/maestro/stack-prevent-remove.yml
+++ b/example/e2e/maestro/stack-prevent-remove.yml
@@ -1,0 +1,7 @@
+appId: ${APP_ID}
+name: Stack Prevent Remove
+---
+- openLink:
+    link: exp://127.0.0.1:8081/--/stack-prevent-remove
+- assertVisible:
+    text: 'Input'

--- a/example/e2e/maestro/stack-transparent.yml
+++ b/example/e2e/maestro/stack-transparent.yml
@@ -1,0 +1,7 @@
+appId: ${APP_ID}
+name: Stack Transparent
+---
+- openLink:
+    link: exp://127.0.0.1:8081/--/stack-transparent
+- assertVisible:
+    text: 'Article'

--- a/example/e2e/maestro/static-screen.yml
+++ b/example/e2e/maestro/static-screen.yml
@@ -1,0 +1,7 @@
+appId: ${APP_ID}
+name: Static Screen
+---
+- openLink:
+    link: exp://127.0.0.1:8081/--/static-screen
+- assertVisible:
+    text: 'Albums'

--- a/example/e2e/maestro/tab-preload-flow.yml
+++ b/example/e2e/maestro/tab-preload-flow.yml
@@ -1,0 +1,7 @@
+appId: ${APP_ID}
+name: Tab Preload Flow
+---
+- openLink:
+    link: exp://127.0.0.1:8081/--/tab-preload-flow
+- assertVisible:
+    text: 'Home'

--- a/example/e2e/maestro/tab-view.yml
+++ b/example/e2e/maestro/tab-view.yml
@@ -1,0 +1,7 @@
+appId: ${APP_ID}
+name: Tab View
+---
+- openLink:
+    link: exp://127.0.0.1:8081/--/tab-view
+- assertVisible:
+    text: 'TabView Examples'

--- a/example/e2e/tests/Link.test.ts
+++ b/example/e2e/tests/Link.test.ts
@@ -26,7 +26,7 @@ test('goes to the album screen and goes back', async ({ page }) => {
   await page.waitForURL('**/link-component/article/gandalf');
 
   const link = page.getByRole('link', {
-    name: 'Go to Albums',
+    name: 'Go to albums',
   });
 
   await expect(link).toHaveAttribute('href', '/link-component/albums');
@@ -58,7 +58,7 @@ test('replaces article with the album screen', async ({ page }) => {
   await page.waitForURL('**/link-component/article/gandalf');
 
   const link = page.getByRole('link', {
-    name: 'Replace with Albums',
+    name: 'Replace with albums',
   });
 
   await expect(link).toHaveAttribute('href', '/link-component/albums');
@@ -102,7 +102,7 @@ test('preserves hash for navigation', async ({ page }) => {
     'Article by Babel fish - React Navigation Example'
   );
 
-  await page.getByRole('link', { name: 'Replace with Albums' }).click();
+  await page.getByRole('link', { name: 'Replace with albums' }).click();
 
   await page.waitForURL('**/link-component/albums');
 });

--- a/example/e2e/tests/maestro.test.ts
+++ b/example/e2e/tests/maestro.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+import { parseAllDocuments } from 'yaml';
+
+test.describe.configure({ mode: 'parallel' });
+
+fs.readdirSync(path.join(__dirname, '../maestro')).forEach((file) => {
+  const content = fs.readFileSync(
+    path.join(__dirname, '../maestro', file),
+    'utf-8'
+  );
+
+  const [metadata, steps] = parseAllDocuments(content).map((doc) =>
+    doc.toJSON()
+  );
+
+  test(metadata.name, async ({ page }) => {
+    for (const step of steps) {
+      switch (Object.keys(step)[0]) {
+        case 'openLink': {
+          await page.goto(
+            step.openLink.link.replace('exp://127.0.0.1:8081/--', '')
+          );
+          break;
+        }
+
+        case 'tapOn': {
+          await page
+            .getByText(step.tapOn.text)
+            .locator('visible=true')
+            .first()
+            .click();
+          break;
+        }
+
+        case 'assertVisible': {
+          await expect(
+            page
+              .getByText(step.assertVisible.text)
+              .locator('visible=true')
+              .first()
+          ).toBeVisible();
+          break;
+        }
+      }
+    }
+  });
+});

--- a/example/package.json
+++ b/example/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "start": "expo start",
     "server": "nodemon -e '.js,.ts,.tsx' --exec \"babel-node -i '/node_modules[/\\](?react-native)/' -x '.web.tsx,.web.ts,.web.js,.tsx,.ts,.js' --config-file ./server/babel.config.js server\"",
-    "test": "npx playwright test --config=e2e/playwright.config.ts"
+    "e2e:web": "npx playwright test --config=e2e/playwright.config.ts",
+    "e2e:native": "maestro test -e APP_ID=host.exp.exponent e2e/maestro"
   },
   "dependencies": {
     "@expo/metro-runtime": "~3.2.1",
@@ -56,6 +57,7 @@
     "react-native-builder-bob": "^0.28.1",
     "react-test-renderer": "18.2.0",
     "serve": "^14.2.1",
-    "typescript": "^5.5.2"
+    "typescript": "^5.5.2",
+    "yaml": "^2.5.0"
   }
 }

--- a/example/src/Screens/CustomLayout.tsx
+++ b/example/src/Screens/CustomLayout.tsx
@@ -78,7 +78,7 @@ const NewsFeedScreen = ({
     <ScrollView>
       <View style={styles.buttons}>
         <Button variant="filled" onPress={() => navigation.navigate('Albums')}>
-          Navigate to album
+          Navigate to albums
         </Button>
         <Button variant="tinted" onPress={() => navigation.goBack()}>
           Go back

--- a/example/src/Screens/LinkComponent.tsx
+++ b/example/src/Screens/LinkComponent.tsx
@@ -35,14 +35,14 @@ const ArticleScreen = ({
     <ScrollView>
       <View style={styles.buttons}>
         <Link screen="LinkComponent" params={{ screen: 'Albums' }}>
-          Go to Albums
+          Go to albums
         </Link>
         <Link
           screen="LinkComponent"
           params={{ screen: 'Albums' }}
           action={StackActions.replace('Albums')}
         >
-          Replace with Albums
+          Replace with albums
         </Link>
 
         <Button screen="Home" variant="filled">

--- a/example/src/Screens/LinkingScreen.tsx
+++ b/example/src/Screens/LinkingScreen.tsx
@@ -112,6 +112,7 @@ export function LinkingScreen() {
             component={SignInScreen}
             options={{
               animationTypeForReplace: !isSignedIn ? 'pop' : 'push',
+              title: 'Sign In',
             }}
           />
         )}

--- a/example/src/Screens/MixedHeaderMode.tsx
+++ b/example/src/Screens/MixedHeaderMode.tsx
@@ -59,7 +59,7 @@ const NewsFeedScreen = ({
     <ScrollView>
       <View style={styles.buttons}>
         <Button variant="filled" onPress={() => navigation.push('Albums')}>
-          Navigate to album
+          Navigate to albums
         </Button>
         <Button variant="tinted" onPress={() => navigation.pop()}>
           Pop screen

--- a/example/src/Screens/MixedNativeStack.tsx
+++ b/example/src/Screens/MixedNativeStack.tsx
@@ -39,7 +39,7 @@ const ArticleScreen = ({
           Go back
         </Button>
         <Button variant="filled" onPress={() => navigation.push('Albums')}>
-          Push album
+          Push albums
         </Button>
       </View>
       <Article
@@ -57,7 +57,7 @@ const AlbumsScreen = ({
     <ScrollView>
       <View style={styles.buttons}>
         <Button variant="filled" onPress={() => navigation.push('Albums')}>
-          Push album
+          Push albums
         </Button>
         <Button variant="tinted" onPress={() => navigation.goBack()}>
           Go back

--- a/example/src/Screens/MixedStack.tsx
+++ b/example/src/Screens/MixedStack.tsx
@@ -39,7 +39,7 @@ const ArticleScreen = ({
           Go back
         </Button>
         <Button variant="filled" onPress={() => navigation.push('Albums')}>
-          Push album
+          Push albums
         </Button>
       </View>
       <Article
@@ -55,7 +55,7 @@ const AlbumsScreen = ({ navigation }: StackScreenProps<MixedStackParams>) => {
     <ScrollView>
       <View style={styles.buttons}>
         <Button variant="filled" onPress={() => navigation.push('Albums')}>
-          Push album
+          Push albums
         </Button>
         <Button variant="tinted" onPress={() => navigation.goBack()}>
           Go back

--- a/example/src/Screens/ModalStack.tsx
+++ b/example/src/Screens/ModalStack.tsx
@@ -30,7 +30,7 @@ const ArticleScreen = ({
     <ScrollView>
       <View style={styles.buttons}>
         <Button variant="filled" onPress={() => navigation.push('Albums')}>
-          Push album
+          Push albums
         </Button>
         <Button variant="tinted" onPress={() => navigation.goBack()}>
           Go back

--- a/example/src/Screens/NativeStack.tsx
+++ b/example/src/Screens/NativeStack.tsx
@@ -48,7 +48,7 @@ const ArticleScreen = ({
             Replace with feed
           </Button>
           <Button variant="filled" onPress={() => navigation.popTo('Albums')}>
-            Pop to Albums
+            Pop to albums
           </Button>
           <Button variant="tinted" onPress={() => navigation.pop()}>
             Pop screen
@@ -81,7 +81,7 @@ const NewsFeedScreen = ({
       <ScrollView contentInsetAdjustmentBehavior="automatic">
         <View style={styles.buttons}>
           <Button variant="filled" onPress={() => navigation.push('Albums')}>
-            Push Albums
+            Push albums
           </Button>
           <Button variant="tinted" onPress={() => navigation.goBack()}>
             Go back

--- a/example/src/Screens/NativeStackHeaderCustomization.tsx
+++ b/example/src/Screens/NativeStackHeaderCustomization.tsx
@@ -70,7 +70,7 @@ const NewsFeedScreen = ({
     <ScrollView>
       <View style={styles.buttons}>
         <Button variant="filled" onPress={() => navigation.push('Albums')}>
-          Push Albums
+          Push albums
         </Button>
         <Button variant="tinted" onPress={() => navigation.goBack()}>
           Go back

--- a/example/src/Screens/SimpleStack.tsx
+++ b/example/src/Screens/SimpleStack.tsx
@@ -40,7 +40,7 @@ const ArticleScreen = ({
           Replace with feed
         </Button>
         <Button variant="filled" onPress={() => navigation.popTo('Albums')}>
-          Pop to Albums
+          Pop to albums
         </Button>
         <Button
           variant="tinted"
@@ -73,7 +73,7 @@ const NewsFeedScreen = ({
     <ScrollView>
       <View style={styles.buttons}>
         <Button variant="filled" onPress={() => navigation.navigate('Albums')}>
-          Navigate to album
+          Navigate to albums
         </Button>
         <Button variant="tinted" onPress={() => navigation.goBack()}>
           Go back

--- a/example/src/Screens/StackHeaderCustomization.tsx
+++ b/example/src/Screens/StackHeaderCustomization.tsx
@@ -47,7 +47,7 @@ const ArticleScreen = ({
     <ScrollView>
       <View style={styles.buttons}>
         <Button variant="filled" onPress={() => navigation.push('Albums')}>
-          Push album
+          Push albums
         </Button>
         <Button variant="tinted" onPress={() => navigation.goBack()}>
           Go back

--- a/example/src/index.tsx
+++ b/example/src/index.tsx
@@ -136,7 +136,7 @@ export function App() {
       try {
         const initialUrl = await Linking.getInitialURL();
 
-        if (Platform.OS !== 'web' || initialUrl === null) {
+        if (Platform.OS !== 'web' && initialUrl === null) {
           const savedState = await AsyncStorage.getItem(
             NAVIGATION_PERSISTENCE_KEY
           );

--- a/packages/native-stack/src/views/NativeStackView.native.tsx
+++ b/packages/native-stack/src/views/NativeStackView.native.tsx
@@ -386,6 +386,11 @@ const SceneView = ({
         {
           useNativeDriver: true,
           listener: (e) => {
+            // FIXME: On Android, we get 0 if the header is transparent
+            if (options.headerTransparent && Platform.OS === 'android') {
+              return;
+            }
+
             if (
               Platform.OS === 'android' &&
               (options.headerBackground != null || options.headerTransparent)

--- a/yarn.lock
+++ b/yarn.lock
@@ -4038,6 +4038,7 @@ __metadata:
     react-test-renderer: "npm:18.2.0"
     serve: "npm:^14.2.1"
     typescript: "npm:^5.5.2"
+    yaml: "npm:^2.5.0"
   languageName: unknown
   linkType: soft
 
@@ -17270,6 +17271,15 @@ __metadata:
   bin:
     yaml: bin.mjs
   checksum: b09bf5a615a65276d433d76b8e34ad6b4c0320b85eb3f1a39da132c61ae6e2ff34eff4624e6458d96d49566c93cf43408ba5e568218293a8c6541a2006883f64
+  languageName: node
+  linkType: hard
+
+"yaml@npm:^2.5.0":
+  version: 2.5.0
+  resolution: "yaml@npm:2.5.0"
+  bin:
+    yaml: bin.mjs
+  checksum: 72e903fdbe3742058885205db4a6c9ff38e5f497f4e05e631264f7756083c05e7d10dfb5e4ce9d7a95de95338f9b20d19dd0b91c60c65f7d7608b6b3929820ad
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This adds some basic Maestro tests. Note that most tests are not testing much, but once we have basic setup, we can update them as we go.

Currently need to be run locally as I haven't been successful with CI setup for Android yet.

This also adds custom logic that runs the Maestro tests to run with Playwright for Web, so we can reuse the same tests. We'll need to update the logic as we add more tests.