### PR TITLE
Allow undefined in path config validation

### DIFF
--- a/packages/core/src/validatePathConfig.tsx
+++ b/packages/core/src/validatePathConfig.tsx
@@ -33,7 +33,7 @@ export function validatePathConfig(config: unknown, root = true) {
           // @ts-expect-error: we know the key exists
           const value = config[key];
 
-          if (typeof value !== type) {
+          if (value !== undefined && typeof value !== type) {
             return [key, `expected '${type}', got '${typeof value}'`];
           }
         } else {


### PR DESCRIPTION
Please provide enough information so that others can review your pull request.

**Motivation**

When validating the linking config, undefined values cause a validation error. I think undefined values should be treated as if the config value was omitted.

For example:

```ts
{
  a: {
    path: '/',
    parse: undefined,
  }, 
}
```

Causes the following error:

```
Error: Found invalid properties in the configuration:
- parse (expected 'object', got 'undefined')

You can only specify the following properties:
- path (string)
- initialRouteName (string)
- screens (object)
- exact (boolean)
- stringify (object)
- parse (object)

If you want to specify configuration for screens, you need to specify them under a 'screens' property.

See https://reactnavigation.org/docs/configuring-links for more details on how to specify a linking configuration.
```

**Test plan**

Tested in an app to make sure the following error is no longer thrown and the linking works fine.