### PR TITLE
feat: add headerBackButtonDisplayMode for stack

### DIFF
--- a/example/src/Screens/StackHeaderCustomization.tsx
+++ b/example/src/Screens/StackHeaderCustomization.tsx
@@ -117,7 +117,7 @@ export function StackHeaderCustomization() {
           header: (props) => <CustomHeader {...props} />,
           headerTintColor: '#fff',
           headerStyle: { backgroundColor: '#ff005d' },
-          headerBackTitleVisible: false,
+          headerBackButtonDisplayMode: 'minimal',
           headerTitleAlign: headerTitleCentered ? 'center' : 'left',
           headerBackImage: ({ tintColor }) => (
             <MaterialCommunityIcons

--- a/packages/elements/src/Header/Header.tsx
+++ b/packages/elements/src/Header/Header.tsx
@@ -65,13 +65,8 @@ export function Header(props: Props) {
     modal = false,
     title,
     headerTitle: customTitle,
-    // eslint-disable-next-line @eslint-react/no-unstable-default-props
-    headerTitleAlign = Platform.select({
-      ios: 'center',
-      default: 'left',
-    }),
+    headerTitleAlign = Platform.OS === 'ios' ? 'center' : 'left',
     headerLeft,
-    headerLeftLabelVisible,
     headerTransparent,
     headerTintColor,
     headerBackground,
@@ -81,6 +76,7 @@ export function Header(props: Props) {
     headerLeftContainerStyle: leftContainerStyle,
     headerRightContainerStyle: rightContainerStyle,
     headerTitleContainerStyle: titleContainerStyle,
+    headerBackButtonDisplayMode = Platform.OS === 'ios' ? 'default' : 'minimal',
     headerBackgroundContainerStyle: backgroundContainerStyle,
     headerStyle: customHeaderStyle,
     headerShadowVisible,
@@ -211,7 +207,7 @@ export function Header(props: Props) {
         tintColor: iconTintColor,
         pressColor: headerPressColor,
         pressOpacity: headerPressOpacity,
-        labelVisible: headerLeftLabelVisible,
+        displayMode: headerBackButtonDisplayMode,
       })
     : null;
 
@@ -276,7 +272,7 @@ export function Header(props: Props) {
                 headerTitleAlign === 'center'
                   ? layout.width -
                     ((leftButton
-                      ? headerLeftLabelVisible !== false
+                      ? headerBackButtonDisplayMode !== 'minimal'
                         ? 80
                         : 32
                       : 16) +

--- a/packages/elements/src/types.tsx
+++ b/packages/elements/src/types.tsx
@@ -6,6 +6,8 @@ import type {
   ViewStyle,
 } from 'react-native';
 
+export type HeaderBackButtonDisplayMode = 'default' | 'generic' | 'minimal';
+
 export type Layout = { width: number; height: number };
 
 export type HeaderOptions = {
@@ -41,13 +43,20 @@ export type HeaderOptions = {
     tintColor?: string;
     pressColor?: string;
     pressOpacity?: number;
-    labelVisible?: boolean;
+    displayMode?: HeaderBackButtonDisplayMode;
     href?: undefined;
   }) => React.ReactNode;
   /**
-   * Whether a label is visible in the left button. Used to add extra padding.
+   * How the back button displays icon and title.
+   *
+   * Supported values:
+   * - "default" - Displays one of the following depending on the available space: previous screen's title, truncated title (e.g. 'Back') or no title (only icon).
+   * - "generic" – Displays one of the following depending on the available space: truncated title (e.g. 'Back') or no title (only icon).
+   * - "minimal" – Always displays only the icon without a title.
+   *
+   * Defaults to "default" on iOS, and "minimal" on Android.
    */
-  headerLeftLabelVisible?: boolean;
+  headerBackButtonDisplayMode?: HeaderBackButtonDisplayMode;
   /**
    * Style object for the container of the `headerLeft` element`.
    */
@@ -209,7 +218,7 @@ export type HeaderBackButtonProps = Omit<HeaderButtonProps, 'children'> & {
    * Whether the label text is visible.
    * Defaults to `true` on iOS and `false` on Android.
    */
-  labelVisible?: boolean;
+  displayMode?: HeaderBackButtonDisplayMode;
   /**
    * Style object for the label.
    */

--- a/packages/stack/src/types.tsx
+++ b/packages/stack/src/types.tsx
@@ -1,5 +1,6 @@
 import type {
   HeaderBackButton,
+  HeaderBackButtonDisplayMode,
   HeaderBackButtonProps,
   HeaderOptions,
   HeaderTitleProps,
@@ -180,23 +181,31 @@ export type StackHeaderOptions = Omit<
   /**
    * Title string used by the back button on iOS.
    * Defaults to the previous screen's title, or "Back" if there's not enough space.
-   * Use `headerBackTitleVisible: false` to hide it.
+   * Use `headerBackButtonDisplayMode` to customize the behavior.
    */
   headerBackTitle?: string;
   /**
-   * Whether the back button title should be visible or not.
+   * Title string used by the back button when `headerBackTitle` doesn't fit on the screen.
+   * Use `headerBackButtonDisplayMode` to customize the behavior.
    *
-   * Defaults to `true` on iOS, `false on Android.
+   * Defaults to "Back".
    */
-  headerBackTitleVisible?: boolean;
+  headerBackTruncatedTitle?: string;
+  /**
+   * How the back button displays icon and title.
+   *
+   * Supported values:
+   * - "default" - Displays one of the following depending on the available space: previous screen's title, truncated title (e.g. 'Back') or no title (only icon).
+   * - "generic" – Displays one of the following depending on the available space: truncated title (e.g. 'Back') or no title (only icon).
+   * - "minimal" – Always displays only the icon without a title.
+   *
+   * Defaults to "default" on iOS, and "minimal" on Android.
+   */
+  headerBackButtonDisplayMode?: HeaderBackButtonDisplayMode;
   /**
    * Style object for the back title.
    */
   headerBackTitleStyle?: StyleProp<TextStyle>;
-  /**
-   * Title string used by the back button when `headerBackTitle` doesn't fit on the screen. `"Back"` by default.
-   */
-  headerTruncatedBackTitle?: string;
   /**
    * Function which returns a React Element to display custom image in header's back button.
    * It receives the `tintColor` in in the options object as an argument. object.

--- a/packages/stack/src/views/Header/HeaderSegment.tsx
+++ b/packages/stack/src/views/Header/HeaderSegment.tsx
@@ -114,8 +114,8 @@ export function HeaderSegment(props: Props) {
     headerRight: right,
     headerBackImage,
     headerBackTitle,
-    headerBackTitleVisible = Platform.OS === 'ios',
-    headerTruncatedBackTitle,
+    headerBackButtonDisplayMode = Platform.OS === 'ios' ? 'default' : 'minimal',
+    headerBackTruncatedTitle,
     headerBackAccessibilityLabel,
     headerBackTestID,
     headerBackAllowFontScaling,
@@ -167,7 +167,7 @@ export function HeaderSegment(props: Props) {
           allowFontScaling: headerBackAllowFontScaling,
           onPress: onGoBack,
           label: headerBackTitle,
-          truncatedLabel: headerTruncatedBackTitle,
+          truncatedLabel: headerBackTruncatedTitle,
           labelStyle: [leftLabelStyle, headerBackTitleStyle],
           onLabelLayout: handleLeftLabelLayout,
           screenLayout: layout,
@@ -195,11 +195,11 @@ export function HeaderSegment(props: Props) {
       layout={layout}
       headerTitle={headerTitle}
       headerLeft={headerLeft}
-      headerLeftLabelVisible={headerBackTitleVisible}
       headerRight={headerRight}
       headerTitleContainerStyle={[titleStyle, headerTitleContainerStyle]}
       headerLeftContainerStyle={[leftButtonStyle, headerLeftContainerStyle]}
       headerRightContainerStyle={[rightButtonStyle, headerRightContainerStyle]}
+      headerBackButtonDisplayMode={headerBackButtonDisplayMode}
       headerBackgroundContainerStyle={[
         backgroundStyle,
         headerBackgroundContainerStyle,


### PR DESCRIPTION
BREAKING CHANGE: This removes the `headerBackTitleVisible` option, and changes `headerTruncatedBackTitle` to `headerBackTruncatedTitle`.

Similarly, `headerLeft` now receives `displayMode` instead of `labelVisible`, and `HeaderBackButton` accepts `displayMode` instead of `labelVisible`