### PR TITLE
fix: improve how navigate and other methods are typed

### DIFF
--- a/example/__typechecks__/common.check.tsx
+++ b/example/__typechecks__/common.check.tsx
@@ -460,6 +460,7 @@ type ThirdParamList = {
   HasParams1: { id: string };
   HasParams2: { user: string };
   NoParams: undefined;
+  NoParams2: undefined;
 };
 
 export const ThirdScreen = ({
@@ -494,6 +495,10 @@ export const ThirdScreen = ({
 
   // @ts-expect-error
   if (ScreenName === 'NoParams') navigation.navigate(ScreenName, { id: '123' });
+
+  const ScreenName2: 'NoParams' | 'NoParams2' = null as any;
+
+  navigation.navigate(ScreenName2);
 };
 
 /**

--- a/packages/core/src/types.tsx
+++ b/packages/core/src/types.tsx
@@ -22,6 +22,21 @@ declare global {
 
 type Keyof<T extends {}> = Extract<keyof T, string>;
 
+type ScreenParamsPair<
+  ParamList extends ParamListBase,
+  RouteName extends keyof ParamList,
+> = {
+  // First we use a mapped type to get an union of screen & params pairs
+  // Then we pick the pair which matches the RouteName
+  // Mapped type is used instead of just ParamList[RouteName]
+  // Otherwise it'll result in union of all params leading to incorrect types
+  [Screen in keyof ParamList]: undefined extends ParamList[Screen] // Params are either undefined or a union with undefined
+    ?
+        | [screen: Screen] // if the params are optional, we don't have to provide it
+        | [screen: Screen, params: ParamList[Screen]]
+    : [screen: Screen, params: ParamList[Screen]];
+}[RouteName];
+
 export type DefaultNavigatorOptions<
   ParamList extends ParamListBase,
   NavigatorID extends string | undefined,
@@ -239,18 +254,7 @@ type NavigationHelpersCommon<
    * @param [params] Params object for the route.
    */
   navigate<RouteName extends keyof ParamList>(
-    ...args: // This condition allows us to iterate over a union type
-    // This is to avoid getting a union of all the params from `ParamList[RouteName]`,
-    // which will get our types all mixed up if a union RouteName is passed in.
-    RouteName extends unknown
-      ? // This condition checks if the params are optional,
-        // which means it's either undefined or a union with undefined
-        undefined extends ParamList[RouteName]
-        ?
-            | [screen: RouteName] // if the params are optional, we don't have to provide it
-            | [screen: RouteName, params: ParamList[RouteName]]
-        : [screen: RouteName, params: ParamList[RouteName]]
-      : never
+    ...args: ScreenParamsPair<ParamList, RouteName>
   ): void;
 
   /**
@@ -259,14 +263,14 @@ type NavigationHelpersCommon<
    * @param route Object with `name` for the route to navigate to, and a `params` object.
    */
   navigate<RouteName extends keyof ParamList>(
-    options: RouteName extends unknown
-      ? {
-          name: RouteName;
-          params: ParamList[RouteName];
-          path?: string;
-          merge?: boolean;
-        }
-      : never
+    options: {
+      [Screen in keyof ParamList]: {
+        name: Screen;
+        params: ParamList[Screen];
+        path?: string;
+        merge?: boolean;
+      };
+    }[RouteName]
   ): void;
 
   /**
@@ -278,18 +282,7 @@ type NavigationHelpersCommon<
    * @param [params] Params object for the route.
    */
   navigateDeprecated<RouteName extends keyof ParamList>(
-    ...args: // This condition allows us to iterate over a union type
-    // This is to avoid getting a union of all the params from `ParamList[RouteName]`,
-    // which will get our types all mixed up if a union RouteName is passed in.
-    RouteName extends unknown
-      ? // This condition checks if the params are optional,
-        // which means it's either undefined or a union with undefined
-        undefined extends ParamList[RouteName]
-        ?
-            | [screen: RouteName] // if the params are optional, we don't have to provide it
-            | [screen: RouteName, params: ParamList[RouteName]]
-        : [screen: RouteName, params: ParamList[RouteName]]
-      : never
+    ...args: ScreenParamsPair<ParamList, RouteName>
   ): void;
 
   /**
@@ -300,13 +293,13 @@ type NavigationHelpersCommon<
    * @param route Object with `name` for the route to navigate to, and a `params` object.
    */
   navigateDeprecated<RouteName extends keyof ParamList>(
-    options: RouteName extends unknown
-      ? {
-          name: RouteName;
-          params: ParamList[RouteName];
-          merge?: boolean;
-        }
-      : never
+    options: {
+      [Screen in keyof ParamList]: {
+        name: Screen;
+        params: ParamList[Screen];
+        merge?: boolean;
+      };
+    }[RouteName]
   ): void;
 
   /**
@@ -316,13 +309,7 @@ type NavigationHelpersCommon<
    * @param [params] Params object for the route.
    */
   preload<RouteName extends keyof ParamList>(
-    ...args: RouteName extends unknown
-      ? undefined extends ParamList[RouteName]
-        ?
-            | [screen: RouteName]
-            | [screen: RouteName, params: ParamList[RouteName]]
-        : [screen: RouteName, params: ParamList[RouteName]]
-      : never
+    ...args: ScreenParamsPair<ParamList, RouteName>
   ): void;
 
   /**

--- a/packages/core/src/useNavigationBuilder.tsx
+++ b/packages/core/src/useNavigationBuilder.tsx
@@ -249,7 +249,7 @@ const getRouteConfigsFromChildren = <
 export function useNavigationBuilder<
   State extends NavigationState,
   RouterOptions extends DefaultRouterOptions,
-  ActionHelpers extends Record<string, () => void>,
+  ActionHelpers extends Record<string, (...args: any) => void>,
   ScreenOptions extends {},
   EventMap extends Record<string, any>,
 >(

--- a/packages/native/src/useLinkProps.tsx
+++ b/packages/native/src/useLinkProps.tsx
@@ -19,11 +19,11 @@ export type LinkProps<
   | ({
       href?: string;
       action?: NavigationAction;
-    } & (RouteName extends unknown // Similar conditional to navigation.navigate
-      ? undefined extends ParamList[RouteName]
-        ? { screen: RouteName; params?: ParamList[RouteName] }
-        : { screen: RouteName; params: ParamList[RouteName] }
-      : never))
+    } & {
+      [Screen in keyof ParamList]: undefined extends ParamList[Screen]
+        ? { screen: Screen; params?: ParamList[Screen] }
+        : { screen: Screen; params: ParamList[Screen] };
+    }[RouteName])
   | {
       href?: string;
       action: NavigationAction;

--- a/packages/routers/src/StackRouter.tsx
+++ b/packages/routers/src/StackRouter.tsx
@@ -68,13 +68,11 @@ export type StackActionHelpers<ParamList extends ParamListBase> = {
    * @param [params] Params object for the new route.
    */
   replace<RouteName extends keyof ParamList>(
-    ...args: RouteName extends unknown
-      ? undefined extends ParamList[RouteName]
-        ?
-            | [screen: RouteName]
-            | [screen: RouteName, params: ParamList[RouteName]]
-        : [screen: RouteName, params: ParamList[RouteName]]
-      : never
+    ...args: {
+      [Screen in keyof ParamList]: undefined extends ParamList[Screen]
+        ? [screen: Screen] | [screen: Screen, params: ParamList[Screen]]
+        : [screen: Screen, params: ParamList[Screen]];
+    }[RouteName]
   ): void;
 
   /**
@@ -84,13 +82,11 @@ export type StackActionHelpers<ParamList extends ParamListBase> = {
    * @param [params] Params object for the route.
    */
   push<RouteName extends keyof ParamList>(
-    ...args: RouteName extends unknown
-      ? undefined extends ParamList[RouteName]
-        ?
-            | [screen: RouteName]
-            | [screen: RouteName, params: ParamList[RouteName]]
-        : [screen: RouteName, params: ParamList[RouteName]]
-      : never
+    ...args: {
+      [Screen in keyof ParamList]: undefined extends ParamList[Screen]
+        ? [screen: Screen] | [screen: Screen, params: ParamList[Screen]]
+        : [screen: Screen, params: ParamList[Screen]];
+    }[RouteName]
   ): void;
 
   /**
@@ -112,19 +108,16 @@ export type StackActionHelpers<ParamList extends ParamListBase> = {
    * @param [merge] Whether to merge the params onto the route.
    */
   popTo<RouteName extends keyof ParamList>(
-    ...args: // This condition allows us to iterate over a union type, similar to navigate
-    RouteName extends unknown
-      ? // This condition checks if the params are optional,
-        // which means it's either undefined or a union with undefined
-        undefined extends ParamList[RouteName]
+    ...args: {
+      [Screen in keyof ParamList]: undefined extends ParamList[Screen]
         ?
-            | [screen: RouteName]
-            | [screen: RouteName, params: ParamList[RouteName]]
-            | [screen: RouteName, params: ParamList[RouteName], merge: boolean]
+            | [screen: Screen]
+            | [screen: Screen, params: ParamList[Screen]]
+            | [screen: RouteName, params: ParamList[Screen], merge: boolean]
         :
-            | [screen: RouteName, params: ParamList[RouteName]]
-            | [screen: RouteName, params: ParamList[RouteName], merge: boolean]
-      : never
+            | [screen: Screen, params: ParamList[Screen]]
+            | [screen: RouteName, params: ParamList[Screen], merge: boolean];
+    }[RouteName]
   ): void;
 };
 

--- a/packages/routers/src/TabRouter.tsx
+++ b/packages/routers/src/TabRouter.tsx
@@ -55,13 +55,11 @@ export type TabActionHelpers<ParamList extends ParamListBase> = {
    * @param [params] Params object for the route.
    */
   jumpTo<RouteName extends Extract<keyof ParamList, string>>(
-    ...args: RouteName extends unknown
-      ? undefined extends ParamList[RouteName]
-        ?
-            | [screen: RouteName]
-            | [screen: RouteName, params: ParamList[RouteName]]
-        : [screen: RouteName, params: ParamList[RouteName]]
-      : never
+    ...args: {
+      [Screen in keyof ParamList]: undefined extends ParamList[Screen]
+        ? [screen: Screen] | [screen: Screen, params: ParamList[Screen]]
+        : [screen: Screen, params: ParamList[Screen]];
+    }[RouteName]
   ): void;
 };
 


### PR DESCRIPTION
The current conditional (`RouteName extends unknown`) is confusing to understand. This updates the logic to make it clearer.