### PR TITLE
fix: add more fallbacks for headerBackButtonDisplayMode

### DIFF
--- a/packages/native-stack/src/types.tsx
+++ b/packages/native-stack/src/types.tsx
@@ -339,8 +339,16 @@ export type NativeStackNavigationOptions = {
    *
    * Supported values:
    * - "default" - Displays one of the following depending on the available space: previous screen's title, generic title (e.g. 'Back') or no title (only icon).
-   * - "generic" – Displays one of the following depending on the available space: generic title (e.g. 'Back') or no title (only icon). iOS >= 14 only, falls back to "default" on older iOS versions.
+   * - "generic" – Displays one of the following depending on the available space: generic title (e.g. 'Back') or no title (only icon).
    * - "minimal" – Always displays only the icon without a title.
+   *
+   * The "generic" mode is not supported when:
+   * - The iOS version is lower than 14
+   * - Custom back title is set
+   * - Custom back title style is set
+   * - Back button menu is disabled
+   *
+   * In such cases, the "default" mode will be used instead.
    *
    * @platform ios
    */

--- a/packages/native-stack/src/views/HeaderConfig.tsx
+++ b/packages/native-stack/src/views/HeaderConfig.tsx
@@ -176,8 +176,17 @@ export function HeaderConfig({
       Platform.OS === 'ios' &&
       headerTransparent !== false);
 
-  const isBackButtonDisplayModeAvailableForCurrentPlatform =
-    Platform.OS === 'ios' && parseInt(Platform.Version, 10) >= 14;
+  const isBackButtonDisplayModeAvailable =
+    // On iOS 14+
+    Platform.OS === 'ios' &&
+    parseInt(Platform.Version, 10) >= 14 &&
+    // Doesn't have custom back title
+    headerBackTitle == null &&
+    // Doesn't have custom styling
+    backTitleFontFamily == null &&
+    backTitleFontSize == null &&
+    // Back button menu is not disabled
+    headerBackButtonMenuEnabled === false;
 
   return (
     <ScreenStackHeaderConfig
@@ -185,12 +194,12 @@ export function HeaderConfig({
       backgroundColor={headerBackgroundColor}
       backTitle={headerBackTitle}
       backTitleVisible={
-        isBackButtonDisplayModeAvailableForCurrentPlatform
+        isBackButtonDisplayModeAvailable
           ? undefined
           : headerBackButtonDisplayMode !== 'minimal'
       }
       backButtonDisplayMode={
-        isBackButtonDisplayModeAvailableForCurrentPlatform
+        isBackButtonDisplayModeAvailable
           ? headerBackButtonDisplayMode
           : undefined
       }

--- a/packages/native-stack/src/views/HeaderConfig.tsx
+++ b/packages/native-stack/src/views/HeaderConfig.tsx
@@ -186,7 +186,7 @@ export function HeaderConfig({
     backTitleFontFamily == null &&
     backTitleFontSize == null &&
     // Back button menu is not disabled
-    headerBackButtonMenuEnabled === false;
+    headerBackButtonMenuEnabled !== false;
 
   return (
     <ScreenStackHeaderConfig


### PR DESCRIPTION
We can't use `backButtonDisplayMode` prop from `react-native-screens` in the following scenarios:

- The iOS version is lower than 14
- Custom back title is set
- Custom back title style is set (`fontFamily` or `fontSize`)
- Back button menu is disabled

This change falls back to `backTitleVisible` in those scenarios.