### PR TITLE
fix: switching navigators nested navigators same route

### DIFF
--- a/packages/stack/src/__tests__/useNavigationBuilder.test.tsx
+++ b/packages/stack/src/__tests__/useNavigationBuilder.test.tsx
@@ -1,0 +1,77 @@
+import {
+  BaseNavigationContainer,
+  NavigationContainerRef,
+} from '@react-navigation/core';
+import { act, render } from '@testing-library/react-native';
+import React, { useImperativeHandle } from 'react';
+
+import createStackNavigator from '../navigators/createStackNavigator';
+
+it('should cleanup state of child routes with same name when switching navigators', () => {
+  const StackA = createStackNavigator();
+  const StackB = createStackNavigator();
+
+  const StackC = createStackNavigator();
+
+  const MockScreen = () => null;
+
+  const appRef = React.createRef<{ toggle: () => void }>();
+  function MyAppNavigator() {
+    const [isAuthenticated, setIsAuthenticated] = React.useState(true);
+    console.log('isAuthenticated', isAuthenticated);
+
+    useImperativeHandle(appRef, () => ({
+      toggle: () => setIsAuthenticated((prev) => !prev),
+    }));
+
+    if (isAuthenticated) {
+      return (
+        <StackA.Navigator id="StackA">
+          <StackA.Screen name="foo">
+            {() => (
+              <StackB.Navigator id="StackB">
+                <StackB.Screen name="bar" component={MockScreen} />
+                <StackB.Screen name="shared" component={MockScreen} />
+              </StackB.Navigator>
+            )}
+          </StackA.Screen>
+          <StackA.Screen name="differentScreenA" component={MockScreen} />
+        </StackA.Navigator>
+      );
+    }
+
+    return (
+      <StackC.Navigator id="StackC">
+        {/* The screen appears to be identical to the first, however… */}
+        <StackC.Screen name="foo" component={MockScreen} />
+        <StackC.Screen name="differentScreenB" component={MockScreen} />
+      </StackC.Navigator>
+    );
+  }
+
+  const navigationRef = React.createRef<NavigationContainerRef<any>>();
+  render(
+    <BaseNavigationContainer ref={navigationRef}>
+      <MyAppNavigator />
+    </BaseNavigationContainer>
+  );
+
+  act(() => {
+    navigationRef.current?.navigate('foo', {
+      screen: 'bar',
+    });
+  });
+
+  act(() => {
+    appRef.current?.toggle();
+  });
+
+  const state = navigationRef.current?.getState();
+  console.log(state);
+
+  expect(state?.routes).toHaveLength(1);
+  expect(state?.routes[0].name).toEqual('foo');
+  // The "foo" screen inside the new navigator is just a screen,
+  // and has no nested statem, so we expect it to be removed:
+  expect(state?.routes[0].state?.routes).toBeUndefined();
+});


### PR DESCRIPTION
Please provide enough information so that others can review your pull request.

**Motivation**

When switching navigators there exists a bug where nested state of a screen route isn't cleared.

Imagine you have:

```tsx
<StackA.Navigator>
  <StackA.Screen name="foo">
    <StackB.Navigator>
      <StackB.Screen name="bar"  />
      <StackB.Screen name="shared" />
    </StackB.Navigator>
  </StackA.Screen>
</StackA.Navigator>
```

In this case screen `foo` contains a nested navigator.

Now, when we switch to another stack, that also contains a screen called `foo` **which isn't a nested navigator**, the state data with the route won't be cleared from the navigator:

```tsx
<StackC.Navigator>
  <StackC.Screen name="foo" />
</StackC.Navigator>
```

If you inspect the navigation state you see that the route "bar" is still there:

```json
    {
      "stale": false,
      "type": "stack",
      "key": "stack-rZFXS0CY_SZilbnrYS1HH",
      "index": 0,
      "routeNames": [
        "foo",
      ],
      "routes": [
        {
          "key": "foo-doNEBgosyONdZtX8ZWz8c",
          "name": "foo",
          "params": {
            "screen": "bar"
          },
          "state": {
            "stale": false,
            "type": "stack",
            "key": "stack-oLBLSVP1ye_WdX_iKbumb",
            "index": 0,
            "routeNames": [
              "bar",
            ],
            "routes": [
              {
                "key": "bar-0uZC9OCaawZsYZ99vU2tZ",
                "name": "bar"
              }
            ]
          }
        }
      ]
    }
```

We have a use case where we switch between an authenticated and unauthenticated stack. They both share for the initial screen the same screen name.
If the user logs out, and then logs in again, the user will be brought back to the screen where the user left off, as we kept the "bar" route in state.
As we switched to a navigator that doesn't have nested routes, I'd expect the route to be cleared.

**Test plan**

Adding unit tests to verify the behaviour should be sufficient.

_Note:_ For now I just added a failing unit test. Will provide a fix tmrw!
