### PR TITLE
fix: update scroTloOffset type of useScrollToTop

### DIFF
--- a/packages/native/src/useScrollToTop.tsx
+++ b/packages/native/src/useScrollToTop.tsx
@@ -13,7 +13,7 @@ type ScrollOptions = { x?: number; y?: number; animated?: boolean };
 type ScrollableView =
   | { scrollToTop(): void }
   | { scrollTo(options: ScrollOptions): void }
-  | { scrollToOffset(options: { offset?: number; animated?: boolean }): void }
+  | { scrollToOffset(options: { offset: number; animated?: boolean }): void }
   | { scrollResponderScrollTo(options: ScrollOptions): void };
 
 type ScrollableWrapper =


### PR DESCRIPTION
Please provide enough information so that others can review your pull request.
Closes #12139 
A `scrollToOffset` function needs to expect an `offset` otherwise there no place to scroll to. Making it optional throws a typescript error with FlashList

**Motivation**
Using useScrollToTop with FlashList in a type safe way

**Test plan**

The change doesnt really affect runtime behavior
