### PR TITLE
fix: spread key into JSX warning

### DIFF
--- a/packages/react-native-tab-view/src/TabBar.tsx
+++ b/packages/react-native-tab-view/src/TabBar.tsx
@@ -45,9 +45,6 @@ export type Props<T extends Route> = SceneRendererProps & {
   options?: Record<string, TabDescriptor<T>>;
   commonOptions?: TabDescriptor<T>;
   renderIndicator?: (props: IndicatorProps<T>) => React.ReactNode;
-  renderTabBarItem?: (
-    props: TabBarItemProps<T> & { key: string }
-  ) => React.ReactElement;
   onTabPress?: (scene: Scene<T> & Event) => void;
   onTabLongPress?: (scene: Scene<T>) => void;
   tabStyle?: StyleProp<ViewStyle>;
@@ -351,7 +348,6 @@ export function TabBar<T extends Route>({
   pressColor,
   pressOpacity,
   direction = I18nManager.getConstants().isRTL ? 'rtl' : 'ltr',
-  renderTabBarItem,
   style,
   tabStyle,
   layout: propLayout,
@@ -526,7 +522,6 @@ export function TabBar<T extends Route>({
 
       const props = {
         ...rest,
-        key: route.key,
         position,
         route,
         navigationState,
@@ -545,16 +540,12 @@ export function TabBar<T extends Route>({
         style: tabStyle,
         defaultTabWidth,
         android_ripple,
-      } satisfies TabBarItemProps<T> & { key: string };
+      } satisfies TabBarItemProps<T>;
 
       return (
         <>
           {gap > 0 && index > 0 ? <Separator width={gap} /> : null}
-          {renderTabBarItem ? (
-            renderTabBarItem(props)
-          ) : (
-            <TabBarItem {...props} />
-          )}
+          <TabBarItem key={route.key} {...props} />
         </>
       );
     },
@@ -577,7 +568,6 @@ export function TabBar<T extends Route>({
       contentContainerStyle,
       gap,
       android_ripple,
-      renderTabBarItem,
       onTabPress,
       jumpTo,
       onTabLongPress,

--- a/packages/react-native-tab-view/src/TabBar.tsx
+++ b/packages/react-native-tab-view/src/TabBar.tsx
@@ -45,6 +45,9 @@ export type Props<T extends Route> = SceneRendererProps & {
   options?: Record<string, TabDescriptor<T>>;
   commonOptions?: TabDescriptor<T>;
   renderIndicator?: (props: IndicatorProps<T>) => React.ReactNode;
+  renderTabBarItem?: (
+    props: TabBarItemProps<T> & { key: string }
+  ) => React.ReactElement;
   onTabPress?: (scene: Scene<T> & Event) => void;
   onTabLongPress?: (scene: Scene<T>) => void;
   tabStyle?: StyleProp<ViewStyle>;
@@ -348,6 +351,7 @@ export function TabBar<T extends Route>({
   pressColor,
   pressOpacity,
   direction = I18nManager.getConstants().isRTL ? 'rtl' : 'ltr',
+  renderTabBarItem,
   style,
   tabStyle,
   layout: propLayout,
@@ -522,6 +526,7 @@ export function TabBar<T extends Route>({
 
       const props = {
         ...rest,
+        key: route.key,
         position,
         route,
         navigationState,
@@ -540,12 +545,16 @@ export function TabBar<T extends Route>({
         style: tabStyle,
         defaultTabWidth,
         android_ripple,
-      } satisfies TabBarItemProps<T>;
+      } satisfies TabBarItemProps<T> & { key: string };
 
       return (
         <>
           {gap > 0 && index > 0 ? <Separator width={gap} /> : null}
-          <TabBarItem key={route.key} {...props} />
+          {renderTabBarItem ? (
+            renderTabBarItem(props)
+          ) : (
+            <TabBarItem {...props} key={props.key} />
+          )}
         </>
       );
     },
@@ -568,6 +577,7 @@ export function TabBar<T extends Route>({
       contentContainerStyle,
       gap,
       android_ripple,
+      renderTabBarItem,
       onTabPress,
       jumpTo,
       onTabLongPress,


### PR DESCRIPTION
**Motivation**

After bumping up versions of `react` from `18.2.0` to `18.3.1` as well as `react-native` from `0.74.5` to `0.75.2` in one of my projects, the application started to give me a warning `A props object containing a "key" prop is being spread into JSX`.

It happens on the screens which use `@react-navigation/material-top-tabs`.

Addresses the existing issue https://github.com/react-navigation/react-navigation/issues/11989.

**Test plan**

1. Initialize a new project with the latest versions of `react` and `react-native`
2. Make use of `@react-navigation/material-top-tabs`
3. See the warning in the console

**Solution**

Passing the key straight to the component instead of spreading it.

I've also removed the `renderTabBarItem` prop since it doesn't seem to be used anywhere and could've caused a more verbose fix. 🤔 
