### PR TITLE
feat: export LocaleDirContext and UNSTABLE_UnhandledLinkingContext

### DIFF
--- a/packages/native/src/index.tsx
+++ b/packages/native/src/index.tsx
@@ -1,11 +1,13 @@
 export { createStaticNavigation } from './createStaticNavigation';
 export { Link } from './Link';
 export { LinkingContext } from './LinkingContext';
+export { LocaleDirContext } from './LocaleDirContext';
 export { NavigationContainer } from './NavigationContainer';
 export { ServerContainer } from './ServerContainer';
 export { DarkTheme } from './theming/DarkTheme';
 export { DefaultTheme } from './theming/DefaultTheme';
 export * from './types';
+export { UnhandledLinkingContext as UNSTABLE_UnhandledLinkingContext } from './UnhandledLinkingContext';
 export { useLinkBuilder } from './useLinkBuilder';
 export { type LinkProps, useLinkProps } from './useLinkProps';
 export { useLinkTo } from './useLinkTo';


### PR DESCRIPTION
**Motivation**

Expo Router is a library built on top of React Navigation. It customises the linking behaviour of React Navigation by providing a custom `<NavigationContainer />` and changes the behaviour how it performs linking.

In React Navigation 7, the packages were changed to use `package.json#exports` which only expose the public APIs and not the internal contexts/hooks that are needed by to create a custom `<NavigationContainer />`.

Instead of adding these values to the public exports, this PR proposes that a new submodule is exposed `@react-navigation/native/extend` which exports public API and the required hooks/contexts needed to create a custom `<NavigationContainer />`
