### PR TITLE
refactor: move web-only checks inside the Platform.OS web condition

### DIFF
--- a/packages/react-native-tab-view/src/PlatformPressable.tsx
+++ b/packages/react-native-tab-view/src/PlatformPressable.tsx
@@ -30,16 +30,16 @@ export function PlatformPressable({
   ...rest
 }: Props) {
   const handlePress = (e: GestureResponderEvent) => {
-    // @ts-expect-error: these properties exist on web, but not in React Native
-    const hasModifierKey = e.metaKey || e.altKey || e.ctrlKey || e.shiftKey; // ignore clicks with modifier keys
-    // @ts-expect-error: these properties exist on web, but not in React Native
-    const isLeftClick = e.button == null || e.button === 0; // only handle left clicks
-    const isSelfTarget = [undefined, null, '', 'self'].includes(
-      // @ts-expect-error: these properties exist on web, but not in React Native
-      e.currentTarget?.target
-    ); // let browser handle "target=_blank" etc.
-
     if (Platform.OS === 'web' && rest.href != null) {
+      // @ts-expect-error: these properties exist on web, but not in React Native
+      const hasModifierKey = e.metaKey || e.altKey || e.ctrlKey || e.shiftKey; // ignore clicks with modifier keys
+      // @ts-expect-error: these properties exist on web, but not in React Native
+      const isLeftClick = e.button == null || e.button === 0; // only handle left clicks
+      const isSelfTarget = [undefined, null, '', 'self'].includes(
+        // @ts-expect-error: these properties exist on web, but not in React Native
+        e.currentTarget?.target
+      ); // let browser handle "target=_blank" etc.
+
       if (!hasModifierKey && isLeftClick && isSelfTarget) {
         e.preventDefault();
         onPress?.(e);

--- a/packages/react-native-tab-view/src/PlatformPressable.tsx
+++ b/packages/react-native-tab-view/src/PlatformPressable.tsx
@@ -34,7 +34,7 @@ export function PlatformPressable({
       // @ts-expect-error: these properties exist on web, but not in React Native
       const hasModifierKey = e.metaKey || e.altKey || e.ctrlKey || e.shiftKey; // ignore clicks with modifier keys
       // @ts-expect-error: these properties exist on web, but not in React Native
-      const isLeftClick = e.button == null || e.button === 0; // only handle left clicks
+      const isLeftClick = e.button === null || e.button === 0; // only handle left clicks
       const isSelfTarget = [undefined, null, '', 'self'].includes(
         // @ts-expect-error: these properties exist on web, but not in React Native
         e.currentTarget?.target

--- a/packages/react-native-tab-view/src/PlatformPressable.tsx
+++ b/packages/react-native-tab-view/src/PlatformPressable.tsx
@@ -30,7 +30,7 @@ export function PlatformPressable({
   ...rest
 }: Props) {
   const handlePress = (e: GestureResponderEvent) => {
-    if (Platform.OS === 'web' && rest.href != null) {
+    if (Platform.OS === 'web' && rest.href !== null) {
       // @ts-expect-error: these properties exist on web, but not in React Native
       const hasModifierKey = e.metaKey || e.altKey || e.ctrlKey || e.shiftKey; // ignore clicks with modifier keys
       // @ts-expect-error: these properties exist on web, but not in React Native

--- a/packages/react-native-tab-view/src/__tests__/PlatformPressable.test.tsx
+++ b/packages/react-native-tab-view/src/__tests__/PlatformPressable.test.tsx
@@ -1,0 +1,51 @@
+import { describe, expect, jest, test } from '@jest/globals';
+import { fireEvent, render, userEvent } from '@testing-library/react-native';
+import { Platform, View } from 'react-native';
+
+import { PlatformPressable } from '../PlatformPressable';
+
+describe('PlatformPressable', () => {
+  const renderUI = (onPress: jest.Mock) => {
+    return render(
+      <PlatformPressable onPress={onPress} testID={'Pressable'}>
+        <View />
+      </PlatformPressable>
+    );
+  };
+
+  describe('tests using Fire Event API', () => {
+    test('should be pressable using simply fireEvent.press', async () => {
+      const onPress = jest.fn();
+      const { getByTestId } = renderUI(onPress);
+
+      fireEvent.press(getByTestId('Pressable'));
+
+      expect(onPress).toHaveBeenCalled();
+    });
+  });
+
+  describe('tests using User Event API', () => {
+    jest.useFakeTimers();
+
+    test('should be pressable on web', async () => {
+      Platform.OS = 'web';
+      const onPress = jest.fn();
+      const { getByTestId } = renderUI(onPress);
+
+      const user = userEvent.setup();
+      await user.press(getByTestId('Pressable'));
+
+      expect(onPress).toHaveBeenCalled();
+    });
+
+    test('should be pressable using the User Event API', async () => {
+      const onPress = jest.fn();
+      const { getByTestId } = renderUI(onPress);
+
+      const user = userEvent.setup();
+      await user.press(getByTestId('Pressable'));
+
+      expect(onPress).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/react-native-tab-view/src/__tests__/PlatformPressable.test.tsx
+++ b/packages/react-native-tab-view/src/__tests__/PlatformPressable.test.tsx
@@ -1,49 +1,69 @@
-import { describe, expect, jest, test } from '@jest/globals';
+import { beforeAll, describe, expect, jest, test } from '@jest/globals';
 import { fireEvent, render, userEvent } from '@testing-library/react-native';
 import { Platform, View } from 'react-native';
 
 import { PlatformPressable } from '../PlatformPressable';
 
 describe('PlatformPressable', () => {
-  const renderUI = (onPress: jest.Mock) => {
-    return render(
-      <PlatformPressable onPress={onPress} testID={'Pressable'}>
-        <View />
-      </PlatformPressable>
-    );
-  };
-
-  describe('tests using Fire Event API', () => {
-    test('should be pressable using simply fireEvent.press', async () => {
+  describe('on native', () => {
+    test('should be pressable using simply fireEvent.press', () => {
       const onPress = jest.fn();
-      const { getByTestId } = renderUI(onPress);
+      const { getByTestId } = render(
+        <PlatformPressable onPress={onPress} testID={'Pressable'}>
+          <View />
+        </PlatformPressable>
+      );
 
       fireEvent.press(getByTestId('Pressable'));
 
       expect(onPress).toHaveBeenCalled();
     });
-  });
 
-  describe('tests using User Event API', () => {
-    jest.useFakeTimers();
-
-    test('should be pressable on web', async () => {
-      Platform.OS = 'web';
+    test('should be pressable using with UserEvent', async () => {
       const onPress = jest.fn();
-      const { getByTestId } = renderUI(onPress);
+      const { getByTestId } = render(
+        <PlatformPressable onPress={onPress} testID={'Pressable'}>
+          <View />
+        </PlatformPressable>
+      );
 
       const user = userEvent.setup();
       await user.press(getByTestId('Pressable'));
 
       expect(onPress).toHaveBeenCalled();
     });
+  });
 
-    test('should be pressable using the User Event API', async () => {
+  describe('on web', () => {
+    const renderWebUI = (onPress: jest.Mock) => {
+      return render(
+        <PlatformPressable onPress={onPress} testID={'Pressable'} href={'/'}>
+          <View />
+        </PlatformPressable>
+      );
+    };
+
+    beforeAll(() => {
+      Platform.OS = 'web';
+    });
+
+    test('should ignore non-left clicks', () => {
       const onPress = jest.fn();
-      const { getByTestId } = renderUI(onPress);
+      const { getByTestId } = renderWebUI(onPress);
 
-      const user = userEvent.setup();
-      await user.press(getByTestId('Pressable'));
+      fireEvent.press(getByTestId('Pressable'), { button: 1 });
+
+      expect(onPress).not.toHaveBeenCalled();
+    });
+
+    test('should be pressable with a left click', () => {
+      const onPress = jest.fn();
+      const { getByTestId } = renderWebUI(onPress);
+
+      fireEvent.press(getByTestId('Pressable'), {
+        button: 0,
+        preventDefault: jest.fn(),
+      });
 
       expect(onPress).toHaveBeenCalled();
     });

--- a/packages/react-native-tab-view/src/__tests__/PlatformPressable.test.tsx
+++ b/packages/react-native-tab-view/src/__tests__/PlatformPressable.test.tsx
@@ -1,71 +1,83 @@
-import { beforeAll, describe, expect, jest, test } from '@jest/globals';
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  jest,
+  test,
+} from '@jest/globals';
 import { fireEvent, render, userEvent } from '@testing-library/react-native';
 import { Platform, View } from 'react-native';
 
 import { PlatformPressable } from '../PlatformPressable';
 
-describe('PlatformPressable', () => {
-  describe('on native', () => {
-    test('should be pressable using simply fireEvent.press', () => {
-      const onPress = jest.fn();
-      const { getByTestId } = render(
-        <PlatformPressable onPress={onPress} testID={'Pressable'}>
-          <View />
-        </PlatformPressable>
-      );
+describe('on native', () => {
+  test('should be pressable using simply fireEvent.press', () => {
+    const onPress = jest.fn();
+    const { getByTestId } = render(
+      <PlatformPressable onPress={onPress} testID={'Pressable'}>
+        <View />
+      </PlatformPressable>
+    );
 
-      fireEvent.press(getByTestId('Pressable'));
+    fireEvent.press(getByTestId('Pressable'));
 
-      expect(onPress).toHaveBeenCalled();
-    });
-
-    test('should be pressable using with UserEvent', async () => {
-      const onPress = jest.fn();
-      const { getByTestId } = render(
-        <PlatformPressable onPress={onPress} testID={'Pressable'}>
-          <View />
-        </PlatformPressable>
-      );
-
-      const user = userEvent.setup();
-      await user.press(getByTestId('Pressable'));
-
-      expect(onPress).toHaveBeenCalled();
-    });
+    expect(onPress).toHaveBeenCalled();
   });
 
-  describe('on web', () => {
-    const renderWebUI = (onPress: jest.Mock) => {
-      return render(
-        <PlatformPressable onPress={onPress} testID={'Pressable'} href={'/'}>
-          <View />
-        </PlatformPressable>
-      );
-    };
+  test('should be pressable using with UserEvent', async () => {
+    const onPress = jest.fn();
+    const { getByTestId } = render(
+      <PlatformPressable onPress={onPress} testID={'Pressable'}>
+        <View />
+      </PlatformPressable>
+    );
 
-    beforeAll(() => {
-      Platform.OS = 'web';
+    const user = userEvent.setup();
+    await user.press(getByTestId('Pressable'));
+
+    expect(onPress).toHaveBeenCalled();
+  });
+});
+
+describe('on web', () => {
+  let originalPlatformOS: typeof Platform.OS;
+
+  beforeAll(() => {
+    originalPlatformOS = Platform.OS;
+    Platform.OS = 'web';
+  });
+
+  afterAll(() => {
+    Platform.OS = originalPlatformOS;
+  });
+
+  const renderWebUI = (onPress: jest.Mock) => {
+    return render(
+      <PlatformPressable onPress={onPress} testID={'Pressable'} href={'/'}>
+        <View />
+      </PlatformPressable>
+    );
+  };
+
+  test('should ignore non-left clicks', () => {
+    const onPress = jest.fn();
+    const { getByTestId } = renderWebUI(onPress);
+
+    fireEvent.press(getByTestId('Pressable'), { button: 1 });
+
+    expect(onPress).not.toHaveBeenCalled();
+  });
+
+  test('should be pressable with a left click', () => {
+    const onPress = jest.fn();
+    const { getByTestId } = renderWebUI(onPress);
+
+    fireEvent.press(getByTestId('Pressable'), {
+      button: 0,
+      preventDefault: jest.fn(),
     });
 
-    test('should ignore non-left clicks', () => {
-      const onPress = jest.fn();
-      const { getByTestId } = renderWebUI(onPress);
-
-      fireEvent.press(getByTestId('Pressable'), { button: 1 });
-
-      expect(onPress).not.toHaveBeenCalled();
-    });
-
-    test('should be pressable with a left click', () => {
-      const onPress = jest.fn();
-      const { getByTestId } = renderWebUI(onPress);
-
-      fireEvent.press(getByTestId('Pressable'), {
-        button: 0,
-        preventDefault: jest.fn(),
-      });
-
-      expect(onPress).toHaveBeenCalled();
-    });
+    expect(onPress).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Prevents react-native-tab-view from throwing an error on fireEvent.press when running Jest tests

**Motivation**

Apps that use react-native-tab-view can't test tab switching using only `fireEvent.press(component)` and devs have to delve into the code to realize that they have to use `fireEvent.press(component, eventObject)` [reproduction proof](https://github.com/bytehala/rntv-issue/pull/1)

When using `fireEvent.press(component)`, Jest throws an error `TypeError: Cannot read properties of undefined (reading 'metaKey')`. This is because of 2 main reasons:

1. The React Native Testing Library fireEvent API [does not send an event](https://callstack.github.io/react-native-testing-library/docs/api/events/fire-event)
2. The code was checking for web-only attributes outside of the `Platform.OS === web` condition, like metaKey

<img width="828" alt="Screenshot 2024-09-21 at 10 04 14 PM" src="https://github.com/user-attachments/assets/32188208-5220-4f8e-b9f9-19ce4b61fc06">


**Test plan**

Proof of the error:
1. Check out this branch
2. Revert the react-native-tab-view PlatformPressable.tsx to the "before" revision
3. Run the new tests `yarn test ./packages/react-native-tab-view/src/__tests__/PlatformPressable.test.tsx`
- [ ] The fireEvent.press test should throw an error


Proof that the refactor works for fireEvent.press and UserEventInstance.press:
1. Check out this branch
2. Run the new tests `yarn test ./packages/react-native-tab-view/src/__tests__/PlatformPressable.test.tsx`
- [ ] All 4 tests should pass
