### PR TITLE
test: react-native-tab-view

### DIFF
--- a/packages/react-native-tab-view/package.json
+++ b/packages/react-native-tab-view/package.json
@@ -53,6 +53,8 @@
     "use-latest-callback": "^0.2.1"
   },
   "devDependencies": {
+    "@jest/globals": "^29.7.0",
+    "@testing-library/react-native": "^12.4.3",
     "del-cli": "^5.1.0",
     "react": "18.2.0",
     "react-native": "0.74.2",

--- a/packages/react-native-tab-view/src/__tests__/index.test.tsx
+++ b/packages/react-native-tab-view/src/__tests__/index.test.tsx
@@ -1,0 +1,52 @@
+import { describe, expect, test } from '@jest/globals';
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+import { type GestureResponderEvent, View } from 'react-native';
+import { SceneMap, TabView } from 'react-native-tab-view';
+
+const FirstRoute = () => (
+  <View style={{ flex: 1, backgroundColor: '#ff4081' }} testID={'route1'} />
+);
+
+const SecondRoute = () => (
+  <View style={{ flex: 1, backgroundColor: '#673ab7' }} testID={'route2'} />
+);
+
+const renderScene = SceneMap({
+  first: FirstRoute,
+  second: SecondRoute,
+});
+
+const ComponentWithTabView = () => {
+  const [index, setIndex] = React.useState(0);
+  const [routes] = React.useState([
+    { key: 'first', title: 'First' },
+    { key: 'second', title: 'Second' },
+  ]);
+
+  return (
+    <TabView
+      navigationState={{ index, routes }}
+      renderScene={renderScene}
+      onIndexChange={setIndex}
+    />
+  );
+};
+
+describe('react-native-tab-view', () => {
+  test('renders using the scene for the initial index', () => {
+    const { getByTestId, queryByTestId } = render(<ComponentWithTabView />);
+
+    expect(getByTestId('route1')).toBeTruthy();
+    expect(queryByTestId('route2')).toBeNull();
+  });
+
+  test('switches tabs when the tab header for another route is pressed', () => {
+    const { getByTestId, getByLabelText } = render(<ComponentWithTabView />);
+
+    expect(getByTestId('route1')).toBeTruthy();
+
+    fireEvent.press(getByLabelText('Second'), {} as GestureResponderEvent);
+    expect(getByTestId('route2')).toBeTruthy();
+  });
+});

--- a/packages/react-native-tab-view/src/__tests__/index.test.tsx
+++ b/packages/react-native-tab-view/src/__tests__/index.test.tsx
@@ -2,7 +2,8 @@ import { describe, expect, test } from '@jest/globals';
 import { fireEvent, render } from '@testing-library/react-native';
 import React from 'react';
 import { type GestureResponderEvent, View } from 'react-native';
-import { SceneMap, TabView } from 'react-native-tab-view';
+
+import { SceneMap, TabView } from '../index';
 
 const FirstRoute = () => (
   <View style={{ flex: 1, backgroundColor: '#ff4081' }} testID={'route1'} />

--- a/packages/react-native-tab-view/src/__tests__/index.test.tsx
+++ b/packages/react-native-tab-view/src/__tests__/index.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, test } from '@jest/globals';
+import { expect, test } from '@jest/globals';
 import { fireEvent, render } from '@testing-library/react-native';
 import React from 'react';
 import { type GestureResponderEvent, View } from 'react-native';
@@ -34,20 +34,18 @@ const ComponentWithTabView = () => {
   );
 };
 
-describe('react-native-tab-view', () => {
-  test('renders using the scene for the initial index', () => {
-    const { getByTestId, queryByTestId } = render(<ComponentWithTabView />);
+test('renders using the scene for the initial index', () => {
+  const { getByTestId, queryByTestId } = render(<ComponentWithTabView />);
 
-    expect(getByTestId('route1')).toBeTruthy();
-    expect(queryByTestId('route2')).toBeNull();
-  });
+  expect(getByTestId('route1')).toBeTruthy();
+  expect(queryByTestId('route2')).toBeNull();
+});
 
-  test('switches tabs when the tab header for another route is pressed', () => {
-    const { getByTestId, getByLabelText } = render(<ComponentWithTabView />);
+test('switches tabs when the tab header for another route is pressed', () => {
+  const { getByTestId, getByLabelText } = render(<ComponentWithTabView />);
 
-    expect(getByTestId('route1')).toBeTruthy();
+  expect(getByTestId('route1')).toBeTruthy();
 
-    fireEvent.press(getByLabelText('Second'), {} as GestureResponderEvent);
-    expect(getByTestId('route2')).toBeTruthy();
-  });
+  fireEvent.press(getByLabelText('Second'), {} as GestureResponderEvent);
+  expect(getByTestId('route2')).toBeTruthy();
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -14537,6 +14537,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "react-native-tab-view@workspace:packages/react-native-tab-view"
   dependencies:
+    "@jest/globals": "npm:^29.7.0"
+    "@testing-library/react-native": "npm:^12.4.3"
     del-cli: "npm:^5.1.0"
     react: "npm:18.2.0"
     react-native: "npm:0.74.2"


### PR DESCRIPTION
**Motivation**

`react-native-tab-view` doesn't have Jest tests yet. This provides the setup as well as initial component and interaction tests for rendering and switching tabs.

Closely related to https://github.com/react-navigation/react-navigation/issues/11493

**Test plan**

- [ ] Optional because CI runs it: Run `yarn test` All tests, including the newly added tests, must pass
- [x] The change must pass lint, typescript and tests.
