### PR TITLE
refactor: Use WeakMap as underlying caching mechanism for linking config resources

### DIFF
--- a/packages/core/src/getStateFromPath.tsx
+++ b/packages/core/src/getStateFromPath.tsx
@@ -169,19 +169,22 @@ export function getStateFromPath<ParamList extends {}>(
 /**
  * Reference to the last used config resources. This is used to avoid recomputing the config resources when the options are the same.
  */
-let cachedConfigResources: [Options<{}> | undefined, ConfigResources] = [
-  undefined,
-  prepareConfigResources(),
-];
+const cachedConfigResources = new WeakMap<Options<{}>, ConfigResources>();
 
 function getConfigResources<ParamList extends {}>(
   options: Options<ParamList> | undefined
 ) {
-  if (cachedConfigResources[0] !== options) {
-    cachedConfigResources = [options, prepareConfigResources(options)];
-  }
+  if (!options) return prepareConfigResources();
 
-  return cachedConfigResources[1];
+  const cached = cachedConfigResources.get(options);
+
+  if (cached) return cached;
+
+  const resources = prepareConfigResources(options);
+
+  cachedConfigResources.set(options, resources);
+
+  return resources;
 }
 
 function prepareConfigResources(options?: Options<{}>) {


### PR DESCRIPTION
**Motivation**

The mechanism for caching config resources of `getStateFromPath` and `getPathFromState` relies on simple tuple approach.

It works as expected but @satya164 noticed that the reference hold by cache might lead to memory leaks.

This PR swaps out tuple approach for WeakMap one for both `gSFP` and `gPFS` caching.

**Test plan**

Testing was mainly focused on whether cache still works as supposed to. 

In the example app, logs were added to the cache retrieval methods (for both `gSFP` and `gPFS`). 

Here's a code snippet showing one of them:

```tsx
function getConfigResources<ParamList extends {}>(
  options: Options<ParamList> | undefined
) {
  console.log('Deboog', 'gSFP', 'cached skipped empty config');
  if (!options) return prepareConfigResources();

  const cached = cachedConfigResources.get(options);

  if (cached) {
    console.log('Deboog', 'gSFP', 'cache hit', cached);
    return cached;
  }

  const resources = prepareConfigResources(options);

  cachedConfigResources.set(options, resources);

  console.log('Deboog', 'gSFP', 'cache missed', resources);

  return resources;
}
```

Testing showed that the cache works just fine:

**_Web_**

https://github.com/user-attachments/assets/bf3eccc0-cc38-4383-b173-41c5ba75167c

**_Mobile_**

https://github.com/user-attachments/assets/56f81a58-d6e8-4e6e-ba9f-07c09a4092e4