### PR TITLE
test: integration test on pointerEvents 'none'

### DIFF
--- a/packages/bottom-tabs/src/__tests__/index.test.tsx
+++ b/packages/bottom-tabs/src/__tests__/index.test.tsx
@@ -71,7 +71,7 @@ test('handles screens preloading', async () => {
   ).not.toBeNull();
 });
 
-test('ignores pointerEvents when hidden', async () => {
+test('tab bar cannot be tapped when hidden', async () => {
   // @ts-expect-error: incomplete mock for testing
   jest.spyOn(Animated, 'timing').mockImplementation(() => ({
     start: (callback) => callback?.({ finished: true }),

--- a/packages/bottom-tabs/src/__tests__/index.test.tsx
+++ b/packages/bottom-tabs/src/__tests__/index.test.tsx
@@ -80,7 +80,7 @@ test('ignores pointerEvents when hidden', async () => {
 
   const Test = ({ route }: BottomTabScreenProps<BottomTabParamList>) => (
     <View>
-      <Text>Screen{route.name}</Text>
+      <Text>Screen {route.name}</Text>
     </View>
   );
 
@@ -99,10 +99,10 @@ test('ignores pointerEvents when hidden', async () => {
     </NavigationContainer>
   );
 
-  expect(queryByText('ScreenB')).toBeNull();
+  expect(queryByText('Screen B')).toBeNull();
 
   fireEvent.press(getByRole('button', { name: 'B, tab, 2 of 2' }), {});
 
-  expect(queryByText('ScreenA')).not.toBeNull();
-  expect(queryByText('ScreenB')).toBeNull();
+  expect(queryByText('Screen A')).not.toBeNull();
+  expect(queryByText('Screen B')).toBeNull();
 });

--- a/packages/bottom-tabs/src/__tests__/index.test.tsx
+++ b/packages/bottom-tabs/src/__tests__/index.test.tsx
@@ -97,7 +97,7 @@ test('tab bar cannot be tapped when hidden', async () => {
   // start at Screen A
   expect(queryByText('Screen B')).toBeNull();
 
-  // move to Screen B
+  // switch to Screen B
   fireEvent.press(getByRole('button', { name: 'B, tab, 2 of 2' }), {});
   jest.runAllTimers();
   expect(queryByText('Screen B')).not.toBeNull();
@@ -108,7 +108,7 @@ test('tab bar cannot be tapped when hidden', async () => {
     Keyboard._emitter.emit?.('keyboardWillShow');
   });
 
-  // attempt to move to Screen A
+  // attempt to switch to Screen A
   fireEvent.press(getByRole('button', { name: 'A, tab, 1 of 2' }), {});
   jest.runAllTimers();
   expect(queryByText('Screen A')).toBeNull();


### PR DESCRIPTION
**Motivation**

There is currently no integration test on the `tabBarHideOnKeyboard` property, which internally sets some states and ultimately sets `pointerEvents: 'none'` inside BottomTabBar.

By adding this test, we can be confident regarding existing and future code on BottomTabBar's visibility-related behaviors.

For example, this issue https://github.com/react-navigation/react-navigation/issues/11691 demonstrates that `style={display: 'none'}` can sometimes still "leak" pointerEvents. This test would be a good starting point for fixing said issue.

**Test plan**

- [ ] Optional sanity check: edit the new test to `tabBarHideOnKeyBoard: false`. The test should fail, since the TabBar accepts pointerEvents, and will navigate to Screen B.
