### PR TITLE
chore: bump react-native-screens version to 4-beta for v7

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -33,7 +33,7 @@
     "react-native-pager-view": "6.3.0",
     "react-native-reanimated": "~3.10.1",
     "react-native-safe-area-context": "4.10.1",
-    "react-native-screens": "4.0.0-beta.1",
+    "react-native-screens": "4.0.0-beta.2",
     "react-native-web": "~0.19.10"
   },
   "devDependencies": {

--- a/example/package.json
+++ b/example/package.json
@@ -33,7 +33,7 @@
     "react-native-pager-view": "6.3.0",
     "react-native-reanimated": "~3.10.1",
     "react-native-safe-area-context": "4.10.1",
-    "react-native-screens": "4.0.0-beta.2",
+    "react-native-screens": "4.0.0-beta.3",
     "react-native-web": "~0.19.10"
   },
   "devDependencies": {

--- a/example/package.json
+++ b/example/package.json
@@ -33,7 +33,7 @@
     "react-native-pager-view": "6.3.0",
     "react-native-reanimated": "~3.10.1",
     "react-native-safe-area-context": "4.10.1",
-    "react-native-screens": "3.32.0",
+    "react-native-screens": "4.0.0-beta.1",
     "react-native-web": "~0.19.10"
   },
   "devDependencies": {

--- a/packages/bottom-tabs/package.json
+++ b/packages/bottom-tabs/package.json
@@ -61,7 +61,7 @@
     "react-native": "0.74.2",
     "react-native-builder-bob": "^0.29.0",
     "react-native-safe-area-context": "4.10.1",
-    "react-native-screens": "4.0.0-beta.1",
+    "react-native-screens": "4.0.0-beta.2",
     "typescript": "^5.5.2"
   },
   "peerDependencies": {

--- a/packages/bottom-tabs/package.json
+++ b/packages/bottom-tabs/package.json
@@ -61,7 +61,7 @@
     "react-native": "0.74.2",
     "react-native-builder-bob": "^0.29.0",
     "react-native-safe-area-context": "4.10.1",
-    "react-native-screens": "3.32.0",
+    "react-native-screens": "4.0.0-beta.1",
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
@@ -69,7 +69,7 @@
     "react": ">= 18.2.0",
     "react-native": ">= 0.72.0",
     "react-native-safe-area-context": ">= 4.0.0",
-    "react-native-screens": ">= 3.21.0"
+    "react-native-screens": ">= 4.0.0"
   },
   "react-native-builder-bob": {
     "source": "src",

--- a/packages/bottom-tabs/package.json
+++ b/packages/bottom-tabs/package.json
@@ -61,7 +61,7 @@
     "react-native": "0.74.2",
     "react-native-builder-bob": "^0.29.0",
     "react-native-safe-area-context": "4.10.1",
-    "react-native-screens": "4.0.0-beta.2",
+    "react-native-screens": "4.0.0-beta.3",
     "typescript": "^5.5.2"
   },
   "peerDependencies": {

--- a/packages/drawer/package.json
+++ b/packages/drawer/package.json
@@ -69,7 +69,7 @@
     "react-native-gesture-handler": "~2.16.1",
     "react-native-reanimated": "~3.10.1",
     "react-native-safe-area-context": "4.10.1",
-    "react-native-screens": "3.32.0",
+    "react-native-screens": "4.0.0-beta.1",
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
@@ -79,7 +79,7 @@
     "react-native-gesture-handler": ">= 2.0.0",
     "react-native-reanimated": ">= 2.0.0",
     "react-native-safe-area-context": ">= 4.0.0",
-    "react-native-screens": ">= 3.21.0"
+    "react-native-screens": ">= 4.0.0"
   },
   "react-native-builder-bob": {
     "source": "src",

--- a/packages/drawer/package.json
+++ b/packages/drawer/package.json
@@ -69,7 +69,7 @@
     "react-native-gesture-handler": "~2.16.1",
     "react-native-reanimated": "~3.10.1",
     "react-native-safe-area-context": "4.10.1",
-    "react-native-screens": "4.0.0-beta.2",
+    "react-native-screens": "4.0.0-beta.3",
     "typescript": "^5.5.2"
   },
   "peerDependencies": {

--- a/packages/drawer/package.json
+++ b/packages/drawer/package.json
@@ -69,7 +69,7 @@
     "react-native-gesture-handler": "~2.16.1",
     "react-native-reanimated": "~3.10.1",
     "react-native-safe-area-context": "4.10.1",
-    "react-native-screens": "4.0.0-beta.1",
+    "react-native-screens": "4.0.0-beta.2",
     "typescript": "^5.5.2"
   },
   "peerDependencies": {

--- a/packages/native-stack/package.json
+++ b/packages/native-stack/package.json
@@ -72,7 +72,7 @@
     "react": ">= 18.2.0",
     "react-native": ">= 0.72.0",
     "react-native-safe-area-context": ">= 4.0.0",
-    "react-native-screens": "4.0.0-beta.1"
+    "react-native-screens": ">= 4.0.0"
   },
   "react-native-builder-bob": {
     "source": "src",

--- a/packages/native-stack/package.json
+++ b/packages/native-stack/package.json
@@ -64,7 +64,7 @@
     "react": "18.2.0",
     "react-native": "0.74.2",
     "react-native-builder-bob": "^0.29.0",
-    "react-native-screens": "3.32.0",
+    "react-native-screens": "4.0.0-beta.1",
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
@@ -72,7 +72,7 @@
     "react": ">= 18.2.0",
     "react-native": ">= 0.72.0",
     "react-native-safe-area-context": ">= 4.0.0",
-    "react-native-screens": ">= 3.21.0"
+    "react-native-screens": "4.0.0-beta.1"
   },
   "react-native-builder-bob": {
     "source": "src",

--- a/packages/native-stack/package.json
+++ b/packages/native-stack/package.json
@@ -64,7 +64,7 @@
     "react": "18.2.0",
     "react-native": "0.74.2",
     "react-native-builder-bob": "^0.29.0",
-    "react-native-screens": "4.0.0-beta.2",
+    "react-native-screens": "4.0.0-beta.3",
     "typescript": "^5.5.2"
   },
   "peerDependencies": {

--- a/packages/native-stack/package.json
+++ b/packages/native-stack/package.json
@@ -64,7 +64,7 @@
     "react": "18.2.0",
     "react-native": "0.74.2",
     "react-native-builder-bob": "^0.29.0",
-    "react-native-screens": "4.0.0-beta.1",
+    "react-native-screens": "4.0.0-beta.2",
     "typescript": "^5.5.2"
   },
   "peerDependencies": {

--- a/packages/native-stack/src/types.tsx
+++ b/packages/native-stack/src/types.tsx
@@ -21,7 +21,6 @@ import type {
   ScreenProps,
   ScreenStackHeaderConfigProps,
   SearchBarProps,
-  SheetDetentTypes,
 } from 'react-native-screens';
 
 export type NativeStackNavigationEventMap = {
@@ -545,7 +544,7 @@ export type NativeStackNavigationOptions = {
    *
    * @platform ios
    */
-  sheetAllowedDetents?: SheetDetentTypes;
+  sheetAllowedDetents?: number[] | 'fitToContents';
   /**
    * Whether the sheet should expand to larger detent when scrolling.
    * Works only when `presentation` is set to `formSheet`.
@@ -587,7 +586,7 @@ export type NativeStackNavigationOptions = {
    *
    * @platform ios
    */
-  sheetLargestUndimmedDetent?: SheetDetentTypes;
+  sheetLargestUndimmedDetent?: number;
   /**
    * The display orientation to use for the screen.
    *

--- a/packages/native-stack/src/views/NativeStackView.native.tsx
+++ b/packages/native-stack/src/views/NativeStackView.native.tsx
@@ -335,6 +335,8 @@ const SceneView = ({
       hasLargeHeader={options.headerLargeTitle ?? false}
       customAnimationOnSwipe={animationMatchesGesture}
       fullScreenSwipeEnabled={fullScreenGestureEnabled}
+      fullScreenSwipeShadowEnabled={fullScreenGestureShadowEnabled}
+      freezeOnBlur={freezeOnBlur}
       gestureEnabled={
         Platform.OS === 'android'
           ? // This prop enables handling of system back gestures on Android
@@ -423,12 +425,9 @@ const SceneView = ({
           },
         }
       )}
-      freezeOnBlur={freezeOnBlur}
       // When ts-expect-error is added, it affects all the props below it
       // So we keep any props that need it at the end
       // Otherwise invalid props may not be caught by TypeScript
-      // @ts-expect-error Props available in newer versions of `react-native-screens`
-      fullScreenSwipeShadowEnabled={fullScreenGestureShadowEnabled} // 3.33.0 onwards
     >
       <NavigationContext.Provider value={navigation}>
         <NavigationRouteContext.Provider value={route}>

--- a/packages/stack/package.json
+++ b/packages/stack/package.json
@@ -66,7 +66,7 @@
     "react-native-builder-bob": "^0.29.0",
     "react-native-gesture-handler": "~2.16.1",
     "react-native-safe-area-context": "4.10.1",
-    "react-native-screens": "3.32.0",
+    "react-native-screens": "4.0.0-beta.1",
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
@@ -75,7 +75,7 @@
     "react-native": ">= 0.72.0",
     "react-native-gesture-handler": ">= 2.0.0",
     "react-native-safe-area-context": ">= 4.0.0",
-    "react-native-screens": ">= 3.21.0"
+    "react-native-screens": ">= 4.0.0"
   },
   "react-native-builder-bob": {
     "source": "src",

--- a/packages/stack/package.json
+++ b/packages/stack/package.json
@@ -66,7 +66,7 @@
     "react-native-builder-bob": "^0.29.0",
     "react-native-gesture-handler": "~2.16.1",
     "react-native-safe-area-context": "4.10.1",
-    "react-native-screens": "4.0.0-beta.1",
+    "react-native-screens": "4.0.0-beta.2",
     "typescript": "^5.5.2"
   },
   "peerDependencies": {

--- a/packages/stack/package.json
+++ b/packages/stack/package.json
@@ -66,7 +66,7 @@
     "react-native-builder-bob": "^0.29.0",
     "react-native-gesture-handler": "~2.16.1",
     "react-native-safe-area-context": "4.10.1",
-    "react-native-screens": "4.0.0-beta.2",
+    "react-native-screens": "4.0.0-beta.3",
     "typescript": "^5.5.2"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4194,7 +4194,7 @@ __metadata:
     react-native: "npm:0.74.2"
     react-native-builder-bob: "npm:^0.29.0"
     react-native-safe-area-context: "npm:4.10.1"
-    react-native-screens: "npm:4.0.0-beta.1"
+    react-native-screens: "npm:4.0.0-beta.2"
     typescript: "npm:^5.5.2"
   peerDependencies:
     "@react-navigation/native": "workspace:^"
@@ -4268,7 +4268,7 @@ __metadata:
     react-native-gesture-handler: "npm:~2.16.1"
     react-native-reanimated: "npm:~3.10.1"
     react-native-safe-area-context: "npm:4.10.1"
-    react-native-screens: "npm:4.0.0-beta.1"
+    react-native-screens: "npm:4.0.0-beta.2"
     typescript: "npm:^5.5.2"
     use-latest-callback: "npm:^0.2.1"
   peerDependencies:
@@ -4353,7 +4353,7 @@ __metadata:
     react-native-pager-view: "npm:6.3.0"
     react-native-reanimated: "npm:~3.10.1"
     react-native-safe-area-context: "npm:4.10.1"
-    react-native-screens: "npm:4.0.0-beta.1"
+    react-native-screens: "npm:4.0.0-beta.2"
     react-native-web: "npm:~0.19.10"
     react-test-renderer: "npm:18.2.0"
     serve: "npm:^14.2.1"
@@ -4400,7 +4400,7 @@ __metadata:
     react: "npm:18.2.0"
     react-native: "npm:0.74.2"
     react-native-builder-bob: "npm:^0.29.0"
-    react-native-screens: "npm:4.0.0-beta.1"
+    react-native-screens: "npm:4.0.0-beta.2"
     typescript: "npm:^5.5.2"
     warn-once: "npm:^0.1.1"
   peerDependencies:
@@ -4466,7 +4466,7 @@ __metadata:
     react-native-builder-bob: "npm:^0.29.0"
     react-native-gesture-handler: "npm:~2.16.1"
     react-native-safe-area-context: "npm:4.10.1"
-    react-native-screens: "npm:4.0.0-beta.1"
+    react-native-screens: "npm:4.0.0-beta.2"
     typescript: "npm:^5.5.2"
   peerDependencies:
     "@react-navigation/native": "workspace:^"
@@ -14520,16 +14520,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-screens@npm:4.0.0-beta.1":
-  version: 4.0.0-beta.1
-  resolution: "react-native-screens@npm:4.0.0-beta.1"
+"react-native-screens@npm:4.0.0-beta.2":
+  version: 4.0.0-beta.2
+  resolution: "react-native-screens@npm:4.0.0-beta.2"
   dependencies:
     react-freeze: "npm:^1.0.0"
     warn-once: "npm:^0.1.0"
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: e2672d35d36f56c0c45698409b0a4b7dc8b5959d091f84c0ecf3cf484965c9867e976339516b3a4704b623b5948473b8be520346e487801fc508a8f529700c41
+  checksum: b03c09f654a7e99ffb9777342e501321d46b15ebe764b9e3e9b52301e7511955e231b28e29ad36f174e6da733b432471e513c7ada0df31c0cda4ee083fd59d6f
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4268,7 +4268,7 @@ __metadata:
     react-native-gesture-handler: "npm:~2.16.1"
     react-native-reanimated: "npm:~3.10.1"
     react-native-safe-area-context: "npm:4.10.1"
-    react-native-screens: "npm:3.32.0"
+    react-native-screens: "npm:4.0.0-beta.1"
     typescript: "npm:^5.5.2"
     use-latest-callback: "npm:^0.2.1"
   peerDependencies:
@@ -4278,7 +4278,7 @@ __metadata:
     react-native-gesture-handler: ">= 2.0.0"
     react-native-reanimated: ">= 2.0.0"
     react-native-safe-area-context: ">= 4.0.0"
-    react-native-screens: ">= 3.21.0"
+    react-native-screens: ">= 4.0.0"
   languageName: unknown
   linkType: soft
 
@@ -14517,19 +14517,6 @@ __metadata:
     react: "*"
     react-native: "*"
   checksum: 89254daa2a4f35a7acffd20d9e42ea859f835d15b37f432c6aae2a1187a4675e3f91c6539cac21720f3746d851744f413a1c33c5a693f860f615bc880d3077f7
-  languageName: node
-  linkType: hard
-
-"react-native-screens@npm:3.32.0":
-  version: 3.32.0
-  resolution: "react-native-screens@npm:3.32.0"
-  dependencies:
-    react-freeze: "npm:^1.0.0"
-    warn-once: "npm:^0.1.0"
-  peerDependencies:
-    react: "*"
-    react-native: "*"
-  checksum: 22f27b2082e0c8d70165c8a26dcf55b4da2a18166d4b9a0b434f558edea57d71458800d5086940fe7cabe8b7e28c8614cf227f35152171d08583f4ef6f6f3a35
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4194,7 +4194,7 @@ __metadata:
     react-native: "npm:0.74.2"
     react-native-builder-bob: "npm:^0.29.0"
     react-native-safe-area-context: "npm:4.10.1"
-    react-native-screens: "npm:4.0.0-beta.2"
+    react-native-screens: "npm:4.0.0-beta.3"
     typescript: "npm:^5.5.2"
   peerDependencies:
     "@react-navigation/native": "workspace:^"
@@ -4268,7 +4268,7 @@ __metadata:
     react-native-gesture-handler: "npm:~2.16.1"
     react-native-reanimated: "npm:~3.10.1"
     react-native-safe-area-context: "npm:4.10.1"
-    react-native-screens: "npm:4.0.0-beta.2"
+    react-native-screens: "npm:4.0.0-beta.3"
     typescript: "npm:^5.5.2"
     use-latest-callback: "npm:^0.2.1"
   peerDependencies:
@@ -4353,7 +4353,7 @@ __metadata:
     react-native-pager-view: "npm:6.3.0"
     react-native-reanimated: "npm:~3.10.1"
     react-native-safe-area-context: "npm:4.10.1"
-    react-native-screens: "npm:4.0.0-beta.2"
+    react-native-screens: "npm:4.0.0-beta.3"
     react-native-web: "npm:~0.19.10"
     react-test-renderer: "npm:18.2.0"
     serve: "npm:^14.2.1"
@@ -4400,7 +4400,7 @@ __metadata:
     react: "npm:18.2.0"
     react-native: "npm:0.74.2"
     react-native-builder-bob: "npm:^0.29.0"
-    react-native-screens: "npm:4.0.0-beta.2"
+    react-native-screens: "npm:4.0.0-beta.3"
     typescript: "npm:^5.5.2"
     warn-once: "npm:^0.1.1"
   peerDependencies:
@@ -4466,7 +4466,7 @@ __metadata:
     react-native-builder-bob: "npm:^0.29.0"
     react-native-gesture-handler: "npm:~2.16.1"
     react-native-safe-area-context: "npm:4.10.1"
-    react-native-screens: "npm:4.0.0-beta.2"
+    react-native-screens: "npm:4.0.0-beta.3"
     typescript: "npm:^5.5.2"
   peerDependencies:
     "@react-navigation/native": "workspace:^"
@@ -14520,16 +14520,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-screens@npm:4.0.0-beta.2":
-  version: 4.0.0-beta.2
-  resolution: "react-native-screens@npm:4.0.0-beta.2"
+"react-native-screens@npm:4.0.0-beta.3":
+  version: 4.0.0-beta.3
+  resolution: "react-native-screens@npm:4.0.0-beta.3"
   dependencies:
     react-freeze: "npm:^1.0.0"
     warn-once: "npm:^0.1.0"
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: b03c09f654a7e99ffb9777342e501321d46b15ebe764b9e3e9b52301e7511955e231b28e29ad36f174e6da733b432471e513c7ada0df31c0cda4ee083fd59d6f
+  checksum: 67e1b9fe435db62255e387fbc6adb0a9f3baa61ab7baf9fa16fc47b868108488049e8d703df1b4ac0355ab0c7859ecab73ff4c1fad83b2d8c4782e8c63dc25d7
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4194,14 +4194,14 @@ __metadata:
     react-native: "npm:0.74.2"
     react-native-builder-bob: "npm:^0.29.0"
     react-native-safe-area-context: "npm:4.10.1"
-    react-native-screens: "npm:3.32.0"
+    react-native-screens: "npm:4.0.0-beta.1"
     typescript: "npm:^5.5.2"
   peerDependencies:
     "@react-navigation/native": "workspace:^"
     react: ">= 18.2.0"
     react-native: ">= 0.72.0"
     react-native-safe-area-context: ">= 4.0.0"
-    react-native-screens: ">= 3.21.0"
+    react-native-screens: ">= 4.0.0"
   languageName: unknown
   linkType: soft
 
@@ -4353,7 +4353,7 @@ __metadata:
     react-native-pager-view: "npm:6.3.0"
     react-native-reanimated: "npm:~3.10.1"
     react-native-safe-area-context: "npm:4.10.1"
-    react-native-screens: "npm:3.32.0"
+    react-native-screens: "npm:4.0.0-beta.1"
     react-native-web: "npm:~0.19.10"
     react-test-renderer: "npm:18.2.0"
     serve: "npm:^14.2.1"
@@ -4400,7 +4400,7 @@ __metadata:
     react: "npm:18.2.0"
     react-native: "npm:0.74.2"
     react-native-builder-bob: "npm:^0.29.0"
-    react-native-screens: "npm:3.32.0"
+    react-native-screens: "npm:4.0.0-beta.1"
     typescript: "npm:^5.5.2"
     warn-once: "npm:^0.1.1"
   peerDependencies:
@@ -4408,7 +4408,7 @@ __metadata:
     react: ">= 18.2.0"
     react-native: ">= 0.72.0"
     react-native-safe-area-context: ">= 4.0.0"
-    react-native-screens: ">= 3.21.0"
+    react-native-screens: ">= 4.0.0"
   languageName: unknown
   linkType: soft
 
@@ -4466,7 +4466,7 @@ __metadata:
     react-native-builder-bob: "npm:^0.29.0"
     react-native-gesture-handler: "npm:~2.16.1"
     react-native-safe-area-context: "npm:4.10.1"
-    react-native-screens: "npm:3.32.0"
+    react-native-screens: "npm:4.0.0-beta.1"
     typescript: "npm:^5.5.2"
   peerDependencies:
     "@react-navigation/native": "workspace:^"
@@ -4474,7 +4474,7 @@ __metadata:
     react-native: ">= 0.72.0"
     react-native-gesture-handler: ">= 2.0.0"
     react-native-safe-area-context: ">= 4.0.0"
-    react-native-screens: ">= 3.21.0"
+    react-native-screens: ">= 4.0.0"
   languageName: unknown
   linkType: soft
 
@@ -14530,6 +14530,19 @@ __metadata:
     react: "*"
     react-native: "*"
   checksum: 22f27b2082e0c8d70165c8a26dcf55b4da2a18166d4b9a0b434f558edea57d71458800d5086940fe7cabe8b7e28c8614cf227f35152171d08583f4ef6f6f3a35
+  languageName: node
+  linkType: hard
+
+"react-native-screens@npm:4.0.0-beta.1":
+  version: 4.0.0-beta.1
+  resolution: "react-native-screens@npm:4.0.0-beta.1"
+  dependencies:
+    react-freeze: "npm:^1.0.0"
+    warn-once: "npm:^0.1.0"
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+  checksum: e2672d35d36f56c0c45698409b0a4b7dc8b5959d091f84c0ecf3cf484965c9867e976339516b3a4704b623b5948473b8be520346e487801fc508a8f529700c41
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**Motivation**

`react-navigation@v7` brings support for `screens@v4` stable version of which will be released soon. This PR bumps used version of react native screens in all the packages and example application.

**Test plan**

Example app.
