### PR TITLE
refactor: move web-only checks inside web condition

### DIFF
--- a/packages/elements/src/PlatformPressable.tsx
+++ b/packages/elements/src/PlatformPressable.tsx
@@ -65,16 +65,15 @@ export function PlatformPressable({
   };
 
   const handlePress = (e: GestureResponderEvent) => {
-    // @ts-expect-error: these properties exist on web, but not in React Native
-    const hasModifierKey = e.metaKey || e.altKey || e.ctrlKey || e.shiftKey; // ignore clicks with modifier keys
-    // @ts-expect-error: these properties exist on web, but not in React Native
-    const isLeftClick = e.button == null || e.button === 0; // only handle left clicks
-    const isSelfTarget = [undefined, null, '', 'self'].includes(
-      // @ts-expect-error: these properties exist on web, but not in React Native
-      e.currentTarget?.target
-    ); // let browser handle "target=_blank" etc.
-
     if (Platform.OS === 'web' && rest.href != null) {
+      // @ts-expect-error: these properties exist on web, but not in React Native
+      const hasModifierKey = e.metaKey || e.altKey || e.ctrlKey || e.shiftKey; // ignore clicks with modifier keys
+      // @ts-expect-error: these properties exist on web, but not in React Native
+      const isLeftClick = e.button == null || e.button === 0; // only handle left clicks
+      const isSelfTarget = [undefined, null, '', 'self'].includes(
+        // @ts-expect-error: these properties exist on web, but not in React Native
+        e.currentTarget?.target
+      ); // let browser handle "target=_blank" etc.
       if (!hasModifierKey && isLeftClick && isSelfTarget) {
         e.preventDefault();
         onPress?.(e);

--- a/packages/elements/src/__tests__/PlatformPressable.test.tsx
+++ b/packages/elements/src/__tests__/PlatformPressable.test.tsx
@@ -1,0 +1,107 @@
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  jest,
+  test,
+} from '@jest/globals';
+import { NavigationContainer } from '@react-navigation/native';
+import {
+  act,
+  fireEvent,
+  render,
+  userEvent,
+} from '@testing-library/react-native';
+import { Platform, View } from 'react-native';
+
+import { PlatformPressable } from '../PlatformPressable';
+
+jest.useFakeTimers();
+
+describe('on native', () => {
+  test('should be pressable using simply fireEvent.press', () => {
+    const onPress = jest.fn();
+    const { getByTestId } = render(
+      <PlatformPressable onPress={onPress} testID={'Pressable'}>
+        <View />
+      </PlatformPressable>,
+      {
+        wrapper: NavigationContainer,
+      }
+    );
+
+    fireEvent.press(getByTestId('Pressable'));
+    jest.runAllTimers();
+
+    expect(onPress).toHaveBeenCalled();
+  });
+
+  test('should be pressable using with UserEvent', async () => {
+    const onPress = jest.fn();
+    const { getByTestId } = render(
+      <PlatformPressable onPress={onPress} testID={'Pressable'}>
+        <View />
+      </PlatformPressable>,
+      {
+        wrapper: NavigationContainer,
+      }
+    );
+
+    const user = userEvent.setup();
+    await user.press(getByTestId('Pressable'));
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    expect(onPress).toHaveBeenCalled();
+  });
+});
+
+describe('on web', () => {
+  let originalPlatformOS: typeof Platform.OS;
+
+  beforeAll(() => {
+    originalPlatformOS = Platform.OS;
+    Platform.OS = 'web';
+  });
+
+  afterAll(() => {
+    Platform.OS = originalPlatformOS;
+  });
+
+  const renderWebUI = (onPress: jest.Mock) => {
+    return render(
+      <PlatformPressable onPress={onPress} testID={'Pressable'} href={'/'}>
+        <View />
+      </PlatformPressable>,
+      {
+        wrapper: NavigationContainer,
+      }
+    );
+  };
+
+  test('should ignore non-left clicks', () => {
+    const onPress = jest.fn();
+    const { getByTestId } = renderWebUI(onPress);
+
+    fireEvent.press(getByTestId('Pressable'), { button: 1 });
+
+    expect(onPress).not.toHaveBeenCalled();
+  });
+
+  test('should be pressable with a left click', () => {
+    const onPress = jest.fn();
+    const preventDefault = jest.fn();
+    const { getByTestId } = renderWebUI(onPress);
+
+    fireEvent.press(getByTestId('Pressable'), {
+      button: 0,
+      preventDefault,
+    });
+    jest.runAllTimers();
+
+    expect(preventDefault).toHaveBeenCalled();
+    expect(onPress).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
**Motivation**

When writing tests that have `fireEvent.press(somePlatformPressable)` the test throws an error because event is undefined.

This change is similar to https://github.com/react-navigation/react-navigation/pull/12161 

**Test plan**

The change must pass lint, typescript and tests.