### PR TITLE
fix: handlePress type coercion

### DIFF
--- a/packages/react-native-tab-view/src/PlatformPressable.tsx
+++ b/packages/react-native-tab-view/src/PlatformPressable.tsx
@@ -30,11 +30,11 @@ export function PlatformPressable({
   ...rest
 }: Props) {
   const handlePress = (e: GestureResponderEvent) => {
-    if (Platform.OS === 'web' && rest.href !== null) {
+    if (Platform.OS === 'web' && rest.href != null) {
       // @ts-expect-error: these properties exist on web, but not in React Native
       const hasModifierKey = e.metaKey || e.altKey || e.ctrlKey || e.shiftKey; // ignore clicks with modifier keys
       // @ts-expect-error: these properties exist on web, but not in React Native
-      const isLeftClick = e.button === null || e.button === 0; // only handle left clicks
+      const isLeftClick = e.button == null || e.button === 0; // only handle left clicks
       const isSelfTarget = [undefined, null, '', 'self'].includes(
         // @ts-expect-error: these properties exist on web, but not in React Native
         e.currentTarget?.target

--- a/packages/react-native-tab-view/src/__tests__/PlatformPressable.test.tsx
+++ b/packages/react-native-tab-view/src/__tests__/PlatformPressable.test.tsx
@@ -78,7 +78,6 @@ describe('on web', () => {
     const { getByTestId } = renderWebUI(onPress);
 
     fireEvent.press(getByTestId('Pressable'), {
-      button: 0,
       preventDefault,
     });
 

--- a/packages/react-native-tab-view/src/__tests__/PlatformPressable.test.tsx
+++ b/packages/react-native-tab-view/src/__tests__/PlatformPressable.test.tsx
@@ -26,6 +26,8 @@ describe('on native', () => {
   });
 
   test('should be pressable using with UserEvent', async () => {
+    jest.useFakeTimers();
+
     const onPress = jest.fn();
     const { getByTestId } = render(
       <PlatformPressable onPress={onPress} testID={'Pressable'}>
@@ -35,6 +37,7 @@ describe('on native', () => {
 
     const user = userEvent.setup();
     await user.press(getByTestId('Pressable'));
+    jest.runAllTimers();
 
     expect(onPress).toHaveBeenCalled();
   });
@@ -71,13 +74,15 @@ describe('on web', () => {
 
   test('should be pressable with a left click', () => {
     const onPress = jest.fn();
+    const preventDefault = jest.fn();
     const { getByTestId } = renderWebUI(onPress);
 
     fireEvent.press(getByTestId('Pressable'), {
       button: 0,
-      preventDefault: jest.fn(),
+      preventDefault,
     });
 
+    expect(preventDefault).toHaveBeenCalled();
     expect(onPress).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
**Motivation**

In a previous PR https://github.com/react-navigation/react-navigation/pull/12161 I mistook the loose equality operators as typo errors. By using strict equality, the logic got changed on `undefined` values.

```typescript
// pseudocode
  if (rest.href != null) {
    // LOGIC A
  } else {
    // LOGIC B
  }
```

When `rest.href` is `undefined`
- Old Behavior --> LOGIC B
- New Behavior --> LOGIC A ❌

This PR reverts the changes to the equality operators to keep the old behavior.

**Test plan**

The change must pass lint, typescript and tests.

- [ ] Optional: temporarily change the `isLeftClick` to have `e.button === null`, the last test should fail
