### PR TITLE
feat(header): add accessibility label to drawer menu button

### DIFF
--- a/packages/drawer/src/views/DrawerToggleButton.tsx
+++ b/packages/drawer/src/views/DrawerToggleButton.tsx
@@ -22,6 +22,7 @@ export function DrawerToggleButton({ tintColor, ...rest }: Props) {
   return (
     <PlatformPressable
       {...rest}
+      accessibilityLabel="Open navigation menu"
       android_ripple={{ borderless: true }}
       onPress={() => navigation.dispatch(DrawerActions.toggleDrawer())}
       style={styles.touchable}


### PR DESCRIPTION
This PR adds an accessibilityLabel to the drawer menu button in the header to improve the app’s accessibility for screen reader users and fix  #12173 