### PR TITLE
chore: bump react-native-screens to 4.0.0-beta.9

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -33,7 +33,7 @@
     "react-native-pager-view": "6.3.0",
     "react-native-reanimated": "~3.10.1",
     "react-native-safe-area-context": "4.10.1",
-    "react-native-screens": "4.0.0-beta.5",
+    "react-native-screens": "4.0.0-beta.9",
     "react-native-web": "~0.19.10"
   },
   "devDependencies": {

--- a/packages/bottom-tabs/package.json
+++ b/packages/bottom-tabs/package.json
@@ -61,7 +61,7 @@
     "react-native": "0.74.2",
     "react-native-builder-bob": "^0.29.0",
     "react-native-safe-area-context": "4.10.1",
-    "react-native-screens": "4.0.0-beta.5",
+    "react-native-screens": "4.0.0-beta.9",
     "typescript": "^5.5.2"
   },
   "peerDependencies": {

--- a/packages/drawer/package.json
+++ b/packages/drawer/package.json
@@ -69,7 +69,7 @@
     "react-native-gesture-handler": "~2.16.1",
     "react-native-reanimated": "~3.10.1",
     "react-native-safe-area-context": "4.10.1",
-    "react-native-screens": "4.0.0-beta.5",
+    "react-native-screens": "4.0.0-beta.9",
     "typescript": "^5.5.2"
   },
   "peerDependencies": {

--- a/packages/native-stack/package.json
+++ b/packages/native-stack/package.json
@@ -64,7 +64,7 @@
     "react": "18.2.0",
     "react-native": "0.74.2",
     "react-native-builder-bob": "^0.29.0",
-    "react-native-screens": "4.0.0-beta.5",
+    "react-native-screens": "4.0.0-beta.9",
     "typescript": "^5.5.2"
   },
   "peerDependencies": {

--- a/packages/stack/package.json
+++ b/packages/stack/package.json
@@ -66,7 +66,7 @@
     "react-native-builder-bob": "^0.29.0",
     "react-native-gesture-handler": "~2.16.1",
     "react-native-safe-area-context": "4.10.1",
-    "react-native-screens": "4.0.0-beta.5",
+    "react-native-screens": "4.0.0-beta.9",
     "typescript": "^5.5.2"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4194,7 +4194,7 @@ __metadata:
     react-native: "npm:0.74.2"
     react-native-builder-bob: "npm:^0.29.0"
     react-native-safe-area-context: "npm:4.10.1"
-    react-native-screens: "npm:4.0.0-beta.5"
+    react-native-screens: "npm:4.0.0-beta.9"
     typescript: "npm:^5.5.2"
   peerDependencies:
     "@react-navigation/native": "workspace:^"
@@ -4268,7 +4268,7 @@ __metadata:
     react-native-gesture-handler: "npm:~2.16.1"
     react-native-reanimated: "npm:~3.10.1"
     react-native-safe-area-context: "npm:4.10.1"
-    react-native-screens: "npm:4.0.0-beta.5"
+    react-native-screens: "npm:4.0.0-beta.9"
     typescript: "npm:^5.5.2"
     use-latest-callback: "npm:^0.2.1"
   peerDependencies:
@@ -4353,7 +4353,7 @@ __metadata:
     react-native-pager-view: "npm:6.3.0"
     react-native-reanimated: "npm:~3.10.1"
     react-native-safe-area-context: "npm:4.10.1"
-    react-native-screens: "npm:4.0.0-beta.5"
+    react-native-screens: "npm:4.0.0-beta.9"
     react-native-web: "npm:~0.19.10"
     react-test-renderer: "npm:18.2.0"
     serve: "npm:^14.2.1"
@@ -4400,7 +4400,7 @@ __metadata:
     react: "npm:18.2.0"
     react-native: "npm:0.74.2"
     react-native-builder-bob: "npm:^0.29.0"
-    react-native-screens: "npm:4.0.0-beta.5"
+    react-native-screens: "npm:4.0.0-beta.9"
     typescript: "npm:^5.5.2"
     warn-once: "npm:^0.1.1"
   peerDependencies:
@@ -4466,7 +4466,7 @@ __metadata:
     react-native-builder-bob: "npm:^0.29.0"
     react-native-gesture-handler: "npm:~2.16.1"
     react-native-safe-area-context: "npm:4.10.1"
-    react-native-screens: "npm:4.0.0-beta.5"
+    react-native-screens: "npm:4.0.0-beta.9"
     typescript: "npm:^5.5.2"
   peerDependencies:
     "@react-navigation/native": "workspace:^"
@@ -14520,16 +14520,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-screens@npm:4.0.0-beta.5":
-  version: 4.0.0-beta.5
-  resolution: "react-native-screens@npm:4.0.0-beta.5"
+"react-native-screens@npm:4.0.0-beta.9":
+  version: 4.0.0-beta.9
+  resolution: "react-native-screens@npm:4.0.0-beta.9"
   dependencies:
     react-freeze: "npm:^1.0.0"
     warn-once: "npm:^0.1.0"
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 91b29bd4596be83b3ab24935b7c32911a6dd5bbefc0106db325b0b0e4efe985fb0153e706f815fecde98fdad64d495cedd389c3d2e6098b10893ba6ca858b36a
+  checksum: 3eb6bfbb894544ee08096ed30fb4afb08bbf52dd7439fe22cd0c7ce5b15529cb208887ce354b15eab84ffd72a5b9fcfcde55c3c27c7d06223243acd73b35c327
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**Motivation**

This PR bumps `react-native-screens` to 4.0.0-beta.9, which contains native code for `preload` functionality for `native-stack`.

**Test plan**

`TestPreload` in `FabricExample` / `Example` in `react-native-screens` repository.

