### PR TITLE
fix(Android): formSheet flex 1 support

### DIFF
--- a/packages/native-stack/src/views/NativeStackView.native.tsx
+++ b/packages/native-stack/src/views/NativeStackView.native.tsx
@@ -101,11 +101,7 @@ const MaybeNestedStack = ({
   const content = (
     <DebugContainer
       style={[
-        presentation === 'formSheet'
-          ? Platform.OS === 'ios'
-            ? styles.absolute
-            : null
-          : styles.container,
+        presentation === 'formSheet' ? styles.absolute : styles.container,
         presentation !== 'transparentModal' &&
           presentation !== 'containedTransparentModal' && {
             backgroundColor: colors.background,
@@ -709,6 +705,7 @@ const styles = StyleSheet.create({
     top: 0,
     start: 0,
     end: 0,
+    maxHeight: '100%',
   },
   translucent: {
     position: 'absolute',

--- a/packages/native-stack/src/views/NativeStackView.native.tsx
+++ b/packages/native-stack/src/views/NativeStackView.native.tsx
@@ -542,7 +542,12 @@ const SceneView = ({
                     ? !isRemovePrevented
                     : headerBackButtonMenuEnabled
                 }
-                headerShown={header !== undefined ? false : headerShown}
+                headerShown={
+                  header !== undefined ||
+                  (presentation === 'formSheet' && Platform.OS === 'android')
+                    ? false
+                    : headerShown
+                }
                 headerHeight={headerHeight}
                 headerBackTitle={
                   options.headerBackTitle !== undefined

--- a/packages/native-stack/src/views/NativeStackView.native.tsx
+++ b/packages/native-stack/src/views/NativeStackView.native.tsx
@@ -101,7 +101,7 @@ const MaybeNestedStack = ({
   const content = (
     <DebugContainer
       style={[
-        presentation === 'formSheet' ? styles.absolute : styles.container,
+        presentation === 'formSheet' ? styles.sheet : styles.container,
         presentation !== 'transparentModal' &&
           presentation !== 'containedTransparentModal' && {
             backgroundColor: colors.background,
@@ -701,6 +701,12 @@ const styles = StyleSheet.create({
     zIndex: 1,
   },
   absolute: {
+    position: 'absolute',
+    top: 0,
+    start: 0,
+    end: 0,
+  },
+  sheet: {
     position: 'absolute',
     top: 0,
     start: 0,

--- a/packages/native-stack/src/views/NativeStackView.native.tsx
+++ b/packages/native-stack/src/views/NativeStackView.native.tsx
@@ -101,7 +101,12 @@ const MaybeNestedStack = ({
   const content = (
     <DebugContainer
       style={[
-        presentation === 'formSheet' ? styles.sheet : styles.container,
+        presentation === 'formSheet'
+          ? {
+              ...styles.sheet,
+              maxHeight: Platform.OS === 'android' ? '100%' : undefined,
+            }
+          : styles.container,
         presentation !== 'transparentModal' &&
           presentation !== 'containedTransparentModal' && {
             backgroundColor: colors.background,
@@ -711,7 +716,6 @@ const styles = StyleSheet.create({
     top: 0,
     start: 0,
     end: 0,
-    maxHeight: '100%',
   },
   translucent: {
     position: 'absolute',


### PR DESCRIPTION
**Motivation**

This PR intents to add `flex: 1` support to android formSheets. Currently when you set `flex: 1` style to a wrapper component (quite usual thing to do) inside a screen with `presentation: 'formSheet'` it doesn't show up on android. On iOS it works fine.

This adjustment prevents the android sheet from breaking when given the `flex: 1` style and ensures that its behaviour aligns better with iOS.

I ensured that sheet w/o `flex:1` style set as well as one using scrollview work just like before. Please try the snack provided to test this change.

**Before**

| without backgroundColor | with backgroundColor (unstable_screenStyle) |
|---|---|
| ![Screenshot 2024-10-16 at 18 29 35](https://github.com/user-attachments/assets/9a524801-f171-44ed-ba32-23c563756934) | ![Screenshot 2024-10-16 at 18 04 50](https://github.com/user-attachments/assets/5296d383-f398-41b0-8981-c97a5f978610) |

**After**

| without backgroundColor | with backgroundColor (unstable_screenStyle) |
|---|---|
|  ![Screenshot 2024-10-16 at 18 30 07](https://github.com/user-attachments/assets/013f7bd4-e05b-40cf-baa4-810bfe2c4db9) | ![Screenshot 2024-10-16 at 18 07 32](https://github.com/user-attachments/assets/1a1199fb-dcf0-457e-b10f-821ddffc891d) |


**Test plan**

I attach a snack that can be used to test this change

<details>
<summary>snack</summary>

```
import * as React from 'react';
import { View, Button, Text, StyleSheet, ScrollView } from 'react-native';
import { NavigationContainer } from '@react-navigation/native';
import {
  createNativeStackNavigator,
  NativeStackNavigationOptions,
  NativeStackNavigationProp,
} from '@react-navigation/native-stack';

type StackParamList = {
  Home: undefined;
  'Sheet One': undefined;
  'Sheet Two': undefined;
  'Sheet Three': undefined;
};

function HomeScreen({
  navigation,
}: {
  navigation: NativeStackNavigationProp<StackParamList>;
}) {
  return (
    <View style={styles.container}>
      <Button
        onPress={() => navigation.navigate('Sheet One')}
        title="Open First Sheet"
      />
      <Button
        onPress={() => navigation.navigate('Sheet Two')}
        title="Open Second Sheet"
      />
      <Button
        onPress={() => navigation.navigate('Sheet Three')}
        title="Open Third Sheet"
      />
    </View>
  );
}

function Screen({
  navigation,
}: {
  navigation: NativeStackNavigationProp<StackParamList>;
}) {
  return (
    <View style={styles.sheetContainer}>
      <Text style={styles.text}>I'm inside a view</Text>
      <Button onPress={navigation.goBack} title="Dismiss" />
    </View>
  );
}

function Screen2({
  navigation,
}: {
  navigation: NativeStackNavigationProp<StackParamList>;
}) {
  return (
    <View style={{ ...styles.sheetContainer, flex: 1 }}>
      <Text style={styles.text}>I'm inside a view with "flex: 1"</Text>
      <Button onPress={navigation.goBack} title="Dismiss" />
    </View>
  );
}

function Screen3({
  navigation,
}: {
  navigation: NativeStackNavigationProp<StackParamList>;
}) {
  return (
    <ScrollView contentContainerStyle={styles.sheetContainer} nestedScrollEnabled>
      {Array(30)
        .fill(0)
        .map((_, index) => (
          <Text style={styles.text} key={index}>
            I'm inside a scrollview
          </Text>
        ))}
      <Button onPress={navigation.goBack} title="Dismiss" />
      <ScrollView>
        {Array(30)
          .fill(0)
          .map((_, index) => (
            <Text style={styles.text} key={'nested' + index}>
              I'm inside a nested scrollview
            </Text>
          ))}
      </ScrollView>
    </ScrollView>
  );
}

const RootStack = createNativeStackNavigator<StackParamList>();

const commonSheetOptions = {
  presentation: 'formSheet',
  sheetAllowedDetents: [0.5, 1],
  unstable_screenStyle: { backgroundColor: 'mediumseagreen' },
} as NativeStackNavigationOptions;

export default function App() {
  return (
    <NavigationContainer>
      <RootStack.Navigator>
        <RootStack.Screen name="Home" component={HomeScreen} />
        <RootStack.Screen
          name="Sheet One"
          component={Screen}
          options={commonSheetOptions}
        />
        <RootStack.Screen
          name="Sheet Two"
          component={Screen2}
          options={commonSheetOptions}
        />
        <RootStack.Screen
          name="Sheet Three"
          component={Screen3}
          options={commonSheetOptions}
        />
      </RootStack.Navigator>
    </NavigationContainer>
  );
}

const styles = StyleSheet.create({
  text: {
    fontWeight: 'bold',
    fontSize: 20,
    padding: 5,
  },
  container: {
    flex: 1,
    alignItems: 'center',
    justifyContent: 'center',
  },
  sheetContainer: {
    backgroundColor: 'goldenrod',
    alignItems: 'center',
    justifyContent: 'center',
  },
});

```
</details>