### PR TITLE
refactor: replace unstable_screenStyle with backgroundColor from contentStyle

### DIFF
--- a/packages/native-stack/src/types.tsx
+++ b/packages/native-stack/src/types.tsx
@@ -445,6 +445,8 @@ export type NativeStackNavigationOptions = {
   gestureDirection?: ScreenProps['swipeDirection'];
   /**
    * Style object for the scene content.
+   *
+   * As a workaround to truncated sheet content, formSheet uses backgroundColor from contentStyle and applies it on Screen.
    */
   contentStyle?: StyleProp<ViewStyle>;
   /**

--- a/packages/native-stack/src/types.tsx
+++ b/packages/native-stack/src/types.tsx
@@ -448,13 +448,6 @@ export type NativeStackNavigationOptions = {
    */
   contentStyle?: StyleProp<ViewStyle>;
   /**
-   * Style object for the screen native component. This might help to workaround
-   * some issues when using `formSheet` presentation.
-   *
-   * Only `backgroundColor` is accepted.
-   */
-  unstable_screenStyle?: ScreenProps['unstable_screenStyle'];
-  /**
    * Whether the gesture to dismiss should use animation provided to `animation` prop. Defaults to `false`.
    *
    * Doesn't affect the behavior of screens presented modally.


### PR DESCRIPTION
Corresponding PR in react-native-screens: https://github.com/software-mansion/react-native-screens/pull/2419. 

## Change

Instead of adding `unstable_screenStyle` that directly adds background on `Screen` component, we can pick the `backgroundColor` from `contentStyle` and apply it on `Screen` component, without exposing unstable prop.