### PR TITLE
refactor: move screen specific logic for native stack to own component

### DIFF
--- a/packages/native-stack/src/views/ScreenStackContent.tsx
+++ b/packages/native-stack/src/views/ScreenStackContent.tsx
@@ -1,0 +1,30 @@
+import {
+  Screen,
+  type ScreenProps,
+  ScreenStackHeaderConfig,
+  type ScreenStackHeaderConfigProps,
+} from 'react-native-screens';
+
+type Props = Omit<ScreenProps, 'enabled' | 'isNativeStack'> & {
+  headerConfig?: ScreenStackHeaderConfigProps;
+};
+
+export function ScreenStackContent({ children, headerConfig, ...rest }: Props) {
+  return (
+    <Screen enabled isNativeStack {...rest}>
+      {children}
+      {/**
+       * `HeaderConfig` needs to be the direct child of `Screen` without any intermediate `View`
+       * We don't render it conditionally to make it possible to dynamically render a custom `header`
+       * Otherwise dynamically rendering a custom `header` leaves the native header visible
+       *
+       * https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md#screenstackheaderconfig
+       *
+       * HeaderConfig must not be first child of a Screen.
+       * See https://github.com/software-mansion/react-native-screens/pull/1825
+       * for detailed explanation.
+       */}
+      <ScreenStackHeaderConfig {...headerConfig} />
+    </Screen>
+  );
+}

--- a/packages/native-stack/src/views/ScreenStackContent.tsx
+++ b/packages/native-stack/src/views/ScreenStackContent.tsx
@@ -1,21 +1,73 @@
+import * as React from 'react';
+import {
+  Platform,
+  type StyleProp,
+  StyleSheet,
+  type ViewStyle,
+} from 'react-native';
 import {
   Screen,
   type ScreenProps,
+  ScreenStack,
   ScreenStackHeaderConfig,
   type ScreenStackHeaderConfigProps,
 } from 'react-native-screens';
+import warnOnce from 'warn-once';
 
-type Props = Omit<ScreenProps, 'enabled' | 'isNativeStack'> & {
+import { DebugContainer } from './DebugContainer';
+
+type Props = Omit<
+  ScreenProps,
+  'enabled' | 'isNativeStack' | 'hasLargeHeader'
+> & {
   headerConfig?: ScreenStackHeaderConfigProps;
+  contentStyle?: StyleProp<ViewStyle>;
 };
 
-export function ScreenStackContent({ children, headerConfig, ...rest }: Props) {
-  return (
-    <Screen enabled isNativeStack {...rest}>
-      {children}
+export function ScreenStackContent({
+  children,
+  headerConfig,
+  activityState,
+  stackPresentation,
+  contentStyle,
+  ...rest
+}: Props) {
+  const isHeaderInModal =
+    Platform.OS === 'android'
+      ? false
+      : stackPresentation !== 'push' && headerConfig?.hidden === false;
+
+  const headerHiddenPreviousRef = React.useRef(headerConfig?.hidden);
+
+  React.useEffect(() => {
+    warnOnce(
+      Platform.OS !== 'android' &&
+        stackPresentation !== 'push' &&
+        headerHiddenPreviousRef.current !== headerConfig?.hidden,
+      `Dynamically changing header's visibility in modals will result in remounting the screen and losing all local state.`
+    );
+
+    headerHiddenPreviousRef.current = headerConfig?.hidden;
+  }, [headerConfig?.hidden, stackPresentation]);
+
+  const content = (
+    <>
+      <DebugContainer
+        style={[
+          stackPresentation === 'formSheet'
+            ? Platform.OS === 'ios'
+              ? styles.absolute
+              : null
+            : styles.container,
+          contentStyle,
+        ]}
+        stackPresentation={stackPresentation ?? 'push'}
+      >
+        {children}
+      </DebugContainer>
       {/**
        * `HeaderConfig` needs to be the direct child of `Screen` without any intermediate `View`
-       * We don't render it conditionally to make it possible to dynamically render a custom `header`
+       * We don't render it conditionally based on visibility to make it possible to dynamically render a custom `header`
        * Otherwise dynamically rendering a custom `header` leaves the native header visible
        *
        * https://github.com/software-mansion/react-native-screens/blob/main/guides/GUIDE_FOR_LIBRARY_AUTHORS.md#screenstackheaderconfig
@@ -25,6 +77,45 @@ export function ScreenStackContent({ children, headerConfig, ...rest }: Props) {
        * for detailed explanation.
        */}
       <ScreenStackHeaderConfig {...headerConfig} />
+    </>
+  );
+
+  return (
+    <Screen
+      enabled
+      isNativeStack
+      activityState={activityState}
+      stackPresentation={stackPresentation}
+      hasLargeHeader={headerConfig?.largeTitle ?? false}
+      {...rest}
+    >
+      {isHeaderInModal ? (
+        <ScreenStack style={styles.container}>
+          <Screen
+            enabled
+            isNativeStack
+            activityState={activityState}
+            hasLargeHeader={headerConfig?.largeTitle ?? false}
+            style={StyleSheet.absoluteFill}
+          >
+            {content}
+          </Screen>
+        </ScreenStack>
+      ) : (
+        content
+      )}
     </Screen>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  absolute: {
+    position: 'absolute',
+    top: 0,
+    start: 0,
+    end: 0,
+  },
+});

--- a/packages/native-stack/src/views/useHeaderConfigProps.tsx
+++ b/packages/native-stack/src/views/useHeaderConfigProps.tsx
@@ -5,7 +5,6 @@ import {
   isSearchBarAvailableForCurrentPlatform,
   ScreenStackHeaderBackButtonImage,
   ScreenStackHeaderCenterView,
-  ScreenStackHeaderConfig,
   ScreenStackHeaderLeftView,
   ScreenStackHeaderRightView,
   ScreenStackHeaderSearchBarView,
@@ -22,7 +21,7 @@ type Props = NativeStackNavigationOptions & {
   canGoBack: boolean;
 };
 
-export function HeaderConfig({
+export function useHeaderConfigProps({
   headerBackImageSource,
   headerBackButtonDisplayMode,
   headerBackButtonMenuEnabled,
@@ -50,7 +49,7 @@ export function HeaderConfig({
   route,
   title,
   canGoBack,
-}: Props): JSX.Element {
+}: Props) {
   const { direction } = useLocale();
   const { colors, fonts } = useTheme();
   const tintColor =
@@ -192,52 +191,8 @@ export function HeaderConfig({
 
   const isCenterViewRenderedAndroid = headerTitleAlign === 'center';
 
-  return (
-    <ScreenStackHeaderConfig
-      backButtonInCustomView={backButtonInCustomView}
-      backgroundColor={headerBackgroundColor}
-      backTitle={headerBackTitle}
-      backTitleVisible={
-        isBackButtonDisplayModeAvailable
-          ? undefined
-          : headerBackButtonDisplayMode !== 'minimal'
-      }
-      backButtonDisplayMode={
-        isBackButtonDisplayModeAvailable
-          ? headerBackButtonDisplayMode
-          : undefined
-      }
-      backTitleFontFamily={backTitleFontFamily}
-      backTitleFontSize={backTitleFontSize}
-      blurEffect={headerBlurEffect}
-      color={tintColor}
-      direction={direction}
-      disableBackButtonMenu={headerBackButtonMenuEnabled === false}
-      hidden={headerShown === false}
-      hideBackButton={headerBackVisible === false}
-      hideShadow={
-        headerShadowVisible === false ||
-        headerBackground != null ||
-        (headerTransparent && headerShadowVisible !== true)
-      }
-      largeTitle={headerLargeTitle}
-      largeTitleBackgroundColor={largeTitleBackgroundColor}
-      largeTitleColor={largeTitleColor}
-      largeTitleFontFamily={largeTitleFontFamily}
-      largeTitleFontSize={largeTitleFontSize}
-      largeTitleFontWeight={largeTitleFontWeight}
-      largeTitleHideShadow={headerLargeTitleShadowVisible === false}
-      title={titleText}
-      titleColor={titleColor}
-      titleFontFamily={titleFontFamily}
-      titleFontSize={titleFontSize}
-      titleFontWeight={String(titleFontWeight)}
-      topInsetEnabled={headerTopInsetEnabled}
-      translucent={
-        // This defaults to `true`, so we can't pass `undefined`
-        translucent === true
-      }
-    >
+  const children = (
+    <>
       {Platform.OS === 'ios' ? (
         <>
           {headerLeftElement != null ? (
@@ -306,6 +261,45 @@ export function HeaderConfig({
           <SearchBar {...headerSearchBarOptions} />
         </ScreenStackHeaderSearchBarView>
       ) : null}
-    </ScreenStackHeaderConfig>
+    </>
   );
+
+  return {
+    backButtonInCustomView,
+    backgroundColor: headerBackgroundColor,
+    backTitle: headerBackTitle,
+    backTitleVisible: isBackButtonDisplayModeAvailable
+      ? undefined
+      : headerBackButtonDisplayMode !== 'minimal',
+    backButtonDisplayMode: isBackButtonDisplayModeAvailable
+      ? headerBackButtonDisplayMode
+      : undefined,
+    backTitleFontFamily,
+    backTitleFontSize,
+    blurEffect: headerBlurEffect,
+    color: tintColor,
+    direction,
+    disableBackButtonMenu: headerBackButtonMenuEnabled === false,
+    hidden: headerShown === false,
+    hideBackButton: headerBackVisible === false,
+    hideShadow:
+      headerShadowVisible === false ||
+      headerBackground != null ||
+      (headerTransparent && headerShadowVisible !== true),
+    largeTitle: headerLargeTitle,
+    largeTitleBackgroundColor,
+    largeTitleColor,
+    largeTitleFontFamily,
+    largeTitleFontSize,
+    largeTitleFontWeight,
+    largeTitleHideShadow: headerLargeTitleShadowVisible === false,
+    title: titleText,
+    titleColor,
+    titleFontFamily,
+    titleFontSize,
+    titleFontWeight: String(titleFontWeight),
+    topInsetEnabled: headerTopInsetEnabled,
+    translucent: translucent === true,
+    children,
+  } as const;
 }


### PR DESCRIPTION
Currently there is a lot of logic to make `Screens` work properly in native-stack, including:

- Making sure screens is enabled and mark it for native-stack
- Making sure screens knows that it contains a large title
- Rendering a `DebugContainer` for `LogBox`
- Making sure the `DebugContainer` contains appropriate logic and wrapper
- Rendering a nested stack to be able to show header in modals

This diff consolidates this logic to a new component `ScreenStackContent`. This makes it possible to move the above logic to the `react-native-screens` package by moving this component. Moving the logic will make it easier to fix bugs in screens.

**Next Steps**: Once we merge this, we should move the `DebugContainer` and `ScreenStackContent` to `react-native-screens` package and update native-stack's code to use the exported `ScreenStackContent` from `react-native-screens`.