### PR TITLE
feat: Detect edge to edge and bypass statusBarTranslucent / navigationBarTranslucent

### DIFF
--- a/packages/native-stack/package.json
+++ b/packages/native-stack/package.json
@@ -53,6 +53,7 @@
   },
   "dependencies": {
     "@react-navigation/elements": "^2.0.0-rc.26",
+    "react-native-is-edge-to-edge": "^1.1.5",
     "warn-once": "^0.1.1"
   },
   "devDependencies": {

--- a/packages/native-stack/src/views/NativeStackView.native.tsx
+++ b/packages/native-stack/src/views/NativeStackView.native.tsx
@@ -136,10 +136,8 @@ const SceneView = ({
 
   if (__DEV__) {
     controlEdgeToEdgeValues({
-      navigationBarColor,
       navigationBarTranslucent,
       statusBarTranslucent,
-      statusBarBackgroundColor,
     });
   }
 
@@ -314,7 +312,7 @@ const SceneView = ({
       }
       homeIndicatorHidden={autoHideHomeIndicator}
       hideKeyboardOnSwipe={keyboardHandlingEnabled}
-      navigationBarColor={IS_EDGE_TO_EDGE ? undefined : navigationBarColor}
+      navigationBarColor={navigationBarColor}
       navigationBarTranslucent={IS_EDGE_TO_EDGE || navigationBarTranslucent}
       navigationBarHidden={navigationBarHidden}
       replaceAnimation={animationTypeForReplace}
@@ -331,7 +329,7 @@ const SceneView = ({
       statusBarAnimation={statusBarAnimation}
       statusBarHidden={statusBarHidden}
       statusBarStyle={statusBarStyle}
-      statusBarColor={IS_EDGE_TO_EDGE ? undefined : statusBarBackgroundColor}
+      statusBarColor={statusBarBackgroundColor}
       statusBarTranslucent={IS_EDGE_TO_EDGE || statusBarTranslucent}
       swipeDirection={gestureDirectionOverride}
       transitionDuration={animationDuration}

--- a/packages/native-stack/src/views/NativeStackView.native.tsx
+++ b/packages/native-stack/src/views/NativeStackView.native.tsx
@@ -26,6 +26,10 @@ import {
   View,
 } from 'react-native';
 import {
+  controlEdgeToEdgeValues,
+  isEdgeToEdge,
+} from 'react-native-is-edge-to-edge';
+import {
   useSafeAreaFrame,
   useSafeAreaInsets,
 } from 'react-native-safe-area-context';
@@ -46,6 +50,7 @@ import { ScreenStackContent } from './ScreenStackContent';
 import { useHeaderConfigProps } from './useHeaderConfigProps';
 
 const ANDROID_DEFAULT_HEADER_HEIGHT = 56;
+const IS_EDGE_TO_EDGE = isEdgeToEdge();
 
 type SceneViewProps = {
   index: number;
@@ -128,6 +133,15 @@ const SceneView = ({
     freezeOnBlur,
     contentStyle,
   } = options;
+
+  if (__DEV__) {
+    controlEdgeToEdgeValues({
+      navigationBarColor,
+      navigationBarTranslucent,
+      statusBarTranslucent,
+      statusBarBackgroundColor,
+    });
+  }
 
   // We want to allow only backgroundColor setting for now.
   // This allows to workaround one issue with truncated
@@ -240,9 +254,10 @@ const SceneView = ({
   // we apply additional padding in header only if its true.
   // For more details see: https://github.com/react-navigation/react-navigation/pull/12014
   const headerTopInsetEnabled =
-    typeof statusBarTranslucent === 'boolean'
+    IS_EDGE_TO_EDGE ||
+    (typeof statusBarTranslucent === 'boolean'
       ? statusBarTranslucent
-      : topInset !== 0;
+      : topInset !== 0);
 
   const canGoBack = previousDescriptor != null || parentHeaderBack != null;
   const backTitle = previousDescriptor
@@ -299,8 +314,8 @@ const SceneView = ({
       }
       homeIndicatorHidden={autoHideHomeIndicator}
       hideKeyboardOnSwipe={keyboardHandlingEnabled}
-      navigationBarColor={navigationBarColor}
-      navigationBarTranslucent={navigationBarTranslucent}
+      navigationBarColor={IS_EDGE_TO_EDGE ? undefined : navigationBarColor}
+      navigationBarTranslucent={IS_EDGE_TO_EDGE || navigationBarTranslucent}
       navigationBarHidden={navigationBarHidden}
       replaceAnimation={animationTypeForReplace}
       stackPresentation={presentation === 'card' ? 'push' : presentation}
@@ -316,8 +331,8 @@ const SceneView = ({
       statusBarAnimation={statusBarAnimation}
       statusBarHidden={statusBarHidden}
       statusBarStyle={statusBarStyle}
-      statusBarColor={statusBarBackgroundColor}
-      statusBarTranslucent={statusBarTranslucent}
+      statusBarColor={IS_EDGE_TO_EDGE ? undefined : statusBarBackgroundColor}
+      statusBarTranslucent={IS_EDGE_TO_EDGE || statusBarTranslucent}
       swipeDirection={gestureDirectionOverride}
       transitionDuration={animationDuration}
       onWillAppear={onWillAppear}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4800,6 +4800,7 @@ __metadata:
     react: "npm:18.2.0"
     react-native: "npm:0.74.5"
     react-native-builder-bob: "npm:^0.29.0"
+    react-native-is-edge-to-edge: "npm:^1.1.5"
     react-native-screens: "npm:4.0.0-beta.9"
     typescript: "npm:^5.5.2"
     warn-once: "npm:^0.1.1"
@@ -15036,6 +15037,16 @@ __metadata:
     react: "*"
     react-native: "*"
   checksum: 227799f5e16f9725d81db524fc06c1fbef226835a5ee989642d132748832f7543ebc750d4309e49bcaa0fb6d1e7dd6b74028785e4b755978ab7f66f05b414c18
+  languageName: node
+  linkType: hard
+
+"react-native-is-edge-to-edge@npm:^1.1.5":
+  version: 1.1.5
+  resolution: "react-native-is-edge-to-edge@npm:1.1.5"
+  peerDependencies:
+    react: ">=18.2.0"
+    react-native: ">=0.73.0"
+  checksum: a8867b92b01de6b329cfdd12dc1245cf122e24fc7b8f280837614b68eee244978743fca0595538fd981abb7cb24d7f567f2f172e6e23567c1a9275d09b892e52
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**Motivation**

The future of Android is [edge-to-edge](https://developer.android.com/about/versions/15/behavior-changes-15#edge-to-edge), and to make the React Native developer experience seamless in this regard, the ecosystem needs to transition from “opaque system bars by default” to “edge-to-edge by default.”

To prevent library authors from implementing their own edge-to-edge solutions—which could interfere with other libraries—and because it’s not possible to reliably detect if edge-to-edge is already enabled on Android, we have collaborated with [Expo](https://expo.dev/) to create a library that handles this functionality and is detectable using a simple helper: [`react-native-is-edge-to-edge`](https://github.com/zoontek/react-native-edge-to-edge/tree/main/react-native-is-edge-to-edge).

This approach allows you to bypass certain options and props (in this case, `SceneView` `statusBarTranslucent` and `navigationBarTranslucent`), helping to avoid frustrating issues like, “My app starts in edge-to-edge, but the system bars reappear immediately.” (because `react-navigation` causes them to reappear)

This PR is intentionally lightweight, as `react-navigation` doesn’t seem to interfere with edge-to-edge when `statusBarTranslucent` and `navigationBarTranslucent` are set to `true`.

> [!NOTE]  
> I didn't update `statusBarBackgroundColor` / `navigationBarColor`, but note that those are [deprecated](https://developer.android.com/about/versions/15/behavior-changes-15#deprecated-apis) and should not be used anymore (and will likely to have no impact on Android 15+, targetting SDK 35)

**Test plan**

- Install [react-native-edge-to-edge](https://github.com/zoontek/react-native-edge-to-edge) on the example app.
- Replace the `StatusBar` call in `example/src/index.tsx` with `<SystemBars style={theme.dark ? 'light' : 'dark'} />` and the one in `example/src/screens/BottomTabs.tsx` with `<SystemBars style="light" />`
- Create an Expo build (react-native-edge-to-edge doesn't work on Expo go yet)

<img width="545" alt="Screenshot 2024-10-28 at 21 50 12" src="https://github.com/user-attachments/assets/b8b999ce-5f7d-41a9-b9a4-8021435e5bc0">