### PR TITLE
Autofix: [React-Navigation 7.x bug] useHeaderConfigProps.js -- "Cannot read property 'regular' of undefined"

### DIFF
--- a/packages/native-stack/src/views/useHeaderConfigProps.tsx
+++ b/packages/native-stack/src/views/useHeaderConfigProps.tsx
@@ -51,7 +51,7 @@ export function useHeaderConfigProps({
   canGoBack,
 }: Props) {
   const { direction } = useLocale();
-  const { colors, fonts } = useTheme();
+  const { colors, fonts = {} } = useTheme();
   const tintColor =
     headerTintColor ?? (Platform.OS === 'ios' ? colors.primary : colors.text);
 


### PR DESCRIPTION
I've identified the issue in the `useHeaderConfigProps` function where `fonts` could be undefined. To fix this, I've added a fallback for when `fonts` is undefined. This ensures that we always have a valid object to work with, preventing the 'Cannot read property 'regular' of undefined' error.

Here's what I've changed in the `useHeaderConfigProps` function: 
> [!CAUTION]  
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission