### PR TITLE
fix: `None of the callbacks in the gesture are worklets` on Drawer

### DIFF
--- a/packages/react-native-drawer-layout/src/views/Drawer.native.tsx
+++ b/packages/react-native-drawer-layout/src/views/Drawer.native.tsx
@@ -217,21 +217,25 @@ export function Drawer({
 
   const startX = useSharedValue(0);
 
-  let pan = Gesture?.Pan()
+  let pan = Gesture.Pan()
     .onBegin((event) => {
+      'worklet';
       startX.value = translationX.value;
       gestureState.value = event.state;
       touchStartX.value = event.x;
     })
     .onStart(() => {
+      'worklet';
       runOnJS(onGestureBegin)();
     })
     .onChange((event) => {
+      'worklet';
       touchX.value = event.x;
       translationX.value = startX.value + event.translationX;
       gestureState.value = event.state;
     })
     .onEnd((event, success) => {
+      'worklet';
       gestureState.value = event.state;
 
       if (!success) {

--- a/packages/react-native-drawer-layout/src/views/Drawer.native.tsx
+++ b/packages/react-native-drawer-layout/src/views/Drawer.native.tsx
@@ -217,7 +217,7 @@ export function Drawer({
 
   const startX = useSharedValue(0);
 
-  let pan = Gesture.Pan()
+  let pan = Gesture?.Pan()
     .onBegin((event) => {
       'worklet';
       startX.value = translationX.value;


### PR DESCRIPTION
**Motivation**

After upgrading to v7, Drawer started throwing this warning: (at least on `"react-native-gesture-handler": "2.20.2"`)

`[react-native-gesture-handler] None of the callbacks in the gesture are worklets. If you wish to run them on the JS thread use '.runOnJS(true)' modifier on the gesture to make this explicit. Otherwise, mark the callbacks as 'worklet' to run them on the UI thread. [Component Stack]`

I identified the issue by adding a `console.log` on `react-native-gesture-handler` `utils.ts`:

```ts
export function checkGestureCallbacksForWorklets(gesture: GestureType) {
  if (!__DEV__) {
    return;
  }
  console.log(gesture.handlers)
  ...
```

output: 

`{"changeEventCalculator": [Function changeEventCalculator], "gestureId": 10, "handlerTag": 3, "isWorklet": [undefined, true, true, undefined, true, true], "onBegin": [Function reactNativeDrawerLayout_DrawerNativeJs5], "onChange": [Function reactNativeDrawerLayout_DrawerNativeJs7], "onEnd": [Function reactNativeDrawerLayout_DrawerNativeJs8], "onStart": [Function reactNativeDrawerLayout_DrawerNativeJs6]}`

**Test plan**

Added `worklet` on ` Gesture.Pan()` callbacks.
