### PR TITLE
chore(devtools): have proper colors in dark mode for the logger

### DIFF
--- a/packages/devtools/src/useLogger.tsx
+++ b/packages/devtools/src/useLogger.tsx
@@ -4,7 +4,6 @@ import * as React from 'react';
 import { useDevToolsBase } from './useDevToolsBase';
 
 export function useLogger(ref: React.RefObject<NavigationContainerRef<any>>) {
-  
   const actionColor = '#C2185B';
   const keyColor = '#43A047';
   const valueColor = '#1E88E5';
@@ -13,7 +12,10 @@ export function useLogger(ref: React.RefObject<NavigationContainerRef<any>>) {
     const log = [[`${result.type} `, 'color: gray; font-weight: lighter']];
 
     if (result.type === 'action') {
-      log.push([`${result.action.type} `, `color: ${actionColor}; font-weight: bold`]);
+      log.push([
+        `${result.action.type} `,
+        `color: ${actionColor}; font-weight: bold`,
+      ]);
 
       const payload = result.action.payload;
 
@@ -25,7 +27,10 @@ export function useLogger(ref: React.RefObject<NavigationContainerRef<any>>) {
               const pair = [
                 [key, `color: ${keyColor}; font-weight: normal`],
                 [': ', 'color: gray; font-weight: lighter'],
-                [JSON.stringify(value), `color: ${valueColor}; font-weight: normal`],
+                [
+                  JSON.stringify(value),
+                  `color: ${valueColor}; font-weight: normal`,
+                ],
               ];
 
               if (i < self.length - 1) {
@@ -65,7 +70,11 @@ export function useLogger(ref: React.RefObject<NavigationContainerRef<any>>) {
           );
         }
       } else if (key !== 'type') {
-        console.log(`%c${key}`, `color: ${actionColor}; font-weight: bold`, value);
+        console.log(
+          `%c${key}`,
+          `color: ${actionColor}; font-weight: bold`,
+          value
+        );
       }
     });
 

--- a/packages/devtools/src/useLogger.tsx
+++ b/packages/devtools/src/useLogger.tsx
@@ -4,11 +4,19 @@ import * as React from 'react';
 import { useDevToolsBase } from './useDevToolsBase';
 
 export function useLogger(ref: React.RefObject<NavigationContainerRef<any>>) {
+   // Simple dark mode check
+   const isDarkMode = window.matchMedia?.('(prefers-color-scheme: dark)').matches;
+    
+   // Define colors based on mode
+   const textColor = isDarkMode ? 'white' : 'black';
+   const keyColor = isDarkMode ? 'lightgreen' : 'green';
+   const valueColor = isDarkMode ? 'lightskyblue' : 'blue';
+
   useDevToolsBase(ref, (result) => {
     const log = [[`${result.type} `, 'color: gray; font-weight: lighter']];
 
     if (result.type === 'action') {
-      log.push([`${result.action.type} `, 'color: black; font-weight: bold']);
+      log.push([`${result.action.type} `, `color: ${textColor}; font-weight: bold`]);
 
       const payload = result.action.payload;
 
@@ -18,9 +26,9 @@ export function useLogger(ref: React.RefObject<NavigationContainerRef<any>>) {
           ...Object.entries(payload)
             .map(([key, value], i, self) => {
               const pair = [
-                [key, 'color: green; font-weight: normal'],
+                [key, `color: ${keyColor}; font-weight: normal`],
                 [': ', 'color: gray; font-weight: lighter'],
-                [JSON.stringify(value), 'color: blue; font-weight: normal'],
+                [JSON.stringify(value), `color: ${valueColor}; font-weight: normal`],
               ];
 
               if (i < self.length - 1) {
@@ -52,7 +60,7 @@ export function useLogger(ref: React.RefObject<NavigationContainerRef<any>>) {
         if (typeof value === 'string') {
           console.log(
             `%cstack`,
-            'color: black; font-weight: bold',
+            `color: ${textColor}; font-weight: bold`,
             `\n${value
               .split('\n')
               .map((line) => line.trim())
@@ -60,7 +68,7 @@ export function useLogger(ref: React.RefObject<NavigationContainerRef<any>>) {
           );
         }
       } else if (key !== 'type') {
-        console.log(`%c${key}`, 'color: black; font-weight: bold', value);
+        console.log(`%c${key}`, `color: ${textColor}; font-weight: bold`, value);
       }
     });
 

--- a/packages/devtools/src/useLogger.tsx
+++ b/packages/devtools/src/useLogger.tsx
@@ -4,19 +4,16 @@ import * as React from 'react';
 import { useDevToolsBase } from './useDevToolsBase';
 
 export function useLogger(ref: React.RefObject<NavigationContainerRef<any>>) {
-   // Simple dark mode check
-   const isDarkMode = window.matchMedia?.('(prefers-color-scheme: dark)').matches;
-    
-   // Define colors based on mode
-   const textColor = isDarkMode ? 'white' : 'black';
-   const keyColor = isDarkMode ? 'lightgreen' : 'green';
-   const valueColor = isDarkMode ? 'lightskyblue' : 'blue';
+  
+  const actionColor = '#C2185B';
+  const keyColor = '#43A047';
+  const valueColor = '#1E88E5';
 
   useDevToolsBase(ref, (result) => {
     const log = [[`${result.type} `, 'color: gray; font-weight: lighter']];
 
     if (result.type === 'action') {
-      log.push([`${result.action.type} `, `color: ${textColor}; font-weight: bold`]);
+      log.push([`${result.action.type} `, `color: ${actionColor}; font-weight: bold`]);
 
       const payload = result.action.payload;
 
@@ -60,7 +57,7 @@ export function useLogger(ref: React.RefObject<NavigationContainerRef<any>>) {
         if (typeof value === 'string') {
           console.log(
             `%cstack`,
-            `color: ${textColor}; font-weight: bold`,
+            `color: ${actionColor}; font-weight: bold`,
             `\n${value
               .split('\n')
               .map((line) => line.trim())
@@ -68,7 +65,7 @@ export function useLogger(ref: React.RefObject<NavigationContainerRef<any>>) {
           );
         }
       } else if (key !== 'type') {
-        console.log(`%c${key}`, `color: ${textColor}; font-weight: bold`, value);
+        console.log(`%c${key}`, `color: ${actionColor}; font-weight: bold`, value);
       }
     });
 


### PR DESCRIPTION
**Motivation**

Firstly congrats on the release of v7 🎊 , my pr attepmts to give better colors for the devtools logger if user was on dark mode 

because It was hard to read for me 

<img width="514" alt="Screenshot 1446-05-05 at 10 27 22 AM" src="https://github.com/user-attachments/assets/6a98a3ba-a5c3-4a2a-942e-a82bf844d1d0">


Here is a demo on how the new color will look like 

| ligth | dark |
|--------|--------|
| <img width="565" alt="Screenshot 1446-05-06 at 9 32 31 PM" src="https://github.com/user-attachments/assets/00f0ccac-3f65-442e-9f7c-88bf5cb6fae0"> | <img width="567" alt="Screenshot 1446-05-06 at 9 32 27 PM" src="https://github.com/user-attachments/assets/7379b0bd-55f6-4123-89a8-ee3dada0513b">
 | 

**Test plan**

Tested it on the example project 

https://github.com/user-attachments/assets/7f59150d-9485-4118-a4e4-a8600e931aa4
