### PR TITLE
fix: add missing screenLayout prop to the bottom tabbar navigator

### DIFF
--- a/packages/bottom-tabs/src/navigators/createBottomTabNavigator.tsx
+++ b/packages/bottom-tabs/src/navigators/createBottomTabNavigator.tsx
@@ -39,6 +39,7 @@ function BottomTabNavigator({
   layout,
   screenListeners,
   screenOptions,
+  screenLayout,
   UNSTABLE_getStateForRouteNamesChange,
   ...rest
 }: Props) {
@@ -57,6 +58,7 @@ function BottomTabNavigator({
       layout,
       screenListeners,
       screenOptions,
+      screenLayout,
       UNSTABLE_getStateForRouteNamesChange,
     });
 


### PR DESCRIPTION
Please provide enough information so that others can review your pull request.

**Motivation**

`screenLayout` prop was missing in  BottomTabNavigator 
