### PR TITLE
Fix: cannot remove child at index

### DIFF
--- a/packages/react-native-drawer-layout/src/views/Drawer.native.tsx
+++ b/packages/react-native-drawer-layout/src/views/Drawer.native.tsx
@@ -406,7 +406,6 @@ export function Drawer({
               ) : null}
             </Animated.View>
             <Animated.View
-              removeClippedSubviews={Platform.OS !== 'ios'}
               style={[
                 styles.drawer,
                 {


### PR DESCRIPTION
**Motivation**

In Android, when new arch enabled, I got the error **cannot remove child at index** when `replace` or `go back` from a screen with drawer layout.
![Screenshot_1731308895](https://github.com/user-attachments/assets/71173a9b-e04f-49c3-8172-a39512a25960)

**Test plan**

Applied the change locally on my project and it won't throw above error anymore. 
