### PR TITLE
fix: the warning about key prop with spread operator

### DIFF
--- a/packages/react-native-tab-view/src/TabView.tsx
+++ b/packages/react-native-tab-view/src/TabView.tsx
@@ -152,9 +152,9 @@ export function TabView<T extends Route>({
 
                   return (
                     <SceneView
+                      key={route.key}
                       {...sceneRendererProps}
                       addEnterListener={addEnterListener}
-                      key={route.key}
                       index={i}
                       lazy={typeof lazy === 'function' ? lazy({ route }) : lazy}
                       lazyPreloadDistance={lazyPreloadDistance}


### PR DESCRIPTION
The warning:
(NOBRIDGE) ERROR  Warning: A props object containing a "key" prop is being spread into JSX: React keys must be passed directly to JSX without using spread.

key prop should come before the spread operator.
