### PR TITLE
fix: `displayMode` description

### DIFF
--- a/packages/elements/src/types.tsx
+++ b/packages/elements/src/types.tsx
@@ -273,8 +273,14 @@ export type HeaderBackButtonProps = Omit<HeaderButtonProps, 'children'> & {
    */
   truncatedLabel?: string;
   /**
-   * Whether the label text is visible.
-   * Defaults to `true` on iOS and `false` on Android.
+   * How the back button displays icon and title.
+   *
+   * Supported values:
+   * - "default" - Displays one of the following depending on the available space: previous screen's title, truncated title (e.g. 'Back') or no title (only icon).
+   * - "generic" – Displays one of the following depending on the available space: truncated title (e.g. 'Back') or no title (only icon).
+   * - "minimal" – Always displays only the icon without a title.
+   *
+   * Defaults to "default" on iOS, and "minimal" on other platforms.
    */
   displayMode?: HeaderBackButtonDisplayMode;
   /**


### PR DESCRIPTION
**Motivation**

I noticed while migrating from v6 to v7 that `labelVisible` was changed to `displayMode`. The migration guide and the elements documentation pages did not include this information, so I went ahead and [updated them](https://github.com/react-navigation/react-navigation.github.io/pull/1384) (the PR just landed).

However, I noticed while hovering in my IDE (VS Code) that the description for `displayMode` was not updated. I went ahead and updated it in the types to match the `headerBackButtonDisplayMode` description (it's the same property).

**Test plan**

There are no code changes, this is strictly related to TypeScript DX.

Before:
![Screenshot of IDE Before](https://github.com/user-attachments/assets/72e9b4fd-b062-4740-bf0f-f7d9c72f712d)

After:
![Screenshot of IDE After](https://github.com/user-attachments/assets/badca395-8c5d-40f9-a5a8-77829f61a917)

