### PR TITLE
fix: labelStyle prop removed from TabBar component (react-native-tab-view)

### DIFF
--- a/packages/react-native-tab-view/src/TabBar.tsx
+++ b/packages/react-native-tab-view/src/TabBar.tsx
@@ -354,6 +354,7 @@ export function TabBar<T extends Route>({
   renderTabBarItem,
   style,
   tabStyle,
+  labelStyle,
   layout: propLayout,
   testID,
   android_ripple,
@@ -538,6 +539,7 @@ export function TabBar<T extends Route>({
         onPress,
         onLongPress,
         style: tabStyle,
+        labelStyle,
         defaultTabWidth,
         android_ripple,
       } satisfies TabBarItemProps<T> & { key: string };
@@ -563,6 +565,7 @@ export function TabBar<T extends Route>({
       pressOpacity,
       isWidthDynamic,
       tabStyle,
+      labelStyle,
       layout,
       routes,
       scrollEnabled,


### PR DESCRIPTION
The labelStyle prop was dropped from the TabBar component in the 4.0 version. It appears to be accidental as it is still defined in the Prop spec. 

This PR fixes that.