### PR TITLE
feat: add badgeStyle to TabBarItem

### DIFF
--- a/packages/react-native-tab-view/src/TabBarItem.tsx
+++ b/packages/react-native-tab-view/src/TabBarItem.tsx
@@ -105,6 +105,7 @@ const TabBarItemInternal = <T extends Route>({
   defaultTabWidth,
   icon: customIcon,
   badge: customBadge,
+  badgeStyle,
   href,
   labelText,
   routesLength,
@@ -241,7 +242,9 @@ const TabBarItemInternal = <T extends Route>({
           </Animated.View>
         </View>
         {customBadge != null ? (
-          <View style={styles.badge}>{customBadge({ route })}</View>
+          <View style={[styles.badge, badgeStyle]}>
+            {customBadge({ route })}
+          </View>
         ) : null}
       </View>
     </PlatformPressable>

--- a/packages/react-native-tab-view/src/types.tsx
+++ b/packages/react-native-tab-view/src/types.tsx
@@ -24,6 +24,7 @@ export type TabDescriptor<T extends Route> = {
     size: number;
   }) => React.ReactNode;
   badge?: (props: { route: T }) => React.ReactElement;
+  badgeStyle?: StyleProp<ViewStyle>;
   sceneStyle?: StyleProp<ViewStyle>;
 };
 


### PR DESCRIPTION
**Motivation**

When specifying the badge prop for TabBarItem, I wanted to also customize the style (e.g., change the position from absolute to something else). However, this is not currently possible. To address this, I added a new badgeStyle prop to TabBarItem, allowing for custom styling of the badge.