### PR TITLE
fix: add pointerEvents box-none to Header container

### DIFF
--- a/packages/elements/src/Screen.tsx
+++ b/packages/elements/src/Screen.tsx
@@ -74,7 +74,7 @@ export function Screen(props: Props) {
         <NavigationContext.Provider value={navigation}>
           <NavigationRouteContext.Provider value={route}>
             <View
-              pointerEvents='box-none'
+              pointerEvents="box-none"
               onLayout={(e) => {
                 const { height } = e.nativeEvent.layout;
 

--- a/packages/elements/src/Screen.tsx
+++ b/packages/elements/src/Screen.tsx
@@ -74,6 +74,7 @@ export function Screen(props: Props) {
         <NavigationContext.Provider value={navigation}>
           <NavigationRouteContext.Provider value={route}>
             <View
+              pointerEvents='box-none'
               onLayout={(e) => {
                 const { height } = e.nativeEvent.layout;
 


### PR DESCRIPTION
**Motivation**

This fixes a problem on web where headerTransparent might overlap other elements and make it unresponsive. By adding box-none, this problem can easily be fixed (all the children containers already have that prop)

**Test plan**

In the browser

<img width="1516" alt="Screenshot 2024-11-27 at 21 37 27" src="https://github.com/user-attachments/assets/bedb57b6-c92c-4d5c-badb-23c29d8b100c">

The screenshot shows a site with `statusbarTranslucent`. The header overlaps `Edit Token`, even though there is no title or HeaderRight.