### PR TITLE
feat: provide gesture in DrawerGestureContext

### DIFF
--- a/packages/react-native-drawer-layout/src/index.tsx
+++ b/packages/react-native-drawer-layout/src/index.tsx
@@ -1,3 +1,4 @@
+export { DrawerGestureContext } from './utils/DrawerGestureContext';
 export { DrawerProgressContext } from './utils/DrawerProgressContext';
 export { useDrawerProgress } from './utils/useDrawerProgress';
 export { Drawer } from './views/Drawer';

--- a/packages/react-native-drawer-layout/src/utils/DrawerGestureContext.tsx
+++ b/packages/react-native-drawer-layout/src/utils/DrawerGestureContext.tsx
@@ -1,0 +1,6 @@
+import * as React from 'react';
+import type { PanGesture } from 'react-native-gesture-handler';
+
+export const DrawerGestureContext = React.createContext<PanGesture | undefined>(
+  undefined
+);

--- a/packages/react-native-drawer-layout/src/views/Drawer.native.tsx
+++ b/packages/react-native-drawer-layout/src/views/Drawer.native.tsx
@@ -21,6 +21,7 @@ import Animated, {
 import useLatestCallback from 'use-latest-callback';
 
 import type { DrawerProps } from '../types';
+import { DrawerGestureContext } from '../utils/DrawerGestureContext';
 import { DrawerProgressContext } from '../utils/DrawerProgressContext';
 import { getDrawerWidth } from '../utils/getDrawerWidth';
 import {
@@ -110,47 +111,51 @@ export function Drawer({
 
   const interactionHandleRef = React.useRef<number | null>(null);
 
-  const startInteraction = () => {
+  const startInteraction = React.useCallback(() => {
     interactionHandleRef.current = InteractionManager.createInteractionHandle();
-  };
+  }, []);
 
-  const endInteraction = () => {
+  const endInteraction = React.useCallback(() => {
     if (interactionHandleRef.current != null) {
       InteractionManager.clearInteractionHandle(interactionHandleRef.current);
       interactionHandleRef.current = null;
     }
-  };
+  }, []);
 
-  const hideKeyboard = () => {
+  const hideKeyboard = React.useCallback(() => {
     if (keyboardDismissMode === 'on-drag') {
       Keyboard.dismiss();
     }
-  };
+  }, [keyboardDismissMode]);
 
-  const onGestureBegin = () => {
+  const onGestureBegin = React.useCallback(() => {
     onGestureStart?.();
     startInteraction();
     hideKeyboard();
     hideStatusBar(true);
-  };
+  }, [onGestureStart, startInteraction, hideKeyboard, hideStatusBar]);
 
-  const onGestureFinish = () => {
+  const onGestureFinish = React.useCallback(() => {
     onGestureEnd?.();
     endInteraction();
-  };
+  }, [onGestureEnd, endInteraction]);
 
-  const onGestureAbort = () => {
+  const onGestureAbort = React.useCallback(() => {
     onGestureCancel?.();
     endInteraction();
-  };
+  }, [onGestureCancel, endInteraction]);
 
   // FIXME: Currently hitSlop is broken when on Android when drawer is on right
   // https://github.com/software-mansion/react-native-gesture-handler/issues/569
-  const hitSlop = isRight
-    ? // Extend hitSlop to the side of the screen when drawer is closed
-      // This lets the user drag the drawer from the side of the screen
-      { right: 0, width: isOpen ? undefined : swipeEdgeWidth }
-    : { left: 0, width: isOpen ? undefined : swipeEdgeWidth };
+  const hitSlop = React.useMemo(
+    () =>
+      isRight
+        ? // Extend hitSlop to the side of the screen when drawer is closed
+          // This lets the user drag the drawer from the side of the screen
+          { right: 0, width: isOpen ? undefined : swipeEdgeWidth }
+        : { left: 0, width: isOpen ? undefined : swipeEdgeWidth },
+    [isRight, isOpen, swipeEdgeWidth]
+  );
 
   const touchStartX = useSharedValue(0);
   const touchX = useSharedValue(0);
@@ -217,53 +222,76 @@ export function Drawer({
 
   const startX = useSharedValue(0);
 
-  let pan = Gesture?.Pan()
-    .onBegin((event) => {
-      'worklet';
-      startX.value = translationX.value;
-      gestureState.value = event.state;
-      touchStartX.value = event.x;
-    })
-    .onStart(() => {
-      'worklet';
-      runOnJS(onGestureBegin)();
-    })
-    .onChange((event) => {
-      'worklet';
-      touchX.value = event.x;
-      translationX.value = startX.value + event.translationX;
-      gestureState.value = event.state;
-    })
-    .onEnd((event, success) => {
-      'worklet';
-      gestureState.value = event.state;
+  const pan = React.useMemo(() => {
+    let panGesture = Gesture?.Pan()
+      .onBegin((event) => {
+        'worklet';
+        startX.value = translationX.value;
+        gestureState.value = event.state;
+        touchStartX.value = event.x;
+      })
+      .onStart(() => {
+        'worklet';
+        runOnJS(onGestureBegin)();
+      })
+      .onChange((event) => {
+        'worklet';
+        touchX.value = event.x;
+        translationX.value = startX.value + event.translationX;
+        gestureState.value = event.state;
+      })
+      .onEnd((event, success) => {
+        'worklet';
+        gestureState.value = event.state;
 
-      if (!success) {
-        runOnJS(onGestureAbort)();
-      }
+        if (!success) {
+          runOnJS(onGestureAbort)();
+        }
 
-      const nextOpen =
-        (Math.abs(event.translationX) > SWIPE_MIN_OFFSET &&
-          Math.abs(event.translationX) > swipeMinVelocity) ||
-        Math.abs(event.translationX) > swipeMinDistance
-          ? drawerPosition === 'left'
-            ? // If swiped to right, open the drawer, otherwise close it
-              (event.velocityX === 0 ? event.translationX : event.velocityX) > 0
-            : // If swiped to left, open the drawer, otherwise close it
-              (event.velocityX === 0 ? event.translationX : event.velocityX) < 0
-          : open;
+        const nextOpen =
+          (Math.abs(event.translationX) > SWIPE_MIN_OFFSET &&
+            Math.abs(event.translationX) > swipeMinVelocity) ||
+          Math.abs(event.translationX) > swipeMinDistance
+            ? drawerPosition === 'left'
+              ? // If swiped to right, open the drawer, otherwise close it
+                (event.velocityX === 0 ? event.translationX : event.velocityX) >
+                0
+              : // If swiped to left, open the drawer, otherwise close it
+                (event.velocityX === 0 ? event.translationX : event.velocityX) <
+                0
+            : open;
 
-      toggleDrawer(nextOpen, event.velocityX);
-      runOnJS(onGestureFinish)();
-    })
-    .activeOffsetX([-SWIPE_MIN_OFFSET, SWIPE_MIN_OFFSET])
-    .failOffsetY([-SWIPE_MIN_OFFSET, SWIPE_MIN_OFFSET])
-    .hitSlop(hitSlop)
-    .enabled(drawerType !== 'permanent' && swipeEnabled);
+        toggleDrawer(nextOpen, event.velocityX);
+        runOnJS(onGestureFinish)();
+      })
+      .activeOffsetX([-SWIPE_MIN_OFFSET, SWIPE_MIN_OFFSET])
+      .failOffsetY([-SWIPE_MIN_OFFSET, SWIPE_MIN_OFFSET])
+      .hitSlop(hitSlop)
+      .enabled(drawerType !== 'permanent' && swipeEnabled);
 
-  if (pan && configureGestureHandler) {
-    pan = configureGestureHandler(pan);
-  }
+    if (panGesture && configureGestureHandler) {
+      panGesture = configureGestureHandler(panGesture);
+    }
+    return panGesture;
+  }, [
+    configureGestureHandler,
+    drawerPosition,
+    drawerType,
+    gestureState,
+    hitSlop,
+    onGestureBegin,
+    onGestureAbort,
+    onGestureFinish,
+    open,
+    startX,
+    swipeEnabled,
+    swipeMinDistance,
+    swipeMinVelocity,
+    toggleDrawer,
+    touchStartX,
+    touchX,
+    translationX,
+  ]);
 
   const translateX = useDerivedValue(() => {
     // Comment stolen from react-native-gesture-handler/DrawerLayout
@@ -376,64 +404,66 @@ export function Drawer({
   return (
     <GestureHandlerRootView style={[styles.container, style]}>
       <DrawerProgressContext.Provider value={progress}>
-        <GestureDetector gesture={pan}>
-          {/* Immediate child of gesture handler needs to be an Animated.View */}
-          <Animated.View
-            style={[
-              styles.main,
-              {
-                flexDirection:
-                  drawerType === 'permanent'
-                    ? (isRight && direction === 'ltr') ||
-                      (!isRight && direction === 'rtl')
-                      ? 'row'
-                      : 'row-reverse'
-                    : 'row',
-              },
-            ]}
-          >
-            <Animated.View style={[styles.content, contentAnimatedStyle]}>
-              <View
-                accessibilityElementsHidden={
-                  isOpen && drawerType !== 'permanent'
-                }
-                importantForAccessibility={
-                  isOpen && drawerType !== 'permanent'
-                    ? 'no-hide-descendants'
-                    : 'auto'
-                }
-                style={styles.content}
-              >
-                {children}
-              </View>
-              {drawerType !== 'permanent' ? (
-                <Overlay
-                  open={open}
-                  progress={progress}
-                  onPress={() => toggleDrawer(false)}
-                  style={overlayStyle}
-                  accessibilityLabel={overlayAccessibilityLabel}
-                />
-              ) : null}
-            </Animated.View>
+        <DrawerGestureContext.Provider value={pan}>
+          <GestureDetector gesture={pan}>
+            {/* Immediate child of gesture handler needs to be an Animated.View */}
             <Animated.View
-              removeClippedSubviews={Platform.OS !== 'ios'}
               style={[
-                styles.drawer,
+                styles.main,
                 {
-                  width: drawerWidth,
-                  position:
-                    drawerType === 'permanent' ? 'relative' : 'absolute',
-                  zIndex: drawerType === 'back' ? -1 : 0,
+                  flexDirection:
+                    drawerType === 'permanent'
+                      ? (isRight && direction === 'ltr') ||
+                        (!isRight && direction === 'rtl')
+                        ? 'row'
+                        : 'row-reverse'
+                      : 'row',
                 },
-                drawerAnimatedStyle,
-                drawerStyle,
               ]}
             >
-              {renderDrawerContent()}
+              <Animated.View style={[styles.content, contentAnimatedStyle]}>
+                <View
+                  accessibilityElementsHidden={
+                    isOpen && drawerType !== 'permanent'
+                  }
+                  importantForAccessibility={
+                    isOpen && drawerType !== 'permanent'
+                      ? 'no-hide-descendants'
+                      : 'auto'
+                  }
+                  style={styles.content}
+                >
+                  {children}
+                </View>
+                {drawerType !== 'permanent' ? (
+                  <Overlay
+                    open={open}
+                    progress={progress}
+                    onPress={() => toggleDrawer(false)}
+                    style={overlayStyle}
+                    accessibilityLabel={overlayAccessibilityLabel}
+                  />
+                ) : null}
+              </Animated.View>
+              <Animated.View
+                removeClippedSubviews={Platform.OS !== 'ios'}
+                style={[
+                  styles.drawer,
+                  {
+                    width: drawerWidth,
+                    position:
+                      drawerType === 'permanent' ? 'relative' : 'absolute',
+                    zIndex: drawerType === 'back' ? -1 : 0,
+                  },
+                  drawerAnimatedStyle,
+                  drawerStyle,
+                ]}
+              >
+                {renderDrawerContent()}
+              </Animated.View>
             </Animated.View>
-          </Animated.View>
-        </GestureDetector>
+          </GestureDetector>
+        </DrawerGestureContext.Provider>
       </DrawerProgressContext.Provider>
     </GestureHandlerRootView>
   );


### PR DESCRIPTION
**Motivation**

The drawer gesture can conflict with other gestures in the app. To coordinate multiple gestures, the app code can use APIs like `requireExternalGestureToFail`. However, since the gesture is hidden in the library, this is not currently possible without patching. This exposes the gesture to the app code so you can use `requireExternalGestureToFail` with it.

```js
import { DrawerGestureContext } from 'react-native-drawer-layout';

// ...
const drawerGesture = useContext(DrawerGestureContext)
const nativeGesture = Gesture.Native()
  .requireExternalGestureToFail(drawerGesture)

// ...

<GestureDetector gesture={nativeGesture}>
  <PagerView
    // ...
  />
</GestureDetector>
```

Note that the existing `configureGestureHandler` is not enough because we need it in the other direction: *other* gestures (deeper in the app) need access to it. It would not be possible to capture it in a closure because by the point `configureGestureHandler` runs, the owner component has already executed and passed the data down.

<s>I opted to use a render prop instead of actually creating a context in order to keep this addition zero-cost. If this was a context exposed by the library, we'd have to either memoize the `pan` gesture (to avoid it getting redefined on drawer re-renders) or we'd have to pay the price of React doing a context search traversal every time it changes. Seems unfortunate if the majority of this library's users don't care about the gesture. Render prop lets the app decide whether it cares.</s>

Re-done as context as requested in review. Added some memoization to avoid it changing on every render.

**Test plan**

Verify you're able to access `gesture` on mobile. On web, it should be `undefined`.

Verify you can use it with RNGH APIs as usual. For example, https://github.com/bluesky-social/social-app/pull/7007 fixes a longstanding problem with the Bluesky app — the drawer swipe barely worked on iOS. The reason it has been broken for the last two years is because this library did not expose the gesture, and we did not know that it needs to be coordinated.