### PR TITLE
feat: export *NavigatorProps for each navigator

### DIFF
--- a/packages/bottom-tabs/src/index.tsx
+++ b/packages/bottom-tabs/src/index.tsx
@@ -35,6 +35,7 @@ export type {
   BottomTabNavigationEventMap,
   BottomTabNavigationOptions,
   BottomTabNavigationProp,
+  BottomTabNavigatorProps,
   BottomTabOptionsArgs,
   BottomTabScreenProps,
 } from './types';

--- a/packages/bottom-tabs/src/navigators/createBottomTabNavigator.tsx
+++ b/packages/bottom-tabs/src/navigators/createBottomTabNavigator.tsx
@@ -1,6 +1,5 @@
 import {
   createNavigatorFactory,
-  type DefaultNavigatorOptions,
   type NavigatorTypeBagBase,
   type ParamListBase,
   type StaticConfig,
@@ -13,23 +12,12 @@ import {
 } from '@react-navigation/native';
 
 import type {
-  BottomTabNavigationConfig,
   BottomTabNavigationEventMap,
   BottomTabNavigationOptions,
   BottomTabNavigationProp,
+  BottomTabNavigatorProps,
 } from '../types';
 import { BottomTabView } from '../views/BottomTabView';
-
-type Props = DefaultNavigatorOptions<
-  ParamListBase,
-  string | undefined,
-  TabNavigationState<ParamListBase>,
-  BottomTabNavigationOptions,
-  BottomTabNavigationEventMap,
-  BottomTabNavigationProp<ParamListBase>
-> &
-  TabRouterOptions &
-  BottomTabNavigationConfig;
 
 function BottomTabNavigator({
   id,
@@ -42,7 +30,7 @@ function BottomTabNavigator({
   screenLayout,
   UNSTABLE_getStateForRouteNamesChange,
   ...rest
-}: Props) {
+}: BottomTabNavigatorProps) {
   const { state, descriptors, navigation, NavigationContent } =
     useNavigationBuilder<
       TabNavigationState<ParamListBase>,

--- a/packages/bottom-tabs/src/types.tsx
+++ b/packages/bottom-tabs/src/types.tsx
@@ -1,5 +1,6 @@
 import type { HeaderOptions } from '@react-navigation/elements';
 import type {
+  DefaultNavigatorOptions,
   Descriptor,
   NavigationHelpers,
   NavigationProp,
@@ -7,6 +8,7 @@ import type {
   RouteProp,
   TabActionHelpers,
   TabNavigationState,
+  TabRouterOptions,
   Theme,
 } from '@react-navigation/native';
 import type * as React from 'react';
@@ -439,3 +441,14 @@ export type BottomTabBarButtonProps = Omit<
     e: React.MouseEvent<HTMLAnchorElement, MouseEvent> | GestureResponderEvent
   ) => void;
 };
+
+export type BottomTabNavigatorProps = DefaultNavigatorOptions<
+  ParamListBase,
+  string | undefined,
+  TabNavigationState<ParamListBase>,
+  BottomTabNavigationOptions,
+  BottomTabNavigationEventMap,
+  BottomTabNavigationProp<ParamListBase>
+> &
+  TabRouterOptions &
+  BottomTabNavigationConfig;

--- a/packages/drawer/src/index.tsx
+++ b/packages/drawer/src/index.tsx
@@ -33,6 +33,7 @@ export type {
   DrawerNavigationEventMap,
   DrawerNavigationOptions,
   DrawerNavigationProp,
+  DrawerNavigatorProps,
   DrawerOptionsArgs,
   DrawerScreenProps,
 } from './types';

--- a/packages/drawer/src/navigators/createDrawerNavigator.tsx
+++ b/packages/drawer/src/navigators/createDrawerNavigator.tsx
@@ -1,6 +1,5 @@
 import {
   createNavigatorFactory,
-  type DefaultNavigatorOptions,
   type DrawerActionHelpers,
   type DrawerNavigationState,
   DrawerRouter,
@@ -13,23 +12,12 @@ import {
 } from '@react-navigation/native';
 
 import type {
-  DrawerNavigationConfig,
   DrawerNavigationEventMap,
   DrawerNavigationOptions,
   DrawerNavigationProp,
+  DrawerNavigatorProps,
 } from '../types';
 import { DrawerView } from '../views/DrawerView';
-
-type Props = DefaultNavigatorOptions<
-  ParamListBase,
-  string | undefined,
-  DrawerNavigationState<ParamListBase>,
-  DrawerNavigationOptions,
-  DrawerNavigationEventMap,
-  DrawerNavigationProp<ParamListBase>
-> &
-  DrawerRouterOptions &
-  DrawerNavigationConfig;
 
 function DrawerNavigator({
   id,
@@ -43,7 +31,7 @@ function DrawerNavigator({
   screenLayout,
   UNSTABLE_getStateForRouteNamesChange,
   ...rest
-}: Props) {
+}: DrawerNavigatorProps) {
   const { state, descriptors, navigation, NavigationContent } =
     useNavigationBuilder<
       DrawerNavigationState<ParamListBase>,

--- a/packages/drawer/src/types.tsx
+++ b/packages/drawer/src/types.tsx
@@ -1,8 +1,10 @@
 import type { HeaderOptions } from '@react-navigation/elements';
 import type {
+  DefaultNavigatorOptions,
   Descriptor,
   DrawerActionHelpers,
   DrawerNavigationState,
+  DrawerRouterOptions,
   NavigationHelpers,
   NavigationProp,
   ParamListBase,
@@ -333,3 +335,14 @@ export type DrawerProps = {
   swipeVelocityThreshold: number;
   overlayAccessibilityLabel?: string;
 };
+
+export type DrawerNavigatorProps = DefaultNavigatorOptions<
+  ParamListBase,
+  string | undefined,
+  DrawerNavigationState<ParamListBase>,
+  DrawerNavigationOptions,
+  DrawerNavigationEventMap,
+  DrawerNavigationProp<ParamListBase>
+> &
+  DrawerRouterOptions &
+  DrawerNavigationConfig;

--- a/packages/material-top-tabs/src/index.tsx
+++ b/packages/material-top-tabs/src/index.tsx
@@ -22,6 +22,7 @@ export type {
   MaterialTopTabNavigationEventMap,
   MaterialTopTabNavigationOptions,
   MaterialTopTabNavigationProp,
+  MaterialTopTabNavigatorProps,
   MaterialTopTabOptionsArgs,
   MaterialTopTabScreenProps,
 } from './types';

--- a/packages/material-top-tabs/src/navigators/createMaterialTopTabNavigator.tsx
+++ b/packages/material-top-tabs/src/navigators/createMaterialTopTabNavigator.tsx
@@ -1,6 +1,5 @@
 import {
   createNavigatorFactory,
-  type DefaultNavigatorOptions,
   type NavigatorTypeBagBase,
   type ParamListBase,
   type StaticConfig,
@@ -13,23 +12,12 @@ import {
 } from '@react-navigation/native';
 
 import type {
-  MaterialTopTabNavigationConfig,
   MaterialTopTabNavigationEventMap,
   MaterialTopTabNavigationOptions,
   MaterialTopTabNavigationProp,
+  MaterialTopTabNavigatorProps,
 } from '../types';
 import { MaterialTopTabView } from '../views/MaterialTopTabView';
-
-type Props = DefaultNavigatorOptions<
-  ParamListBase,
-  string | undefined,
-  TabNavigationState<ParamListBase>,
-  MaterialTopTabNavigationOptions,
-  MaterialTopTabNavigationEventMap,
-  MaterialTopTabNavigationProp<ParamListBase>
-> &
-  TabRouterOptions &
-  MaterialTopTabNavigationConfig;
 
 function MaterialTopTabNavigator({
   id,
@@ -42,7 +30,7 @@ function MaterialTopTabNavigator({
   screenLayout,
   UNSTABLE_getStateForRouteNamesChange,
   ...rest
-}: Props) {
+}: MaterialTopTabNavigatorProps) {
   const { state, descriptors, navigation, NavigationContent } =
     useNavigationBuilder<
       TabNavigationState<ParamListBase>,

--- a/packages/material-top-tabs/src/types.tsx
+++ b/packages/material-top-tabs/src/types.tsx
@@ -1,4 +1,5 @@
 import type {
+  DefaultNavigatorOptions,
   Descriptor,
   NavigationHelpers,
   NavigationProp,
@@ -7,6 +8,7 @@ import type {
   RouteProp,
   TabActionHelpers,
   TabNavigationState,
+  TabRouterOptions,
   Theme,
 } from '@react-navigation/native';
 import type React from 'react';
@@ -316,3 +318,14 @@ export type MaterialTopTabBarProps = SceneRendererProps & {
 export type MaterialTopTabAnimationContext = {
   position: Animated.AnimatedInterpolation<number>;
 };
+
+export type MaterialTopTabNavigatorProps = DefaultNavigatorOptions<
+  ParamListBase,
+  string | undefined,
+  TabNavigationState<ParamListBase>,
+  MaterialTopTabNavigationOptions,
+  MaterialTopTabNavigationEventMap,
+  MaterialTopTabNavigationProp<ParamListBase>
+> &
+  TabRouterOptions &
+  MaterialTopTabNavigationConfig;

--- a/packages/native-stack/src/index.tsx
+++ b/packages/native-stack/src/index.tsx
@@ -23,6 +23,7 @@ export type {
   NativeStackNavigationEventMap,
   NativeStackNavigationOptions,
   NativeStackNavigationProp,
+  NativeStackNavigatorProps,
   NativeStackOptionsArgs,
   NativeStackScreenProps,
 } from './types';

--- a/packages/stack/src/index.tsx
+++ b/packages/stack/src/index.tsx
@@ -47,6 +47,7 @@ export type {
   StackNavigationEventMap,
   StackNavigationOptions,
   StackNavigationProp,
+  StackNavigatorProps,
   StackOptionsArgs,
   StackScreenProps,
   TransitionPreset,

--- a/packages/stack/src/navigators/createStackNavigator.tsx
+++ b/packages/stack/src/navigators/createStackNavigator.tsx
@@ -1,6 +1,5 @@
 import {
   createNavigatorFactory,
-  type DefaultNavigatorOptions,
   type EventArg,
   type NavigatorTypeBagBase,
   type ParamListBase,
@@ -17,23 +16,12 @@ import {
 import * as React from 'react';
 
 import type {
-  StackNavigationConfig,
   StackNavigationEventMap,
   StackNavigationOptions,
   StackNavigationProp,
+  StackNavigatorProps,
 } from '../types';
 import { StackView } from '../views/Stack/StackView';
-
-type Props = DefaultNavigatorOptions<
-  ParamListBase,
-  string | undefined,
-  StackNavigationState<ParamListBase>,
-  StackNavigationOptions,
-  StackNavigationEventMap,
-  StackNavigationProp<ParamListBase>
-> &
-  StackRouterOptions &
-  StackNavigationConfig;
 
 function StackNavigator({
   id,
@@ -45,7 +33,7 @@ function StackNavigator({
   screenLayout,
   UNSTABLE_getStateForRouteNamesChange,
   ...rest
-}: Props) {
+}: StackNavigatorProps) {
   const { direction } = useLocale();
 
   const { state, describe, descriptors, navigation, NavigationContent } =

--- a/packages/stack/src/types.tsx
+++ b/packages/stack/src/types.tsx
@@ -6,6 +6,7 @@ import type {
   HeaderTitleProps,
 } from '@react-navigation/elements';
 import type {
+  DefaultNavigatorOptions,
   Descriptor,
   LocaleDirection,
   NavigationHelpers,
@@ -15,6 +16,7 @@ import type {
   RouteProp,
   StackActionHelpers,
   StackNavigationState,
+  StackRouterOptions,
   Theme,
 } from '@react-navigation/native';
 import type * as React from 'react';
@@ -624,3 +626,14 @@ export type TransitionPreset = {
    */
   headerStyleInterpolator: StackHeaderStyleInterpolator;
 };
+
+export type StackNavigatorProps = DefaultNavigatorOptions<
+  ParamListBase,
+  string | undefined,
+  StackNavigationState<ParamListBase>,
+  StackNavigationOptions,
+  StackNavigationEventMap,
+  StackNavigationProp<ParamListBase>
+> &
+  StackRouterOptions &
+  StackNavigationConfig;


### PR DESCRIPTION
**Motivation**

Fix the TypeScript error when trying to use inferred types with React Navigation navigators

```
 The inferred type of 'NativeStackNavigator' cannot be named without a reference to '../node_modules/@react-navigation/native-stack/lib/typescript/module/src/types'. This is likely not portable. A type annotation is necessary.
```

The inferred type of `NativeStackNavigator` references `NativeStackNavigatorProps` which is located in `@react-navigation/native-stack/lib/typescript/module/src/types` and not exposed by `package.json#exports`. 

This issue only affects apps using `moduleResolution: nodenext/bundler`

I have added additional types to support type inference for `NativeStack`, `Tab` & `Drawer`

**Issue Reproduction**

`npx create-expo-app@latest --template react-navigation/template`

- Ensure `moduleResolution: 'bundler'` is set in `tsconfig.json`
- Add these lines to `App.tsx`

```
const NativeStackNavigator = createNativeStackNavigator().Navigator;

export type A = typeof NativeStackNavigator & {
  foo: "bar";
};
```

- Run `npx tsx` in the root directory and observe error
