### PR TITLE
fix(native): correctly extract path from url with multiple `?` characters

### DIFF
--- a/packages/native/src/__tests__/extractPathFromURL.test.tsx
+++ b/packages/native/src/__tests__/extractPathFromURL.test.tsx
@@ -334,4 +334,11 @@ test('returns a valid search query when it has a url as param', () => {
       'https://mysite.com/readPolicy?url=https://test.com'
     )
   ).toBe('/readPolicy?url=https://test.com');
+
+  expect(
+    extractPathFromURL(
+      ['https://mysite.com'],
+      'https://mysite.com/readPolicy?url=https://test.com?param=1'
+    )
+  ).toBe('/readPolicy?url=https://test.com?param=1');
 });

--- a/packages/native/src/extractPathFromURL.tsx
+++ b/packages/native/src/extractPathFromURL.tsx
@@ -15,10 +15,10 @@ export function extractPathFromURL(prefixes: string[], url: string) {
         .join('\\.')}`
     );
 
-    const [originAndPath, searchParams] = url.split('?');
+    const [originAndPath, ...searchParams] = url.split('?');
     const normalizedURL = originAndPath
       .replace(/\/+/g, '/')
-      .concat(searchParams ? `?${searchParams}` : '');
+      .concat(searchParams.length ? `?${searchParams.join('?')}` : '');
 
     if (prefixRegex.test(normalizedURL)) {
       return normalizedURL.replace(prefixRegex, '');


### PR DESCRIPTION
**Motivation**

`extractPathFromURL` gobbles up parts of url if it contains multiple `?` characters.

For example:

```typescript
extractPathFromURL(
      ['https://mysite.com'],
      'https://mysite.com/readPolicy?url=https://test.com?param=1'
    )

// expected (good): /readPolicy?url=https://test.com?param=1
// got (bad):       /readPolicy?url=https://test.com
```

**Test plan**

Added test case which passes with this PR.