### PR TITLE
feat: animatable font size and color

### DIFF
--- a/example/src/Screens/MaterialTopTabs.tsx
+++ b/example/src/Screens/MaterialTopTabs.tsx
@@ -23,7 +23,17 @@ const ChatScreen = () => <Chat bottom />;
 
 export function MaterialTopTabsScreen() {
   return (
-    <MaterialTopTabs.Navigator>
+    <MaterialTopTabs.Navigator
+      screenOptions={{
+        tabBarActiveFontSize: 18,
+        tabBarInactiveFontSize: 14,
+        tabBarActiveTintColor: '#FF0000',
+        tabBarInactiveTintColor: '#000000',
+        tabBarActiveFontWeight: 900,
+        tabBarInactiveFontWeight: 500,
+        tabBarStyle: { height: 50 },
+      }}
+    >
       <MaterialTopTabs.Screen
         name="Chat"
         component={ChatScreen}

--- a/packages/material-top-tabs/src/types.tsx
+++ b/packages/material-top-tabs/src/types.tsx
@@ -97,7 +97,11 @@ export type MaterialTopTabNavigationOptions = {
     | string
     | ((props: {
         focused: boolean;
-        color: string;
+        color: string | Animated.AnimatedInterpolation<string | number>;
+        fontSize: number | Animated.AnimatedInterpolation<number>;
+        fontWeight:
+          | TextStyle['fontWeight']
+          | Animated.AnimatedInterpolation<string | number>;
         children: string;
       }) => React.ReactNode);
 
@@ -171,6 +175,26 @@ export type MaterialTopTabNavigationOptions = {
    * Color for the icon and label in the inactive tabs.
    */
   tabBarInactiveTintColor?: string;
+
+  /**
+   * Font size for the label in the active tab.
+   */
+  tabBarActiveFontSize?: number;
+
+  /**
+   * Font size for the label in the inactive tabs.
+   */
+  tabBarInactiveFontSize?: number;
+
+  /**
+   * Font weight for the label in the active tab.
+   */
+  tabBarActiveFontWeight?: TextStyle['fontWeight'];
+
+  /**
+   * Font weight for the label in the inactive tabs.
+   */
+  tabBarInactiveFontWeight?: TextStyle['fontWeight'];
 
   /**
    * Color for material ripple (Android >= 5.0 only).

--- a/packages/material-top-tabs/src/views/MaterialTopTabBar.tsx
+++ b/packages/material-top-tabs/src/views/MaterialTopTabBar.tsx
@@ -1,4 +1,3 @@
-import { Text } from '@react-navigation/elements';
 import {
   type ParamListBase,
   type TabNavigationState,
@@ -7,7 +6,7 @@ import {
   useTheme,
 } from '@react-navigation/native';
 import Color from 'color';
-import { StyleSheet } from 'react-native';
+import { Animated, StyleSheet } from 'react-native';
 import {
   type Route,
   TabBar,
@@ -26,14 +25,16 @@ const renderLabelDefault = ({
   labelText,
   style,
   allowFontScaling,
+  fontSize,
+  fontWeight,
 }: MaterialLabelProps) => {
   return (
-    <Text
-      style={[{ color }, styles.label, style]}
+    <Animated.Text
+      style={[{ color, fontSize, fontWeight }, styles.label, style]}
       allowFontScaling={allowFontScaling}
     >
       {labelText}
-    </Text>
+    </Animated.Text>
   );
 };
 
@@ -53,6 +54,12 @@ export function MaterialTopTabBar({
   const inactiveColor =
     focusedOptions.tabBarInactiveTintColor ??
     Color(activeColor).alpha(0.5).rgb().string();
+
+  const activeFontSize = focusedOptions.tabBarActiveFontSize ?? 18;
+  const inactiveFontSize = focusedOptions.tabBarInactiveFontSize ?? 14;
+
+  const activeFontWeight = focusedOptions.tabBarActiveFontWeight ?? 500;
+  const inactiveFontWeight = focusedOptions.tabBarInactiveFontWeight ?? 500;
 
   const tabBarOptions = Object.fromEntries(
     state.routes.map((route) => {
@@ -83,10 +90,17 @@ export function MaterialTopTabBar({
             tabBarShowLabel === false
               ? undefined
               : typeof tabBarLabel === 'function'
-                ? ({ labelText, color }: MaterialLabelProps) =>
+                ? ({
+                    labelText,
+                    color,
+                    fontSize,
+                    fontWeight,
+                  }: MaterialLabelProps) =>
                     tabBarLabel({
                       focused: state.routes[state.index].key === route.key,
                       color,
+                      fontSize,
+                      fontWeight,
                       children: labelText ?? route.name,
                     })
                 : renderLabelDefault,
@@ -115,6 +129,10 @@ export function MaterialTopTabBar({
       bounces={focusedOptions.tabBarBounces}
       activeColor={activeColor}
       inactiveColor={inactiveColor}
+      activeFontSize={activeFontSize}
+      inactiveFontSize={inactiveFontSize}
+      activeFontWeight={activeFontWeight}
+      inactiveFontWeight={inactiveFontWeight}
       pressColor={focusedOptions.tabBarPressColor}
       pressOpacity={focusedOptions.tabBarPressOpacity}
       tabStyle={focusedOptions.tabBarItemStyle}
@@ -161,7 +179,6 @@ export function MaterialTopTabBar({
 const styles = StyleSheet.create({
   label: {
     textAlign: 'center',
-    fontSize: 14,
     margin: 4,
     backgroundColor: 'transparent',
   },

--- a/packages/material-top-tabs/src/views/MaterialTopTabView.tsx
+++ b/packages/material-top-tabs/src/views/MaterialTopTabView.tsx
@@ -55,6 +55,9 @@ export function MaterialTopTabView({
   };
 
   const focusedOptions = descriptors[state.routes[state.index].key].options;
+  const doNotSupportNativeDrive =
+    !!focusedOptions.tabBarActiveFontSize ||
+    !!focusedOptions.tabBarInactiveFontSize;
 
   return (
     <TabView<Route<string>>
@@ -102,6 +105,7 @@ export function MaterialTopTabView({
           ];
         })
       )}
+      useNativeDriver={!doNotSupportNativeDrive}
     />
   );
 }

--- a/packages/react-native-tab-view/src/PagerViewAdapter.tsx
+++ b/packages/react-native-tab-view/src/PagerViewAdapter.tsx
@@ -34,7 +34,7 @@ type Props<T extends Route> = PagerProps & {
   ) => React.ReactElement;
 };
 
-const useNativeDriver = Platform.OS !== 'web';
+const canUseNativeDriver = Platform.OS !== 'web';
 
 export function PagerViewAdapter<T extends Route>({
   keyboardDismissMode = 'auto',
@@ -46,6 +46,7 @@ export function PagerViewAdapter<T extends Route>({
   children,
   style,
   animationEnabled,
+  useNativeDriver = true,
   ...rest
 }: Props<T>) {
   const { index } = navigationState;
@@ -159,7 +160,7 @@ export function PagerViewAdapter<T extends Route>({
               },
             },
           ],
-          { useNativeDriver }
+          { useNativeDriver: useNativeDriver && canUseNativeDriver }
         )}
         onPageSelected={(e) => {
           const index = e.nativeEvent.position;

--- a/packages/react-native-tab-view/src/PagerViewAdapter.tsx
+++ b/packages/react-native-tab-view/src/PagerViewAdapter.tsx
@@ -32,6 +32,7 @@ type Props<T extends Route> = PagerProps & {
       jumpTo: (key: string) => void;
     }
   ) => React.ReactElement;
+  useNativeDriver?: boolean;
 };
 
 const canUseNativeDriver = Platform.OS !== 'web';

--- a/packages/react-native-tab-view/src/PanResponderAdapter.tsx
+++ b/packages/react-native-tab-view/src/PanResponderAdapter.tsx
@@ -37,6 +37,8 @@ type Props<T extends Route> = PagerProps & {
       jumpTo: (key: string) => void;
     }
   ) => React.ReactElement;
+  // On web, this prop has no effect.
+  useNativeDriver?: boolean;
 };
 
 const DEAD_ZONE = 12;

--- a/packages/react-native-tab-view/src/TabBar.tsx
+++ b/packages/react-native-tab-view/src/TabBar.tsx
@@ -10,6 +10,7 @@ import {
   type PressableAndroidRippleConfig,
   type StyleProp,
   StyleSheet,
+  type TextStyle,
   View,
   type ViewStyle,
   type ViewToken,
@@ -39,6 +40,10 @@ export type Props<T extends Route> = SceneRendererProps & {
   bounces?: boolean;
   activeColor?: string;
   inactiveColor?: string;
+  activeFontSize?: number;
+  inactiveFontSize?: number;
+  activeFontWeight?: TextStyle['fontWeight'];
+  inactiveFontWeight?: TextStyle['fontWeight'];
   pressColor?: string;
   pressOpacity?: number;
   options?: Record<string, TabDescriptor<T>>;
@@ -342,6 +347,10 @@ export function TabBar<T extends Route>({
   bounces,
   contentContainerStyle,
   inactiveColor,
+  activeFontSize,
+  inactiveFontSize,
+  activeFontWeight,
+  inactiveFontWeight,
   indicatorContainerStyle,
   indicatorStyle,
   onTabLongPress,
@@ -387,6 +396,8 @@ export function TabBar<T extends Route>({
     routes
       .slice(0, navigationState.index)
       .every((r) => typeof tabWidths[r.key] === 'number');
+
+  const cannotUseNativeDriver = !!activeFontSize || !!inactiveFontSize;
 
   React.useEffect(() => {
     if (isFirst.current) {
@@ -530,6 +541,10 @@ export function TabBar<T extends Route>({
         accessibilityLabel,
         activeColor,
         inactiveColor,
+        activeFontSize,
+        inactiveFontSize,
+        activeFontWeight,
+        inactiveFontWeight,
         pressColor,
         pressOpacity,
         onLayout,
@@ -552,6 +567,10 @@ export function TabBar<T extends Route>({
       );
     },
     [
+      activeFontSize,
+      inactiveFontSize,
+      activeFontWeight,
+      inactiveFontWeight,
       position,
       navigationState,
       options,
@@ -596,9 +615,9 @@ export function TabBar<T extends Route>({
             },
           },
         ],
-        { useNativeDriver }
+        { useNativeDriver: useNativeDriver && !cannotUseNativeDriver }
       ),
-    [scrollAmount]
+    [scrollAmount, cannotUseNativeDriver]
   );
 
   const handleViewableItemsChanged = useLatestCallback(

--- a/packages/react-native-tab-view/src/TabBarItemLabel.tsx
+++ b/packages/react-native-tab-view/src/TabBarItemLabel.tsx
@@ -1,16 +1,42 @@
 import React from 'react';
-import type { StyleProp, ViewStyle } from 'react-native';
+import type {
+  OpaqueColorValue,
+  StyleProp,
+  TextStyle,
+  ViewStyle,
+} from 'react-native';
 import { Animated, StyleSheet } from 'react-native';
 
 interface TabBarItemLabelProps {
-  color: string;
+  color:
+    | string
+    | OpaqueColorValue
+    | Animated.Value
+    | Animated.AnimatedInterpolation<string | number>;
+  fontSize:
+    | number
+    | Animated.Value
+    | Animated.AnimatedInterpolation<string | number>
+    | undefined;
+  fontWeight:
+    | TextStyle['fontWeight']
+    | Animated.Value
+    | Animated.AnimatedInterpolation<string | number>
+    | undefined;
   label?: string;
   style: StyleProp<ViewStyle>;
   icon: React.ReactNode;
 }
 
 export const TabBarItemLabel = React.memo(
-  ({ color, label, style, icon }: TabBarItemLabelProps) => {
+  ({
+    color,
+    label,
+    style,
+    icon,
+    fontSize,
+    fontWeight,
+  }: TabBarItemLabelProps) => {
     if (!label) {
       return null;
     }
@@ -21,7 +47,7 @@ export const TabBarItemLabel = React.memo(
           styles.label,
           icon ? { marginTop: 0 } : null,
           style,
-          { color: color },
+          { color: color, fontSize: fontSize, fontWeight },
         ]}
       >
         {label}

--- a/packages/react-native-tab-view/src/TabView.tsx
+++ b/packages/react-native-tab-view/src/TabView.tsx
@@ -42,6 +42,7 @@ export type Props<T extends Route> = Omit<PagerProps, 'layoutDirection'> & {
   renderScene: (props: SceneRendererProps & { route: T }) => React.ReactNode;
   options?: Record<string, TabDescriptor<T>>;
   commonOptions?: TabDescriptor<T>;
+  useNativeDriver?: boolean;
 };
 
 const renderLazyPlaceholderDefault = () => null;
@@ -68,6 +69,7 @@ export function TabView<T extends Route>({
   overScrollMode,
   options: sceneOptions,
   commonOptions,
+  useNativeDriver,
 }: Props<T>) {
   if (
     Platform.OS !== 'web' &&
@@ -128,6 +130,7 @@ export function TabView<T extends Route>({
         overScrollMode={overScrollMode}
         style={pagerStyle}
         layoutDirection={direction}
+        useNativeDriver={useNativeDriver ?? true}
       >
         {({ position, render, addEnterListener, jumpTo }) => {
           // All the props here must not change between re-renders

--- a/packages/react-native-tab-view/src/types.tsx
+++ b/packages/react-native-tab-view/src/types.tsx
@@ -12,7 +12,9 @@ export type TabDescriptor<T extends Route> = {
     route: T;
     labelText?: string;
     focused: boolean;
-    color: string;
+    color: string | Animated.AnimatedInterpolation<number | string>;
+    fontSize: number | Animated.AnimatedInterpolation<number>;
+    fontWeight: TextStyle['fontWeight'];
     allowFontScaling?: boolean;
     style?: StyleProp<TextStyle>;
   }) => React.ReactNode;


### PR DESCRIPTION
Please provide enough information so that others can review your pull request.

**Motivation**

This commit uses the `interpolate` method to support animated gradients of tab color and font size in `material-top-tab` and `react-native-tab-view`.

Active and inactive tabs usually have different colors and font sizes to show their active state, and I added a gradient process to make it smoother and more natural.

Changed:
`tabBarActiveTintColor`, `tabBarInactiveTintColor` now supports gradients.

Added:
`tabBarActiveFontSize`, `tabBarInactiveFontSize`, animatable.
`tabBarActiveFontWeight`, `tabBarInactiveFontWeight`, not animatable.

**Test plan**

On native platforms, the `fontSize` property does not support `useNativeDriver`, so currently if `tabBarActiveFontSize` or `tabBarInactiveFontSize` is passed, the `useNativeDriver` value will be automatically set to `false`. This change may cause differences between web and native platforms and may cause performance loss, so you can focus on testing this. The latest code effects can be seen in the "Material Top Tab" and "Tab View" in the example project.

Example videos:

https://github.com/user-attachments/assets/cc928743-58c8-4073-b645-27d78b9186e6


https://github.com/user-attachments/assets/0aeea75e-445b-461a-833d-1c15e1f4f69a




