### PR TITLE
fix: full screen modal on Web in nested navigator

### DIFF
--- a/packages/native-stack/src/views/NativeStackView.tsx
+++ b/packages/native-stack/src/views/NativeStackView.tsx
@@ -14,7 +14,7 @@ import {
   useLinkBuilder,
 } from '@react-navigation/native';
 import * as React from 'react';
-import { Animated, Image, StyleSheet, View } from 'react-native';
+import { Animated, Image, Platform, StyleSheet, View } from 'react-native';
 
 import type {
   NativeStackDescriptor,
@@ -35,6 +35,13 @@ type Props = {
 };
 
 const TRANSPARENT_PRESENTATIONS = [
+  'transparentModal',
+  'containedTransparentModal',
+];
+
+const MODAL_PRESENTATIONS = [
+  'modal',
+  'fullScreenModal',
   'transparentModal',
   'containedTransparentModal',
 ];
@@ -152,6 +159,12 @@ export function NativeStackView({ state, descriptors, describe }: Props) {
             }
             style={[
               StyleSheet.absoluteFill,
+              // Always fill the whole screen, even in the case of nested navigators.
+              Platform.OS === 'web' &&
+              presentation != null &&
+              MODAL_PRESENTATIONS.includes(presentation)
+                ? { position: 'fixed' as 'absolute' }
+                : null,
               {
                 display:
                   (isFocused ||


### PR DESCRIPTION
**Motivation**

For nested navigators (e.g. Tab > Stack) this change makes screens in the nested navigator with their presentation set to modal fill the whole screen. This makes web match the behaviour of native platforms.

Previously in the case of Tab > Stack, the tabs in Tab would still be visible.

**Test plan**

[Unsure beyond manual testing, please advise on the best approach to testing this]
