### PR TITLE
chore(example): update expo-blur version to 14.0.3 to fix issues with building on Android

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -21,7 +21,7 @@
     "color": "^4.2.3",
     "expo": "^52.0.10",
     "expo-asset": "~11.0.1",
-    "expo-blur": "~14.0.1",
+    "expo-blur": "~14.0.3",
     "expo-linking": "~7.0.3",
     "expo-localization": "~16.0.0",
     "expo-splash-screen": "~0.29.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4032,7 +4032,7 @@ __metadata:
     expect-type: "npm:^0.17.3"
     expo: "npm:^52.0.10"
     expo-asset: "npm:~11.0.1"
-    expo-blur: "npm:~14.0.1"
+    expo-blur: "npm:~14.0.3"
     expo-dev-client: "npm:~5.0.3"
     expo-linking: "npm:~7.0.3"
     expo-localization: "npm:~16.0.0"
@@ -8203,14 +8203,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expo-blur@npm:~14.0.1":
-  version: 14.0.1
-  resolution: "expo-blur@npm:14.0.1"
+"expo-blur@npm:~14.0.3":
+  version: 14.0.3
+  resolution: "expo-blur@npm:14.0.3"
   peerDependencies:
     expo: "*"
     react: "*"
     react-native: "*"
-  checksum: 263fe270941b8d05792f266ac1101de34f89cd1cf69e54802bc97daf798a89d2c3bf9f72780840fd5ed0519a209f71845f4758b49757be0fdc67942fab7da477
+  checksum: c69dfb542530dae4ca66caf341b8e72f1555ef0cf700c94603e487a31d53f31885a03f3aadd208e9d531969dbcd558856f4475ccb9b77a37580fc6062dee4cda
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**Motivation**

There is a problem with building the examples app for Android. The build fails because of one of the dependencies of expo-blur. The issue has been resolved in newest version of expo-blur@14.0.3 (https://github.com/expo/expo/pull/34012).

**Test plan**

Build the examples app for Android.
