### PR TITLE
chore(CI): fix failing playwright installation on e2e CI

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -43,7 +43,7 @@
     "@babel/core": "^7.24.0",
     "@babel/node": "^7.22.19",
     "@babel/plugin-transform-strict-mode": "^7.24.7",
-    "@playwright/test": "^1.41.1",
+    "@playwright/test": "^1.50.1",
     "@types/cheerio": "^0.22.35",
     "@types/koa": "^2.14.0",
     "@types/mock-require": "^2.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3565,14 +3565,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@playwright/test@npm:^1.41.1":
-  version: 1.44.1
-  resolution: "@playwright/test@npm:1.44.1"
+"@playwright/test@npm:^1.50.1":
+  version: 1.50.1
+  resolution: "@playwright/test@npm:1.50.1"
   dependencies:
-    playwright: "npm:1.44.1"
+    playwright: "npm:1.50.1"
   bin:
     playwright: cli.js
-  checksum: 572b4c97834fae54fda833939b8f376df2c301b724f9825a3c705533efc124beb346dd9406f54cd771b3f79c00f0e5c70b5469ef33818a0d2e2ea17b19636f9a
+  checksum: 0d8d2291d6554c492cb163b4d463e1e9cc6d3ae50680d790473f693f36a243c16c3620406849dd40115046c47a6ad5cc36a24511caec6d054dc1a1d9fffb4138
   languageName: node
   linkType: hard
 
@@ -4016,7 +4016,7 @@ __metadata:
     "@expo/metro-runtime": "npm:~4.0.0"
     "@expo/react-native-action-sheet": "npm:^4.0.1"
     "@expo/vector-icons": "npm:^14.0.3"
-    "@playwright/test": "npm:^1.41.1"
+    "@playwright/test": "npm:^1.50.1"
     "@react-native-async-storage/async-storage": "npm:1.23.1"
     "@react-native-masked-view/masked-view": "npm:0.3.2"
     "@types/cheerio": "npm:^0.22.35"
@@ -13634,27 +13634,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"playwright-core@npm:1.44.1":
-  version: 1.44.1
-  resolution: "playwright-core@npm:1.44.1"
+"playwright-core@npm:1.50.1":
+  version: 1.50.1
+  resolution: "playwright-core@npm:1.50.1"
   bin:
     playwright-core: cli.js
-  checksum: f79f9022bbb760daed371e36c802b27d43dc75e67de4d139d83b47feea51c8b884f3296cce85c3afa71c942290cef1b4369cd9ddf4dda5457a0a81772c73b50a
+  checksum: 9a310b8a66bf7fd926e620c1c8e27be29bdbdce91640e5f975b2fd4dc706d0307faec2bb0456cc8e7dedb1e71c0b5eb35c6a58acd5cedc7d8fd849a9067e637b
   languageName: node
   linkType: hard
 
-"playwright@npm:1.44.1":
-  version: 1.44.1
-  resolution: "playwright@npm:1.44.1"
+"playwright@npm:1.50.1":
+  version: 1.50.1
+  resolution: "playwright@npm:1.50.1"
   dependencies:
     fsevents: "npm:2.3.2"
-    playwright-core: "npm:1.44.1"
+    playwright-core: "npm:1.50.1"
   dependenciesMeta:
     fsevents:
       optional: true
   bin:
     playwright: cli.js
-  checksum: 3207178a78f1c971dddf99c9a08052e462c882092e0d47e3dd8287ced40897a49e387e545a61d31e5d68f7e443d7818660aa12ce43ab662d01d95bcfcfeca2ca
+  checksum: a3687614ac3238a81cbe3018e4f4a2ae92c71f3f65110cc6087068c020f6134f0628308da33177b9b08102644706e835d4053f6890beeb4a935f433bc4ac107a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**Motivation**

Currently the playwright installation on CI fails with [following error](https://github.com/react-navigation/react-navigation/actions/runs/13436891400/job/37541233565?pr=12449): 

```
Package libasound2 is a virtual package provided by:
  liboss4-salsa-asound2 4.2-build2020-1ubuntu3
  libasound2t64 1.2.11-1build2 (= 1.2.11-1build2)

E: Package 'libasound2' has no installation candidate
E: Unable to locate package libffi7
E: Unable to locate package libx264-163
Failed to install browsers
Error: Installation process exited with code: 100
Error: Process completed with exit code 1.
```

This is because playwright has some issues on newest ubuntu-24.04 (see [issue on playwright repo](https://github.com/microsoft/playwright/issues/30368)).

The CI started failing out of a sudden, because our CI is configured to use `ubuntu-latest` and the switch from `22.04` to `24.04` must have been done lately.

Support for `24.04` has been released with recent version of playwright. 

**Test plan**

CI e2e should pass.

