### PR TITLE
fix: Allow Start and End to Override indicatorStyle in `react-native-tab-view`

### DIFF
--- a/packages/react-native-tab-view/src/TabBar.tsx
+++ b/packages/react-native-tab-view/src/TabBar.tsx
@@ -644,8 +644,8 @@ export function TabBar<T extends Route>({
                 (tabBarWidth - separatorsWidth - paddingsWidth) / routes.length
               ),
           style: [
-            indicatorStyle,
             { start: flattenedPaddingStart, end: flattenedPaddingEnd },
+            indicatorStyle,
           ],
           getTabWidth: (i: number) =>
             getComputedTabWidth(


### PR DESCRIPTION
Please provide enough information so that others can review your pull request.

**Motivation**

fixes #12451 

**Test plan**

Tested locally
