### PR TITLE
fix: header search not taking remaining space when title centered

### DIFF
--- a/packages/elements/src/Header/Header.tsx
+++ b/packages/elements/src/Header/Header.tsx
@@ -326,7 +326,7 @@ export function Header(props: Props) {
           pointerEvents="box-none"
           style={[
             styles.start,
-            headerTitleAlign === 'center' && styles.expand,
+            !searchBarVisible && headerTitleAlign === 'center' && styles.expand,
             { marginStart: insets.left },
             leftContainerStyle,
           ]}


### PR DESCRIPTION
**Motivation**
This problem occurs when using `headerTitleAlign` set to `"center"` when using the simple stack. The search should span the entire header.

**Test plan**
1. Open example app;
2. Go to Simple Stack > Navigate to feed > Replace with contacts;
3. Change `headerTitleAlign` to `"center"` in the code;
4. Check result.

Without fix:
<img width="300" src="https://github.com/user-attachments/assets/a3e4593d-1568-422a-8bc8-b07fc9a890df ">


With fix:
<img width="300" src="https://github.com/user-attachments/assets/a29abbc0-85dd-41c3-8d17-8d820b902ec6">
