### PR TITLE
feat: add typing for onSubmitEditing

### DIFF
--- a/packages/elements/src/types.tsx
+++ b/packages/elements/src/types.tsx
@@ -59,6 +59,11 @@ export type HeaderSearchBarOptions = {
    */
   onChangeText?: TextInputProps['onChange'];
   /**
+   * Callback that is called when the submit button is pressed.
+   * It receives the current text value of the search input.
+   */
+  onSubmitEditing?: TextInputProps['onSubmitEditing'];
+  /**
    * A callback that gets called when search input is closed
    */
   onClose?: () => void;


### PR DESCRIPTION
Allows sending `onSubmitEditing` to the underlying `TextInput` element. Useful when searching should happen after user hits the keyboard submit button.