### PR TITLE
feat: add enterKeyHint

### DIFF
--- a/packages/elements/src/Header/HeaderSearchBar.tsx
+++ b/packages/elements/src/Header/HeaderSearchBar.tsx
@@ -43,6 +43,7 @@ function HeaderSearchBarInternal(
     autoFocus = true,
     placeholder = 'Search',
     cancelButtonText = 'Cancel',
+    enterKeyHint = 'search',
     onChangeText,
     onClose,
     style,
@@ -166,6 +167,7 @@ function HeaderSearchBarInternal(
           onChangeText={setValue}
           autoFocus={autoFocus}
           inputMode={INPUT_TYPE_TO_MODE[inputType ?? 'text']}
+          enterKeyHint={enterKeyHint}
           placeholder={placeholder}
           placeholderTextColor={Color(colors.text).alpha(0.5).string()}
           cursorColor={colors.primary}

--- a/packages/elements/src/types.tsx
+++ b/packages/elements/src/types.tsx
@@ -50,7 +50,7 @@ export type HeaderSearchBarOptions = {
    */
   inputType?: 'text' | 'phone' | 'number' | 'email';
   /**
-   * Determines how the return key should look.
+   * Determines how the return key should look. Defaults to `search`.
    */
   enterKeyHint?: TextInputProps['enterKeyHint'];
   /**

--- a/packages/elements/src/types.tsx
+++ b/packages/elements/src/types.tsx
@@ -50,6 +50,10 @@ export type HeaderSearchBarOptions = {
    */
   inputType?: 'text' | 'phone' | 'number' | 'email';
   /**
+   * Determines how the return key should look.
+   */
+  enterKeyHint?: TextInputProps['enterKeyHint'];
+  /**
    * A callback that gets called when search input has lost focus
    */
   onBlur?: TextInputProps['onBlur'];


### PR DESCRIPTION
Adds and passes `enterKeyHint` to header search's text input. Defaults to `"search"`.