### PR TITLE
fix: screen overlay opacity

### DIFF
--- a/packages/stack/src/TransitionConfigs/CardStyleInterpolators.tsx
+++ b/packages/stack/src/TransitionConfigs/CardStyleInterpolators.tsx
@@ -39,7 +39,7 @@ export function forHorizontalIOS({
 
   const overlayOpacity = current.progress.interpolate({
     inputRange: [0, 1],
-    outputRange: [0, 0.07],
+    outputRange: [0, 0.7],
     extrapolate: 'clamp',
   });
 


### PR DESCRIPTION
Fixed a bug that prevented the card overlay from showing for navigation stacks when presenting and dismissing a navigation card/screen 😁

**Motivation**

For the navigation Stack, I think that 0.07 opacity should have been 0.7. Because of this, the overly is so opaque that it's not visible. It's as if it's not even there.

This is how it looks currently. There is no overlay over the previous screen when animating back and forth to a new screen.

https://github.com/user-attachments/assets/f05c26de-8720-47be-82e0-f9cb810f7c97

This is how it looks after the fix. The overlay is visible and is fading in as we animate to the new screen

https://github.com/user-attachments/assets/cbdaacf3-18da-4f3c-993e-e8138bfffd0a

**Test plan**

Ensure you enable `cardOverlayEnabled: true` for the screen options for the navigator
