### PR TITLE
feat: pass all TextInput props to search

### DIFF
--- a/example/src/Screens/SimpleStack.tsx
+++ b/example/src/Screens/SimpleStack.tsx
@@ -6,7 +6,7 @@ import {
   type StackScreenProps,
 } from '@react-navigation/stack';
 import * as React from 'react';
-import { Platform, ScrollView, StyleSheet, View } from 'react-native';
+import { Alert, Platform, ScrollView, StyleSheet, View } from 'react-native';
 
 import { COMMON_LINKING_CONFIG } from '../constants';
 import { Albums } from '../Shared/Albums';
@@ -97,6 +97,9 @@ const ContactsScreen = ({
     navigation.setOptions({
       headerSearchBarOptions: {
         placeholder: 'Filter contacts',
+        onSubmitEditing: (e) => {
+          Alert.alert(`Submitted: ${e.nativeEvent.text}`);
+        },
         onChangeText: (e) => {
           setQuery(e.nativeEvent.text);
         },

--- a/packages/elements/src/Header/HeaderSearchBar.tsx
+++ b/packages/elements/src/Header/HeaderSearchBar.tsx
@@ -4,10 +4,12 @@ import * as React from 'react';
 import {
   Animated,
   Image,
+  type NativeSyntheticEvent,
   Platform,
   type StyleProp,
   StyleSheet,
   TextInput,
+  type TextInputChangeEventData,
   View,
   type ViewStyle,
 } from 'react-native';
@@ -38,20 +40,22 @@ const INPUT_TYPE_TO_MODE = {
 const useNativeDriver = Platform.OS !== 'web';
 
 function HeaderSearchBarInternal(
-  {
+  props: Props,
+  ref: React.ForwardedRef<HeaderSearchBarRef>
+) {
+  const {
     visible,
     inputType,
-    autoFocus = true,
-    placeholder = 'Search',
     cancelButtonText = 'Cancel',
-    onChangeText,
     onClose,
     tintColor,
     style,
+    inputStyle,
+    onChange,
+    onChangeText,
     ...rest
-  }: Props,
-  ref: React.ForwardedRef<HeaderSearchBarRef>
-) {
+  } = props;
+
   const navigation = useNavigation();
   const { dark, colors, fonts } = useTheme();
   const [value, setValue] = React.useState('');
@@ -104,6 +108,14 @@ function HeaderSearchBarInternal(
       }
     });
   }, [clearVisibleAnim, hasText]);
+
+  const handleChange = React.useCallback(
+    (e: NativeSyntheticEvent<TextInputChangeEventData>) => {
+      setValue(e.nativeEvent.text);
+      onChangeText?.(e);
+    },
+    [onChangeText]
+  );
 
   const clearText = React.useCallback(() => {
     inputRef.current?.clear();
@@ -168,17 +180,16 @@ function HeaderSearchBarInternal(
           style={styles.inputSearchIcon}
         />
         <TextInput
-          {...rest}
-          ref={inputRef}
-          onChange={onChangeText}
-          onChangeText={setValue}
-          autoFocus={autoFocus}
+          enterKeyHint="search"
           inputMode={INPUT_TYPE_TO_MODE[inputType ?? 'text']}
-          placeholder={placeholder}
           placeholderTextColor={Color(textColor).alpha(0.5).string()}
           cursorColor={colors.primary}
           selectionHandleColor={colors.primary}
           selectionColor={Color(colors.primary).alpha(0.3).string()}
+          {...rest}
+          ref={inputRef}
+          onChange={handleChange}
+          onChangeText={onChange}
           style={[
             fonts.regular,
             styles.searchbar,
@@ -190,6 +201,7 @@ function HeaderSearchBarInternal(
               color: textColor,
               borderBottomColor: Color(textColor).alpha(0.2).string(),
             },
+            inputStyle,
           ]}
         />
         {Platform.OS === 'ios' ? (

--- a/packages/elements/src/types.tsx
+++ b/packages/elements/src/types.tsx
@@ -19,7 +19,10 @@ export type HeaderSearchBarRef = {
   cancelSearch: () => void;
 };
 
-export type HeaderSearchBarOptions = {
+export type HeaderSearchBarOptions = Omit<
+  TextInputProps,
+  'style' | 'value' | 'onChange' | 'onChangeText'
+> & {
   /**
    * Ref to imperatively update the search bar.
    *
@@ -32,14 +35,6 @@ export type HeaderSearchBarOptions = {
    */
   ref?: React.Ref<HeaderSearchBarRef>;
   /**
-   * The auto-capitalization behavior
-   */
-  autoCapitalize?: 'none' | 'words' | 'sentences' | 'characters';
-  /**
-   * Automatically focuses search input on mount
-   */
-  autoFocus?: boolean;
-  /**
    * The text to be used instead of default `Cancel` button text
    *
    * @platform ios
@@ -50,26 +45,22 @@ export type HeaderSearchBarOptions = {
    */
   inputType?: 'text' | 'phone' | 'number' | 'email';
   /**
-   * A callback that gets called when search input has lost focus
+   * Style that gets passed to the underlying TextInput.
    */
-  onBlur?: TextInputProps['onBlur'];
+  inputStyle?: TextInputProps['style'];
   /**
-   * A callback that gets called when the text changes.
-   * It receives the current text value of the search input.
+   * Callback that is called when the text input's text changes.
+   * Changed text is passed as a single string argument to the callback handler.
+   */
+  onChange?: TextInputProps['onChangeText']; // FIXME: onChange and onChangeText are reversed
+  /**
+   * Callback that is called when the text input's text changes.
    */
   onChangeText?: TextInputProps['onChange'];
   /**
    * A callback that gets called when search input is closed
    */
   onClose?: () => void;
-  /**
-   * A callback that gets called when search input has received focus
-   */
-  onFocus?: TextInputProps['onFocus'];
-  /**
-   * Text displayed when search field is empty
-   */
-  placeholder?: string;
 };
 
 export type HeaderOptions = {


### PR DESCRIPTION
**Motivation**
I had a need to pass `onSubmitEditing` to the stack navigator to get the input value after the user submits it using the phone's keyboard. This allow me to trigger my search logic after the user finished inputing his search string.

**Description**
Allows passing all `TextInput` props, except `value`, to the `TextInput` used by `HeaderSearchBarInternal`. The `onChange` and `onChangeText` props are reversed for compatibility with `react-native-screens`. This also defaults `enterKeyHint` to `"search"` to properly reflect the keyboard action.

**Test plan**
1. Open example app;
2. Go to Simple Stack > Navigate to feed > Replace with contacts;
3. Edit `headerSearchBarOptions` property in the source code to pass `TextInput` props;
4. Check result.

In the example app, the `onSubmitEditing` prop is passed for testing purposes. It launches an alert with the inputed string after submitting from the keyboard.

**Additional info**
Supersedes #12462 and  #12464.  If merged, close the other PRs.