### PR TITLE
fix: stop navigate and push from rearranging stack history

### DIFF
--- a/example/e2e/maestro/native-stack.yml
+++ b/example/e2e/maestro/native-stack.yml
@@ -39,4 +39,4 @@ name: Native Stack
     text: 'Pop by 2'
     retryTapIfNoChange: false
 - assertVisible:
-    text: 'Contacts'
+    text: 'Article by Babel fish'

--- a/example/e2e/maestro/simple-stack.yml
+++ b/example/e2e/maestro/simple-stack.yml
@@ -39,4 +39,4 @@ name: Simple Stack
     text: 'Pop by 2'
     retryTapIfNoChange: false
 - assertVisible:
-    text: 'Contacts'
+    text: 'Article by Babel fish'

--- a/packages/routers/src/StackRouter.tsx
+++ b/packages/routers/src/StackRouter.tsx
@@ -404,7 +404,12 @@ export function StackRouter(options: StackRouterOptions) {
                 routes.push(r);
               }
             } else {
-              routes = state.routes.filter((r) => r.key !== route.key);
+              routes =
+                action.type === 'NAVIGATE' &&
+                state.routes[state.index].key === route.key
+                  ? state.routes.slice(0, -1)
+                  : [...state.routes];
+
               routes.push({
                 ...route,
                 path:

--- a/packages/routers/src/__tests__/StackRouter.test.tsx
+++ b/packages/routers/src/__tests__/StackRouter.test.tsx
@@ -540,10 +540,11 @@ test('ensures unique ID for navigate', () => {
     stale: false,
     type: 'stack',
     key: 'root',
-    index: 1,
+    index: 2,
     preloadedRoutes: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
+      { key: 'bar-test', name: 'bar', params: { foo: 'a' } },
       { key: 'bar', name: 'bar' },
       { key: 'bar-test', name: 'bar', params: { foo: 'a' } },
     ],
@@ -1727,11 +1728,12 @@ test('ensures unique ID for push', () => {
     stale: false,
     type: 'stack',
     key: 'root',
-    index: 1,
+    index: 2,
     preloadedRoutes: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'bar', name: 'bar' },
+      { key: 'bar-test', name: 'bar', params: { foo: 'a' } },
       { key: 'bar-test', name: 'bar', params: { foo: 'a' } },
     ],
   });
@@ -2488,7 +2490,7 @@ test('handles screen preloading', () => {
     stale: false,
     type: 'stack',
     key: 'root',
-    index: 1,
+    index: 2,
     preloadedRoutes: [
       {
         key: 'bar-test',
@@ -2497,6 +2499,7 @@ test('handles screen preloading', () => {
     ],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
+      { key: 'qux-some', name: 'qux' },
       {
         key: 'bar-test',
         name: 'bar',


### PR DESCRIPTION
**Motivation**

Fix the behaviour of `navigate` and `push` within the StackRouter to never rearrange history. The goal is to match the desired behaviour of `react-native-screens`, which does not allow a stack to be rearranged.

In the docs and CHANGELOG, it is stated that `navigate(screenName)` will stay on the current screen if the screen is already focused, otherwise push a new screen to the stack. This is later clarified that if a `getID()` is provided, then it will match on the result of `getID()`, not the name.

StackRouter does not seem to follow this logic. The current logic check if *any* route in the history matches, and if so *move* it to the current route with updated params. Otherwise push the new route. 

For `push` the history rearranging logic does not appear to be documented. 

**Test plan**

Test suite already covers the test scenarious. Updated tests with the new behaviour and added comments explaining the changes.