### PR TITLE
fix: update pointerEvents handling to prevent deprecation warnings

### DIFF
--- a/packages/bottom-tabs/src/__tests__/index.test.tsx
+++ b/packages/bottom-tabs/src/__tests__/index.test.tsx
@@ -120,6 +120,7 @@ test('tab bar cannot be tapped when hidden', async () => {
   act(() => jest.runAllTimers());
 
   expect(queryByText('Screen B')).not.toBeNull();
+  expect(queryByText('Screen A')).toBeNull();
 
   act(() => {
     // Show the keyboard to hide the tab bar
@@ -133,8 +134,8 @@ test('tab bar cannot be tapped when hidden', async () => {
 
   act(() => jest.runAllTimers());
 
-  expect(queryByText('Screen A')).toBeNull();
-  expect(queryByText('Screen B')).not.toBeNull();
+  expect(queryByText('Screen A')).not.toBeNull();
+  expect(queryByText('Screen B')).toBeNull();
 
   spy.mockRestore();
 });

--- a/packages/bottom-tabs/src/views/BottomTabBar.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabBar.tsx
@@ -376,10 +376,9 @@ export function BottomTabBar({
             ],
         tabBarStyle,
       ]}
-      pointerEvents={isTabBarHidden ? 'none' : 'auto'}
       onLayout={sidebar ? undefined : handleLayout}
     >
-      <View pointerEvents="none" style={StyleSheet.absoluteFill}>
+      <View style={[StyleSheet.absoluteFill, { pointerEvents: 'none' }]}>
         {tabBarBackgroundElement}
       </View>
       <View

--- a/packages/elements/src/Header/Header.tsx
+++ b/packages/elements/src/Header/Header.tsx
@@ -289,46 +289,59 @@ export function Header(props: Props) {
 
   return (
     <Animated.View
-      pointerEvents="box-none"
-      style={[{ height, minHeight, maxHeight, opacity, transform }]}
+      style={[
+        {
+          height,
+          minHeight,
+          maxHeight,
+          opacity,
+          transform,
+        },
+        { pointerEvents: 'box-none' },
+      ]}
     >
       <Animated.View
-        pointerEvents="box-none"
-        style={[StyleSheet.absoluteFill, backgroundContainerStyle]}
+        style={[
+          StyleSheet.absoluteFill,
+          backgroundContainerStyle,
+          { pointerEvents: 'box-none' },
+        ]}
       >
         {headerBackground ? (
           headerBackground({ style: backgroundStyle })
         ) : (
           <HeaderBackground
-            pointerEvents={
+            style={[
+              backgroundStyle,
               // Allow touch through the header when background color is transparent
               headerTransparent &&
               (backgroundStyle.backgroundColor === 'transparent' ||
                 Color(backgroundStyle.backgroundColor).alpha() === 0)
-                ? 'none'
-                : 'auto'
-            }
-            style={backgroundStyle}
+                ? { pointerEvents: 'none' }
+                : { pointerEvents: 'auto' },
+            ]}
           />
         )}
       </Animated.View>
-      <View pointerEvents="none" style={{ height: headerStatusBarHeight }} />
       <View
-        pointerEvents="box-none"
+        style={[{ height: headerStatusBarHeight }, { pointerEvents: 'none' }]}
+      />
+      <View
         style={[
           styles.content,
           Platform.OS === 'ios' && frame.width >= IPAD_MINI_MEDIUM_WIDTH
             ? styles.large
             : null,
+          { pointerEvents: 'box-none' },
         ]}
       >
         <Animated.View
-          pointerEvents="box-none"
           style={[
             styles.start,
             headerTitleAlign === 'center' && styles.expand,
             { marginStart: insets.left },
             leftContainerStyle,
+            { pointerEvents: 'box-none' },
           ]}
         >
           {leftButton}
@@ -336,7 +349,6 @@ export function Header(props: Props) {
         {Platform.OS === 'ios' || !searchBarVisible ? (
           <>
             <Animated.View
-              pointerEvents="box-none"
               style={[
                 styles.title,
                 {
@@ -362,6 +374,7 @@ export function Header(props: Props) {
                   ? { marginStart: 4 }
                   : { marginHorizontal: 16 },
                 titleContainerStyle,
+                { pointerEvents: 'box-none' },
               ]}
             >
               {headerTitle({
@@ -373,12 +386,12 @@ export function Header(props: Props) {
               })}
             </Animated.View>
             <Animated.View
-              pointerEvents="box-none"
               style={[
                 styles.end,
                 styles.expand,
                 { marginEnd: insets.right },
                 rightContainerStyle,
+                { pointerEvents: 'box-none' },
               ]}
             >
               {rightButton}

--- a/packages/elements/src/Header/HeaderSearchBar.tsx
+++ b/packages/elements/src/Header/HeaderSearchBar.tsx
@@ -155,11 +155,15 @@ function HeaderSearchBarInternal(
 
   return (
     <Animated.View
-      pointerEvents={visible ? 'auto' : 'none'}
       accessibilityLiveRegion="polite"
       accessibilityElementsHidden={!visible}
       importantForAccessibility={visible ? 'auto' : 'no-hide-descendants'}
-      style={[styles.container, { opacity: visibleAnim }, style]}
+      style={[
+        styles.container,
+        { opacity: visibleAnim },
+        style,
+        { pointerEvents: visible ? 'auto' : 'none' },
+      ]}
     >
       <View style={styles.searchbarContainer}>
         <HeaderIcon

--- a/packages/elements/src/ResourceSavingView.tsx
+++ b/packages/elements/src/ResourceSavingView.tsx
@@ -30,8 +30,8 @@ export function ResourceSavingView({
           { display: visible ? 'flex' : 'none' },
           styles.container,
           style,
+          { pointerEvents: visible ? 'auto' : 'none' },
         ]}
-        pointerEvents={visible ? 'auto' : 'none'}
         {...rest}
       >
         {children}
@@ -41,9 +41,12 @@ export function ResourceSavingView({
 
   return (
     <View
-      style={[styles.container, style]}
+      style={[
+        styles.container,
+        style,
+        { pointerEvents: visible ? 'auto' : 'none' },
+      ]}
       // box-none doesn't seem to work properly on Android
-      pointerEvents={visible ? 'auto' : 'none'}
     >
       <View
         collapsable={false}
@@ -52,8 +55,10 @@ export function ResourceSavingView({
           // This is an workaround for a bug where the clipped view never re-appears
           Platform.OS === 'ios' || Platform.OS === 'macos' ? !visible : true
         }
-        pointerEvents={visible ? 'auto' : 'none'}
-        style={visible ? styles.attached : styles.detached}
+        style={[
+          visible ? styles.attached : styles.detached,
+          { pointerEvents: visible ? 'auto' : 'none' },
+        ]}
       >
         {children}
       </View>

--- a/packages/elements/src/Screen.tsx
+++ b/packages/elements/src/Screen.tsx
@@ -74,7 +74,6 @@ export function Screen(props: Props) {
         <NavigationContext.Provider value={navigation}>
           <NavigationRouteContext.Provider value={route}>
             <View
-              pointerEvents="box-none"
               onLayout={(e) => {
                 const { height } = e.nativeEvent.layout;
 
@@ -83,6 +82,7 @@ export function Screen(props: Props) {
               style={[
                 styles.header,
                 headerTransparent ? styles.absolute : null,
+                { pointerEvents: 'box-none' },
               ]}
             >
               {header}

--- a/packages/react-native-tab-view/src/TabBar.tsx
+++ b/packages/react-native-tab-view/src/TabBar.tsx
@@ -623,12 +623,12 @@ export function TabBar<T extends Route>({
   return (
     <Animated.View onLayout={handleLayout} style={[styles.tabBar, style]}>
       <Animated.View
-        pointerEvents="none"
         style={[
           styles.indicatorContainer,
           scrollEnabled ? { transform: [{ translateX }] as any } : null,
           scrollEnabled ? { width: tabBarWidth } : null,
           indicatorContainerStyle,
+          { pointerEvents: 'none' },
         ]}
       >
         {renderIndicator({

--- a/packages/react-native-tab-view/src/TabBarItem.tsx
+++ b/packages/react-native-tab-view/src/TabBarItem.tsx
@@ -228,7 +228,7 @@ const TabBarItemInternal = <T extends Route>({
       href={href}
       style={[styles.pressable, tabContainerStyle]}
     >
-      <View pointerEvents="none" style={[styles.item, tabStyle]}>
+      <View style={[styles.item, tabStyle, { pointerEvents: 'none' }]}>
         {icon}
         <View>
           <Animated.View style={{ opacity: inactiveOpacity }}>

--- a/packages/stack/src/views/Header/HeaderContainer.tsx
+++ b/packages/stack/src/views/Header/HeaderContainer.tsx
@@ -57,7 +57,7 @@ export function HeaderContainer({
   const { buildHref } = useLinkBuilder();
 
   return (
-    <Animated.View pointerEvents="box-none" style={style}>
+    <Animated.View style={[style, { pointerEvents: 'box-none' }]}>
       {scenes.slice(-3).map((scene, i, self) => {
         if ((mode === 'screen' && i !== self.length - 1) || !scene) {
           return null;
@@ -164,18 +164,18 @@ export function HeaderContainer({
                       }
                     : undefined
                 }
-                pointerEvents={isFocused ? 'box-none' : 'none'}
                 accessibilityElementsHidden={!isFocused}
                 importantForAccessibility={
                   isFocused ? 'auto' : 'no-hide-descendants'
                 }
-                style={
+                style={[
                   // Avoid positioning the focused header absolutely
                   // Otherwise accessibility tools don't seem to be able to find it
                   (mode === 'float' && !isFocused) || headerTransparent
                     ? styles.header
-                    : null
-                }
+                    : null,
+                  { pointerEvents: isFocused ? 'box-none' : 'none' },
+                ]}
               >
                 {header !== undefined ? header(props) : <Header {...props} />}
               </View>

--- a/packages/stack/src/views/Stack/Card.tsx
+++ b/packages/stack/src/views/Stack/Card.tsx
@@ -102,7 +102,9 @@ export class Card extends React.Component<Props> {
       style: Animated.WithAnimatedValue<StyleProp<ViewStyle>>;
     }) =>
       style ? (
-        <Animated.View pointerEvents="none" style={[styles.overlay, style]} />
+        <Animated.View
+          style={[styles.overlay, style, { pointerEvents: 'none' }]}
+        />
       ) : null,
   };
 
@@ -552,20 +554,26 @@ export class Card extends React.Component<Props> {
           collapsable={false}
         />
         <View
-          pointerEvents="box-none"
+          style={{ pointerEvents: 'box-none' }}
           // Make sure this view is not removed on the new architecture, as it causes focus loss during navigation on Android.
           // This can happen when the view flattening results in different trees - due to `overflow` style changing in a parent.
           collapsable={false}
           {...rest}
         >
           {overlayEnabled ? (
-            <View pointerEvents="box-none" style={StyleSheet.absoluteFill}>
+            <View
+              style={[StyleSheet.absoluteFill, { pointerEvents: 'box-none' }]}
+            >
               {overlay({ style: overlayStyle })}
             </View>
           ) : null}
           <Animated.View
-            style={[styles.container, containerStyle, customContainerStyle]}
-            pointerEvents="box-none"
+            style={[
+              styles.container,
+              containerStyle,
+              customContainerStyle,
+              { pointerEvents: 'box-none' },
+            ]}
           >
             <PanGestureHandler
               enabled={layout.width !== 0 && gestureEnabled}
@@ -590,8 +598,8 @@ export class Card extends React.Component<Props> {
                             : [styles.shadowVertical, styles.shadowBottom],
                       { backgroundColor },
                       shadowStyle,
+                      { pointerEvents: 'none' },
                     ]}
-                    pointerEvents="none"
                   />
                 ) : null}
                 <CardSheet

--- a/packages/stack/src/views/Stack/CardContainer.tsx
+++ b/packages/stack/src/views/Stack/CardContainer.tsx
@@ -260,7 +260,6 @@ function CardContainerInner({
       styleInterpolator={cardStyleInterpolator}
       accessibilityElementsHidden={!focused}
       importantForAccessibility={focused ? 'auto' : 'no-hide-descendants'}
-      pointerEvents={active ? 'box-none' : pointerEvents}
       pageOverflowEnabled={headerMode !== 'float' && presentation !== 'modal'}
       preloaded={preloaded}
       containerStyle={
@@ -293,6 +292,7 @@ function CardContainerInner({
               : 'flex',
         },
         StyleSheet.absoluteFill,
+        { pointerEvents: active ? 'box-none' : pointerEvents },
       ]}
     >
       <View style={styles.container}>

--- a/packages/stack/src/views/Stack/CardSheet.tsx
+++ b/packages/stack/src/views/Stack/CardSheet.tsx
@@ -88,8 +88,11 @@ export const CardSheet = React.forwardRef<CardSheetRef, Props>(
     return (
       <View
         {...rest}
-        pointerEvents={pointerEvents}
-        style={[enabled && fill ? styles.page : styles.card, style]}
+        style={[
+          enabled && fill ? styles.page : styles.card,
+          style,
+          { pointerEvents: pointerEvents },
+        ]}
       />
     );
   }

--- a/packages/stack/src/views/Stack/CardStack.tsx
+++ b/packages/stack/src/views/Stack/CardStack.tsx
@@ -750,13 +750,12 @@ export class CardStack extends React.Component<Props, State> {
             return (
               <MaybeScreen
                 key={route.key}
-                style={[StyleSheet.absoluteFill]}
+                style={[StyleSheet.absoluteFill, { pointerEvents: 'box-none' }]}
                 enabled={detachInactiveScreens}
                 active={isScreenActive}
                 freezeOnBlur={freezeOnBlur}
                 shouldFreeze={isScreenActive === STATE_INACTIVE && !isPreloaded}
                 homeIndicatorHidden={autoHideHomeIndicator}
-                pointerEvents="box-none"
               >
                 <CardContainer
                   index={index}


### PR DESCRIPTION
**Motivation**

Fixed the handling of `pointerEvents`, replacing direct props with style objects.

**Test**

Fix broken test code: When you press the button that says `"A, tab, 1 of 2"` while Screen B is on, it should go to `Screen A`.

**Related?**
https://github.com/expo/expo/issues/33248#issuecomment-2500453610
