### PR TITLE
feat: drawerToggleButton image option

### DIFF
--- a/packages/drawer/src/views/DrawerToggleButton.tsx
+++ b/packages/drawer/src/views/DrawerToggleButton.tsx
@@ -4,7 +4,12 @@ import {
   type ParamListBase,
   useNavigation,
 } from '@react-navigation/native';
-import { Image, Platform, StyleSheet } from 'react-native';
+import {
+  Image,
+  type ImageSourcePropType,
+  Platform,
+  StyleSheet,
+} from 'react-native';
 
 import type { DrawerNavigationProp } from '../types';
 import toggleDrawerIcon from './assets/toggle-drawer-icon.png';
@@ -14,23 +19,16 @@ type Props = {
   pressColor?: string;
   pressOpacity?: number;
   tintColor?: string;
-  iconSource?:
-    | number
-    | string
-    | { uri: string }
-    | { uri?: string; [key: string]: any };
+  imageSource?: ImageSourcePropType;
 };
 
 export function DrawerToggleButton({
   tintColor,
   accessibilityLabel = 'Show navigation menu',
-  iconSource = toggleDrawerIcon,
+  imageSource = toggleDrawerIcon,
   ...rest
 }: Props) {
   const navigation = useNavigation<DrawerNavigationProp<ParamListBase>>();
-
-  const imageSource =
-    typeof iconSource === 'string' ? { uri: iconSource } : iconSource;
 
   return (
     <PlatformPressable

--- a/packages/drawer/src/views/DrawerToggleButton.tsx
+++ b/packages/drawer/src/views/DrawerToggleButton.tsx
@@ -20,7 +20,7 @@ type Props = {
 export function DrawerToggleButton({
   tintColor,
   accessibilityLabel = "Show navigation menu",
-  iconImage = {toggleDrawerIcon}
+  iconImage = { toggleDrawerIcon },
   ...rest
 }: Props) {
   const navigation = useNavigation<DrawerNavigationProp<ParamListBase>>();

--- a/packages/drawer/src/views/DrawerToggleButton.tsx
+++ b/packages/drawer/src/views/DrawerToggleButton.tsx
@@ -5,7 +5,7 @@ import {
   useNavigation,
 } from "@react-navigation/native";
 import { Image, Platform, StyleSheet } from "react-native";
-import type { ImageSourcePropType } from "react-native";
+
 import type { DrawerNavigationProp } from "../types";
 import toggleDrawerIcon from "./assets/toggle-drawer-icon.png";
 
@@ -14,16 +14,24 @@ type Props = {
   pressColor?: string;
   pressOpacity?: number;
   tintColor?: string;
-  iconImage?: ImageSourcePropType;
+  iconSource?:
+    | number
+    | string
+    | { uri: string }
+    | { uri?: string; [key: string]: any };
 };
 
 export function DrawerToggleButton({
   tintColor,
   accessibilityLabel = "Show navigation menu",
-  iconImage = { toggleDrawerIcon },
+  iconSource = toggleDrawerIcon
   ...rest
 }: Props) {
   const navigation = useNavigation<DrawerNavigationProp<ParamListBase>>();
+
+  const imageSource = typeof iconSource === 'string'
+      ? { uri: iconSource }
+      : iconSource;
 
   return (
     <PlatformPressable
@@ -39,7 +47,7 @@ export function DrawerToggleButton({
     >
       <Image
         resizeMode="contain"
-        source={iconImage ? iconImage : toggleDrawerIcon}
+        source={imageSource}
         fadeDuration={0}
         tintColor={tintColor}
         style={styles.icon}

--- a/packages/drawer/src/views/DrawerToggleButton.tsx
+++ b/packages/drawer/src/views/DrawerToggleButton.tsx
@@ -1,13 +1,13 @@
-import { PlatformPressable } from "@react-navigation/elements";
+import { PlatformPressable } from '@react-navigation/elements';
 import {
   DrawerActions,
   type ParamListBase,
   useNavigation,
 } from "@react-navigation/native";
-import { Image, Platform, StyleSheet } from "react-native";
+import { Image, Platform, StyleSheet } from 'react-native';
 
-import type { DrawerNavigationProp } from "../types";
-import toggleDrawerIcon from "./assets/toggle-drawer-icon.png";
+import type { DrawerNavigationProp } from '../types';
+import toggleDrawerIcon from './assets/toggle-drawer-icon.png';
 
 type Props = {
   accessibilityLabel?: string;
@@ -23,14 +23,14 @@ type Props = {
 
 export function DrawerToggleButton({
   tintColor,
-  accessibilityLabel = "Show navigation menu",
+  accessibilityLabel = 'Show navigation menu',
   iconSource = toggleDrawerIcon,
   ...rest
 }: Props) {
   const navigation = useNavigation<DrawerNavigationProp<ParamListBase>>();
 
   const imageSource =
-    typeof iconSource === "string" ? { uri: iconSource } : iconSource;
+    typeof iconSource === 'string' ? { uri: iconSource } : iconSource;
 
   return (
     <PlatformPressable

--- a/packages/drawer/src/views/DrawerToggleButton.tsx
+++ b/packages/drawer/src/views/DrawerToggleButton.tsx
@@ -3,7 +3,7 @@ import {
   DrawerActions,
   type ParamListBase,
   useNavigation,
-} from "@react-navigation/native";
+} from '@react-navigation/native';
 import { Image, Platform, StyleSheet } from 'react-native';
 
 import type { DrawerNavigationProp } from '../types';

--- a/packages/drawer/src/views/DrawerToggleButton.tsx
+++ b/packages/drawer/src/views/DrawerToggleButton.tsx
@@ -20,6 +20,7 @@ type Props = {
 export function DrawerToggleButton({
   tintColor,
   accessibilityLabel = "Show navigation menu",
+  iconImage = {toggleDrawerIcon}
   ...rest
 }: Props) {
   const navigation = useNavigation<DrawerNavigationProp<ParamListBase>>();

--- a/packages/drawer/src/views/DrawerToggleButton.tsx
+++ b/packages/drawer/src/views/DrawerToggleButton.tsx
@@ -1,24 +1,25 @@
-import { PlatformPressable } from '@react-navigation/elements';
+import { PlatformPressable } from "@react-navigation/elements";
 import {
   DrawerActions,
   type ParamListBase,
   useNavigation,
-} from '@react-navigation/native';
-import { Image, Platform, StyleSheet } from 'react-native';
-
-import type { DrawerNavigationProp } from '../types';
-import toggleDrawerIcon from './assets/toggle-drawer-icon.png';
+} from "@react-navigation/native";
+import { Image, Platform, StyleSheet } from "react-native";
+import type { ImageSourcePropType } from "react-native";
+import type { DrawerNavigationProp } from "../types";
+import toggleDrawerIcon from "./assets/toggle-drawer-icon.png";
 
 type Props = {
   accessibilityLabel?: string;
   pressColor?: string;
   pressOpacity?: number;
   tintColor?: string;
+  iconImage?: ImageSourcePropType;
 };
 
 export function DrawerToggleButton({
   tintColor,
-  accessibilityLabel = 'Show navigation menu',
+  accessibilityLabel = "Show navigation menu",
   ...rest
 }: Props) {
   const navigation = useNavigation<DrawerNavigationProp<ParamListBase>>();
@@ -37,7 +38,7 @@ export function DrawerToggleButton({
     >
       <Image
         resizeMode="contain"
-        source={toggleDrawerIcon}
+        source={iconImage ? iconImage : toggleDrawerIcon}
         fadeDuration={0}
         tintColor={tintColor}
         style={styles.icon}

--- a/packages/drawer/src/views/DrawerToggleButton.tsx
+++ b/packages/drawer/src/views/DrawerToggleButton.tsx
@@ -24,14 +24,13 @@ type Props = {
 export function DrawerToggleButton({
   tintColor,
   accessibilityLabel = "Show navigation menu",
-  iconSource = toggleDrawerIcon
+  iconSource = toggleDrawerIcon,
   ...rest
 }: Props) {
   const navigation = useNavigation<DrawerNavigationProp<ParamListBase>>();
 
-  const imageSource = typeof iconSource === 'string'
-      ? { uri: iconSource }
-      : iconSource;
+  const imageSource =
+    typeof iconSource === "string" ? { uri: iconSource } : iconSource;
 
   return (
     <PlatformPressable


### PR DESCRIPTION
Please provide enough information so that others can review your pull request.

**Motivation**

Want a feature which could change the togglebutton image.

**Test plan**

You can now give props to the drawertogglebutton so that its image can change. I checked myself in my app through importing the edited file.

The change must pass lint, typescript and tests.
