### PR TITLE
feat: add prop for drawer item icon position

### DIFF
--- a/example/src/Screens/DrawerView.tsx
+++ b/example/src/Screens/DrawerView.tsx
@@ -1,5 +1,6 @@
 import { useActionSheet } from '@expo/react-native-action-sheet';
-import { Button } from '@react-navigation/elements';
+import { DrawerItem } from '@react-navigation/drawer';
+import { Button, Text } from '@react-navigation/elements';
 import { useLocale, useTheme } from '@react-navigation/native';
 import * as React from 'react';
 import { StyleSheet, View } from 'react-native';
@@ -20,6 +21,9 @@ export function DrawerView() {
   const [drawerPosition, setDrawerPosition] = React.useState<'left' | 'right'>(
     'left'
   );
+  const [drawerIconPosition, setDrawerIconPosition] = React.useState<
+    'left' | 'right'
+  >('left');
 
   return (
     <Drawer
@@ -31,7 +35,34 @@ export function DrawerView() {
       drawerPosition={drawerPosition}
       renderDrawerContent={() => {
         return (
-          <View style={styles.container}>
+          <View style={[styles.container, styles.gap]}>
+            <View style={styles.fullWidth}>
+              <DrawerItem
+                label="Focused drawer item"
+                focused
+                icon={() => <Text>💎</Text>}
+                iconPosition={drawerIconPosition}
+                onPress={() => {}}
+              />
+
+              <DrawerItem
+                label="Unfocused drawer item"
+                icon={() => <Text>🪨</Text>}
+                iconPosition={drawerIconPosition}
+                onPress={() => {}}
+              />
+            </View>
+
+            <Button
+              onPress={() =>
+                setDrawerIconPosition((prevPosition) =>
+                  prevPosition === 'left' ? 'right' : 'left'
+                )
+              }
+            >
+              Change icon position ({drawerIconPosition})
+            </Button>
+
             <Button color="tomato" onPress={() => setOpen(false)}>
               Close drawer
             </Button>
@@ -41,7 +72,7 @@ export function DrawerView() {
     >
       <View style={[styles.container, { backgroundColor: colors.background }]}>
         <DrawerProgress />
-        <View style={styles.buttons}>
+        <View style={styles.gap}>
           <Button
             variant="filled"
             onPress={() => setOpen((prevOpen) => !prevOpen)}
@@ -98,7 +129,10 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     padding: 8,
   },
-  buttons: {
+  fullWidth: {
+    width: '100%',
+  },
+  gap: {
     gap: 8,
   },
 });

--- a/packages/drawer/src/types.tsx
+++ b/packages/drawer/src/types.tsx
@@ -79,6 +79,11 @@ export type DrawerNavigationOptions = HeaderOptions & {
   }) => React.ReactNode;
 
   /**
+   * Display drawer icon on the left or right side.
+   */
+  drawerIconPosition?: 'left' | 'right';
+
+  /**
    * Color for the icon and label in the active item in the drawer.
    */
   drawerActiveTintColor?: string;

--- a/packages/drawer/src/views/DrawerItem.tsx
+++ b/packages/drawer/src/views/DrawerItem.tsx
@@ -34,6 +34,10 @@ type Props = {
     color: string;
   }) => React.ReactNode;
   /**
+   * Display icon on the left or right side.
+   */
+  iconPosition?: 'left' | 'right';
+  /**
    * Whether to highlight the drawer item as active.
    */
   focused?: boolean;
@@ -103,6 +107,7 @@ export function DrawerItem(props: Props) {
   const {
     href,
     icon,
+    iconPosition = 'left',
     label,
     labelStyle,
     focused = false,
@@ -149,8 +154,16 @@ export function DrawerItem(props: Props) {
         href={href}
       >
         <View style={[styles.wrapper, { borderRadius }]}>
-          {iconNode}
-          <View style={[styles.label, { marginStart: iconNode ? 12 : 0 }]}>
+          {iconPosition === 'left' ? iconNode : null}
+          <View
+            style={[
+              styles.label,
+              {
+                [iconPosition === 'left' ? 'marginStart' : 'marginEnd']:
+                  iconNode ? 12 : 0,
+              },
+            ]}
+          >
             {typeof label === 'string' ? (
               <Text
                 numberOfLines={1}
@@ -163,6 +176,7 @@ export function DrawerItem(props: Props) {
               label({ color, focused })
             )}
           </View>
+          {iconPosition === 'right' ? iconNode : null}
         </View>
       </PlatformPressable>
     </View>

--- a/packages/drawer/src/views/DrawerItemList.tsx
+++ b/packages/drawer/src/views/DrawerItemList.tsx
@@ -57,6 +57,7 @@ export function DrawerItemList({ state, navigation, descriptors }: Props) {
       title,
       drawerLabel,
       drawerIcon,
+      drawerIconPosition,
       drawerLabelStyle,
       drawerItemStyle,
       drawerAllowFontScaling,
@@ -75,6 +76,7 @@ export function DrawerItemList({ state, navigation, descriptors }: Props) {
               : route.name
         }
         icon={drawerIcon}
+        iconPosition={drawerIconPosition}
         focused={focused}
         activeTintColor={drawerActiveTintColor}
         inactiveTintColor={drawerInactiveTintColor}


### PR DESCRIPTION
**Motivation**
For design purposes, this adds a new prop `iconPosition` to the `DrawerIcon` component and a new option `drawerIconPosition` to the `DrawerNavigationOptions` type. Accepted values are `left` and `right`, defaulting to `left`.

**Test plan**
1. Open Example app;
2. Go to  "Drawer Layout";
3. Press "Open Drawer";
4. Press "Change icon position" to toggle icon position.

<img width="300" src="https://github.com/user-attachments/assets/e6708c2e-cae2-4586-a754-b6e71955d1df ">
<img width="300" src="https://github.com/user-attachments/assets/835535fe-86e8-4b05-90f7-faa965129e79">