### PR TITLE
fix: jumping back button

### DIFF
--- a/packages/native-stack/src/types.tsx
+++ b/packages/native-stack/src/types.tsx
@@ -352,7 +352,7 @@ export type NativeStackNavigationOptions = {
    * - The iOS version is 13 or lower
    * - Custom back title is set (e.g. with `headerBackTitle`)
    * - Custom font family or size is set (e.g. with `headerBackTitleStyle`)
-   * - Back button menu is enabled (e.g. with `headerBackButtonMenuEnabled`)
+   * - Back button menu is disabled (e.g. with `headerBackButtonMenuEnabled`)
    *
    * In such cases, a static title and icon are always displayed.
    *

--- a/packages/native-stack/src/types.tsx
+++ b/packages/native-stack/src/types.tsx
@@ -155,7 +155,7 @@ export type NativeStackNavigationOptions = {
   headerBackVisible?: boolean;
   /**
    * Title string used by the back button on iOS.
-   * Defaults to the previous scene's title, or "Back" if there's not enough space.
+   * Defaults to the previous scene's title.
    * Use `headerBackButtonDisplayMode: "minimal"` to hide it.
    *
    * Only supported on iOS and Web.
@@ -348,13 +348,12 @@ export type NativeStackNavigationOptions = {
    * - "generic" – Displays one of the following depending on the available space: generic title (e.g. 'Back') or no title (only icon).
    * - "minimal" – Always displays only the icon without a title.
    *
-   * The "generic" mode is not supported when:
-   * - The iOS version is lower than 14
-   * - Custom back title is set
-   * - Custom back title style is set
-   * - Back button menu is disabled
-   *
-   * In such cases, the "default" mode will be used instead.
+   * When any of following props will be set:
+   * - headerBackTitle
+   * - headerBackTitleStyle
+   * - headerBackButtonMenuEnabled
+   * or iOS 13 or lower is in use, the space-aware behavior will be omitted resulting in
+   * static title and icon.
    *
    * Defaults to "default" on iOS, and "minimal" on other platforms.
    *

--- a/packages/native-stack/src/types.tsx
+++ b/packages/native-stack/src/types.tsx
@@ -348,12 +348,13 @@ export type NativeStackNavigationOptions = {
    * - "generic" – Displays one of the following depending on the available space: generic title (e.g. 'Back') or no title (only icon).
    * - "minimal" – Always displays only the icon without a title.
    *
-   * When any of following props will be set:
-   * - headerBackTitle
-   * - headerBackTitleStyle
-   * - headerBackButtonMenuEnabled
-   * or iOS 13 or lower is in use, the space-aware behavior will be omitted resulting in
-   * static title and icon.
+   * The space-aware behavior is disabled when:
+   * - The iOS version is 13 or lower
+   * - Custom back title is set (e.g. with `headerBackTitle`)
+   * - Custom font family or size is set (e.g. with `headerBackTitleStyle`)
+   * - Back button menu is enabled (e.g. with `headerBackButtonMenuEnabled`)
+   *
+   * In such cases, a static title and icon are always displayed.
    *
    * Defaults to "default" on iOS, and "minimal" on other platforms.
    *

--- a/packages/native-stack/src/views/useHeaderConfigProps.tsx
+++ b/packages/native-stack/src/views/useHeaderConfigProps.tsx
@@ -188,7 +188,7 @@ export function useHeaderConfigProps({
     // Doesn't have custom back title
     headerBackTitle == null &&
     // Doesn't have custom styling
-    backTitleFontFamily == null &&
+    backTitleFontFamily === 'System' &&
     backTitleFontSize == null &&
     // Back button menu is not disabled
     headerBackButtonMenuEnabled !== false;

--- a/packages/native-stack/src/views/useHeaderConfigProps.tsx
+++ b/packages/native-stack/src/views/useHeaderConfigProps.tsx
@@ -188,7 +188,7 @@ export function useHeaderConfigProps({
     // Doesn't have custom back title
     headerBackTitle == null &&
     // Doesn't have custom styling, by default System, see: https://github.com/software-mansion/react-native-screens/pull/2105#discussion_r1565222738
-    backTitleFontFamily === 'System' &&
+    (backTitleFontFamily == null || backTitleFontFamily === 'System') &&
     backTitleFontSize == null &&
     // Back button menu is not disabled
     headerBackButtonMenuEnabled !== false;

--- a/packages/native-stack/src/views/useHeaderConfigProps.tsx
+++ b/packages/native-stack/src/views/useHeaderConfigProps.tsx
@@ -187,7 +187,7 @@ export function useHeaderConfigProps({
     parseInt(Platform.Version, 10) >= 14 &&
     // Doesn't have custom back title
     headerBackTitle == null &&
-    // Doesn't have custom styling
+    // Doesn't have custom styling, by default System, see: https://github.com/software-mansion/react-native-screens/pull/2105#discussion_r1565222738
     backTitleFontFamily === 'System' &&
     backTitleFontSize == null &&
     // Back button menu is not disabled


### PR DESCRIPTION
## The Problem 

The problem is that the back button jumps, when the`backButtonDisplayMode` is set to `minimal`.

|The Problem|
|-|
|<video src="https://github.com/user-attachments/assets/214c3af9-fdea-43a8-9976-453246a48079" />

## Investigation

The problem is noted as caused by the `backButtonDisplayMode` set to `minimal`, but that's not true. The flag that enables the `backButtonDisplayMode` looks as follows:

```
  const isBackButtonDisplayModeAvailable =
    // On iOS 14+
    Platform.OS === 'ios' &&
    parseInt(Platform.Version, 10) >= 14 &&
    // Doesn't have custom back title
    headerBackTitle == null &&
    // Doesn't have custom styling
    backTitleFontFamily == null &&
    backTitleFontSize == null &&
    // Back button menu is not disabled
    headerBackButtonMenuEnabled !== false;
```

but as stated in https://github.com/software-mansion/react-native-screens/pull/2105#discussion_r1565222738, the `backTitleFontFamily` is by default set to `System`, so it always results in `isBackButtonDisplayModeAvailable` being `false`. 

So, when `backButtonDisplayMode: 'minimal'` is set, those are the actual props (passed from react-navigation to react-native-screens): 

```
    backTitleVisible: false,
    backButtonDisplayMode: undefined,
```

and it results in setting the title of `UIBarButtonItem` to `nil`. This is what causes the button to jump, and it can be reproduced without react-native:


|RN|Native|
|-|-|
|<video src="https://github.com/user-attachments/assets/cd692734-db05-43ba-ab05-50e628d36d04" />|<video src="https://github.com/user-attachments/assets/767b5daa-3418-4a9e-8071-84f5ad93e68a" />| 

### Can it be fixed?

**Yes**, we can set the title to a string space( `@" "`), **but** it breaks the back button menu:

|Works, but breaks menu|
|-|
|<video src="https://github.com/user-attachments/assets/a7c00cc2-53fe-47df-b84b-4267bd4c9802" />|


It seems to break the back button menu because the title and back button menu [are synced](https://developer.apple.com/forums/thread/653913?answerId=624077022#624077022), the [backButtonTitle](https://developer.apple.com/documentation/uikit/uinavigationitem/backbuttontitle?language=objc) should override it, but it does not work on our case (I guess that because of this part _"set it in the current view controller before pushing a new view controller onto the navigation stack"_).


**On a side note** - you could think:  "why not just pass an empty string from RN?". react-native-screens make sure that this prop is not empty (with trim), and if it is, the title from the previous screen is used. I assume it was done this way as a workaround for the back button menu issue mentioned before. 

### What about `backButtonDisplayMode` then? 

Fixing the condition I mentioned in the first paragraph, could be the other solution. In this case, we end up with: 

```
    backTitleVisible: undefined (which is true, by default in native)
    backButtonDisplayMode: 'minimal',
```

|Works, but animation is broken|
|-|
|<video src="https://github.com/user-attachments/assets/ba58bca9-c766-44bb-a661-0a411f40d0d4" />|

Which works, but there is no fade-out animation. 

|empty string|backButtonDisplayMode (no animation)|
|-|-|
|<video src="https://github.com/user-attachments/assets/f10554da-07ec-47ac-9a99-6a799dadd086" />|<video src="https://github.com/user-attachments/assets/c13f3b2f-c348-4ad0-af23-57f4c9a08b52" />| 

I don't think that this problem can be a workaround - this is a known native issue: https://stackoverflow.com/questions/77764576/setting-backbuttondisplaymode-to-minimal-breaks-large-title-animation, and given workaround is just using empty string, which brings us back to problems with `backButtonMenu`.

## What are the next steps? 

**[ReactNavigation]Changes from this PR** - this should solve the problem.

**[RNScreens][iOS] get rid of `backTitileVisible` in `react-native-screens`** - on iOS currently this is really confusing, the only scenario where it can be used is the one described here - buggy one. I think we should get rid of this implementation and just clearly highlight that eny header modification will override this property. I wonder, what about iOS < 14 (?). 

**[RNScreens][Android] use `backButtonDisplayMode` instead of `backTitleVisible`** - just ignore the `generic` option. What I don't like, is that we're using iOS specific prop for Android, but react-navigation removed the `backTitleVisible` already, so maybe it's ok. 

