### PR TITLE
fix: fix JSX and useScrollToTop types for React 19 compatibility

### DIFF
--- a/packages/core/src/StaticNavigation.tsx
+++ b/packages/core/src/StaticNavigation.tsx
@@ -403,7 +403,7 @@ export function createComponentForStaticNavigation(
     );
   }
 
-  const items: (() => JSX.Element | null)[] = [];
+  const items: (() => React.JSX.Element | null)[] = [];
 
   // Loop through the config to find screens and groups
   // So we add the screens and groups in the same order as they are defined

--- a/packages/core/src/types.tsx
+++ b/packages/core/src/types.tsx
@@ -551,7 +551,7 @@ export type Descriptor<
   /**
    * Render the component associated with this route.
    */
-  render(): JSX.Element;
+  render(): React.JSX.Element;
 
   /**
    * Options for the route.

--- a/packages/core/src/useComponent.tsx
+++ b/packages/core/src/useComponent.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-type Render = (children: React.ReactNode) => JSX.Element;
+type Render = (children: React.ReactNode) => React.JSX.Element;
 
 type Props = {
   render: Render;

--- a/packages/native/src/useScrollToTop.tsx
+++ b/packages/native/src/useScrollToTop.tsx
@@ -19,7 +19,8 @@ type ScrollableView =
 type ScrollableWrapper =
   | { getScrollResponder(): React.ReactNode | ScrollView }
   | { getNode(): ScrollableView }
-  | ScrollableView;
+  | ScrollableView
+  | null;
 
 function getScrollableNode(ref: React.RefObject<ScrollableWrapper>) {
   if (ref.current == null) {


### PR DESCRIPTION
**Motivation**

This PR addresses some TypeScript errors under React Native 0.78.x, namely React 19. They are also discussed in #12468 .

Specifically, 2 parts are modified in this PR:

1. Rewrite `JSX` into `React.JSX`: since React 19 `JSX` global namespace is removed ([ref](https://react.dev/blog/2024/04/25/react-19-upgrade-guide#the-jsx-namespace-in-typescript)). We need to use `React.JSX` instead.
2. Add `null` type into `ScrollableWrapper` type definition: React 19 removes `MutableRefObject` and makes all refs mutable ([ref](https://react.dev/blog/2024/04/25/react-19-upgrade-guide#useref-requires-argument)). That makes the `ref` argument of `useScrollToTop` become `RefObject<ScrollView | null>` (using `ScrollView` as an example here) under React 19. In order to take this change into account, we can add `null` type into `ScrollableWrapper` def directly to solve this issue.

**Test plan**

Run `yarn typecheck` and ensure modified codes pass the test. Since those modifications are compatible with older React versions as well, we don't need to update `react` dependencies to 19.