### PR TITLE
feat: add pageSheet presentation to native stack

### DIFF
--- a/packages/native-stack/src/types.tsx
+++ b/packages/native-stack/src/types.tsx
@@ -536,6 +536,7 @@ export type NativeStackNavigationOptions = {
    * - "containedTransparentModal": will use "UIModalPresentationOverCurrentContext" modal style on iOS and will fallback to "transparentModal" on Android.
    * - "fullScreenModal": will use "UIModalPresentationFullScreen" modal style on iOS and will fallback to "modal" on Android.
    * - "formSheet": will use "UIModalPresentationFormSheet" modal style on iOS and will fallback to "modal" on Android.
+   * - "pageSheet": will use "UIModalPresentationPageSheet" modal style on iOS and will fallback to "modal" on Android.
    *
    * Only supported on iOS and Android.
    */

--- a/packages/native-stack/src/utils/getModalRoutesKeys.ts
+++ b/packages/native-stack/src/utils/getModalRoutesKeys.ts
@@ -12,6 +12,7 @@ export const getModalRouteKeys = (
     if (
       (acc.length && !presentation) ||
       presentation === 'modal' ||
+      presentation === 'pageSheet' ||
       presentation === 'transparentModal'
     ) {
       acc.push(route.key);

--- a/packages/native-stack/src/views/NativeStackView.native.tsx
+++ b/packages/native-stack/src/views/NativeStackView.native.tsx
@@ -173,8 +173,11 @@ const SceneView = ({
   const insets = useSafeAreaInsets();
   const frame = useSafeAreaFrame();
 
-  // `modal` and `formSheet` presentations do not take whole screen, so should not take the inset.
-  const isModal = presentation === 'modal' || presentation === 'formSheet';
+  // `modal`, `formSheet` and `pageSheet` presentations do not take whole screen, so should not take the inset.
+  const isModal =
+    presentation === 'modal' ||
+    presentation === 'formSheet' ||
+    presentation === 'pageSheet';
 
   // Modals are fullscreen in landscape only on iPhone
   const isIPhone = Platform.OS === 'ios' && !(Platform.isPad || Platform.isTV);


### PR DESCRIPTION
**Motivation**

Since the release of iOS 18, screens with`presentation: 'modal'` changed size on devices with a bigger screen, such as an iPad - they became much smaller, which impacted applications of the library's users (see issue https://github.com/software-mansion/react-native-screens/issues/2549). 

To address the issue, `react-native-screens` will introduce new presentation type for native stack (`pageSheet`) that will allow users to use previous modal behavior (see PR https://github.com/software-mansion/react-native-screens/pull/2793). The behavior of `pageSheet` on Android will be the same as `modal`.

This PR contains changes required to support `pageSheet` in `react-navigation`. It will be also necessary to bump `react-native-screens` version.

**Test plan**

Open Stack Presentation and Modals example screens in example apps from `react-native-screens` and open a `pageSheet`.
