### PR TITLE
feat: add StackHeaderRightProps type to exports

### DIFF
--- a/packages/stack/src/index.tsx
+++ b/packages/stack/src/index.tsx
@@ -43,6 +43,7 @@ export type {
   StackHeaderInterpolatedStyle,
   StackHeaderInterpolationProps,
   StackHeaderProps,
+  StackHeaderRightProps,
   StackHeaderStyleInterpolator,
   StackNavigationEventMap,
   StackNavigationOptions,

--- a/packages/stack/src/index.tsx
+++ b/packages/stack/src/index.tsx
@@ -42,6 +42,7 @@ export type {
   StackCardStyleInterpolator,
   StackHeaderInterpolatedStyle,
   StackHeaderInterpolationProps,
+  StackHeaderLeftProps,
   StackHeaderProps,
   StackHeaderRightProps,
   StackHeaderStyleInterpolator,


### PR DESCRIPTION
Please provide enough information so that others can review your pull request.

**Motivation**

- This adds a missing type, StackHeaderRightProps, to the stack types export

**Test plan**

No tests needed as this is a change to a type file for developer experience

The change must pass lint, typescript and tests.

![image](https://github.com/user-attachments/assets/e64dd823-c3ee-4131-bbb4-d1f97a664ca3)

