### PR TITLE
fix: fix `navigationRef.getRootState()` returning an incomplete state during render

### DIFF
--- a/packages/core/src/useOnGetState.tsx
+++ b/packages/core/src/useOnGetState.tsx
@@ -25,7 +25,7 @@ export function useOnGetState({ getState, getStateListeners }: Options) {
     const routes = state.routes.map((route) => {
       const childState = getStateListeners[route.key]?.();
 
-      if (route.state === childState) {
+      if (!childState || route.state === childState) {
         return route;
       }
 


### PR DESCRIPTION
[`navigationRef.getRootState()`](https://reactnavigation.org/docs/navigation-container/#getrootstate) may return an incomplete state during the first render of nested navigators.

## Repro

https://github.com/zetavg/react-navigation-getRootState-bug-repro-202503

1. Run the app (`yarn start`), open web (`http://localhost:8081`).
2. Press the “Go to SubStack/Page via RESET” button.
3. See the displayed root state is incomplete: `routes[1].state` is missing.
4. Press “Re-render Page” button, see `routes[1].state` is there now.

## Why this is happening?

### Context

`navigationRef.getRootState()` is:
* Provided [via `React.useImperativeHandle`](https://github.com/react-navigation/react-navigation/blob/%40react-navigation/core%407.2.0/packages/core/src/BaseNavigationContainer.tsx#L230) in `BaseNavigationContainer`.
* [Defined as `keyedListeners.getState.root?.()` in `BaseNavigationContainer`](https://github.com/react-navigation/react-navigation/blob/%40react-navigation/core%407.2.0/packages/core/src/BaseNavigationContainer.tsx#L172-L174).
* Where `keyedListeners.getState.root?.()` should be [registered](https://github.com/react-navigation/react-navigation/blob/%40react-navigation/core%407.2.0/packages/core/src/useOnGetState.tsx#L43) by a navigator which [isn’t nested under a route](https://github.com/react-navigation/react-navigation/blob/%40react-navigation/core%407.2.0/packages/core/src/useOnGetState.tsx#L19), by `useOnGetState()`, in `useNavigationBuilder()`.
* With is a function named [`getRehydratedState`](https://github.com/react-navigation/react-navigation/blob/%40react-navigation/core%407.2.0/packages/core/src/useOnGetState.tsx#L21-L40), also defined in `useOnGetState()`, 

A thing that `getRehydratedState` will do, besides just returning the state from `getState()` (which in root should be provided by `BaseNavigationContainer`, with `useSyncState` which manages the store), is it will,
* As commented, [“avoid returning new route objects if it don't need to”](https://github.com/react-navigation/react-navigation/blob/%40react-navigation/core%407.2.0/packages/core/src/useOnGetState.tsx#L24-L33). 
  * (Also, in my understanding, that will make the function return the “derived” state that is actually being used to render instead just the state stored in the store, which [may be different](https://github.com/react-navigation/react-navigation/blob/%40react-navigation/core%407.2.0/packages/core/src/useNavigationBuilder.tsx#L477-L483).)
  * That is done by going through all the routes, trying to call `getStateListeners[route.key]?.()`, and replacing the state (used for nested navigator) of the route with the state returned by `getStateListeners[...]()`.
    * `getStateListeners` is `keyedListeners.getState`, here `keyedListeners` is “scoped” since each `useNavigationBuilder` will have it’s own one for nested navigators under the current navigator.
      * Children navigators will register their keyedListeners.getState also with their `useOnGetState`, in [a `React.useEffect`](https://github.com/react-navigation/react-navigation/blob/%40react-navigation/core%407.2.0/packages/core/src/useOnGetState.tsx#L42-L44).
    * What it achieves, basically, is making `getRehydratedState` a recursive function: for every route that contains a navigator, call the navigator’s `getRehydratedState` to get the state from that navigator until the leaf navigator - where all its routes don’t have a navigator.

### What causes the bug

* [`addKeyedListener?.('getState', ...)` is called inside a `React.useEffect`](https://github.com/react-navigation/react-navigation/blob/%40react-navigation/core%407.2.0/packages/core/src/useOnGetState.tsx#L42-L44) - which means that it will only be registered **after** the first render.
* So **during** the first render, `getStateListeners[route.key]?.()` will be `undefined`. [And we will end up with `{ ...route, state: undefined }`](https://github.com/react-navigation/react-navigation/blob/%40react-navigation/core%407.7.0/packages/core/src/useOnGetState.tsx#L26-L32).

## Test plan

Can use the [repro](https://github.com/zetavg/react-navigation-getRootState-bug-repro-202503) to verify this fixes the issue.

Can add a test case for this perhaps, but I'm not sure how to do it for now.