### PR TITLE
docs: add deprecation message to some status/navigation bar related props

### DIFF
--- a/packages/native-stack/src/types.tsx
+++ b/packages/native-stack/src/types.tsx
@@ -378,11 +378,19 @@ export type NativeStackNavigationOptions = {
   /**
    * Sets the navigation bar color. Defaults to initial navigation bar color.
    *
+   * @deprecated For all apps targeting Android SDK 35 or above edge-to-edge is enabled by default.
+   *  This prop is subject to removal in the future.
+   *  See: https://developer.android.com/about/versions/15/behavior-changes-15#ux.
+   *
    * @platform android
    */
   navigationBarColor?: string;
   /**
    * Boolean indicating whether the content should be visible behind the navigation bar. Defaults to `false`.
+   *
+   * @deprecated For all apps targeting Android SDK 35 or above edge-to-edge is enabled by default.
+   *  This prop is subject to removal in the future.
+   *  See: https://developer.android.com/about/versions/15/behavior-changes-15#ux.
    *
    * @platform android
    */
@@ -404,6 +412,10 @@ export type NativeStackNavigationOptions = {
   statusBarAnimation?: ScreenProps['statusBarAnimation'];
   /**
    * Sets the status bar color (similar to the `StatusBar` component). Defaults to initial status bar color.
+   *
+   * @deprecated For all apps targeting Android SDK 35 or above edge-to-edge is enabled by default.
+   *  This prop is subject to removal in the future.
+   *  See: https://developer.android.com/about/versions/15/behavior-changes-15#ux.
    *
    * @platform android
    */
@@ -428,6 +440,10 @@ export type NativeStackNavigationOptions = {
   statusBarStyle?: ScreenProps['statusBarStyle'];
   /**
    * Sets the translucency of the status bar. Defaults to `false`.
+   *
+   * @deprecated For all apps targeting Android SDK 35 or above edge-to-edge is enabled by default.
+   *  This prop is subject to removal in the future.
+   *  See: https://developer.android.com/about/versions/15/behavior-changes-15#ux.
    *
    * @platform android
    */


### PR DESCRIPTION
**Motivation**
For all apps targeting Android SDK 35 the edge-to-edge mode is enabled by default (it is effectively enforced, opting out takes some effort) and everything indicates that it will be enforced in future SDKs.

For SDKs below 35 the status / navigation bar APIs affected by this PR are deprecated or deprecated & disabled.

For details please see this PR: https://github.com/software-mansion/react-native-screens/pull/2638

`react-native-screens` deprecated `navigationBarColor`, `navigationBarTranslucent`, `statusBarColor`, `statusBarTranslucent` props. This PR makes them deprecated also in `react-navigation/native-stack`.

`topInsetEnabled` was also deprecated. No changes connected with this prop has been implemented yet.