### PR TITLE
fix(native-stack): align headerBackTitle with iOS behavior 

### DIFF
--- a/packages/native-stack/src/types.tsx
+++ b/packages/native-stack/src/types.tsx
@@ -155,8 +155,9 @@ export type NativeStackNavigationOptions = {
   headerBackVisible?: boolean;
   /**
    * Title string used by the back button on iOS.
-   * Defaults to the previous scene's title, "Back" or arrow icon depending on the available space.
-   * See `headerBackButtonDisplayMode` to read about limitations and customize the behavior.
+   * Defaults to the previous scene's title.
+   * On iOS the text might be shortened to "Back" or arrow icon depending on the available space, following native iOS behaviour.
+   * See `headerBackButtonDisplayMode` to read about limitations and interactions with other props. 
    * Use `headerBackButtonDisplayMode: "minimal"` to hide it.
    *
    * Only supported on iOS and Web.

--- a/packages/native-stack/src/types.tsx
+++ b/packages/native-stack/src/types.tsx
@@ -157,7 +157,7 @@ export type NativeStackNavigationOptions = {
    * Title string used by the back button on iOS.
    * Defaults to the previous scene's title.
    * On iOS the text might be shortened to "Back" or arrow icon depending on the available space, following native iOS behaviour.
-   * See `headerBackButtonDisplayMode` to read about limitations and interactions with other props. 
+   * See `headerBackButtonDisplayMode` to read about limitations and interactions with other props.
    * Use `headerBackButtonDisplayMode: "minimal"` to hide it.
    *
    * Only supported on iOS and Web.

--- a/packages/native-stack/src/types.tsx
+++ b/packages/native-stack/src/types.tsx
@@ -155,7 +155,8 @@ export type NativeStackNavigationOptions = {
   headerBackVisible?: boolean;
   /**
    * Title string used by the back button on iOS.
-   * Defaults to the previous scene's title.
+   * Defaults to the previous scene's title, "Back" or arrow icon depending on the available space.
+   * See `headerBackButtonDisplayMode` to read about limitations and customize the behavior.
    * Use `headerBackButtonDisplayMode: "minimal"` to hide it.
    *
    * Only supported on iOS and Web.
@@ -350,7 +351,6 @@ export type NativeStackNavigationOptions = {
    *
    * The space-aware behavior is disabled when:
    * - The iOS version is 13 or lower
-   * - Custom back title is set (e.g. with `headerBackTitle`)
    * - Custom font family or size is set (e.g. with `headerBackTitleStyle`)
    * - Back button menu is disabled (e.g. with `headerBackButtonMenuEnabled`)
    *

--- a/packages/native-stack/src/views/useHeaderConfigProps.tsx
+++ b/packages/native-stack/src/views/useHeaderConfigProps.tsx
@@ -185,8 +185,6 @@ export function useHeaderConfigProps({
     // On iOS 14+
     Platform.OS === 'ios' &&
     parseInt(Platform.Version, 10) >= 14 &&
-    // Doesn't have custom back title
-    headerBackTitle == null &&
     // Doesn't have custom styling, by default System, see: https://github.com/software-mansion/react-native-screens/pull/2105#discussion_r1565222738
     (backTitleFontFamily == null || backTitleFontFamily === 'System') &&
     backTitleFontSize == null &&


### PR DESCRIPTION
**Motivation**

The iOS has a default behavior how to deal with back title label - it changes its size depending on available space. It didn't work for custom back title, as react-native-screens used custom back button item when custom back title was provided. This changes in https://github.com/software-mansion/react-native-screens/pull/2860, thus we can remove check on react-navigation side.

Corresponding docs update: https://github.com/react-navigation/react-navigation.github.io/pull/1422

**Test plan**

See `Test code and steps to reproduce` in https://github.com/software-mansion/react-native-screens/pull/2860 or test this snippet (very long custom back button title should be changed to `Back`):


<details>
<summary>Source code</summary>

```
import * as React from 'react';
import { Button, Text, View } from 'react-native';
import { ParamListBase } from '@react-navigation/native';
import {
  createNativeStackNavigator,
  NativeStackNavigationProp,
} from '@react-navigation/native-stack';


export function FinalScreen({
  navigation,
}: {
  navigation: NativeStackNavigationProp<ParamListBase>;
}) {
  return (
    <View style={{ flex: 1, backgroundColor: 'yellow', justifyContent: 'center', alignItems: 'center' }}>
      <Text>VOID</Text>
      <Button title="Pop to top" onPress={() => navigation.popTo('Home')} />
    </View>
  );
}

export function Home({
  navigation,
}: {
  navigation: NativeStackNavigationProp<ParamListBase>;
}) {
  return (
    <View style={{ flex: 1, backgroundColor: 'yellow' }}>
      <Button
        title="Open screen"
        onPress={() => navigation.navigate('Second')}
      />
    </View>
  );
}

export default () =>{
  const Stack = createNativeStackNavigator();

  return (
      <Stack.Navigator>
        <Stack.Screen name="First" component={Home} />
        <Stack.Screen name="Second" component={FinalScreen} options={{headerBackTitle: 'LongLongLongLongLong'}} />
      </Stack.Navigator>
  );
};

```
</details>

⚠️ Keep in mind that it requires changes from screens to work