### PR TITLE
feat: add options parameter to layout and screenLayout

### DIFF
--- a/packages/core/src/types.tsx
+++ b/packages/core/src/types.tsx
@@ -669,6 +669,7 @@ export type RouteConfigProps<
    */
   layout?: (props: {
     route: RouteProp<ParamList, RouteName>;
+    options: ScreenOptions;
     navigation: Navigation;
     theme: ReactNavigation.Theme;
     children: React.ReactElement;

--- a/packages/core/src/types.tsx
+++ b/packages/core/src/types.tsx
@@ -86,12 +86,14 @@ export type DefaultNavigatorOptions<
   /**
    * Layout for all screens under this navigator.
    */
-  screenLayout?: (props: {
-    route: RouteProp<ParamList, keyof ParamList>;
-    navigation: Navigation;
-    theme: ReactNavigation.Theme;
-    children: React.ReactElement;
-  }) => React.ReactElement;
+  screenLayout?: (
+    props: ScreenLayoutProps<
+      ParamList,
+      keyof ParamList,
+      ScreenOptions,
+      Navigation
+    >
+  ) => React.ReactElement;
 
   /**
    * A function returning overrides for the underlying router used by the navigator.
@@ -543,6 +545,19 @@ export type CompositeScreenProps<
   route: A['route'];
 };
 
+export type ScreenLayoutProps<
+  ParamList extends ParamListBase,
+  RouteName extends keyof ParamList,
+  ScreenOptions extends {},
+  Navigation,
+> = {
+  route: RouteProp<ParamList, RouteName>;
+  options: ScreenOptions;
+  navigation: Navigation;
+  theme: ReactNavigation.Theme;
+  children: React.ReactElement;
+};
+
 export type Descriptor<
   ScreenOptions extends {},
   Navigation extends NavigationProp<any, any, any, any, any, any>,
@@ -667,13 +682,9 @@ export type RouteConfigProps<
    * Useful for wrapping the screen with custom containers.
    * e.g. for styling, error boundaries, suspense, etc.
    */
-  layout?: (props: {
-    route: RouteProp<ParamList, RouteName>;
-    options: ScreenOptions;
-    navigation: Navigation;
-    theme: ReactNavigation.Theme;
-    children: React.ReactElement;
-  }) => React.ReactElement;
+  layout?: (
+    props: ScreenLayoutProps<ParamList, RouteName, ScreenOptions, Navigation>
+  ) => React.ReactElement;
 
   /**
    * Function to return an unique ID for this screen.
@@ -737,12 +748,14 @@ export type RouteGroupConfig<
    * This will override the `screenLayout` of parent group or navigator.
    */
   screenLayout?:
-    | ((props: {
-        route: RouteProp<ParamList, keyof ParamList>;
-        navigation: Navigation;
-        theme: ReactNavigation.Theme;
-        children: React.ReactElement;
-      }) => React.ReactElement)
+    | ((
+        props: ScreenLayoutProps<
+          ParamList,
+          keyof ParamList,
+          ScreenOptions,
+          Navigation
+        >
+      ) => React.ReactElement)
     | {
         // FIXME: TypeScript doesn't seem to infer `navigation` correctly without this
       };

--- a/packages/core/src/useDescriptors.tsx
+++ b/packages/core/src/useDescriptors.tsx
@@ -35,7 +35,7 @@ export type ScreenConfigWithParent<
 > = {
   keys: (string | undefined)[];
   options: (ScreenOptionsOrCallback<ScreenOptions> | undefined)[] | undefined;
-  layout: ScreenLayout | undefined;
+  layout: ScreenLayout<ScreenOptions> | undefined;
   props: RouteConfig<
     ParamListBase,
     string,
@@ -46,8 +46,9 @@ export type ScreenConfigWithParent<
   >;
 };
 
-type ScreenLayout = (props: {
+type ScreenLayout<ScreenOptions extends {}> = (props: {
   route: RouteProp<ParamListBase, string>;
+  options: ScreenOptions;
   navigation: any;
   theme: ReactNavigation.Theme;
   children: React.ReactElement;
@@ -73,7 +74,7 @@ type Options<
   >;
   navigation: NavigationHelpers<ParamListBase>;
   screenOptions: ScreenOptionsOrCallback<ScreenOptions> | undefined;
-  screenLayout: ScreenLayout | undefined;
+  screenLayout: ScreenLayout<ScreenOptions> | undefined;
   onAction: (action: NavigationAction) => boolean;
   getState: () => State;
   setState: (state: State) => void;
@@ -258,6 +259,7 @@ export function useDescriptors<
       element = layout({
         route,
         navigation,
+        options: customOptions,
         // @ts-expect-error: in practice `theme` will be defined
         theme,
         children: element,


### PR DESCRIPTION
Please provide enough information so that others can review your pull request.

**Motivation**

I would like to access screen options in the screenLayout render function. This is usefull for Suspense layouts where you want to show a loader. In this case I can access a tintColor prop to correctly style the loader.

If this pull request addresses an existing issue, link to the issue. If an issue is not present, describe the issue here.

**Test plan**

Describe the **steps to test this change** so that a reviewer can verify it. Provide screenshots or videos if the change affects UI.

The change must pass lint, typescript and tests.
