### PR TITLE
fix: browser history

### DIFF
--- a/example/e2e/tests/createMemoryHistory.test.ts
+++ b/example/e2e/tests/createMemoryHistory.test.ts
@@ -1,0 +1,28 @@
+import { expect, test } from '@playwright/test';
+
+test('pops to the proper screen after going back and forward in history', async ({
+  page,
+}) => {
+  await page.goto('/native-stack/article/gandalf');
+
+  const buttonToFeed = page.getByRole('button', {
+    name: 'Navigate to feed',
+  });
+
+  await buttonToFeed.click();
+
+  await page.goBack();
+
+  await page.goForward();
+
+  const buttonGoBack = page.getByRole('button', {
+    name: 'Go back',
+  });
+
+  // After click, we have [not-found, home] on history stack
+  await buttonGoBack.click();
+
+  await expect(page).toHaveTitle(
+    'Article by Gandalf - React Navigation Example'
+  );
+});

--- a/example/e2e/tests/useLinking.test.ts
+++ b/example/e2e/tests/useLinking.test.ts
@@ -1,0 +1,42 @@
+import { expect, test } from '@playwright/test';
+
+test('go back to the proper history entry after popping nested stack', async ({
+  page,
+}) => {
+  await page.goto('/not-found');
+
+  const buttonGoToHome = page.getByRole('button', {
+    name: 'Go to home',
+  });
+
+  // After click, we have [not-found, home] on history stack
+  await buttonGoToHome.click();
+
+  const button = page.getByRole('button', {
+    name: 'Simple Stack',
+  });
+
+  // Open nested stack
+  await button.click();
+
+  const buttonToFeed = page.getByRole('button', {
+    name: 'Navigate to feed',
+  });
+
+  // Push second screen to the nested stack
+  // After click, we have [not-found, home, article, feed] on history stack
+  await buttonToFeed.click();
+
+  const buttonPopToHome = page.getByRole('button', {
+    name: 'Pop to home',
+  });
+
+  // After click, we have [not-found, home] on history stack
+  await buttonPopToHome.click();
+
+  await expect(page).toHaveTitle('Examples - React Navigation Example');
+
+  await page.goBack();
+
+  await expect(page).toHaveTitle('Oops! - React Navigation Example');
+});

--- a/example/src/Screens/SimpleStack.tsx
+++ b/example/src/Screens/SimpleStack.tsx
@@ -9,6 +9,7 @@ import * as React from 'react';
 import { Platform, ScrollView, StyleSheet, View } from 'react-native';
 
 import { COMMON_LINKING_CONFIG } from '../constants';
+import type { RootStackParamList } from '../screens';
 import { Albums } from '../Shared/Albums';
 import { Article } from '../Shared/Article';
 import { Contacts } from '../Shared/Contacts';
@@ -73,11 +74,17 @@ const NewsFeedScreen = ({
   route,
   navigation,
 }: StackScreenProps<SimpleStackParams, 'NewsFeed'>) => {
+  const rootNavigation =
+    navigation.getParent<StackScreenProps<RootStackParamList>['navigation']>();
+
   return (
     <ScrollView>
       <View style={styles.buttons}>
         <Button variant="filled" onPress={() => navigation.replace('Contacts')}>
           Replace with contacts
+        </Button>
+        <Button variant="tinted" onPress={() => rootNavigation.popTo('Home')}>
+          Pop to home
         </Button>
         <Button variant="tinted" onPress={() => navigation.goBack()}>
           Go back

--- a/packages/native/src/createMemoryHistory.tsx
+++ b/packages/native/src/createMemoryHistory.tsx
@@ -176,21 +176,20 @@ export function createMemoryHistory() {
         // But on Firefox, it seems to take much longer, around 50ms from our testing
         // We're using a hacky timeout since there doesn't seem to be way to know for sure
         const timer = setTimeout(() => {
-          const index = pending.findIndex((it) => it.ref === done);
+          const foundIndex = pending.findIndex((it) => it.ref === done);
 
-          if (index > -1) {
-            pending[index].cb();
-            pending.splice(index, 1);
+          if (foundIndex > -1) {
+            pending[foundIndex].cb();
+            pending.splice(foundIndex, 1);
           }
+
+          index = this.index;
         }, 100);
 
         const onPopState = () => {
-          const id = window.history.state?.id;
-          const currentIndex = items.findIndex((item) => item.id === id);
-
           // Fix createMemoryHistory.index variable's value
           // as it may go out of sync when navigating in the browser.
-          index = Math.max(currentIndex, 0);
+          index = this.index;
 
           const last = pending.pop();
 
@@ -208,6 +207,10 @@ export function createMemoryHistory() {
     // Here we normalize it so that only external changes (e.g. user pressing back/forward) trigger the listener
     listen(listener: () => void) {
       const onPopState = () => {
+        // Fix createMemoryHistory.index variable's value
+        // as it may go out of sync when navigating in the browser.
+        index = this.index;
+
         if (pending.length) {
           // This was triggered by `history.go(n)`, we shouldn't call the listener
           return;

--- a/packages/native/src/useLinking.tsx
+++ b/packages/native/src/useLinking.tsx
@@ -403,7 +403,7 @@ export function useLinking(
               nextIndex !== -1 &&
               nextIndex < currentIndex &&
               // We should only go back if the entry exists and it's less than current index
-              history.get(nextIndex - currentIndex)
+              history.get(nextIndex)
             ) {
               // An existing entry for this path exists and it's less than current index, go back to that
               await history.go(nextIndex - currentIndex);


### PR DESCRIPTION
**Motivation**
I found two bugs in the current handling of the browser history

**1. The index in createMemoryHistory may be out of sync, and that causes the items array to drop entries in some cases.**  

This causes the navigation state to be lost when going back and forward in the browser. From this moment, it is recreated from the URL instead of saved state objects. 

**2. The `history.get()` function was provided with the relative instead of the absolute position.**

```ts
if (
  nextIndex !== -1 &&
  nextIndex < currentIndex &&
  // We should only go back if the entry exists and it's less than the current index
  history.get(nextIndex - currentIndex)
)
```

If the `nextIndex < currentIndex`, then `nextIndex - currentIndex` is always negative, and this `if` will never be true. It should be `history.get(nextIndex)`

This causes problems with finding the right history entry to go back after a nested stack.

**Test plan**

**Bug 1 - index out of sync**

Besides the videos below, I created e2e tests

❌ before ❌ 

https://github.com/user-attachments/assets/45d639b9-0f9c-45bb-9253-ffd1129ad188

🟢 after 🟢 

https://github.com/user-attachments/assets/c7f7accf-2a8c-4536-904d-fc3468ce839e

**Bug 2 - wrong argument for get function**

❌ before ❌ 

https://github.com/user-attachments/assets/39c72ece-9608-47e0-8c38-ea5463b97992

🟢 after 🟢 

https://github.com/user-attachments/assets/1d157d47-be0c-4436-842b-862d6f6b4cde

Describe the **steps to test this change** so that a reviewer can verify it. Provide screenshots or videos if the change affects UI.

The change must pass lint, typescript and tests.
