### PR TITLE
feat: allow setting bottom tab press color and press opacity (Android)

### DIFF
--- a/packages/bottom-tabs/src/types.tsx
+++ b/packages/bottom-tabs/src/types.tsx
@@ -1,4 +1,7 @@
-import type { HeaderOptions } from '@react-navigation/elements';
+import type {
+  HeaderOptions,
+  PlatformPressable,
+} from '@react-navigation/elements';
 import type {
   DefaultNavigatorOptions,
   Descriptor,
@@ -15,7 +18,6 @@ import type * as React from 'react';
 import type {
   Animated,
   GestureResponderEvent,
-  Pressable,
   StyleProp,
   TextStyle,
   ViewStyle,
@@ -431,7 +433,7 @@ export type BottomTabBarProps = {
 };
 
 export type BottomTabBarButtonProps = Omit<
-  React.ComponentProps<typeof Pressable>,
+  React.ComponentProps<typeof PlatformPressable>,
   'style'
 > & {
   href?: string;

--- a/packages/bottom-tabs/src/views/BottomTabItem.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabItem.tsx
@@ -347,7 +347,8 @@ export function BottomTabItem({
           variant === 'material' || (sidebar && horizontal)
             ? { color: colors.text }
             : undefined,
-        pressOpacity: 1,
+        pressOpacity: options.headerPressOpacity ?? 1,
+        pressColor: options.headerPressColor,
         style: [
           styles.tab,
           { flex, backgroundColor, borderRadius },


### PR DESCRIPTION
**Motivation**

Bottom Tabs Navigator has the navigation options of `headerPressColor` and `headerPressOpacity`, but setting these has no effect. 
 Because these options are exposed, I believe that it is a good feature to make them work.   This is an Android only change because the ripple effect is only on Android.

**Test plan**

Create a Bottom Tab Navigator with `headerPressColor` and `headerPressOpacity` set to some non-default value.  This can be done by adding the following to the [BottomTab.tsx](../blob/-/example/src/Screens/BottomTabs.tsx) `Tab.Navigator` `screenOptions` property

```javascript
headerPressColor: 'yellow',
headerPressOpacity: 0.5,
```

When running on an Android device, this will make the press have a ripple color that is not the default grey with an opacity that is not 1.
