### PR TITLE
chore: add `GroupConfig` and `StaticConfigScreens` to public type exports in `@react-navigation/core`

### DIFF
--- a/packages/core/src/StaticNavigation.tsx
+++ b/packages/core/src/StaticNavigation.tsx
@@ -102,7 +102,7 @@ type StaticRouteConfig<
 > &
   RouteConfigComponent<ParamList, RouteName>;
 
-type StaticConfigScreens<
+export type StaticConfigScreens<
   ParamList extends ParamListBase,
   State extends NavigationState,
   ScreenOptions extends {},
@@ -156,7 +156,7 @@ type StaticConfigScreens<
       });
 };
 
-type GroupConfig<
+export type GroupConfig<
   ParamList extends ParamListBase,
   State extends NavigationState,
   ScreenOptions extends {},

--- a/packages/core/src/StaticNavigation.tsx
+++ b/packages/core/src/StaticNavigation.tsx
@@ -156,7 +156,7 @@ export type StaticConfigScreens<
       });
 };
 
-export type GroupConfig<
+export type StaticConfigGroup<
   ParamList extends ParamListBase,
   State extends NavigationState,
   ScreenOptions extends {},
@@ -240,7 +240,7 @@ type StaticConfigInternal<
          * Groups of screens to render in the navigator and their configuration.
          */
         groups?: {
-          [key: string]: GroupConfig<
+          [key: string]: StaticConfigGroup<
             ParamList,
             State,
             ScreenOptions,
@@ -264,7 +264,7 @@ type StaticConfigInternal<
          * Groups of screens to render in the navigator and their configuration.
          */
         groups: {
-          [key: string]: GroupConfig<
+          [key: string]: StaticConfigGroup<
             ParamList,
             State,
             ScreenOptions,

--- a/packages/core/src/index.tsx
+++ b/packages/core/src/index.tsx
@@ -17,8 +17,8 @@ export { PreventRemoveProvider } from './PreventRemoveProvider';
 export {
   createComponentForStaticNavigation,
   createPathConfigForStaticNavigation,
-  type GroupConfig,
   type StaticConfig,
+  type StaticConfigGroup,
   type StaticConfigScreens,
   type StaticNavigation,
   type StaticParamList,

--- a/packages/core/src/index.tsx
+++ b/packages/core/src/index.tsx
@@ -17,7 +17,9 @@ export { PreventRemoveProvider } from './PreventRemoveProvider';
 export {
   createComponentForStaticNavigation,
   createPathConfigForStaticNavigation,
+  type GroupConfig,
   type StaticConfig,
+  type StaticConfigScreens,
   type StaticNavigation,
   type StaticParamList,
   type StaticScreenProps,


### PR DESCRIPTION
**Motivation**

I am working in an app where we are breaking up the static screen and group configs into feature folders. Ultimately they are consumed by `createNativeStackNavigator`, which is correctly type checking them. But the type errors are indirect because an error in a static config will warn in `createNativeStackNavigator` instead of closer to their feature screen config, making it harder to debug.

Exporting these types that are used by `createNativeStackNavigator` make it easier to break up the screen config into smaller chunks and type check using `satisfies`.

Example:

```tsx
// feature/profile/screens.tsx

// base type with loose default type arguments to be used with satisfies later
type BaseScreenConfig = StaticConfigScreens<
  ParamListBase,
  NavigationState,
  Record<string, unknown>,
  EventMapBase,
  NavigationListBase<ParamListBase>
>;

// actual type shape inferred using satisfies but still type checked to ensure valid keys are used
const authenticatedScreens = {
  Profile: {
    screen: ProfileScreen,
  },
} satisfies BaseScreenConfig;

export default authenticatedScreens;
```

```tsx
// AuthenticatedGroup.tsx
// base type with loose default type arguments to be used with satisfies later
type BaseGroupConfig = GroupConfig<
  ParamListBase,
  NavigationState,
  Record<string, unknown>,
  EventMapBase,
  NavigationListBase<ParamListBase>
>;

// actual type shape inferred using satisfies but still type checked to ensure valid keys are used
const authenticatedGroup = {
  if: useIsLoggedIn,
  screens: authenticatedScreens,
} satisfies BaseGroupConfig;
```


```tsx
// RootNavigator.tsx
// createNativeStackNavigator will type check that config argument is correct shape
const RootStack = createNativeStackNavigator({
   groups: {
     authenticated: authenticatedGroup,
   },
});
```

**Test plan**

See that CI passes. 
Consider running locally and see that export keywords are added in bundled build.

I have this as a pnpm patch in our app and it is successfully working.