### PR TITLE
Allow Overlay to be focusable in iOS with Full Keyboard Access enabled

### DIFF
--- a/packages/react-native-drawer-layout/src/views/Overlay.native.tsx
+++ b/packages/react-native-drawer-layout/src/views/Overlay.native.tsx
@@ -41,6 +41,7 @@ export function Overlay({
         style={styles.pressable}
         role="button"
         aria-label={accessibilityLabel}
+        accessible
       />
     </Animated.View>
   );


### PR DESCRIPTION
**Motivation**

Currently, if you are using Full Keyboard Access in iOS, there is no way to close the drawer once it has been opened, as the Pressable within the Overlay is not focusable.

**Test plan**

in iOS, with Full Keyboard Access enabled at the OS level (System Settings -> Accessibility -> Keyboards and Typing -> Full Keyboard Access -> On)

- Open a drawer
- Try to navigate using only the keyboard to the Overlay to close it
- Press space to close the Overlay
