### PR TITLE
fix: error thrown when applying transform style to tabBarStyle

### DIFF
--- a/packages/bottom-tabs/src/views/BottomTabBar.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabBar.tsx
@@ -304,7 +304,7 @@ export function BottomTabBar({
 
   const tabBarBackgroundElement = tabBarBackground?.();
 
-  const {transform = [], ...restTabBarStyle} = (tabBarStyle ?? {}) as ViewStyle;
+  const { transform = [], ...restTabBarStyle } = (tabBarStyle ?? {}) as ViewStyle;
 
   return (
     <Animated.View

--- a/packages/bottom-tabs/src/views/BottomTabBar.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabBar.tsx
@@ -304,7 +304,8 @@ export function BottomTabBar({
 
   const tabBarBackgroundElement = tabBarBackground?.();
 
-  const { transform = [], ...restTabBarStyle } = (tabBarStyle ?? {}) as ViewStyle;
+  const { transform = [], ...restTabBarStyle } = (tabBarStyle ??
+    {}) as ViewStyle;
 
   return (
     <Animated.View

--- a/packages/bottom-tabs/src/views/BottomTabBar.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabBar.tsx
@@ -304,6 +304,8 @@ export function BottomTabBar({
 
   const tabBarBackgroundElement = tabBarBackground?.();
 
+  const {transform = [], ...restTabBarStyle} = (tabBarStyle as ViewStyle);
+
   return (
     <Animated.View
       style={[
@@ -335,19 +337,22 @@ export function BottomTabBar({
           borderColor: colors.border,
         },
         sidebar
-          ? {
-              paddingTop:
-                (hasHorizontalLabels ? spacing : spacing / 2) + insets.top,
-              paddingBottom:
-                (hasHorizontalLabels ? spacing : spacing / 2) + insets.bottom,
-              paddingStart:
-                spacing + (tabBarPosition === 'left' ? insets.left : 0),
-              paddingEnd:
-                spacing + (tabBarPosition === 'right' ? insets.right : 0),
-              minWidth: hasHorizontalLabels
-                ? getDefaultSidebarWidth(dimensions)
-                : 0,
-            }
+          ? [
+              {
+                paddingTop:
+                  (hasHorizontalLabels ? spacing : spacing / 2) + insets.top,
+                paddingBottom:
+                  (hasHorizontalLabels ? spacing : spacing / 2) + insets.bottom,
+                paddingStart:
+                  spacing + (tabBarPosition === 'left' ? insets.left : 0),
+                paddingEnd:
+                  spacing + (tabBarPosition === 'right' ? insets.right : 0),
+                minWidth: hasHorizontalLabels
+                  ? getDefaultSidebarWidth(dimensions)
+                  : 0,
+              },
+              tabBarStyle,
+            ]
           : [
               {
                 transform: [
@@ -362,6 +367,7 @@ export function BottomTabBar({
                       ],
                     }),
                   },
+                  ...(transform as []),
                 ],
                 // Absolutely position the tab bar so that the content is below it
                 // This is needed to avoid gap at bottom when the tab bar is hidden
@@ -373,8 +379,8 @@ export function BottomTabBar({
                 paddingTop: tabBarPosition === 'top' ? insets.top : 0,
                 paddingHorizontal: Math.max(insets.left, insets.right),
               },
+              restTabBarStyle,
             ],
-        tabBarStyle,
       ]}
       pointerEvents={isTabBarHidden ? 'none' : 'auto'}
       onLayout={sidebar ? undefined : handleLayout}

--- a/packages/bottom-tabs/src/views/BottomTabBar.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabBar.tsx
@@ -304,7 +304,7 @@ export function BottomTabBar({
 
   const tabBarBackgroundElement = tabBarBackground?.();
 
-  const {transform = [], ...restTabBarStyle} = (tabBarStyle as ViewStyle);
+  const {transform = [], ...restTabBarStyle} = (tabBarStyle ?? {}) as ViewStyle;
 
   return (
     <Animated.View


### PR DESCRIPTION
Please provide enough information so that others can review your pull request.

**Motivation**

When trying to apply a `transform` style to `tabBarStyle` in the bottom tabs navigator, the following error is thrown:

```bash
 (NOBRIDGE) ERROR  Warning: Invariant Violation: Transform with key of "translateY" must be number or a percentage. Passed value: {"translateY":0}
```
For example, with this usage:

```tsx
//...
export const Tab = createBottomTabNavigator();
//...
return (
  <Tab.Navigator screenOptions={{tabBarStyle: {
     transform: [{scaleX: -1}],
   }}}>
   {/* ... */}
```

We'll get the error mentioned above. This PR enables applying a custom transform style to the tab bar.

**Test plan**

- Extracting the `transform` style from `tabBarStyle` and merging it with the existing transforms (when not in sidebar mode)
- Merging it with the existing transforms (when not in sidebar mode)
- Applying the remaining styles to the tab bar (in the sidebar mode, applies `tabBarStyle` directly)

Env: RN v0.79.2
