### PR TITLE
docs: add missing information in status bar docs

### DIFF
--- a/packages/native-stack/src/types.tsx
+++ b/packages/native-stack/src/types.tsx
@@ -425,18 +425,21 @@ export type NativeStackNavigationOptions = {
    * Whether the status bar should be hidden on this screen.
    * Requires setting `View controller-based status bar appearance -> YES` in your Info.plist file.
    *
-   * Only supported on iOS.
+   * Only supported on Android and iOS.
    *
-   * @platform ios
+   * @platform android, ios
    */
   statusBarHidden?: boolean;
   /**
    * Sets the status bar color (similar to the `StatusBar` component).
    * Requires setting `View controller-based status bar appearance -> YES` (or removing the config) in your `Info.plist` file.
+   * `auto` and `inverted` are supported only on iOS. On Android, they will fallback to `light`.
    *
-   * Only supported on iOS.
+   * Defaults to `auto` on iOS and `light` on Android.
    *
-   * @platform ios
+   * Only supported on Android and iOS.
+   *
+   * @platform android, ios
    */
   statusBarStyle?: ScreenProps['statusBarStyle'];
   /**


### PR DESCRIPTION
**Motivation**

Recently noticed that docs for `statusBarStyle` and `statusBarHidden` are not kept in sync between files in `react-native-screens` repo, `react-naviagtion` in-code docs and `reactnavigation.org/docs`.

I added information about support on Android for `statusBarStyle` and `statusBarHidden` props and `auto` and `inverted` values not being supported on Android for `statusBarStyle`.

Similar PR in `react-native-screens`: https://github.com/software-mansion/react-native-screens/pull/2953, `react-navigation.github.io`: https://github.com/react-navigation/react-navigation.github.io/pull/1432.
