### PR TITLE
docs: add missing information in statusBarAnimation docs

### DIFF
--- a/packages/native-stack/src/types.tsx
+++ b/packages/native-stack/src/types.tsx
@@ -404,11 +404,14 @@ export type NativeStackNavigationOptions = {
   navigationBarHidden?: boolean;
   /**
    * Sets the status bar animation (similar to the `StatusBar` component).
+   * On Android, setting either `fade` or `slide` will set the transition of status bar color. On iOS, this option applies to appereance animation of the status bar.
    * Requires setting `View controller-based status bar appearance -> YES` (or removing the config) in your `Info.plist` file.
    *
-   * Only supported on iOS.
+   * Defaults to `fade` on iOS and `none` on Android.
    *
-   * @platform ios
+   * Only supported on Android and iOS.
+   *
+   * @platform android, ios
    */
   statusBarAnimation?: ScreenProps['statusBarAnimation'];
   /**


### PR DESCRIPTION
**Motivation**

This is a follow-up to https://github.com/react-navigation/react-navigation/pull/12618#issuecomment-2918729663. Changed the in-code docs for `statusBarAnimation` to match [current online docs](https://reactnavigation.org/docs/native-stack-navigator#statusbaranimation).

Similar PR in `react-native-screens`: https://github.com/software-mansion/react-native-screens/pull/2953.
