### PR TITLE
feat: add scrollable bottom tabs

### DIFF
--- a/example/src/Screens/BottomTabs.tsx
+++ b/example/src/Screens/BottomTabs.tsx
@@ -9,6 +9,7 @@ import {
   HeaderBackButton,
   HeaderButton,
   PlatformPressable,
+  Text,
   useHeaderHeight,
 } from '@react-navigation/elements';
 import {
@@ -28,6 +29,7 @@ import {
   View,
 } from 'react-native';
 import { SystemBars } from 'react-native-edge-to-edge';
+import { Switch } from 'react-native-gesture-handler';
 
 import { Albums } from '../Shared/Albums';
 import { Chat } from '../Shared/Chat';
@@ -92,7 +94,7 @@ export function BottomTabs() {
     React.useState<(typeof variants)[number]>('material');
   const [animation, setAnimation] =
     React.useState<(typeof animations)[number]>('none');
-
+  const [scrollingEnabled, setScrollingEnabled] = React.useState(true);
   const [isCompact, setIsCompact] = React.useState(false);
 
   const isLargeScreen = dimensions.width >= 1024;
@@ -100,6 +102,25 @@ export function BottomTabs() {
   return (
     <>
       <Tab.Navigator
+        scrollableProps={
+          scrollingEnabled
+            ? {
+                tabCountPerPage: 2,
+                pagingIcons: {
+                  left: (
+                    <View>
+                      <Text>{`<`}</Text>
+                    </View>
+                  ),
+                  right: (
+                    <View>
+                      <Text>{`>`}</Text>
+                    </View>
+                  ),
+                },
+              }
+            : undefined
+        }
         screenOptions={({
           navigation,
         }: BottomTabScreenProps<BottomTabParams>) => ({
@@ -272,6 +293,10 @@ export function BottomTabs() {
           />
         </PlatformPressable>
       ) : null}
+      <View style={styles.scrollingContainer}>
+        <Switch value={scrollingEnabled} onValueChange={setScrollingEnabled} />
+        <Text>Scrolling enabled</Text>
+      </View>
     </>
   );
 }
@@ -285,5 +310,12 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     gap: 16,
     marginEnd: 16,
+  },
+  scrollingContainer: {
+    padding: 16,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 16,
   },
 });

--- a/packages/bottom-tabs/src/navigators/createBottomTabNavigator.tsx
+++ b/packages/bottom-tabs/src/navigators/createBottomTabNavigator.tsx
@@ -29,6 +29,7 @@ function BottomTabNavigator({
   screenOptions,
   screenLayout,
   UNSTABLE_router,
+  scrollableProps,
   ...rest
 }: BottomTabNavigatorProps) {
   const { state, descriptors, navigation, NavigationContent } =
@@ -55,6 +56,7 @@ function BottomTabNavigator({
       <BottomTabView
         {...rest}
         state={state}
+        scrollableProps={scrollableProps}
         navigation={navigation}
         descriptors={descriptors}
       />

--- a/packages/bottom-tabs/src/types.tsx
+++ b/packages/bottom-tabs/src/types.tsx
@@ -109,6 +109,17 @@ export type TabBarVisibilityAnimationConfig =
 
 export type TabAnimationName = 'none' | 'fade' | 'shift';
 
+export type ScrollViewPagingIcons = {
+  left?: React.JSX.Element;
+  right?: React.JSX.Element;
+};
+
+export type ScrollableProps = {
+  scrollViewProps?: ScrollViewProps;
+  pagingIcons?: ScrollViewPagingIcons;
+  tabCountPerPage?: number;
+};
+
 export type BottomTabNavigationOptions = HeaderOptions & {
   /**
    * Title text for the screen.
@@ -317,20 +328,10 @@ export type BottomTabNavigationOptions = HeaderOptions & {
   transitionSpec?: TransitionSpec;
 
   /**
-   * Hanldes all bottom tab scrolling logic
+   * Whether to enable swipe gestures to switch tabs.
+   * Defaults to `true`.
    */
-  scrollEnabled?: boolean;
-  scrollViewProps?: ScrollViewProps;
-
-  /**
-   * Option to add icons for scroll view paging
-   */
-  pagingIcons?: ScrollViewPagingIcons;
-
-  /**
-   * Count of tab items per page, when scroll is enabled
-   */
-  tabCountPerPage?: number;
+  scrollableProps?: ScrollableProps;
 };
 
 export type BottomTabDescriptor = Descriptor<
@@ -442,20 +443,12 @@ export type BottomTabHeaderProps = {
   navigation: BottomTabNavigationProp<ParamListBase>;
 };
 
-export interface ScrollViewPagingIcons {
-  left?: React.JSX.Element;
-  right?: React.JSX.Element;
-}
-
 export type BottomTabBarProps = {
   state: TabNavigationState<ParamListBase>;
   descriptors: BottomTabDescriptorMap;
   navigation: NavigationHelpers<ParamListBase, BottomTabNavigationEventMap>;
   insets: EdgeInsets;
-  scrollEnabled?: boolean;
-  scrollViewProps?: ScrollViewProps;
-  pagingIcons?: ScrollViewPagingIcons;
-  tabCountPerPage?: number;
+  scrollableProps?: ScrollableProps;
 };
 
 export type BottomTabBarButtonProps = Omit<
@@ -479,4 +472,6 @@ export type BottomTabNavigatorProps = DefaultNavigatorOptions<
   BottomTabNavigationProp<ParamListBase>
 > &
   TabRouterOptions &
-  BottomTabNavigationConfig;
+  BottomTabNavigationConfig & {
+    scrollableProps?: ScrollableProps;
+  };

--- a/packages/bottom-tabs/src/types.tsx
+++ b/packages/bottom-tabs/src/types.tsx
@@ -315,6 +315,22 @@ export type BottomTabNavigationOptions = HeaderOptions & {
    * Object which specifies the animation type (timing or spring) and their options (such as duration for timing).
    */
   transitionSpec?: TransitionSpec;
+
+  /**
+   * Hanldes all bottom tab scrolling logic
+   */
+  scrollEnabled?: boolean;
+  scrollViewProps?: ScrollViewProps;
+
+  /**
+   * Option to add icons for scroll view paging
+   */
+  pagingIcons?: ScrollViewPagingIcons;
+
+  /**
+   * Count of tab items per page, when scroll is enabled
+   */
+  tabCountPerPage?: number;
 };
 
 export type BottomTabDescriptor = Descriptor<

--- a/packages/bottom-tabs/src/types.tsx
+++ b/packages/bottom-tabs/src/types.tsx
@@ -18,6 +18,7 @@ import type * as React from 'react';
 import type {
   Animated,
   GestureResponderEvent,
+  ScrollViewProps,
   StyleProp,
   TextStyle,
   ViewStyle,
@@ -425,11 +426,20 @@ export type BottomTabHeaderProps = {
   navigation: BottomTabNavigationProp<ParamListBase>;
 };
 
+export interface ScrollViewPagingIcons {
+  left?: React.JSX.Element;
+  right?: React.JSX.Element;
+}
+
 export type BottomTabBarProps = {
   state: TabNavigationState<ParamListBase>;
   descriptors: BottomTabDescriptorMap;
   navigation: NavigationHelpers<ParamListBase, BottomTabNavigationEventMap>;
   insets: EdgeInsets;
+  scrollEnabled?: boolean;
+  scrollViewProps?: ScrollViewProps;
+  pagingIcons?: ScrollViewPagingIcons;
+  tabCountPerPage?: number;
 };
 
 export type BottomTabBarButtonProps = Omit<

--- a/packages/bottom-tabs/src/views/BottomTabBar.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabBar.tsx
@@ -317,13 +317,12 @@ export function BottomTabBar({
   descriptors,
   insets,
   style,
-  scrollEnabled,
-  scrollViewProps,
-  pagingIcons,
-  tabCountPerPage = 4,
+  scrollableProps,
 }: Props) {
   const { colors } = useTheme();
   const { direction } = useLocale();
+
+  console.log('BottomTabBar rendered', scrollableProps);
 
   const focusedRoute = state.routes[state.index];
   const focusedDescriptor = descriptors[focusedRoute.key];
@@ -420,12 +419,12 @@ export function BottomTabBar({
   }, [visible, shouldShowTabBar]);
 
   const pages = React.useMemo(() => {
-    if (scrollEnabled) {
-      return chunkArray(state.routes, tabCountPerPage);
+    if (scrollableProps) {
+      return chunkArray(state.routes, scrollableProps?.tabCountPerPage || 4);
     } else {
       return [];
     }
-  }, [tabCountPerPage, scrollEnabled, state.routes]);
+  }, [scrollableProps, state.routes]);
 
   const [layout, setLayout] = React.useState({
     height: 0,
@@ -547,22 +546,27 @@ export function BottomTabBar({
       <View pointerEvents="none" style={StyleSheet.absoluteFill}>
         {tabBarBackgroundElement}
       </View>
-      {scrollEnabled ? (
+      {scrollableProps ? (
         <View style={scrollViewStyles.content}>
-          {(selectedPage <= 1 && pages?.[selectedPage + 1] && (
-            <View style={scrollViewStyles.rightIcon}>{pagingIcons?.right}</View>
-          )) ||
+          {(scrollableProps?.pagingIcons?.right &&
+            selectedPage <= 1 &&
+            pages?.[selectedPage + 1] && (
+              <View style={scrollViewStyles.rightIcon}>
+                {scrollableProps?.pagingIcons?.right}
+              </View>
+            )) ||
             null}
 
-          {(selectedPage >= 1 && (
-            <View style={scrollViewStyles.leftIcon}>{pagingIcons?.left}</View>
+          {(scrollableProps?.pagingIcons?.left && selectedPage >= 1 && (
+            <View style={scrollViewStyles.leftIcon}>
+              {scrollableProps?.pagingIcons?.left}
+            </View>
           )) ||
             null}
-
           <ScrollView
             accessibilityRole="tablist"
             horizontal
-            {...(pagingIcons
+            {...(scrollableProps?.pagingIcons
               ? {
                   onMomentumScrollEnd: ({ nativeEvent }) => {
                     const index = Math.round(
@@ -575,7 +579,12 @@ export function BottomTabBar({
                   },
                 }
               : undefined)}
-            {...(scrollViewProps || {})}
+            {...(scrollableProps?.scrollViewProps || {
+              pagingEnabled: true,
+              showsHorizontalScrollIndicator: false,
+              disableIntervalMomentum: true,
+              snapToInterval: layout.width,
+            })}
           >
             <TabRoutes
               state={state}
@@ -583,7 +592,7 @@ export function BottomTabBar({
               focusedOptions={focusedOptions}
               layout={layout}
               navigation={navigation}
-              tabCountPerPage={tabCountPerPage}
+              tabCountPerPage={scrollableProps?.tabCountPerPage || 4}
             />
           </ScrollView>
         </View>
@@ -598,7 +607,6 @@ export function BottomTabBar({
             layout={layout}
             navigation={navigation}
             state={state}
-            tabCountPerPage={tabCountPerPage}
           />
         </View>
       )}

--- a/packages/bottom-tabs/src/views/BottomTabBar.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabBar.tsx
@@ -322,8 +322,6 @@ export function BottomTabBar({
   const { colors } = useTheme();
   const { direction } = useLocale();
 
-  console.log('BottomTabBar rendered', scrollableProps);
-
   const focusedRoute = state.routes[state.index];
   const focusedDescriptor = descriptors[focusedRoute.key];
   const focusedOptions = focusedDescriptor.options;

--- a/packages/bottom-tabs/src/views/BottomTabItem.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabItem.tsx
@@ -8,6 +8,7 @@ import {
   type StyleProp,
   StyleSheet,
   type TextStyle,
+  useWindowDimensions,
   View,
   type ViewStyle,
 } from 'react-native';
@@ -184,8 +185,9 @@ export function BottomTabItem({
   iconStyle,
   style,
   tabCountPerPage,
-  width,
 }: Props) {
+  const { width } = useWindowDimensions();
+
   if (style && width !== undefined && tabCountPerPage !== undefined) {
     style = [...[style], { width: width / tabCountPerPage }];
   }

--- a/packages/bottom-tabs/src/views/BottomTabItem.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabItem.tsx
@@ -141,6 +141,9 @@ type Props = {
    * Style object for the wrapper element.
    */
   style?: StyleProp<ViewStyle>;
+  tabCountPerPage?: number;
+
+  width?: number;
 };
 
 const renderButtonDefault = (props: BottomTabBarButtonProps) => (
@@ -180,7 +183,13 @@ export function BottomTabItem({
   labelStyle,
   iconStyle,
   style,
+  tabCountPerPage,
+  width,
 }: Props) {
+  if (style && width !== undefined && tabCountPerPage !== undefined) {
+    style = [...[style], { width: width / tabCountPerPage }];
+  }
+
   const { colors, fonts } = useTheme();
 
   const activeTintColor =

--- a/packages/bottom-tabs/src/views/BottomTabView.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabView.tsx
@@ -11,7 +11,12 @@ import {
   type TabNavigationState,
 } from '@react-navigation/native';
 import * as React from 'react';
-import { Animated, Platform, StyleSheet } from 'react-native';
+import {
+  Animated,
+  Platform,
+  type ScrollViewProps,
+  StyleSheet,
+} from 'react-native';
 import { SafeAreaInsetsContext } from 'react-native-safe-area-context';
 
 import {
@@ -26,6 +31,7 @@ import type {
   BottomTabNavigationHelpers,
   BottomTabNavigationOptions,
   BottomTabNavigationProp,
+  ScrollViewPagingIcons,
 } from '../types';
 import { BottomTabBarHeightCallbackContext } from '../utils/BottomTabBarHeightCallbackContext';
 import { BottomTabBarHeightContext } from '../utils/BottomTabBarHeightContext';
@@ -37,6 +43,10 @@ type Props = BottomTabNavigationConfig & {
   state: TabNavigationState<ParamListBase>;
   navigation: BottomTabNavigationHelpers;
   descriptors: BottomTabDescriptorMap;
+  scrollEnabled?: boolean;
+  scrollViewProps?: ScrollViewProps;
+  pagingIcons?: ScrollViewPagingIcons;
+  tabCountPerPage?: number;
 };
 
 const EPSILON = 1e-5;
@@ -82,6 +92,10 @@ export function BottomTabView(props: Props) {
     detachInactiveScreens = Platform.OS === 'web' ||
       Platform.OS === 'android' ||
       Platform.OS === 'ios',
+    scrollEnabled,
+    scrollViewProps,
+    pagingIcons,
+    tabCountPerPage,
   } = props;
 
   const focusedRouteKey = state.routes[state.index].key;
@@ -206,6 +220,10 @@ export function BottomTabView(props: Props) {
       <SafeAreaInsetsContext.Consumer>
         {(insets) =>
           tabBar({
+            scrollEnabled,
+            scrollViewProps,
+            tabCountPerPage: tabCountPerPage,
+            pagingIcons,
             state: state,
             descriptors: descriptors,
             navigation: navigation,

--- a/packages/bottom-tabs/src/views/BottomTabView.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabView.tsx
@@ -11,12 +11,7 @@ import {
   type TabNavigationState,
 } from '@react-navigation/native';
 import * as React from 'react';
-import {
-  Animated,
-  Platform,
-  type ScrollViewProps,
-  StyleSheet,
-} from 'react-native';
+import { Animated, Platform, StyleSheet } from 'react-native';
 import { SafeAreaInsetsContext } from 'react-native-safe-area-context';
 
 import {
@@ -31,7 +26,7 @@ import type {
   BottomTabNavigationHelpers,
   BottomTabNavigationOptions,
   BottomTabNavigationProp,
-  ScrollViewPagingIcons,
+  ScrollableProps,
 } from '../types';
 import { BottomTabBarHeightCallbackContext } from '../utils/BottomTabBarHeightCallbackContext';
 import { BottomTabBarHeightContext } from '../utils/BottomTabBarHeightContext';
@@ -43,10 +38,7 @@ type Props = BottomTabNavigationConfig & {
   state: TabNavigationState<ParamListBase>;
   navigation: BottomTabNavigationHelpers;
   descriptors: BottomTabDescriptorMap;
-  scrollEnabled?: boolean;
-  scrollViewProps?: ScrollViewProps;
-  pagingIcons?: ScrollViewPagingIcons;
-  tabCountPerPage?: number;
+  scrollableProps?: ScrollableProps;
 };
 
 const EPSILON = 1e-5;
@@ -92,10 +84,7 @@ export function BottomTabView(props: Props) {
     detachInactiveScreens = Platform.OS === 'web' ||
       Platform.OS === 'android' ||
       Platform.OS === 'ios',
-    scrollEnabled,
-    scrollViewProps,
-    pagingIcons,
-    tabCountPerPage,
+    scrollableProps,
   } = props;
 
   const focusedRouteKey = state.routes[state.index].key;
@@ -220,10 +209,7 @@ export function BottomTabView(props: Props) {
       <SafeAreaInsetsContext.Consumer>
         {(insets) =>
           tabBar({
-            scrollEnabled,
-            scrollViewProps,
-            tabCountPerPage: tabCountPerPage,
-            pagingIcons,
+            scrollableProps,
             state: state,
             descriptors: descriptors,
             navigation: navigation,


### PR DESCRIPTION
**Motivation**

This PR introduces scrollable functionality to react-navigation bottom tabs to address the common issue where apps with many tabs create an overcrowded and unusable bottom navigation experience.

**Testing**
Feature can be tested from BottomTabs example screen
https://github.com/user-attachments/assets/2b3c64be-a5d6-4891-a3ac-a608540b089b


