### PR TITLE
Fix: react-native-tab-view glitching on initial load

### DIFF
--- a/packages/react-native-tab-view/src/PanResponderAdapter.tsx
+++ b/packages/react-native-tab-view/src/PanResponderAdapter.tsx
@@ -117,11 +117,51 @@ export function PanResponderAdapter<T extends Route>({
     onTabSelectRef.current = onTabSelect;
   });
 
+  const [position, setPosition] =
+    React.useState<Animated.AnimatedDivision<number> | null>(null);
+
+  const [translateX, setTranslateX] =
+    React.useState<Animated.AnimatedMultiplication<number> | null>(null);
+
   React.useEffect(() => {
     const offset = -navigationStateRef.current.index * layout.width;
 
     panX.setValue(offset);
-  }, [layout.width, panX]);
+
+    // If the layout.width is 0 it means we still waiting for calculating it.
+    if (!layout.width) {
+      // Non null values of these states indicates that we have a proper layout.width
+      // We should make them null again if the layout.width is 0 again to avoid glitching.
+      // This can happen if the component is still mounted but not rendered anymore. e.g. on the screen
+      // eslint-disable-next-line @eslint-react/hooks-extra/no-direct-set-state-in-use-effect
+      setPosition(null);
+      // eslint-disable-next-line @eslint-react/hooks-extra/no-direct-set-state-in-use-effect
+      setTranslateX(null);
+      return;
+    }
+
+    // Setting these states in the same useEffect as panX.setValue() prevents visual glitches
+    // that occur when layout.width is known but panX hasn't been recalculated yet (still at 0).
+    // This can happen if we do it in a separate useEffect or use useMemo for setting these values.
+    // eslint-disable-next-line @eslint-react/hooks-extra/no-direct-set-state-in-use-effect
+    setPosition(layout.width ? Animated.divide(panX, -layout.width) : null);
+
+    const maxTranslate = layout.width * (routes.length - 1);
+
+    // eslint-disable-next-line @eslint-react/hooks-extra/no-direct-set-state-in-use-effect
+    setPosition(layout.width ? Animated.divide(panX, -layout.width) : null);
+    // eslint-disable-next-line @eslint-react/hooks-extra/no-direct-set-state-in-use-effect
+    setTranslateX(
+      Animated.multiply(
+        panX.interpolate({
+          inputRange: [-maxTranslate, 0],
+          outputRange: [-maxTranslate, 0],
+          extrapolate: 'clamp',
+        }),
+        layoutDirection === 'rtl' ? -1 : 1
+      )
+    );
+  }, [layout.width, panX, routes.length, layoutDirection]);
 
   React.useEffect(() => {
     if (keyboardDismissMode === 'auto') {
@@ -278,21 +318,6 @@ export function PanResponderAdapter<T extends Route>({
     onPanResponderTerminationRequest: () => true,
   });
 
-  const maxTranslate = layout.width * (routes.length - 1);
-  const translateX = Animated.multiply(
-    panX.interpolate({
-      inputRange: [-maxTranslate, 0],
-      outputRange: [-maxTranslate, 0],
-      extrapolate: 'clamp',
-    }),
-    layoutDirection === 'rtl' ? -1 : 1
-  );
-
-  const position = React.useMemo(
-    () => (layout.width ? Animated.divide(panX, -layout.width) : null),
-    [layout.width, panX]
-  );
-
   return children({
     position: position ?? new Animated.Value(index),
     addEnterListener,
@@ -301,7 +326,7 @@ export function PanResponderAdapter<T extends Route>({
       <Animated.View
         style={[
           styles.sheet,
-          layout.width
+          translateX
             ? {
                 width: routes.length * layout.width,
                 transform: [{ translateX }],
@@ -326,7 +351,7 @@ export function PanResponderAdapter<T extends Route>({
                     : null
               }
             >
-              {focused || layout.width ? child : null}
+              {focused || translateX ? child : null}
             </View>
           );
         })}


### PR DESCRIPTION
Please provide enough information so that others can review your pull request.

**Motivation**

While working for Expensify, we encountered a bug with glitching material top tabs. After investigation, it turned out that the `react-native-tab-view` causes it. 

It happens on refresh or initial load of the page, when any tab except the first one is selected.

Disclaimer: In our case, we use the `position` value to animate the top bar. 

The same effect can be reproduced in an example app with material top tabs. Hover on the example app, it is not as visible as in the production app due to the performance.

In the example app, it was visible for one or two frames.

https://github.com/user-attachments/assets/a285cce4-333d-4294-854f-a82057820d42

The root cause is:
- `layout.width` determines if we should use a layout that uses the `position` and `translateX` animated values.
- Both `position` and `translateX` are derived from `panX`
- There is a brief moment where `layout.width` is known, so we use `position` and `translateX`, but the `panX` isn't set yet and is still 0.

I changed the code to make sure that switching to the layout that uses `position` and `translateX` is after the `panX` value is updated

After fixing:

https://github.com/user-attachments/assets/f1eeda37-8861-4be7-8d4f-237a7438446a

**Test plan**

See if the glitching occurs

The change must pass lint, typescript and tests.
