### PR TITLE
feat: prevent freezing modal screens on iOS

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -35,7 +35,7 @@
     "react-native-pager-view": "6.7.1",
     "react-native-reanimated": "~3.17.5",
     "react-native-safe-area-context": "5.4.0",
-    "react-native-screens": "~4.10.0",
+    "react-native-screens": "~4.11.1",
     "react-native-web": "~0.20.0"
   },
   "devDependencies": {

--- a/packages/bottom-tabs/package.json
+++ b/packages/bottom-tabs/package.json
@@ -55,7 +55,7 @@
     "react-native": "0.79.2",
     "react-native-builder-bob": "^0.40.9",
     "react-native-safe-area-context": "5.4.0",
-    "react-native-screens": "~4.10.0",
+    "react-native-screens": "~4.11.1",
     "react-test-renderer": "19.0.0",
     "typescript": "^5.8.3"
   },

--- a/packages/drawer/package.json
+++ b/packages/drawer/package.json
@@ -64,7 +64,7 @@
     "react-native-gesture-handler": "~2.25.0",
     "react-native-reanimated": "~3.17.5",
     "react-native-safe-area-context": "5.4.0",
-    "react-native-screens": "~4.10.0",
+    "react-native-screens": "~4.11.1",
     "react-test-renderer": "19.0.0",
     "typescript": "^5.8.3"
   },

--- a/packages/native-stack/package.json
+++ b/packages/native-stack/package.json
@@ -58,7 +58,7 @@
     "react": "19.0.0",
     "react-native": "0.79.2",
     "react-native-builder-bob": "^0.40.9",
-    "react-native-screens": "~4.10.0",
+    "react-native-screens": "~4.11.1",
     "react-test-renderer": "19.0.0",
     "typescript": "^5.8.3"
   },

--- a/packages/native-stack/src/types.tsx
+++ b/packages/native-stack/src/types.tsx
@@ -556,6 +556,7 @@ export type NativeStackNavigationOptions = {
    * - "containedTransparentModal": will use "UIModalPresentationOverCurrentContext" modal style on iOS and will fallback to "transparentModal" on Android.
    * - "fullScreenModal": will use "UIModalPresentationFullScreen" modal style on iOS and will fallback to "modal" on Android.
    * - "formSheet": will use "UIModalPresentationFormSheet" modal style on iOS and will fallback to "modal" on Android.
+   * - "pageSheet": will use "UIModalPresentationPageSheet" modal style on iOS and will fallback to "modal" on Android.
    *
    * Only supported on iOS and Android.
    */

--- a/packages/native-stack/src/utils/getModalRoutesKeys.ts
+++ b/packages/native-stack/src/utils/getModalRoutesKeys.ts
@@ -12,6 +12,7 @@ export const getModalRouteKeys = (
     if (
       (acc.length && !presentation) ||
       presentation === 'modal' ||
+      presentation === 'pageSheet' ||
       presentation === 'transparentModal'
     ) {
       acc.push(route.key);

--- a/packages/native-stack/src/utils/getModalRoutesKeys.ts
+++ b/packages/native-stack/src/utils/getModalRoutesKeys.ts
@@ -12,8 +12,12 @@ export const getModalRouteKeys = (
     if (
       (acc.length && !presentation) ||
       presentation === 'modal' ||
-      presentation === 'pageSheet' ||
-      presentation === 'transparentModal'
+      presentation === 'transparentModal' ||
+      presentation === 'containedModal' ||
+      presentation === 'containedTransparentModal' ||
+      presentation === 'formSheet' ||
+      presentation === 'fullScreenModal' ||
+      presentation === 'pageSheet'
     ) {
       acc.push(route.key);
     }

--- a/packages/native-stack/src/views/NativeStackView.native.tsx
+++ b/packages/native-stack/src/views/NativeStackView.native.tsx
@@ -173,8 +173,11 @@ const SceneView = ({
   const insets = useSafeAreaInsets();
   const frame = useSafeAreaFrame();
 
-  // `modal` and `formSheet` presentations do not take whole screen, so should not take the inset.
-  const isModal = presentation === 'modal' || presentation === 'formSheet';
+  // `modal`, `formSheet` and `pageSheet` presentations do not take whole screen, so should not take the inset.
+  const isModal =
+    presentation === 'modal' ||
+    presentation === 'formSheet' ||
+    presentation === 'pageSheet';
 
   // Modals are fullscreen in landscape only on iPhone
   const isIPhone = Platform.OS === 'ios' && !(Platform.isPad || Platform.isTV);

--- a/packages/native-stack/src/views/NativeStackView.native.tsx
+++ b/packages/native-stack/src/views/NativeStackView.native.tsx
@@ -512,8 +512,11 @@ export function NativeStackView({
           // On Fabric, when screen is frozen, animated and reanimated values are not updated
           // due to component being unmounted. To avoid this, we don't freeze the previous screen there
           const shouldFreeze = isFabric()
-            ? !isPreloaded && !isFocused && !isBelowFocused
-            : !isPreloaded && !isFocused;
+            ? !isPreloaded &&
+              !isFocused &&
+              !isBelowFocused &&
+              !(Platform.OS === 'ios' && isModal)
+            : !isPreloaded && !isFocused && !(Platform.OS === 'ios' && isModal);
 
           return (
             <SceneView

--- a/packages/stack/package.json
+++ b/packages/stack/package.json
@@ -60,7 +60,7 @@
     "react-native-builder-bob": "^0.40.9",
     "react-native-gesture-handler": "~2.25.0",
     "react-native-safe-area-context": "5.4.0",
-    "react-native-screens": "~4.10.0",
+    "react-native-screens": "~4.11.1",
     "react-test-renderer": "19.0.0",
     "typescript": "^5.8.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3814,7 +3814,7 @@ __metadata:
     react-native: "npm:0.79.2"
     react-native-builder-bob: "npm:^0.40.9"
     react-native-safe-area-context: "npm:5.4.0"
-    react-native-screens: "npm:~4.10.0"
+    react-native-screens: "npm:~4.11.1"
     react-test-renderer: "npm:19.0.0"
     typescript: "npm:^5.8.3"
   peerDependencies:
@@ -3890,7 +3890,7 @@ __metadata:
     react-native-gesture-handler: "npm:~2.25.0"
     react-native-reanimated: "npm:~3.17.5"
     react-native-safe-area-context: "npm:5.4.0"
-    react-native-screens: "npm:~4.10.0"
+    react-native-screens: "npm:~4.11.1"
     react-test-renderer: "npm:19.0.0"
     typescript: "npm:^5.8.3"
     use-latest-callback: "npm:^0.2.3"
@@ -3978,7 +3978,7 @@ __metadata:
     react-native-pager-view: "npm:6.7.1"
     react-native-reanimated: "npm:~3.17.5"
     react-native-safe-area-context: "npm:5.4.0"
-    react-native-screens: "npm:~4.10.0"
+    react-native-screens: "npm:~4.11.1"
     react-native-web: "npm:~0.20.0"
     react-test-renderer: "npm:19.0.0"
     serve: "npm:^14.2.4"
@@ -4028,7 +4028,7 @@ __metadata:
     react: "npm:19.0.0"
     react-native: "npm:0.79.2"
     react-native-builder-bob: "npm:^0.40.9"
-    react-native-screens: "npm:~4.10.0"
+    react-native-screens: "npm:~4.11.1"
     react-test-renderer: "npm:19.0.0"
     typescript: "npm:^5.8.3"
     warn-once: "npm:^0.1.1"
@@ -4096,7 +4096,7 @@ __metadata:
     react-native-builder-bob: "npm:^0.40.9"
     react-native-gesture-handler: "npm:~2.25.0"
     react-native-safe-area-context: "npm:5.4.0"
-    react-native-screens: "npm:~4.10.0"
+    react-native-screens: "npm:~4.11.1"
     react-test-renderer: "npm:19.0.0"
     typescript: "npm:^5.8.3"
   peerDependencies:
@@ -13883,7 +13883,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-is-edge-to-edge@npm:1.1.7, react-native-is-edge-to-edge@npm:^1.1.6":
+"react-native-is-edge-to-edge@npm:1.1.7, react-native-is-edge-to-edge@npm:^1.1.6, react-native-is-edge-to-edge@npm:^1.1.7":
   version: 1.1.7
   resolution: "react-native-is-edge-to-edge@npm:1.1.7"
   peerDependencies:
@@ -13947,16 +13947,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-screens@npm:~4.10.0":
-  version: 4.10.0
-  resolution: "react-native-screens@npm:4.10.0"
+"react-native-screens@npm:~4.11.1":
+  version: 4.11.1
+  resolution: "react-native-screens@npm:4.11.1"
   dependencies:
     react-freeze: "npm:^1.0.0"
+    react-native-is-edge-to-edge: "npm:^1.1.7"
     warn-once: "npm:^0.1.0"
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 10c0/09d1f55431b85e556ef7b5efd776ac5e85303e47d9138f910cb8c25ff3804effc43185f84e8842bcae2219e8fee12366b3725f955f638c109387efb82e0260f3
+  checksum: 10c0/88a33ba419bd571cc318e80d25eb172f5829677f2dd80dcb69cbeaa6a35ba26214e0e82af87baa375182afe41a276e8ef1a9d13b826f662f3a389982492c2879
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
To be merged after https://github.com/react-navigation/react-navigation/pull/12503.

**Motivation**

iOS modals are presented in a seperate hierarchy. When you open a modal screen and push multiple `presentation: 'card'` screens (they are pushed "behind" the modal), the modal screen gets frozen, because it isn't `preloaded`, `focused` nor `belowFocused` (pushed screens are above the modal in `routes` list). You can't interact with the content of the modal, you can only dismiss it.

| before | after |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/b8f22ec4-9072-45da-877d-fe2c9ae9f045" alt="before" /> | <video src="https://github.com/user-attachments/assets/b5914f9c-99e3-4417-a2b7-54008a8ed821" alt="after" />

In this PR, we prevent freezing modal screens on iOS in order to avoid this problem.

The reasoning behind this change is that you shouldn't show more that 1-2 modal screens at the same time - this is also a recommendation in [Apple's Human Interface Guidlines](https://developer.apple.com/design/human-interface-guidelines/modality):
> **Let people dismiss a modal view before presenting another one.** Allowing multiple modal views to be visible at the same time tends to create visual clutter and can make your app seem scattered and disorganized. People need to remember the context they were in before a modal view appears, so presenting multiple views adds to people’s cognitive load, especially when a modal view hides another one by appearing on top of it. Although an alert can appear on top of all other content — including other modal views — you never want to display more than one alert at the same time.

**Test plan**

Run `Test791` in `react-native-screens`' example app.
