### PR TITLE
Update react-native-safe-area-context to match the APIs actually used

### DIFF
--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@react-navigation/elements",
   "description": "UI Components for React Navigation",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "keywords": [
     "react-native",
     "react-navigation",
@@ -65,7 +65,7 @@
     "@react-navigation/native": "workspace:^",
     "react": ">= 18.2.0",
     "react-native": "*",
-    "react-native-safe-area-context": ">= 4.0.0"
+    "react-native-safe-area-context": ">= 5.5.0"
   },
   "peerDependenciesMeta": {
     "@react-native-masked-view/masked-view": {


### PR DESCRIPTION
`SafeAreaListener` was introduced in [react-native-safe-area-context@5.5.0](https://github.com/AppAndFlow/react-native-safe-area-context/releases/tag/v5.5.0). With this commit, developers using Expo 52 and RN 76 will be notified about incompatibility upon installing latest `@react-navigation/elements`.

**Motivation**

In my project with Expo 52 and RN 76, the build failed when I upgraded `@react-navigation/elements` to the latest version:

```text
ERROR in ../../node_modules/@react-navigation/elements/lib/module/useFrameSize.js 99:16-32
export 'SafeAreaListener' (imported as 'SafeAreaListener') was not found in 'react-native-safe-area-context' (possible exports: SafeAreaConsumer, SafeAreaContext, SafeAreaFrameContext, SafeAreaInsetsContext, SafeAreaProvider, SafeAreaView, initialWindowMetrics, initialWindowSafeAreaInsets, useSafeArea, useSafeAreaFrame, useSafeAreaInsets, withSafeAreaInsets)
 @ ../../node_modules/@react-navigation/elements/lib/module/index.js 30:0-49 30:0-49
 @ ../../packages/navigation/src/components/NavigationBar.tsx 10:0-60 160:116-130
 @ ../../packages/navigation/src/components/index.ts 5:0-32 5:0-32 6:0-59 6:0-59
 @ ../../packages/navigation/src/index.ts 4:0-46 4:0-46
 @ ./src/App.tsx 7:0-58 31:31-45
 @ ./src/index.tsx 3:0-24 36:17-20

ERROR in ../../node_modules/@react-navigation/elements/lib/module/useFrameSize.js 101:14-30
export 'SafeAreaListener' (imported as 'SafeAreaListener') was not found in 'react-native-safe-area-context' (possible exports: SafeAreaConsumer, SafeAreaContext, SafeAreaFrameContext, SafeAreaInsetsContext, SafeAreaProvider, SafeAreaView, initialWindowMetrics, initialWindowSafeAreaInsets, useSafeArea, useSafeAreaFrame, useSafeAreaInsets, withSafeAreaInsets)
 @ ../../node_modules/@react-navigation/elements/lib/module/index.js 30:0-49 30:0-49
 @ ../../packages/navigation/src/components/NavigationBar.tsx 10:0-60 160:116-130
 @ ../../packages/navigation/src/components/index.ts 5:0-32 5:0-32 6:0-59 6:0-59
 @ ../../packages/navigation/src/index.ts 4:0-46 4:0-46
 @ ./src/App.tsx 7:0-58 31:31-45
 @ ./src/index.tsx 3:0-24 36:17-20
```

I want to be explicitly notified about any incompatibility.

**Test plan**

1. Create a project with Expo 52 and React Navigation.
2. Update React Navigation to the latest version.
3. Build and run the project on any platform.

At this moment, the build should fail. If the build didn't fail, runtime shall fail on the code that uses `SafeAreaListener`.