### PR TITLE
refactor(tab-view): Attach event via ref instead of using onPageScroll handler

### DIFF
--- a/packages/react-native-tab-view/src/PagerViewAdapter.tsx
+++ b/packages/react-native-tab-view/src/PagerViewAdapter.tsx
@@ -79,11 +79,12 @@ export function PagerViewAdapter<T extends Route>({
   });
 
   React.useEffect(() => {
+    let subscription: { detach: () => void } | null = null;
     if (pagerRef.current) {
       // @ts-expect-error - Typescript types are missing but this API is exported by Animated since React Native 0.60.2
       // https://github.com/facebook/react-native/commit/77b8c097277b5cf248d08e772ea8bb8d8583e9a1
       // It allows to attach native event using native element's ref instead of passing in an event callback
-      const subscription = Animated.attachNativeEvent(
+      subscription = Animated.attachNativeEvent(
         pagerRef.current,
         'onPageScroll',
         [
@@ -95,12 +96,10 @@ export function PagerViewAdapter<T extends Route>({
           },
         ]
       );
-
-      return () => {
-        subscription.detach();
-      };
     }
-    return;
+    return () => {
+      subscription?.detach();
+    };
   }, [offset, position]);
 
   React.useEffect(() => {


### PR DESCRIPTION
**Motivation**

We want to allow passing [reanimated event handler](https://github.com/callstack/react-native-pager-view?tab=readme-ov-file#reanimated-onpagescroll-handler) to the underlying pager view. This PR partially enables it by unblocking the usage of `onPageScroll` event callback. 

It would be helpful to add an API to pass reanimated handler in material tabs since it is closely coupled with navigation. It can be used to apply custom animations without relying on `Animated` API (`useAnimatedValue` returns `Animated` value). We can introduce `onPageScroll` prop support in tab view and material tabs since it is not used by the tab view anymore.


**Test plan**

Test all the tab examples, the animation should work as expected.
