### PR TITLE
fix: Reset offset to 0 on swipe end to prevent indicator jump

### DIFF
--- a/packages/react-native-tab-view/src/PagerViewAdapter.tsx
+++ b/packages/react-native-tab-view/src/PagerViewAdapter.tsx
@@ -102,6 +102,7 @@ export function PagerViewAdapter<T extends Route>({
 
     switch (pageScrollState) {
       case 'idle':
+        offset.setValue(0);
         onSwipeEnd?.();
         return;
       case 'dragging': {


### PR DESCRIPTION
## Summary

When swiping between tabs, especially in React Native's New Architecture or on some devices, the `offset` value may retain a small negative or positive value (e.g. `-0.02`) even after the swipe ends. This causes a visual glitch where the indicator briefly "jumps" backward before settling on the correct tab.

This PR resets `offset` to `0` when `pageScrollState` becomes `"idle"`, ensuring that the final position is stable and that the indicator aligns correctly with the selected tab.

## Changes

- Added `offset.setValue(0);` to `onPageScrollStateChanged` when state is `'idle'`

## Why

To prevent the tab indicator from jumping slightly backward after swiping, improving visual consistency. #12493 

## Notes

This fix has no functional side effects and only affects the visual animation when the swipe ends.

Tested on:
- React Native 0.79.4
- Fabric enabled
- Android