### PR TITLE
fix: crash when path contains emoji

### DIFF
--- a/packages/core/src/__tests__/getStateFromPath.test.tsx
+++ b/packages/core/src/__tests__/getStateFromPath.test.tsx
@@ -2726,7 +2726,7 @@ See https://reactnavigation.org/docs/configuring-links for more details on how t
 // query params after '?' should be encoded fully with encodeURIComponent
 test('encodes special characters in params', () => {
   const paramWithValidSymbols = `User09-A_Z~!$&'()*+,;=:@__`;
-  const invalidSymbols = '#?[]{}%<>||';
+  const invalidSymbols = '#?[]{}%<>||😄';
   const queryString = 'user#email@gmail.com=2&4';
 
   const path = `users/id/${paramWithValidSymbols}${encodeURIComponent(invalidSymbols)}?query=${encodeURIComponent(queryString)}`;

--- a/packages/core/src/getPathFromState.tsx
+++ b/packages/core/src/getPathFromState.tsx
@@ -224,10 +224,13 @@ export function getPathFromState<ParamList extends {}>(
 
             // Valid characters according to
             // https://datatracker.ietf.org/doc/html/rfc3986#section-3.3 (see pchar definition)
-            return String(value).replace(
-              /[^A-Za-z0-9\-._~!$&'()*+,;=:@]/g,
-              (char) => encodeURIComponent(char)
-            );
+            return Array.from(String(value))
+              .map((char) =>
+                /[^A-Za-z0-9\-._~!$&'()*+,;=:@]/g.test(char)
+                  ? encodeURIComponent(char)
+                  : char
+              )
+              .join('');
           }
 
           return encodeURIComponent(segment);


### PR DESCRIPTION
**Motivation**

After https://github.com/react-navigation/react-navigation/pull/11867, we only encode the necessary characters from the path. However, this fails if the path contains emojis and causes a crash.

**Test plan**

Run the unit test