### PR TITLE
fix: remove production check in useRouteCache

### DIFF
--- a/packages/core/src/useRouteCache.tsx
+++ b/packages/core/src/useRouteCache.tsx
@@ -23,11 +23,6 @@ export function useRouteCache<State extends NavigationState>(
   // Cache object which holds route objects for each screen
   const cache = React.useMemo(() => ({ current: new Map() as RouteCache }), []);
 
-  if (process.env.NODE_ENV === 'production') {
-    // We don't want the overhead of creating extra maps every render in prod
-    return routes;
-  }
-
   cache.current = routes.reduce((acc, route) => {
     const previous = cache.current.get(route.key);
     const { state, ...routeWithoutState } = route;


### PR DESCRIPTION
https://github.com/react-navigation/react-navigation/issues/12685

I think that the cost of unnecessary re-renders of each navigator is higher than the cost of computing map for each route, especially considering complex pages. However, I don't have concrete evidence for that.

**Test plan**

1. Run the app in the production and development