### PR TITLE
fix: update BottomTabView.tsx to prevent undefined preloadedRouteKeys…

### DIFF
--- a/packages/bottom-tabs/src/views/BottomTabView.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabView.tsx
@@ -266,7 +266,7 @@ export function BottomTabView(props: Props) {
               .sceneStyleInterpolator,
           } = descriptor.options;
           const isFocused = state.index === index;
-          const isPreloaded = state.preloadedRouteKeys.includes(route.key);
+          const isPreloaded = !!state.preloadedRouteKeys?.includes(route.key);
 
           if (
             lazy &&


### PR DESCRIPTION
… error

I have this error with the version 7.4.5
<img width="645" height="366" alt="Capture d’écran 2025-08-09 à 12 17 49" src="https://github.com/user-attachments/assets/a492aa62-bd84-4d36-9833-24491b836083" />
<img width="558" height="63" alt="Capture d’écran 2025-08-09 à 12 19 59" src="https://github.com/user-attachments/assets/bc32ee9c-dae9-4e6d-b4b6-5725a325d676" />

**Motivation**

I update BottonTabView to prevent the application showing that error

**Test plan**

You just have to create a TabNavigator instance:
const Tab = createBottomTabNavigator<RootTabParamList>();

and then add a tab screen component
<Tab.Screen name="Home" component={Home} />
