### PR TITLE
fix: render drawer toggle button on the right side

### DIFF
--- a/packages/drawer/src/views/DrawerView.tsx
+++ b/packages/drawer/src/views/DrawerView.tsx
@@ -14,7 +14,7 @@ import {
   useTheme,
 } from '@react-navigation/native';
 import * as React from 'react';
-import { Platform, StyleSheet } from 'react-native';
+import { I18nManager, Platform, StyleSheet } from 'react-native';
 import { Drawer } from 'react-native-drawer-layout';
 import { Screen, ScreenContainer } from 'react-native-screens';
 import useLatestCallback from 'use-latest-callback';
@@ -220,6 +220,7 @@ function DrawerViewBase({
           const { lazy = true } = descriptor.options;
           const isFocused = state.index === index;
           const isPreloaded = state.preloadedRouteKeys.includes(route.key);
+          const isRTL = I18nManager.isRTL ?? document?.dir === 'rtl';
 
           if (
             lazy &&
@@ -230,7 +231,6 @@ function DrawerViewBase({
             // Don't render a lazy screen if we've never navigated to it or it wasn't preloaded
             return null;
           }
-
           const {
             freezeOnBlur,
             header = ({ options }: DrawerHeaderProps) => (
@@ -238,9 +238,18 @@ function DrawerViewBase({
                 {...options}
                 title={getHeaderTitle(options, route.name)}
                 headerLeft={
+                  ((isRTL && drawerPosition === 'right') ||
+                    (!isRTL && drawerPosition === 'left')) &&
                   options.headerLeft == null
                     ? (props) => <DrawerToggleButton {...props} />
                     : options.headerLeft
+                }
+                headerRight={
+                  ((!isRTL && drawerPosition === 'right') ||
+                    (isRTL && drawerPosition === 'left')) &&
+                  options.headerRight == null
+                    ? (props) => <DrawerToggleButton {...props} />
+                    : options.headerRight
                 }
               />
             ),

--- a/packages/drawer/src/views/DrawerView.tsx
+++ b/packages/drawer/src/views/DrawerView.tsx
@@ -14,7 +14,7 @@ import {
   useTheme,
 } from '@react-navigation/native';
 import * as React from 'react';
-import { I18nManager, Platform, StyleSheet } from 'react-native';
+import { Platform, StyleSheet } from 'react-native';
 import { Drawer } from 'react-native-drawer-layout';
 import { Screen, ScreenContainer } from 'react-native-screens';
 import useLatestCallback from 'use-latest-callback';
@@ -58,6 +58,7 @@ function DrawerViewBase({
     Platform.OS === 'ios',
 }: Props) {
   const { direction } = useLocale();
+  const isRTL = direction === 'rtl';
 
   const focusedRouteKey = state.routes[state.index].key;
   const {
@@ -220,7 +221,6 @@ function DrawerViewBase({
           const { lazy = true } = descriptor.options;
           const isFocused = state.index === index;
           const isPreloaded = state.preloadedRouteKeys.includes(route.key);
-          const isRTL = I18nManager.isRTL ?? document?.dir === 'rtl';
 
           if (
             lazy &&

--- a/packages/drawer/src/views/DrawerView.tsx
+++ b/packages/drawer/src/views/DrawerView.tsx
@@ -238,14 +238,9 @@ function DrawerViewBase({
                 {...options}
                 title={getHeaderTitle(options, route.name)}
                 headerLeft={
-                  drawerPosition === 'left' && options.headerLeft == null
+                  options.headerLeft == null
                     ? (props) => <DrawerToggleButton {...props} />
                     : options.headerLeft
-                }
-                headerRight={
-                  drawerPosition === 'right' && options.headerRight == null
-                    ? (props) => <DrawerToggleButton {...props} />
-                    : options.headerRight
                 }
               />
             ),


### PR DESCRIPTION
**Motivation**

I've noticed that drawer toggle button not rendering on the right in RTL mode as expected, while I was able to use swipe gesture from the right to open the drawer.

**Test plan**

Switched between RTL and LTR mode to make sure it renders on the proper side.. the example app is a bit buggy when switching to RTL/LTR but reloading the app would fix that.
I've tested this change on iOS, Android and web, as well as running the tests.
