### PR TITLE
fix: add missing dependency arrays to useDerivedValue hooks in drawer

### DIFF
--- a/packages/react-native-drawer-layout/src/views/Drawer.native.tsx
+++ b/packages/react-native-drawer-layout/src/views/Drawer.native.tsx
@@ -510,11 +510,7 @@ export function Drawer({
           ],
           [0, 1]
         );
-  }, [
-    drawerType,
-    layoutWidth,
-    translateX,
-  ]);
+  }, [drawerType, layoutWidth, translateX]);
 
   return (
     <GestureHandlerRootView style={[styles.container, style]}>

--- a/packages/react-native-drawer-layout/src/views/Drawer.native.tsx
+++ b/packages/react-native-drawer-layout/src/views/Drawer.native.tsx
@@ -417,7 +417,15 @@ export function Drawer({
         : minmax(translationX.get() - touchDistance, 0, drawerWidth);
 
     return translateX;
-  });
+  }, [
+    customWidth,
+    drawerPosition,
+    drawerType,
+    gestureState,
+    layoutWidth,
+    touchStartX,
+    translationX,
+  ]);
 
   const drawerAnimatedStyle = useAnimatedStyle(() => {
     const drawerWidth = getDrawerWidthNative({
@@ -502,7 +510,11 @@ export function Drawer({
           ],
           [0, 1]
         );
-  });
+  }, [
+    drawerType,
+    layoutWidth,
+    translateX,
+  ]);
 
   return (
     <GestureHandlerRootView style={[styles.container, style]}>


### PR DESCRIPTION
Fixes #12742

Added dependency arrays to translateX and progress useDerivedValue hooks to prevent worklet recompilation on every render.

Tested on iOS and Android. No breaking changes.