### PR TITLE
docs(iOS): update docs for animationDuration

### DIFF
--- a/packages/native-stack/src/types.tsx
+++ b/packages/native-stack/src/types.tsx
@@ -504,7 +504,7 @@ export type NativeStackNavigationOptions = {
   animation?: ScreenProps['stackAnimation'];
   /**
    * Changes the duration (in milliseconds) of `slide_from_bottom`, `fade_from_bottom`, `fade` and `simple_push` transitions on iOS. Defaults to `500`.
-   * The duration of `default` and `flip` transitions isn't customizable.
+   * For screens with `default` and `flip` transitions, and, as of now, for screens with `presentation` set to `modal`, `formSheet`, `pageSheet` (regardless of transition), the duration isn't customizable.
    *
    * @platform ios
    */


### PR DESCRIPTION
Docs update to match changes in react-native-screens https://github.com/software-mansion/react-native-screens/pull/3189.

**Motivation**

In RN Screens, we fixed the bug with delay when dismissing full screen modals, and updated the docs for `transitionDuration` to reflect that we don't support customizing it for modals. This PR adds matching change to `animationDuration` doc.