### PR TITLE
fix: use popTo in popToTop

### DIFF
--- a/packages/native-stack/src/navigators/createNativeStackNavigator.tsx
+++ b/packages/native-stack/src/navigators/createNativeStackNavigator.tsx
@@ -61,7 +61,6 @@ function NativeStackNavigator({
         // This is necessary to know if preventDefault() has been called
         requestAnimationFrame(() => {
           if (
-            state.index > 0 &&
             isFocused &&
             !(e as EventArg<'tabPress', true>).defaultPrevented
           ) {

--- a/packages/routers/src/StackRouter.tsx
+++ b/packages/routers/src/StackRouter.tsx
@@ -524,8 +524,8 @@ export function StackRouter(options: StackRouterOptions) {
           return router.getStateForAction(
             state,
             {
-              type: 'POP',
-              payload: { count: state.routes.length - 1 },
+              type: 'POP_TO',
+              payload: { name: router.getInitialState(options).routes[0].name },
             },
             options
           );

--- a/packages/routers/src/__tests__/StackRouter.test.tsx
+++ b/packages/routers/src/__tests__/StackRouter.test.tsx
@@ -1045,6 +1045,39 @@ test('handles pop to top action', () => {
   });
 });
 
+test('handles pop to top action with no history', () => {
+  const router = StackRouter({});
+  const options: RouterConfigOptions = {
+    routeNames: ['baz', 'bar', 'qux'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+
+  expect(
+    router.getStateForAction(
+      {
+        stale: false,
+        type: 'stack',
+        key: 'root',
+        index: 0,
+        preloadedRoutes: [],
+        routeNames: ['baz', 'bar', 'qux'],
+        routes: [{ key: 'qux', name: 'qux' }],
+      },
+      StackActions.popToTop(),
+      options
+    )
+  ).toEqual({
+    stale: false,
+    type: 'stack',
+    key: 'root',
+    index: 0,
+    preloadedRoutes: [],
+    routeNames: ['baz', 'bar', 'qux'],
+    routes: [{ key: 'baz-test', name: 'baz' }],
+  });
+});
+
 test('handles pop action with route history', () => {
   const router = StackRouter({});
   const options: RouterConfigOptions = {

--- a/packages/stack/src/navigators/createStackNavigator.tsx
+++ b/packages/stack/src/navigators/createStackNavigator.tsx
@@ -64,7 +64,6 @@ function StackNavigator({
         // This is necessary to know if preventDefault() has been called
         requestAnimationFrame(() => {
           if (
-            state.index > 0 &&
             isFocused &&
             !(e as unknown as EventArg<'tabPress', true>).defaultPrevented
           ) {


### PR DESCRIPTION
**Motivation**

[When `popToTop` was first created](https://github.com/react-navigation/react-navigation/commit/7e050044da27c3e1800dfb2c23a7fb9813037663), `popTo` didn't exist yet, so it was implemented by using `pop` with a count.

This breaks the case where someone starts navigating from a screen deep in a stack, because the top screen hasn't been put in the stack yet. This is most obvious when tapping an already-active bottom tab, which is supposed to navigate to the top screen always.

**Test plan**

New test added in `StackRouter.test.tsx`

Manually, you can create a stack navigator inside a tab navigator, hard navigate to the nested page, then tap the active tab