### PR TITLE
fix: update back button configuration logic to match new logic in `react-native-screens`

### DIFF
--- a/packages/native-stack/src/views/useHeaderConfigProps.tsx
+++ b/packages/native-stack/src/views/useHeaderConfigProps.tsx
@@ -175,16 +175,6 @@ export function useHeaderConfigProps({
       Platform.OS === 'ios' &&
       headerTransparent !== false);
 
-  const isBackButtonDisplayModeAvailable =
-    // On iOS 14+
-    Platform.OS === 'ios' &&
-    parseInt(Platform.Version, 10) >= 14 &&
-    // Doesn't have custom styling, by default System, see: https://github.com/software-mansion/react-native-screens/pull/2105#discussion_r1565222738
-    (backTitleFontFamily == null || backTitleFontFamily === 'System') &&
-    backTitleFontSize == null &&
-    // Back button menu is not disabled
-    headerBackButtonMenuEnabled !== false;
-
   const isCenterViewRenderedAndroid = headerTitleAlign === 'center';
 
   const children = (
@@ -264,12 +254,7 @@ export function useHeaderConfigProps({
     backButtonInCustomView,
     backgroundColor: headerBackgroundColor,
     backTitle: headerBackTitle,
-    backTitleVisible: isBackButtonDisplayModeAvailable
-      ? undefined
-      : headerBackButtonDisplayMode !== 'minimal',
-    backButtonDisplayMode: isBackButtonDisplayModeAvailable
-      ? headerBackButtonDisplayMode
-      : undefined,
+    backButtonDisplayMode: headerBackButtonDisplayMode,
     backTitleFontFamily,
     backTitleFontSize,
     blurEffect: headerBlurEffect,

--- a/packages/native-stack/src/views/useHeaderConfigProps.tsx
+++ b/packages/native-stack/src/views/useHeaderConfigProps.tsx
@@ -175,6 +175,16 @@ export function useHeaderConfigProps({
       Platform.OS === 'ios' &&
       headerTransparent !== false);
 
+  const isBackButtonDisplayModeAvailable =
+    // On iOS 14+
+    Platform.OS === 'ios' &&
+    parseInt(Platform.Version, 10) >= 14 &&
+    // Doesn't have custom styling, by default System, see: https://github.com/software-mansion/react-native-screens/pull/2105#discussion_r1565222738
+    (backTitleFontFamily == null || backTitleFontFamily === 'System') &&
+    backTitleFontSize == null &&
+    // Back button menu is not disabled
+    headerBackButtonMenuEnabled !== false;
+
   const isCenterViewRenderedAndroid = headerTitleAlign === 'center';
 
   const children = (
@@ -254,7 +264,11 @@ export function useHeaderConfigProps({
     backButtonInCustomView,
     backgroundColor: headerBackgroundColor,
     backTitle: headerBackTitle,
+    backTitleVisible: isBackButtonDisplayModeAvailable
+      ? undefined
+      : headerBackButtonDisplayMode !== 'minimal',
     backButtonDisplayMode: headerBackButtonDisplayMode,
+    backButtonUseModernImplementation: true,
     backTitleFontFamily,
     backTitleFontSize,
     blurEffect: headerBlurEffect,


### PR DESCRIPTION
**Motivation**

Due to changes in native back button behavior starting from iOS 26, logic handling configuration of back button item needed to change in `react-native-screens`. We managed to handle more cases correctly and simplify the API. For more details, please see [the PR in `react-native-screens`](https://github.com/software-mansion/react-native-screens/pull/3303).

**Backward compatibility**

By using `backButtonUseModernImplementation` flag, we maintain backward compatibility. If outdated version of `react-navigation` or `react-native-screens` will be used, previous implementation will be used. Passing `backButtonDisplayMode` directly in all cases will not break previous implementation. For more details, see `Compatibility with previous versions` section in [PR from `react-native-screens`](https://github.com/software-mansion/react-native-screens/pull/3303).

**Test plan**

Back button should follow configuration table posted in [the PR in `react-native-screens`](https://github.com/software-mansion/react-native-screens/pull/3303). With default configuration on iOS 26, back button should only display the chevron (without any text).
