### PR TITLE
fix(bottom-tabs): add BottomTabBarHeightContext.Provider to unstable NativeBottomTabView

### DIFF
--- a/packages/bottom-tabs/src/unstable/NativeBottomTabView.native.tsx
+++ b/packages/bottom-tabs/src/unstable/NativeBottomTabView.native.tsx
@@ -22,6 +22,7 @@ import {
   type TabsScreenItemStateAppearance,
 } from 'react-native-screens';
 
+import { BottomTabBarHeightContext } from '../utils/BottomTabBarHeightContext';
 import { NativeScreen } from './NativeScreen/NativeScreen';
 import type {
   NativeBottomTabDescriptorMap,
@@ -307,9 +308,11 @@ export function NativeBottomTabView({ state, navigation, descriptors }: Props) {
                   navigation={navigation}
                   options={options}
                 >
-                  <NavigationMetaContext.Provider value={meta}>
-                    {render()}
-                  </NavigationMetaContext.Provider>
+                  <BottomTabBarHeightContext.Provider value={0}>
+                    <NavigationMetaContext.Provider value={meta}>
+                      {render()}
+                    </NavigationMetaContext.Provider>
+                  </BottomTabBarHeightContext.Provider>
                 </ScreenWithHeader>
               </Lazy>
             </Tabs.Screen>


### PR DESCRIPTION
## Summary

- Adds the missing `BottomTabBarHeightContext.Provider` to the unstable `NativeBottomTabView` component
- Prevents `useBottomTabBarHeight()` from throwing and `BottomTabBarHeightContext` from returning `undefined` when using `@react-navigation/bottom-tabs/unstable`
- Uses `0` as a stopgap value (matching the approach on `main` branch), since `react-native-screens` does not yet expose the native tab bar height from `Tabs.Host`

## Problem

The stable `BottomTabView` wraps each screen with `BottomTabBarHeightContext.Provider`:

```tsx
// Stable BottomTabView.tsx
<BottomTabBarHeightContext.Provider value={tabBarHeight}>
  {descriptor.render()}
</BottomTabBarHeightContext.Provider>
```

The unstable `NativeBottomTabView` was missing this provider entirely, causing:
1. `useBottomTabBarHeight()` to throw: *"Couldn't find the bottom tab bar height. Are you inside a screen in Bottom Tab Navigator?"*
2. `BottomTabBarHeightContext` to return `undefined`

## Fix

Added `BottomTabBarHeightContext.Provider` wrapping the rendered screen content in `NativeBottomTabView.native.tsx`. The value is set to `0` as the native tab bar height is not yet available from `react-native-screens`.

Once `react-native-screens` adds support for exposing the native `Tabs.Host` tab bar height (via `onTabBarLayout` or similar), the hardcoded `0` should be replaced with the actual value.

## Test plan

- [x] `useBottomTabBarHeight()` no longer throws when used inside a screen rendered by the unstable native bottom tab navigator
- [x] `BottomTabBarHeightContext` returns `0` instead of `undefined`
- [x] Verify on Android with transparent native tab bar
- [x] Verify on iOS with Liquid Glass tab bar

Fixes #12958