### PR TITLE
fix(types): enable exactOptionalPropertyTypes across the monorepo

### DIFF
--- a/example/__typechecks__/static.check.tsx
+++ b/example/__typechecks__/static.check.tsx
@@ -1698,6 +1698,7 @@ createStackScreen({
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const ProfileComponent = createComponentForStaticNavigation(Stack, 'Profile');
 
+  // @ts-expect-error — expect-type#128: toExtend incompatible with exactOptionalPropertyTypes
   expectTypeOf<React.ComponentProps<typeof ProfileComponent>>().toExtend<{
     initialRouteName?: 'Profile' | 'Settings';
   }>();

--- a/example/e2e/playwright.config.ts
+++ b/example/e2e/playwright.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
+  ...(process.env.CI ? { workers: 1 } : {}),
   projects: [
     {
       name: 'Chromium',

--- a/example/src/Screens/ComponentsHeaders.tsx
+++ b/example/src/Screens/ComponentsHeaders.tsx
@@ -16,7 +16,11 @@ export function ComponentsHeaders(_: StaticScreenProps<{}>) {
   const { colors } = useTheme();
   const insets = useSafeAreaInsets();
 
-  const headerRight = ({ tintColor }: { tintColor?: ColorValue }) => (
+  const headerRight = ({
+    tintColor,
+  }: {
+    tintColor?: ColorValue | undefined;
+  }) => (
     <>
       <HeaderButton>
         <MaterialCommunityIcons

--- a/example/src/Screens/ComponentsSFSymbols.tsx
+++ b/example/src/Screens/ComponentsSFSymbols.tsx
@@ -215,7 +215,7 @@ const SFSymbolRow = React.memo(function SFSymbolRow({
   scale: SFSymbolScale;
   mode: SFSymbolMode;
   colors?: SFSymbolProps['colors'];
-  animation?: SFSymbolAnimationEffect;
+  animation?: SFSymbolAnimationEffect | undefined;
 }) {
   const { colors } = useTheme();
 

--- a/packages/bottom-tabs/src/views/BottomTabViewNativeImpl.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabViewNativeImpl.tsx
@@ -241,6 +241,7 @@ export function BottomTabViewNative({
       {tabBarPosition === 'top' || tabBarPosition === 'left'
         ? tabBarElement
         : null}
+      {/* @ts-expect-error — react-native-bottom-tabs types need | undefined for exactOptionalPropertyTypes */}
       <Tabs.Host
         tabBarHidden={hasCustomTabBar || shouldHideTabBar}
         bottomAccessory={
@@ -414,6 +415,7 @@ export function BottomTabViewNative({
               systemItem={tabBarSystemItem}
               isFocused={isFocused}
               title={tabTitle}
+              // @ts-expect-error — react-native-bottom-tabs types need | undefined for exactOptionalPropertyTypes
               scrollEdgeEffects={{
                 top:
                   scrollEdgeEffects?.top === 'auto'
@@ -432,6 +434,7 @@ export function BottomTabViewNative({
                     ? 'automatic'
                     : scrollEdgeEffects?.right,
               }}
+              // @ts-expect-error — react-native-bottom-tabs types need | undefined for exactOptionalPropertyTypes
               scrollEdgeAppearance={{
                 tabBarBackgroundColor,
                 tabBarShadowColor,
@@ -446,6 +449,7 @@ export function BottomTabViewNative({
                   normal: tabItemAppearance,
                 },
               }}
+              // @ts-expect-error — react-native-bottom-tabs types need | undefined for exactOptionalPropertyTypes
               standardAppearance={{
                 tabBarBackgroundColor,
                 tabBarShadowColor,
@@ -550,12 +554,14 @@ function AnimatedScreenContent({
 function getPlatformIcon(icon: BottomTabIcon): PlatformIcon {
   switch (icon.type) {
     case 'sfSymbol':
+      // @ts-expect-error — react-native-bottom-tabs types need | undefined for exactOptionalPropertyTypes
       return {
         ios: icon,
         android: undefined,
         shared: undefined,
       };
     case 'materialSymbol':
+      // @ts-expect-error — react-native-bottom-tabs types need | undefined for exactOptionalPropertyTypes
       return {
         ios: undefined,
         android: {
@@ -570,6 +576,7 @@ function getPlatformIcon(icon: BottomTabIcon): PlatformIcon {
         shared: undefined,
       };
     case 'image':
+      // @ts-expect-error — react-native-bottom-tabs types need | undefined for exactOptionalPropertyTypes
       return {
         ios:
           icon.tinted === false

--- a/packages/native-stack/src/views/NativeStackView.native.tsx
+++ b/packages/native-stack/src/views/NativeStackView.native.tsx
@@ -340,6 +340,7 @@ const SceneView = ({
 
   return (
     <NavigationProvider navigation={navigation} route={route}>
+      {/* @ts-expect-error — react-native-screens types need | undefined for exactOptionalPropertyTypes */}
       <ScreenStackItem
         key={route.key}
         screenId={route.key}

--- a/packages/native-stack/src/views/useHeaderConfigProps.tsx
+++ b/packages/native-stack/src/views/useHeaderConfigProps.tsx
@@ -96,6 +96,7 @@ const processBarButtonItems = (
 
           processedItem = {
             ...processedItemCommon,
+            // @ts-expect-error — react-native-screens types need | undefined for exactOptionalPropertyTypes
             menu: {
               ...processedItemCommon.menu,
               singleSelection: !multiselectable,
@@ -107,6 +108,7 @@ const processBarButtonItems = (
           processedItemCommon.type === 'button' &&
           item.type === 'button'
         ) {
+          // @ts-expect-error — react-native-screens types need | undefined for exactOptionalPropertyTypes
           processedItem = processedItemCommon;
         } else {
           throw new Error(
@@ -124,6 +126,7 @@ const processBarButtonItems = (
             badge: {
               ...badge,
               value: String(badge.value),
+              // @ts-expect-error — react-native-screens types need | undefined for exactOptionalPropertyTypes
               style: {
                 backgroundColor: badgeBackgroundColor,
                 color: badgeTextColor,
@@ -165,6 +168,7 @@ const getMenuItem = (
     const { label, icon, inline, layout, items, multiselectable, ...rest } =
       item;
 
+    // @ts-expect-error — react-native-screens types need | undefined for exactOptionalPropertyTypes
     return {
       ...rest,
       icon: transformIcon(icon),
@@ -178,6 +182,7 @@ const getMenuItem = (
 
   const { label, icon, description, ...rest } = item;
 
+  // @ts-expect-error — react-native-screens types need | undefined for exactOptionalPropertyTypes
   return {
     ...rest,
     icon: transformIcon(icon),
@@ -404,6 +409,7 @@ export function useHeaderConfigProps({
             leftItems.map((item, index) => {
               if (item.type === 'custom') {
                 return (
+                  // @ts-expect-error — react-native-screens types need | undefined for exactOptionalPropertyTypes
                   <ScreenStackHeaderLeftView
                     // eslint-disable-next-line @eslint-react/no-array-index-key
                     key={index}
@@ -478,6 +484,7 @@ export function useHeaderConfigProps({
         rightItems.map((item, index) => {
           if (item.type === 'custom') {
             return (
+              // @ts-expect-error — react-native-screens types need | undefined for exactOptionalPropertyTypes
               <ScreenStackHeaderRightView
                 // eslint-disable-next-line @eslint-react/no-array-index-key
                 key={index}
@@ -499,6 +506,7 @@ export function useHeaderConfigProps({
       ) : null}
       {hasHeaderSearchBar ? (
         <ScreenStackHeaderSearchBarView>
+          {/* @ts-expect-error — react-native-screens types need | undefined for exactOptionalPropertyTypes */}
           <SearchBar
             {...headerSearchBarOptions}
             onChangeText={headerSearchBarOptions.onChange}
@@ -508,6 +516,7 @@ export function useHeaderConfigProps({
     </>
   );
 
+  // @ts-expect-error — react-native-screens types need | undefined for exactOptionalPropertyTypes
   return {
     backButtonInCustomView,
     backgroundColor: headerBackgroundColor,

--- a/packages/native/src/native/MaterialSymbol.android.tsx
+++ b/packages/native/src/native/MaterialSymbol.android.tsx
@@ -23,6 +23,7 @@ export function MaterialSymbol({
   ...rest
 }: MaterialSymbolProps): React.ReactElement {
   return (
+    // @ts-expect-error — NativeComponent codegen types lack | undefined for exactOptionalPropertyTypes
     <MaterialSymbolViewNativeComponent
       name={name}
       weight={typeof weight === 'string' ? FONT_WEIGHTS[weight] : (weight ?? 0)}

--- a/packages/native/src/native/SFSymbol.ios.tsx
+++ b/packages/native/src/native/SFSymbol.ios.tsx
@@ -22,6 +22,7 @@ export function SFSymbol({
     typeof animation === 'string' ? { effect: animation } : animation;
 
   return (
+    // @ts-expect-error — NativeComponent codegen types lack | undefined for exactOptionalPropertyTypes
     <SFSymbolViewNativeComponent
       name={name}
       size={size}

--- a/packages/react-native-drawer-layout/src/views/Drawer.native.tsx
+++ b/packages/react-native-drawer-layout/src/views/Drawer.native.tsx
@@ -233,6 +233,7 @@ export function Drawer({
       translationX.set(
         withSpring(
           toValue,
+          // @ts-expect-error — react-native-reanimated SpringConfig.velocity lacks | undefined for exactOptionalPropertyTypes
           {
             velocity,
             stiffness: 1000,

--- a/packages/stack/src/views/Stack/Card.tsx
+++ b/packages/stack/src/views/Stack/Card.tsx
@@ -528,6 +528,7 @@ function Card({
       <Animated.View
         style={[styles.container, containerStyle, customContainerStyle]}
       >
+        {/* @ts-expect-error — react-native-gesture-handler types need | undefined for exactOptionalPropertyTypes */}
         <PanGestureHandler
           enabled={layout.width !== 0 && gestureEnabled}
           onGestureEvent={onGestureEvent}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,7 @@
     "resolvePackageJsonImports": false,
     "skipLibCheck": true,
     "strict": true,
+    "exactOptionalPropertyTypes": true,
     "target": "esnext",
     "verbatimModuleSyntax": true
   },


### PR DESCRIPTION
## Motivation

PR 4 of 4 in the stacked PR series to enable `exactOptionalPropertyTypes` in the react-navigation monorepo (see #12990 for context and discussion with @satya164).

PRs 1-3 added `| undefined` to all optional property type definitions in react-navigation's own packages (64 files, ~611 properties). This final PR handles the remaining 30 errors — all outside our type definitions — and enables the flag in `tsconfig.json`.

### Error reduction

| Milestone | Errors remaining |
|---|---|
| Baseline (main) | 311 |
| After PR 1 (routers) | ~179 |
| After PR 2 (core + native + elements) | ~78 |
| After PR 3 (navigator packages) | 30 |
| **After this PR (enable flag)** | **0** |

### What changed

**1. External library `@ts-expect-error` (21 call sites)**

These errors occur where react-navigation passes `T | undefined` values to external library components whose types declare `prop?: T` (without `| undefined`). The external libraries need their own `exactOptionalPropertyTypes` fixes — `@ts-expect-error` is the correct bridge until then.

| Library | Files | Errors |
|---|---|---|
| react-native-screens | `NativeStackView.native.tsx`, `useHeaderConfigProps.tsx` | 10 |
| react-native-bottom-tabs | `BottomTabViewNativeImpl.tsx` | 7 |
| NativeComponent codegen | `SFSymbol.ios.tsx`, `MaterialSymbol.android.tsx` | 2 |
| react-native-reanimated | `Drawer.native.tsx` | 1 |
| react-native-gesture-handler | `Card.tsx` | 1 |

**2. Example app type fixes (8 errors)**

- `ComponentsHeaders.tsx` (6) — function parameter contravariance: `{ tintColor?: ColorValue }` → `{ tintColor?: ColorValue | undefined }`
- `ComponentsSFSymbols.tsx` (1) — inline prop type missing `| undefined`
- `playwright.config.ts` (1) — conditional spread for `workers` (Playwright types don't accept `undefined`)

**3. Type assertion test (1 error)**

- `static.check.tsx` — known `expect-type` library bug ([expect-type#128](https://github.com/mmkal/expect-type/issues/128)) where `toExtend` is incompatible with `exactOptionalPropertyTypes`

**4. Enable the flag**

Added `"exactOptionalPropertyTypes": true` to `tsconfig.json`.

## Test plan

- [x] `yarn typecheck` — passes (0 errors)
- [x] `yarn lint` — passes (0 errors)
- [x] `yarn test --maxWorkers=2` — 47 suites, 613 tests, 134 snapshots pass
- [x] `yarn lerna run prepack` — all 12 packages build successfully
- [x] `yarn check-dependency-version-consistency` — passes
- [x] `yarn example expo export --platform all` — Metro bundles web/iOS/Android successfully
- [x] `yarn example web build` — Vite builds successfully
- [x] Post-build `yarn typecheck` — passes
- [x] All lefthook pre-commit hooks pass (types, lint, test, commitlint)
