### PR TITLE
feat(bottom-tabs): expose native tab specialEffects

### DIFF
--- a/packages/bottom-tabs/src/types.tsx
+++ b/packages/bottom-tabs/src/types.tsx
@@ -443,6 +443,20 @@ type BottomTabNativeOptions = {
    * @platform ios
    */
   overrideScrollViewContentInsetAdjustmentBehavior?: boolean;
+
+  /**
+   * Native tab special effects forwarded to `react-native-screens`.
+   *
+   * Only supported with `native` implementation.
+   *
+   * @platform ios, android
+   */
+  specialEffects?: {
+    repeatedTabSelection?: {
+      popToRoot?: boolean;
+      scrollToTop?: boolean;
+    };
+  };
 };
 
 export type BottomTabNavigationOptions = {

--- a/packages/bottom-tabs/src/views/BottomTabViewNativeImpl.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabViewNativeImpl.tsx
@@ -460,12 +460,14 @@ export function BottomTabViewNative({
                   normal: tabItemAppearance,
                 },
               }}
-              specialEffects={{
-                repeatedTabSelection: {
-                  popToRoot: true,
-                  scrollToTop: true,
-                },
-              }}
+              specialEffects={
+                options.specialEffects ?? {
+                  repeatedTabSelection: {
+                    popToRoot: true,
+                    scrollToTop: true,
+                  },
+                }
+              }
               overrideScrollViewContentInsetAdjustmentBehavior={
                 overrideScrollViewContentInsetAdjustmentBehavior
               }


### PR DESCRIPTION
**Motivation**

`react-native-screens` already supports per-screen repeated tab selection behavior through `Tabs.Screen.specialEffects`, but React Navigation's native bottom-tabs implementation currently hardcodes:

```tsx
specialEffects={{
  repeatedTabSelection: {
    popToRoot: true,
    scrollToTop: true,
  },
}}
```

That means apps using native bottom tabs cannot opt out of forced `popToRoot + scrollToTop` when reselecting the active tab, even though the underlying native API already supports doing so.

In our case, this caused a real bug with a nested dashboard stack:
1. navigate to a child screen inside the dashboard tab
2. switch to another tab
3. switch back to the dashboard tab
4. tap the active dashboard tab again

The native tab would return to the root dashboard route, but the restored root content could become non-interactive. The app-level workaround was to patch `@react-navigation/bottom-tabs` locally so it would forward `specialEffects` instead of hardcoding the repeated tab selection behavior.

This PR makes that behavior configurable in a backward-compatible way by:
- adding an optional `specialEffects` field to `BottomTabNavigationOptions`
- passing `options.specialEffects` through to `Tabs.Screen`
- preserving the current `popToRoot: true` and `scrollToTop: true` defaults when `specialEffects` is not provided

Example:

```tsx
<BottomTab.Screen
  name="DashboardTab"
  component={DashboardStack}
  options={{
    specialEffects: {
      repeatedTabSelection: {
        popToRoot: false,
        scrollToTop: false,
      },
    },
  }}
/>
```

This is a minimal change in `packages/bottom-tabs/src/types.tsx` and `packages/bottom-tabs/src/views/BottomTabViewNativeImpl.tsx`, and it only exposes capability that already exists lower in the stack.

**Test plan**

1. Create a native bottom tab navigator with a nested stack tab.
2. Configure one tab with:
   - `specialEffects.repeatedTabSelection.popToRoot = false`
   - `specialEffects.repeatedTabSelection.scrollToTop = false`
3. Reselect the active tab and verify that it no longer forces a root reset.
4. Verify that tabs without `specialEffects` still keep the current `popToRoot + scrollToTop` behavior.
5. Verify TypeScript accepts the new option on `BottomTab.Screen` options.
