### PR TITLE
fix(tab-view): reset Android offset when pager becomes idle

### DIFF
--- a/packages/react-native-tab-view/src/PagerViewAdapter.native.tsx
+++ b/packages/react-native-tab-view/src/PagerViewAdapter.native.tsx
@@ -90,6 +90,10 @@ export function PagerViewAdapter({
 
     switch (pageScrollState) {
       case 'idle':
+        if (Platform.OS === 'android') {
+          // Work around pager offset drift that can leave indicator in-between tabs.
+          offset.setValue(0);
+        }
         onSwipeEnd?.();
         return;
       case 'dragging': {


### PR DESCRIPTION
# react-native-tab-view

## What does this fix?
- Reset the tab-view pager `offset` to `0` when `pageScrollState` becomes `idle` on Android.
- Prevent offset drift that can leave the indicator visually between tabs after swipe completion.
- Keep scope limited to `PagerViewAdapter.native.tsx`; iOS and web behavior remain unchanged.

**Before** (glitches start at 0:14)

https://github.com/user-attachments/assets/a7cdbf2f-11b9-4684-96d2-48db28239fac



**After**

https://github.com/user-attachments/assets/20ad9d6d-b345-4a8b-9d93-6529118dc6c4

## Reproduction
* [Repo](https://github.com/christophby/rn-true-sheet-repro)
* run `npm i`
* `npm run android`
* Navigate to "Profile" Tab. -> You should see the issue
* Run `npx patch-package`
* Reload app
* Issue should be gone

