### PR TITLE
fix: disable pointer events on inactive bottom tab screens

### DIFF
--- a/packages/bottom-tabs/src/views/BottomTabViewCustom.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabViewCustom.tsx
@@ -322,7 +322,11 @@ export function BottomTabViewCustom({
               key={route.key}
               mode={isFocused ? 'normal' : isActive ? 'inert' : 'paused'}
               visible={isFocused || isAnimatingRoute}
-              style={{ ...StyleSheet.absoluteFill, zIndex: isFocused ? 0 : -1 }}
+              style={{
+                ...StyleSheet.absoluteFill,
+                zIndex: isFocused ? 0 : -1,
+                pointerEvents: isFocused ? 'auto' : 'none',
+              }}
             >
               {content}
             </ActivityView>


### PR DESCRIPTION
## Summary

This fixes a accessibility/usability bug where inactive bottom tab screens remained fully interactive despite being visually behind the focused screen (`zIndex: -1`).

### The Problem

When `detachInactiveScreens={false}`, inactive screens remain mounted in the DOM but are hidden behind the active screen via `zIndex: -1`. However, they still capture pointer, wheel, and touch events because `zIndex` only controls visual stacking, not event handling. On web, this breaks scrolling and other interactions — the inactive screen's scroll containers intercept events before they reach the focused screen.

### The Fix

Added `pointerEvents: isFocused ? 'auto' : 'none'` to the `ActivityView` style in `BottomTabViewCustom.tsx`:

```tsx
style={{
  ...StyleSheet.absoluteFill,
  zIndex: isFocused ? 0 : -1,
  pointerEvents: isFocused ? 'auto' : 'none',
}}
```

This is the standard React Native way to disable interaction on a view tree. It has no visual side effects and matches user intent — inactive screens shouldn't receive input.

### Notes

- When `detachInactiveScreens={true}` (the default), inactive screens already use `display: none` or are fully detached, so `pointerEvents` is redundant but harmless. It only meaningfully affects the `false` case where screens remain mounted and visible in the DOM.
- Precedent exists: `@react-navigation/elements`'s `Screen` component already sets `aria-hidden={!focused}` on inactive screens. Adding `pointerEvents` is the logical complement for actual event blocking.
- TypeScript check passes. No CodeQL alerts.