### PR TITLE
refactor: dark, colors and fonts optional in `NativeTheme`

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import { LogBox, Platform } from 'react-native';
 import { configure } from 'react-native-showtime';
 
-import { App } from './src/index';
+import { UserInterfaceBug } from './src/userinterface-bug';
 
 if (Platform.OS === 'ios') {
   configure({
@@ -23,6 +23,6 @@ LogBox.ignoreLogs([
 
 registerRootComponent(() => (
   <React.StrictMode>
-    <App />
+    <UserInterfaceBug />
   </React.StrictMode>
 ));

--- a/example/app.json
+++ b/example/app.json
@@ -11,6 +11,7 @@
       "android",
       "web"
     ],
+    "userInterfaceStyle": "automatic",
     "scheme": "rne",
     "android": {
       "package": "org.reactnavigation.playground",

--- a/example/src/Screens/ActivityModes.tsx
+++ b/example/src/Screens/ActivityModes.tsx
@@ -61,10 +61,12 @@ function Content() {
     <View
       style={[
         styles.clock,
-        { borderColor: colors.border, backgroundColor: colors.card },
+        { borderColor: colors?.border, backgroundColor: colors?.card },
       ]}
     >
-      <Text style={[styles.time, { color: colors.text }]}>{formattedTime}</Text>
+      <Text style={[styles.time, { color: colors?.text }]}>
+        {formattedTime}
+      </Text>
       <View style={styles.buttons}>
         <PlatformPressable onPress={() => setOffset((o) => --o)}>
           <Text style={styles.button}>↓</Text>
@@ -77,7 +79,7 @@ function Content() {
         style={[
           styles.dot,
           {
-            backgroundColor: colors.text,
+            backgroundColor: colors?.text,
             transform: [
               {
                 translateX: dotAnim.interpolate({

--- a/example/src/Screens/AuthFlow.tsx
+++ b/example/src/Screens/AuthFlow.tsx
@@ -39,7 +39,7 @@ const SplashScreen = () => {
 
   return (
     <View style={styles.content}>
-      <ActivityIndicator color={colors.primary} />
+      <ActivityIndicator color={colors?.primary} />
     </View>
   );
 };
@@ -55,7 +55,7 @@ const SignInScreen = () => {
         placeholder="Username"
         style={[
           styles.input,
-          { backgroundColor: colors.card, color: colors.text },
+          { backgroundColor: colors?.card, color: colors?.text },
         ]}
       />
       <TextInput
@@ -63,7 +63,7 @@ const SignInScreen = () => {
         secureTextEntry
         style={[
           styles.input,
-          { backgroundColor: colors.card, color: colors.text },
+          { backgroundColor: colors?.card, color: colors?.text },
         ]}
       />
       <Button variant="filled" onPress={signIn} style={styles.button}>

--- a/example/src/Screens/BottomTabs.tsx
+++ b/example/src/Screens/BottomTabs.tsx
@@ -222,7 +222,7 @@ export function BottomTabs(
               color,
               size,
             }: {
-              color: ColorValue;
+              color: ColorValue | undefined;
               size: number;
             }) => (
               <MaterialCommunityIcons

--- a/example/src/Screens/ComponentsHeaders.tsx
+++ b/example/src/Screens/ComponentsHeaders.tsx
@@ -40,7 +40,7 @@ export function ComponentsHeaders(_: StaticScreenProps<{}>) {
       contentContainerStyle={[
         styles.content,
         {
-          backgroundColor: colors.background,
+          backgroundColor: colors?.background,
           paddingTop: insets.top + SPACING,
           paddingLeft: insets.left + SPACING,
           paddingRight: insets.right + SPACING,

--- a/example/src/Screens/ComponentsMaterialSymbols.tsx
+++ b/example/src/Screens/ComponentsMaterialSymbols.tsx
@@ -63,8 +63,8 @@ export function ComponentsMaterialSymbols(_: StaticScreenProps<{}>) {
 
   if (Platform.OS !== 'android') {
     return (
-      <View style={[styles.centered, { backgroundColor: colors.background }]}>
-        <Text style={{ color: colors.text }}>
+      <View style={[styles.centered, { backgroundColor: colors?.background }]}>
+        <Text style={{ color: colors?.text }}>
           MaterialSymbol is only available on Android
         </Text>
       </View>
@@ -80,8 +80,8 @@ export function ComponentsMaterialSymbols(_: StaticScreenProps<{}>) {
           style={[
             styles.header,
             {
-              backgroundColor: colors.background,
-              borderBottomColor: colors.border,
+              backgroundColor: colors?.background,
+              borderBottomColor: colors?.border,
             },
           ]}
         >
@@ -100,7 +100,7 @@ export function ComponentsMaterialSymbols(_: StaticScreenProps<{}>) {
       )}
       keyExtractor={(item) => item[0]}
       contentContainerStyle={{
-        backgroundColor: colors.background,
+        backgroundColor: colors?.background,
         paddingLeft: insets.left,
         paddingRight: insets.right,
         paddingBottom: insets.bottom,
@@ -129,20 +129,20 @@ const MaterialSymbolRow = React.memo(function MaterialSymbolRow({
   return (
     <View style={styles.row}>
       {items.map((item) => (
-        <View key={item} style={[styles.item, { borderColor: colors.border }]}>
+        <View key={item} style={[styles.item, { borderColor: colors?.border }]}>
           {image ? (
             <Image
               source={MaterialSymbol.getImageSource({
                 name: item,
                 size: ICON_SIZE,
-                color: colors.text,
+                color: colors?.text,
               })}
             />
           ) : (
             <MaterialSymbol name={item} size={ICON_SIZE} />
           )}
           <Text
-            style={[styles.iconName, { color: colors.text }]}
+            style={[styles.iconName, { color: colors?.text }]}
             numberOfLines={1}
           >
             {item}

--- a/example/src/Screens/ComponentsSFSymbols.tsx
+++ b/example/src/Screens/ComponentsSFSymbols.tsx
@@ -106,16 +106,16 @@ export function ComponentsSFSymbols(_: StaticScreenProps<{}>) {
   const symbolColors =
     mode === 'palette'
       ? {
-          primary: colors.primary,
-          secondary: colors.notification,
-          tertiary: colors.text,
+          primary: colors?.primary,
+          secondary: colors?.notification,
+          tertiary: colors?.text,
         }
       : undefined;
 
   if (Platform.OS !== 'ios') {
     return (
-      <View style={[styles.centered, { backgroundColor: colors.background }]}>
-        <Text style={{ color: colors.text }}>
+      <View style={[styles.centered, { backgroundColor: colors?.background }]}>
+        <Text style={{ color: colors?.text }}>
           SFSymbol is only available on iOS
         </Text>
       </View>
@@ -131,8 +131,8 @@ export function ComponentsSFSymbols(_: StaticScreenProps<{}>) {
           style={[
             styles.header,
             {
-              backgroundColor: colors.background,
-              borderBottomColor: colors.border,
+              backgroundColor: colors?.background,
+              borderBottomColor: colors?.border,
             },
           ]}
         >
@@ -140,11 +140,11 @@ export function ComponentsSFSymbols(_: StaticScreenProps<{}>) {
             onPress={() => setExpanded((v) => !v)}
             style={styles.headerToggle}
           >
-            <Text style={{ color: colors.text }}>Customization</Text>
+            <Text style={{ color: colors?.text }}>Customization</Text>
             <SFSymbol
               name={expanded ? 'chevron.up' : 'chevron.down'}
               size={14}
-              color={colors.text}
+              color={colors?.text}
             />
           </Pressable>
           {expanded && (
@@ -185,7 +185,7 @@ export function ComponentsSFSymbols(_: StaticScreenProps<{}>) {
       )}
       keyExtractor={(item) => item[0]}
       contentContainerStyle={{
-        backgroundColor: colors.background,
+        backgroundColor: colors?.background,
         paddingLeft: insets.left,
         paddingRight: insets.right,
         paddingBottom: insets.bottom,
@@ -222,7 +222,7 @@ const SFSymbolRow = React.memo(function SFSymbolRow({
   return (
     <View style={styles.row}>
       {items.map((item) => (
-        <View key={item} style={[styles.item, { borderColor: colors.border }]}>
+        <View key={item} style={[styles.item, { borderColor: colors?.border }]}>
           <SFSymbol
             name={item}
             size={ICON_SIZE}
@@ -232,7 +232,10 @@ const SFSymbolRow = React.memo(function SFSymbolRow({
             colors={symbolColors}
             animation={animation}
           />
-          <Text style={[styles.name, { color: colors.text }]} numberOfLines={1}>
+          <Text
+            style={[styles.name, { color: colors?.text }]}
+            numberOfLines={1}
+          >
             {item}
           </Text>
         </View>

--- a/example/src/Screens/LibrariesDrawerLayout.tsx
+++ b/example/src/Screens/LibrariesDrawerLayout.tsx
@@ -79,7 +79,7 @@ export function LibrariesDrawerLayout(_: StaticScreenProps<Params>) {
         );
       }}
     >
-      <View style={[styles.container, { backgroundColor: colors.background }]}>
+      <View style={[styles.container, { backgroundColor: colors?.background }]}>
         <DrawerProgress />
         <View style={styles.buttons}>
           <Button

--- a/example/src/Screens/NativeStack.tsx
+++ b/example/src/Screens/NativeStack.tsx
@@ -195,8 +195,8 @@ const HeaderHeightView = ({ hasOffset }: { hasOffset: boolean }) => {
       style={[
         styles.headerHeight,
         {
-          backgroundColor: colors.card,
-          borderColor: colors.border,
+          backgroundColor: colors?.card,
+          borderColor: colors?.border,
         },
         hasOffset && {
           transform: [{ translateY: animatedHeaderHeight }],
@@ -462,7 +462,7 @@ export function NativeStack(
           headerStyle: {
             backgroundColor: Platform.select({
               // Add a background color since Android doesn't support blur effect
-              android: colors.card,
+              android: colors?.card,
               default: 'transparent',
             }),
           },

--- a/example/src/Screens/NativeStackFormSheet.tsx
+++ b/example/src/Screens/NativeStackFormSheet.tsx
@@ -170,8 +170,8 @@ const UnsupportedScreen = () => {
   const { colors } = useTheme();
 
   return (
-    <View style={[styles.centered, { backgroundColor: colors.background }]}>
-      <Text style={{ color: colors.text }}>
+    <View style={[styles.centered, { backgroundColor: colors?.background }]}>
+      <Text style={{ color: colors?.text }}>
         Form Sheet presentation is only available on Android and iOS
       </Text>
     </View>

--- a/example/src/Screens/NativeStackPreventRemove.tsx
+++ b/example/src/Screens/NativeStackPreventRemove.tsx
@@ -87,7 +87,7 @@ const InputScreen = () => {
         autoFocus
         style={[
           styles.input,
-          { backgroundColor: colors.card, color: colors.text },
+          { backgroundColor: colors?.card, color: colors?.text },
         ]}
         value={text}
         placeholder="Type something…"

--- a/example/src/Screens/NavigatorLayout.tsx
+++ b/example/src/Screens/NavigatorLayout.tsx
@@ -122,8 +122,8 @@ function BreadcrumbLayout({
       <ScrollView
         horizontal
         style={{
-          backgroundColor: colors.card,
-          borderBottomColor: colors.border,
+          backgroundColor: colors?.card,
+          borderBottomColor: colors?.border,
           borderBottomWidth: StyleSheet.hairlineWidth,
           maxHeight: defaultHeaderHeight,
         }}
@@ -143,12 +143,12 @@ function BreadcrumbLayout({
                   });
                 }}
               >
-                <Text style={[styles.title, { color: colors.text }]}>
+                <Text style={[styles.title, { color: colors?.text }]}>
                   {getHeaderTitle(descriptors[route.key].options, route.name)}
                 </Text>
               </Pressable>
               {self.length - 1 !== i ? (
-                <Text style={[styles.arrow, { color: colors.text }]}>❯</Text>
+                <Text style={[styles.arrow, { color: colors?.text }]}>❯</Text>
               ) : null}
             </React.Fragment>
           );

--- a/example/src/Screens/StackPreventRemove.tsx
+++ b/example/src/Screens/StackPreventRemove.tsx
@@ -94,7 +94,7 @@ const InputScreen = () => {
         autoFocus
         style={[
           styles.input,
-          { backgroundColor: colors.card, color: colors.text },
+          { backgroundColor: colors?.card, color: colors?.text },
         ]}
         value={text}
         placeholder="Type something…"

--- a/example/src/Screens/StackTransparentModal.tsx
+++ b/example/src/Screens/StackTransparentModal.tsx
@@ -82,7 +82,7 @@ const DialogScreen = () => {
         style={[
           styles.dialog,
           {
-            backgroundColor: colors.card,
+            backgroundColor: colors?.card,
             transform: [
               {
                 scale: current.progress.interpolate({

--- a/example/src/Screens/StaticConfig.tsx
+++ b/example/src/Screens/StaticConfig.tsx
@@ -65,7 +65,7 @@ const HomeTabs = createBottomTabNavigator({
     headerLeft: (props) => (
       <HeaderBackButton {...props} onPress={navigation.goBack} />
     ),
-    tabBarActiveTintColor: theme.colors.notification,
+    tabBarActiveTintColor: theme.colors?.notification,
   }),
   screens: {
     Albums: {

--- a/example/src/Shared/Article.tsx
+++ b/example/src/Shared/Article.tsx
@@ -24,7 +24,7 @@ const Heading = ({
   const { colors } = useTheme();
 
   return (
-    <Text style={[styles.heading, { color: colors.text }, style]} {...rest} />
+    <Text style={[styles.heading, { color: colors?.text }, style]} {...rest} />
   );
 };
 
@@ -35,7 +35,10 @@ const Paragraph = ({
   const { colors } = useTheme();
 
   return (
-    <Text style={[styles.paragraph, { color: colors.text }, style]} {...rest} />
+    <Text
+      style={[styles.paragraph, { color: colors?.text }, style]}
+      {...rest}
+    />
   );
 };
 
@@ -57,7 +60,7 @@ export function Article({
   return (
     <ScrollView
       ref={ref}
-      style={{ backgroundColor: colors.card }}
+      style={{ backgroundColor: colors?.card }}
       contentContainerStyle={styles.content}
       {...rest}
     >
@@ -67,10 +70,12 @@ export function Article({
           source={require('../../assets/misc/avatar-1.png')}
         />
         <View style={styles.meta}>
-          <Text style={[styles.name, { color: colors.text }]}>
+          <Text style={[styles.name, { color: colors?.text }]}>
             {author.name}
           </Text>
-          <Text style={[styles.timestamp, { color: colors.text }]}>{date}</Text>
+          <Text style={[styles.timestamp, { color: colors?.text }]}>
+            {date}
+          </Text>
         </View>
       </View>
       <Heading>What is Lorem Ipsum?</Heading>

--- a/example/src/Shared/Chat.tsx
+++ b/example/src/Shared/Chat.tsx
@@ -57,10 +57,10 @@ export function Chat({
               <View
                 style={[
                   styles.bubble,
-                  { backgroundColor: odd ? colors.primary : colors.card },
+                  { backgroundColor: odd ? colors?.primary : colors?.card },
                 ]}
               >
-                <Text style={{ color: odd ? 'white' : colors.text }}>
+                <Text style={{ color: odd ? 'white' : colors?.text }}>
                   {text}
                 </Text>
               </View>
@@ -71,9 +71,11 @@ export function Chat({
       <TextInput
         style={[
           styles.input,
-          { backgroundColor: colors.card, color: colors.text },
+          { backgroundColor: colors?.card, color: colors?.text },
         ]}
-        placeholderTextColor={Color(colors.text)?.alpha(0.5).string()}
+        placeholderTextColor={Color(colors?.text ?? 'transparent')
+          ?.alpha(0.5)
+          .string()}
         placeholder="Write a message"
         underlineColorAndroid="transparent"
       />

--- a/example/src/Shared/Contacts.tsx
+++ b/example/src/Shared/Contacts.tsx
@@ -67,7 +67,7 @@ const ContactItem = React.memo(
     const { colors } = useTheme();
 
     return (
-      <View style={[styles.item, { backgroundColor: colors.card }]}>
+      <View style={[styles.item, { backgroundColor: colors?.card }]}>
         <View style={styles.avatar}>
           <Text style={styles.letter}>
             {item.name.slice(0, 1).toUpperCase()}
@@ -88,7 +88,7 @@ const ItemSeparator = () => {
   const { colors } = useTheme();
 
   return (
-    <View style={[styles.separator, { backgroundColor: colors.border }]} />
+    <View style={[styles.separator, { backgroundColor: colors?.border }]} />
   );
 };
 

--- a/example/src/Shared/Divider.tsx
+++ b/example/src/Shared/Divider.tsx
@@ -5,7 +5,7 @@ export function Divider() {
   const { colors } = useTheme();
 
   return (
-    <View style={[styles.divider, { borderBottomColor: colors.border }]} />
+    <View style={[styles.divider, { borderBottomColor: colors?.border }]} />
   );
 }
 

--- a/example/src/Shared/ListGroupItem.tsx
+++ b/example/src/Shared/ListGroupItem.tsx
@@ -13,12 +13,12 @@ export function ListGroupItem({ title, children }: Props) {
   return (
     <View style={styles.container}>
       {title != null ? (
-        <Text style={[fonts.medium, styles.title]}>{title}</Text>
+        <Text style={[fonts?.medium, styles.title]}>{title}</Text>
       ) : null}
       <View
         style={[
           styles.group,
-          { backgroundColor: colors.card, borderColor: colors.border },
+          { backgroundColor: colors?.card, borderColor: colors?.border },
         ]}
       >
         {children}

--- a/example/src/Shared/NewsFeed.tsx
+++ b/example/src/Shared/NewsFeed.tsx
@@ -22,7 +22,7 @@ const Card = ({ children }: { children: React.ReactNode }) => {
   const { colors } = useTheme();
 
   return (
-    <View style={[styles.card, { backgroundColor: colors.card }]}>
+    <View style={[styles.card, { backgroundColor: colors?.card }]}>
       {children}
     </View>
   );
@@ -39,7 +39,7 @@ const FooterIcon = ({
 
   return (
     <PlatformPressable style={styles.icon}>
-      <MaterialCommunityIcons name={icon} size={size} color={colors.text} />
+      <MaterialCommunityIcons name={icon} size={size} color={colors?.text} />
     </PlatformPressable>
   );
 };
@@ -78,7 +78,9 @@ export function NewsFeed(props: Props) {
       <Card>
         <TextInput
           placeholder="What's on your mind?"
-          placeholderTextColor={Color(colors.text)?.alpha(0.5).string()}
+          placeholderTextColor={Color(colors?.text ?? 'transparent')
+            ?.alpha(0.5)
+            .string()}
           style={styles.input}
         />
       </Card>

--- a/example/src/Shared/SegmentedPicker.tsx
+++ b/example/src/Shared/SegmentedPicker.tsx
@@ -32,17 +32,17 @@ export function SegmentedPicker<T extends string | number | boolean>({
           onPress={() => onValueChange(option.value)}
           style={[
             styles.segment,
-            option.value === value && { backgroundColor: colors.primary },
+            option.value === value && { backgroundColor: colors?.primary },
           ]}
         >
           <Text
             style={[
-              fonts.medium,
+              fonts?.medium,
               {
                 color:
                   option.value === value
-                    ? Color.foreground(colors.primary)
-                    : colors.text,
+                    ? Color.foreground(colors?.primary ?? 'transparent')
+                    : colors?.text,
               },
             ]}
           >

--- a/example/src/Showcase/BottomTabsShowcase.tsx
+++ b/example/src/Showcase/BottomTabsShowcase.tsx
@@ -185,12 +185,12 @@ const AlbumsScreen = () => {
           />
 
           <View style={styles.albumInfo}>
-            <Text style={[styles.albumTitle, fonts.bold]} numberOfLines={1}>
+            <Text style={[styles.albumTitle, fonts?.bold]} numberOfLines={1}>
               {item.title}
             </Text>
 
             <Text
-              style={[styles.artistText, { color: colors.text }]}
+              style={[styles.artistText, { color: colors?.text }]}
               numberOfLines={1}
             >
               {item.artist}
@@ -215,13 +215,13 @@ const ForYouScreen = () => {
         <Image source={featured.cover} style={styles.featuredImage} />
 
         <View style={styles.featuredOverlay}>
-          <Text style={[styles.featuredLabel, fonts.medium]}>Featured</Text>
+          <Text style={[styles.featuredLabel, fonts?.medium]}>Featured</Text>
 
-          <Text style={[styles.featuredTitle, fonts.heavy]}>
+          <Text style={[styles.featuredTitle, fonts?.heavy]}>
             {featured.title}
           </Text>
 
-          <Text style={[styles.featuredArtist, fonts.medium]}>
+          <Text style={[styles.featuredArtist, fonts?.medium]}>
             {featured.artist}
           </Text>
         </View>
@@ -229,7 +229,9 @@ const ForYouScreen = () => {
 
       {FOR_YOU_SECTIONS.map((section) => (
         <View key={section.title} style={styles.section}>
-          <Text style={[styles.sectionTitle, fonts.bold]}>{section.title}</Text>
+          <Text style={[styles.sectionTitle, fonts?.bold]}>
+            {section.title}
+          </Text>
 
           <FlatList
             horizontal
@@ -242,14 +244,14 @@ const ForYouScreen = () => {
                 <Image source={item.cover} style={styles.horizontalCover} />
 
                 <Text
-                  style={[styles.horizontalTitle, fonts.medium]}
+                  style={[styles.horizontalTitle, fonts?.medium]}
                   numberOfLines={1}
                 >
                   {item.title}
                 </Text>
 
                 <Text
-                  style={[styles.artistText, { color: colors.text }]}
+                  style={[styles.artistText, { color: colors?.text }]}
                   numberOfLines={1}
                 >
                   {item.artist}
@@ -273,7 +275,7 @@ const RadioScreen = () => {
       contentInsetAdjustmentBehavior="automatic"
       contentContainerStyle={styles.stationList}
       ItemSeparatorComponent={() => (
-        <View style={[styles.separator, { backgroundColor: colors.border }]} />
+        <View style={[styles.separator, { backgroundColor: colors?.border }]} />
       )}
       renderItem={({ item }) => (
         <View style={styles.stationRow}>
@@ -290,12 +292,12 @@ const RadioScreen = () => {
                 ]}
               />
 
-              <Text style={[styles.stationName, fonts.bold]}>{item.name}</Text>
+              <Text style={[styles.stationName, fonts?.bold]}>{item.name}</Text>
 
               <View
-                style={[styles.genreTag, { backgroundColor: colors.border }]}
+                style={[styles.genreTag, { backgroundColor: colors?.border }]}
               >
-                <Text style={[styles.genreText, fonts.medium]}>
+                <Text style={[styles.genreText, fonts?.medium]}>
                   {item.genre}
                 </Text>
               </View>
@@ -304,7 +306,7 @@ const RadioScreen = () => {
             <Text
               style={[
                 styles.stationDetailText,
-                { color: colors.text, opacity: item.nowPlaying ? 1 : 0.6 },
+                { color: colors?.text, opacity: item.nowPlaying ? 1 : 0.6 },
               ]}
               numberOfLines={1}
             >
@@ -367,7 +369,10 @@ const SearchScreenContent = () => {
       {query ? (
         filteredAlbums.length > 0 ? (
           <View
-            style={[styles.searchResultsCard, { backgroundColor: colors.card }]}
+            style={[
+              styles.searchResultsCard,
+              { backgroundColor: colors?.card },
+            ]}
           >
             {filteredAlbums.map((item, index) => (
               <React.Fragment key={item.id}>
@@ -375,7 +380,7 @@ const SearchScreenContent = () => {
                   <View
                     style={[
                       styles.searchResultSeparator,
-                      { backgroundColor: colors.border },
+                      { backgroundColor: colors?.border },
                     ]}
                   />
                 )}
@@ -384,14 +389,14 @@ const SearchScreenContent = () => {
                   <Image source={item.cover} style={styles.searchResultCover} />
 
                   <View style={styles.searchResultInfo}>
-                    <Text style={[styles.searchResultTitle, fonts.medium]}>
+                    <Text style={[styles.searchResultTitle, fonts?.medium]}>
                       {item.title}
                     </Text>
 
                     <Text
                       style={[
                         styles.searchResultArtist,
-                        { color: colors.text },
+                        { color: colors?.text },
                       ]}
                     >
                       {item.artist}
@@ -403,14 +408,14 @@ const SearchScreenContent = () => {
           </View>
         ) : (
           <Text
-            style={[styles.emptyText, { color: colors.text, opacity: 0.5 }]}
+            style={[styles.emptyText, { color: colors?.text, opacity: 0.5 }]}
           >
             No results
           </Text>
         )
       ) : (
         <>
-          <Text style={[styles.browseSectionTitle, fonts.bold]}>
+          <Text style={[styles.browseSectionTitle, fonts?.bold]}>
             Browse Categories
           </Text>
 
@@ -425,7 +430,7 @@ const SearchScreenContent = () => {
                   { backgroundColor: genre.color },
                 ]}
               >
-                <Text style={[styles.genreCardText, fonts.bold]}>
+                <Text style={[styles.genreCardText, fonts?.bold]}>
                   {genre.name}
                 </Text>
               </View>
@@ -464,8 +469,8 @@ const NowPlayingBar = ({ placement }: { placement: 'inline' | 'regular' }) => {
             <Text
               style={[
                 styles.nowPlayingTitle,
-                fonts.bold,
-                { color: colors.text },
+                fonts?.bold,
+                { color: colors?.text },
               ]}
               numberOfLines={1}
             >
@@ -473,7 +478,7 @@ const NowPlayingBar = ({ placement }: { placement: 'inline' | 'regular' }) => {
             </Text>
 
             <Text
-              style={[styles.nowPlayingArtist, { color: colors.text }]}
+              style={[styles.nowPlayingArtist, { color: colors?.text }]}
               numberOfLines={1}
             >
               {NOW_PLAYING.artist}
@@ -481,15 +486,15 @@ const NowPlayingBar = ({ placement }: { placement: 'inline' | 'regular' }) => {
           </View>
 
           <View style={styles.nowPlayingButtons}>
-            <Ionicons name="play" size={28} color={colors.text} />
-            <Ionicons name="play-forward" size={28} color={colors.text} />
+            <Ionicons name="play" size={28} color={colors?.text} />
+            <Ionicons name="play-forward" size={28} color={colors?.text} />
           </View>
         </>
       ) : (
         <View style={styles.nowPlayingButtons}>
-          <Ionicons name="play-back" size={28} color={colors.text} />
-          <Ionicons name="play" size={28} color={colors.text} />
-          <Ionicons name="play-forward" size={28} color={colors.text} />
+          <Ionicons name="play-back" size={28} color={colors?.text} />
+          <Ionicons name="play" size={28} color={colors?.text} />
+          <Ionicons name="play-forward" size={28} color={colors?.text} />
         </View>
       )}
     </View>

--- a/example/src/Showcase/DrawerShowcase.tsx
+++ b/example/src/Showcase/DrawerShowcase.tsx
@@ -215,14 +215,14 @@ const OverviewScreen = () => {
         style={[
           styles.card,
           styles.cardLarge,
-          { backgroundColor: colors.card, borderColor: colors.border },
+          { backgroundColor: colors?.card, borderColor: colors?.border },
         ]}
       >
-        <Text style={[styles.label, { color: colors.text, opacity: 0.6 }]}>
+        <Text style={[styles.label, { color: colors?.text, opacity: 0.6 }]}>
           Total Balance
         </Text>
 
-        <Text style={[styles.amountLarge, fonts.bold]}>
+        <Text style={[styles.amountLarge, fonts?.bold]}>
           {formatCurrency(totalBalance)}
         </Text>
       </View>
@@ -232,15 +232,19 @@ const OverviewScreen = () => {
           style={[
             styles.card,
             styles.summaryItem,
-            { backgroundColor: colors.card, borderColor: colors.border },
+            { backgroundColor: colors?.card, borderColor: colors?.border },
           ]}
         >
-          <Text style={[styles.label, { color: colors.text, opacity: 0.6 }]}>
+          <Text style={[styles.label, { color: colors?.text, opacity: 0.6 }]}>
             Income
           </Text>
 
           <Text
-            style={[styles.amountMedium, fonts.bold, { color: COLOR_POSITIVE }]}
+            style={[
+              styles.amountMedium,
+              fonts?.bold,
+              { color: COLOR_POSITIVE },
+            ]}
           >
             {formatCurrency(income)}
           </Text>
@@ -250,26 +254,26 @@ const OverviewScreen = () => {
           style={[
             styles.card,
             styles.summaryItem,
-            { backgroundColor: colors.card, borderColor: colors.border },
+            { backgroundColor: colors?.card, borderColor: colors?.border },
           ]}
         >
-          <Text style={[styles.label, { color: colors.text, opacity: 0.6 }]}>
+          <Text style={[styles.label, { color: colors?.text, opacity: 0.6 }]}>
             Expenses
           </Text>
 
-          <Text style={[styles.amountMedium, fonts.bold]}>
+          <Text style={[styles.amountMedium, fonts?.bold]}>
             {formatCurrency(expenses)}
           </Text>
         </View>
       </View>
 
-      <Text style={[styles.sectionTitle, fonts.bold]}>This Week</Text>
+      <Text style={[styles.sectionTitle, fonts?.bold]}>This Week</Text>
 
       <View
         style={[
           styles.card,
           styles.chartCard,
-          { backgroundColor: colors.card, borderColor: colors.border },
+          { backgroundColor: colors?.card, borderColor: colors?.border },
         ]}
       >
         {DAILY_SPEND.map((spend, index) => (
@@ -280,7 +284,7 @@ const OverviewScreen = () => {
                   styles.barFill,
                   {
                     height: `${(spend / maxSpend) * 100}%`,
-                    backgroundColor: colors.primary,
+                    backgroundColor: colors?.primary,
                     opacity: index === DAILY_SPEND.length - 1 ? 1 : 0.5,
                   },
                 ]}
@@ -290,8 +294,8 @@ const OverviewScreen = () => {
             <Text
               style={[
                 styles.barLabel,
-                fonts.medium,
-                { color: colors.text, opacity: 0.6 },
+                fonts?.medium,
+                { color: colors?.text, opacity: 0.6 },
               ]}
             >
               {DAY_LABELS[index]}
@@ -300,13 +304,15 @@ const OverviewScreen = () => {
         ))}
       </View>
 
-      <Text style={[styles.sectionTitle, fonts.bold]}>Recent Transactions</Text>
+      <Text style={[styles.sectionTitle, fonts?.bold]}>
+        Recent Transactions
+      </Text>
 
       {TRANSACTIONS.map((transaction, index) => (
         <React.Fragment key={transaction.id}>
           {index > 0 && (
             <View
-              style={[styles.divider, { backgroundColor: colors.border }]}
+              style={[styles.divider, { backgroundColor: colors?.border }]}
             />
           )}
 
@@ -317,18 +323,18 @@ const OverviewScreen = () => {
                 { backgroundColor: getCategoryColor(transaction.category) },
               ]}
             >
-              <Text style={[styles.categoryDotText, fonts.bold]}>
+              <Text style={[styles.categoryDotText, fonts?.bold]}>
                 {transaction.category.charAt(0)}
               </Text>
             </View>
 
             <View style={styles.flexFill}>
-              <Text style={[styles.bodyText, fonts.medium]}>
+              <Text style={[styles.bodyText, fonts?.medium]}>
                 {transaction.merchant}
               </Text>
 
               <Text
-                style={[styles.caption, { color: colors.text, opacity: 0.6 }]}
+                style={[styles.caption, { color: colors?.text, opacity: 0.6 }]}
               >
                 {transaction.category} · {transaction.date}
               </Text>
@@ -337,7 +343,7 @@ const OverviewScreen = () => {
             <Text
               style={[
                 styles.bodyText,
-                fonts.bold,
+                fonts?.bold,
                 transaction.amount > 0 && { color: COLOR_POSITIVE },
               ]}
             >
@@ -365,14 +371,14 @@ const BudgetsScreen = () => {
         style={[
           styles.card,
           styles.cardLarge,
-          { backgroundColor: colors.card, borderColor: colors.border },
+          { backgroundColor: colors?.card, borderColor: colors?.border },
         ]}
       >
-        <Text style={[styles.label, { color: colors.text, opacity: 0.6 }]}>
+        <Text style={[styles.label, { color: colors?.text, opacity: 0.6 }]}>
           Monthly Budget
         </Text>
 
-        <Text style={[styles.amountLarge, fonts.bold]}>
+        <Text style={[styles.amountLarge, fonts?.bold]}>
           {formatCurrency(totalSpent)}{' '}
           <Text style={{ opacity: 0.4 }}>/ {formatCurrency(totalLimit)}</Text>
         </Text>
@@ -380,7 +386,7 @@ const BudgetsScreen = () => {
         <View
           style={[
             styles.progressTrack,
-            { backgroundColor: colors.border, marginTop: SPACING_M },
+            { backgroundColor: colors?.border, marginTop: SPACING_M },
           ]}
         >
           <View
@@ -389,7 +395,7 @@ const BudgetsScreen = () => {
               {
                 width: `${Math.min((totalSpent / totalLimit) * 100, 100)}%`,
                 backgroundColor:
-                  totalSpent > totalLimit ? COLOR_NEGATIVE : colors.primary,
+                  totalSpent > totalLimit ? COLOR_NEGATIVE : colors?.primary,
               },
             ]}
           />
@@ -406,7 +412,7 @@ const BudgetsScreen = () => {
             style={[
               styles.card,
               styles.budgetCard,
-              { backgroundColor: colors.card, borderColor: colors.border },
+              { backgroundColor: colors?.card, borderColor: colors?.border },
             ]}
           >
             <View style={styles.rowBetween}>
@@ -415,7 +421,7 @@ const BudgetsScreen = () => {
                   style={[styles.colorDot, { backgroundColor: budget.color }]}
                 />
 
-                <Text style={[styles.bodyText, fonts.medium]}>
+                <Text style={[styles.bodyText, fonts?.medium]}>
                   {budget.name}
                 </Text>
               </View>
@@ -423,7 +429,7 @@ const BudgetsScreen = () => {
               <Text
                 style={[
                   styles.caption,
-                  fonts.medium,
+                  fonts?.medium,
                   isOver && { color: COLOR_NEGATIVE },
                 ]}
               >
@@ -432,7 +438,10 @@ const BudgetsScreen = () => {
             </View>
 
             <View
-              style={[styles.progressTrack, { backgroundColor: colors.border }]}
+              style={[
+                styles.progressTrack,
+                { backgroundColor: colors?.border },
+              ]}
             >
               <View
                 style={[
@@ -449,7 +458,7 @@ const BudgetsScreen = () => {
               <Text
                 style={[
                   styles.caption,
-                  fonts.medium,
+                  fonts?.medium,
                   { color: COLOR_NEGATIVE, marginTop: SPACING_XS },
                 ]}
               >
@@ -479,7 +488,7 @@ const AccountsScreen = () => {
           style={[
             styles.card,
             styles.accountCard,
-            { backgroundColor: colors.card, borderColor: colors.border },
+            { backgroundColor: colors?.card, borderColor: colors?.border },
           ]}
         >
           <View style={styles.rowBetween}>
@@ -488,14 +497,14 @@ const AccountsScreen = () => {
                 style={[styles.colorDot, { backgroundColor: account.color }]}
               />
 
-              <Text style={[styles.bodyText, fonts.bold]}>{account.name}</Text>
+              <Text style={[styles.bodyText, fonts?.bold]}>{account.name}</Text>
             </View>
 
             <Text
               style={[
                 styles.caption,
-                fonts.medium,
-                { color: colors.text, opacity: 0.6 },
+                fonts?.medium,
+                { color: colors?.text, opacity: 0.6 },
               ]}
             >
               {account.typeLabel}
@@ -505,14 +514,14 @@ const AccountsScreen = () => {
           <Text
             style={[
               styles.amountMedium,
-              fonts.bold,
+              fonts?.bold,
               account.balance < 0 && { color: COLOR_NEGATIVE },
             ]}
           >
             {formatCurrency(account.balance)}
           </Text>
 
-          <Text style={[styles.caption, { color: colors.text, opacity: 0.4 }]}>
+          <Text style={[styles.caption, { color: colors?.text, opacity: 0.4 }]}>
             •••• {account.lastFour}
           </Text>
         </View>
@@ -522,14 +531,14 @@ const AccountsScreen = () => {
         style={[
           styles.card,
           styles.totalCard,
-          { backgroundColor: colors.card, borderColor: colors.border },
+          { backgroundColor: colors?.card, borderColor: colors?.border },
         ]}
       >
-        <Text style={[styles.label, { color: colors.text, opacity: 0.6 }]}>
+        <Text style={[styles.label, { color: colors?.text, opacity: 0.6 }]}>
           Net Worth
         </Text>
 
-        <Text style={[styles.amountLarge, fonts.bold]}>
+        <Text style={[styles.amountLarge, fonts?.bold]}>
           {formatCurrency(totalBalance)}
         </Text>
       </View>
@@ -546,33 +555,33 @@ const CustomDrawerContent = (props: DrawerContentComponentProps) => {
       contentContainerStyle={styles.drawerContentContainer}
     >
       <View style={styles.profileSection}>
-        <View style={[styles.avatar, { backgroundColor: colors.primary }]}>
-          <Text style={[styles.avatarText, fonts.bold]}>AC</Text>
+        <View style={[styles.avatar, { backgroundColor: colors?.primary }]}>
+          <Text style={[styles.avatarText, fonts?.bold]}>AC</Text>
         </View>
 
-        <Text style={[styles.bodyText, fonts.bold]}>Alex Chen</Text>
+        <Text style={[styles.bodyText, fonts?.bold]}>Alex Chen</Text>
 
-        <Text style={[styles.caption, { color: colors.text, opacity: 0.6 }]}>
+        <Text style={[styles.caption, { color: colors?.text, opacity: 0.6 }]}>
           alex@ledger.app
         </Text>
       </View>
 
       <View
-        style={[styles.drawerDivider, { backgroundColor: colors.border }]}
+        style={[styles.drawerDivider, { backgroundColor: colors?.border }]}
       />
 
       <DrawerItemList {...props} />
 
       <View
-        style={[styles.drawerDivider, { backgroundColor: colors.border }]}
+        style={[styles.drawerDivider, { backgroundColor: colors?.border }]}
       />
 
       <View style={styles.drawerFooter}>
         <Text
           style={[
             styles.caption,
-            fonts.medium,
-            { color: colors.text, opacity: 0.4 },
+            fonts?.medium,
+            { color: colors?.text, opacity: 0.4 },
           ]}
         >
           Ledger v1.0
@@ -585,7 +594,9 @@ const CustomDrawerContent = (props: DrawerContentComponentProps) => {
         onPress={() => props.navigation.dispatch(StackActions.pop())}
         style={styles.backButton}
       >
-        <Text style={[styles.caption, fonts.medium, { color: colors.primary }]}>
+        <Text
+          style={[styles.caption, fonts?.medium, { color: colors?.primary }]}
+        >
           Back
         </Text>
       </PlatformPressable>

--- a/example/src/Showcase/MaterialTopTabsShowcase.tsx
+++ b/example/src/Showcase/MaterialTopTabsShowcase.tsx
@@ -374,8 +374,8 @@ const Badge = ({ count }: { count: number }) => {
   const { colors, fonts } = useTheme();
 
   return (
-    <View style={[styles.badge, { backgroundColor: colors.notification }]}>
-      <Text style={[styles.badgeText, fonts.medium]}>{count}</Text>
+    <View style={[styles.badge, { backgroundColor: colors?.notification }]}>
+      <Text style={[styles.badgeText, fonts?.medium]}>{count}</Text>
     </View>
   );
 };
@@ -387,18 +387,18 @@ const RecipeCard = ({ item, width }: { item: Recipe; width?: number }) => {
     <View
       style={[
         styles.card,
-        { backgroundColor: colors.card },
+        { backgroundColor: colors?.card },
         width != null && { width },
       ]}
     >
       <Image source={item.image} style={styles.cardImage} resizeMode="cover" />
 
       <View style={styles.cardBody}>
-        <Text style={[styles.cardTitle, fonts.medium]} numberOfLines={2}>
+        <Text style={[styles.cardTitle, fonts?.medium]} numberOfLines={2}>
           {item.title}
         </Text>
 
-        <Text style={[styles.cardMeta, { color: colors.text, opacity: 0.5 }]}>
+        <Text style={[styles.cardMeta, { color: colors?.text, opacity: 0.5 }]}>
           {item.time} · {item.difficulty}
         </Text>
       </View>
@@ -439,21 +439,21 @@ const RecipeListItem = ({ item }: { item: Recipe }) => {
       />
 
       <View style={styles.flexFill}>
-        <Text style={[styles.cardTitle, fonts.medium]} numberOfLines={1}>
+        <Text style={[styles.cardTitle, fonts?.medium]} numberOfLines={1}>
           {item.title}
         </Text>
 
         <Text
           style={[
             styles.listItemAuthor,
-            fonts.medium,
-            { color: colors.text, opacity: 0.6 },
+            fonts?.medium,
+            { color: colors?.text, opacity: 0.6 },
           ]}
         >
           {item.author}
         </Text>
 
-        <Text style={[styles.cardMeta, { color: colors.text, opacity: 0.5 }]}>
+        <Text style={[styles.cardMeta, { color: colors?.text, opacity: 0.5 }]}>
           {item.time} · {item.difficulty}
         </Text>
       </View>
@@ -470,7 +470,7 @@ const RecipeList = ({ items }: { items: Recipe[] }) => {
         <React.Fragment key={item.id}>
           {index > 0 && (
             <View
-              style={[styles.listDivider, { backgroundColor: colors.border }]}
+              style={[styles.listDivider, { backgroundColor: colors?.border }]}
             />
           )}
 
@@ -512,11 +512,11 @@ const TrendingScreen = () => {
 
       <View style={styles.metaRow}>
         <Text
-          style={[styles.smallText, fonts.medium, { color: colors.primary }]}
+          style={[styles.smallText, fonts?.medium, { color: colors?.primary }]}
         >
           {featured.author}
         </Text>
-        <Text style={[styles.smallText, { color: colors.text, opacity: 0.5 }]}>
+        <Text style={[styles.smallText, { color: colors?.text, opacity: 0.5 }]}>
           {' · '}
           {featured.time}
           {' · '}
@@ -527,7 +527,7 @@ const TrendingScreen = () => {
       </View>
 
       <View
-        style={[styles.accentDivider, { backgroundColor: colors.border }]}
+        style={[styles.accentDivider, { backgroundColor: colors?.border }]}
       />
 
       <Text style={styles.bodyText}>{featured.description}</Text>
@@ -612,11 +612,11 @@ const FeaturedCategoryScreen = ({
         />
 
         <View style={styles.featuredImageOverlay}>
-          <Text style={[styles.featuredImageTitle, fonts.medium]}>
+          <Text style={[styles.featuredImageTitle, fonts?.medium]}>
             {featured.title}
           </Text>
 
-          <Text style={[styles.featuredImageMeta, fonts.medium]}>
+          <Text style={[styles.featuredImageMeta, fonts?.medium]}>
             {featured.time} · {featured.difficulty}
           </Text>
         </View>
@@ -679,7 +679,7 @@ const SeasonalScreen = () => {
       </Text>
 
       <View
-        style={[styles.accentDivider, { backgroundColor: colors.border }]}
+        style={[styles.accentDivider, { backgroundColor: colors?.border }]}
       />
 
       <RecipeList items={recipes} />

--- a/example/src/Showcase/NativeStackShowcase.tsx
+++ b/example/src/Showcase/NativeStackShowcase.tsx
@@ -222,11 +222,11 @@ const MapScreen = () => {
   const place = PLACES[0];
 
   return (
-    <View style={[styles.mapContainer, { backgroundColor: colors.card }]}>
+    <View style={[styles.mapContainer, { backgroundColor: colors?.card }]}>
       <View
         style={[
           StyleSheet.absoluteFill,
-          { backgroundColor: colors.primary, opacity: 0.08 },
+          { backgroundColor: colors?.primary, opacity: 0.08 },
         ]}
       />
       {MAP_ROADS.map((road, i) => (
@@ -234,7 +234,7 @@ const MapScreen = () => {
           key={`road-${String(i)}`}
           style={[
             styles.absolute,
-            { backgroundColor: colors.border, opacity: 0.15 },
+            { backgroundColor: colors?.border, opacity: 0.15 },
             {
               top: road.top,
               left: road.left,
@@ -259,7 +259,7 @@ const MapScreen = () => {
               width: lm.size,
               height: lm.size,
               borderRadius: lm.size / 2,
-              backgroundColor: colors.text,
+              backgroundColor: colors?.text,
               opacity: 0.1,
             },
           ]}
@@ -272,13 +272,13 @@ const MapScreen = () => {
           navigation.navigate('LocationDetails', { placeId: place.id })
         }
       >
-        <View style={[styles.pinDot, { backgroundColor: colors.primary }]} />
-        <View style={[styles.pinRing, { borderColor: colors.primary }]} />
+        <View style={[styles.pinDot, { backgroundColor: colors?.primary }]} />
+        <View style={[styles.pinRing, { borderColor: colors?.primary }]} />
         <Text
           style={[
             styles.pinLabel,
-            fonts.bold,
-            { color: colors.text, backgroundColor: colors.card },
+            fonts?.bold,
+            { color: colors?.text, backgroundColor: colors?.card },
           ]}
           numberOfLines={1}
         >
@@ -302,12 +302,12 @@ const PlaceItem = React.memo(({ item }: { item: Place }) => {
       <Image source={item.image} style={styles.placeImage} />
 
       <View style={styles.placeInfo}>
-        <Text style={[styles.placeName, fonts.bold]} numberOfLines={1}>
+        <Text style={[styles.placeName, fonts?.bold]} numberOfLines={1}>
           {item.name}
         </Text>
 
         <Text
-          style={[styles.caption, fonts.medium, { color: colors.primary }]}
+          style={[styles.caption, fonts?.medium, { color: colors?.primary }]}
           numberOfLines={1}
         >
           {item.category}
@@ -321,7 +321,9 @@ const PlaceItem = React.memo(({ item }: { item: Place }) => {
         </Text>
       </View>
 
-      <Text style={[styles.placeRating, fonts.medium, { color: colors.text }]}>
+      <Text
+        style={[styles.placeRating, fonts?.medium, { color: colors?.text }]}
+      >
         {'★ '}
         {item.rating}
       </Text>
@@ -335,7 +337,7 @@ const ItemSeparator = () => {
   const { colors } = useTheme();
 
   return (
-    <View style={[styles.separator, { backgroundColor: colors.border }]} />
+    <View style={[styles.separator, { backgroundColor: colors?.border }]} />
   );
 };
 
@@ -388,15 +390,19 @@ const LocationDetailsScreen = ({
 
   return (
     <ScrollView
-      style={{ backgroundColor: colors.card }}
+      style={{ backgroundColor: colors?.card }}
       contentInsetAdjustmentBehavior="automatic"
       contentContainerStyle={styles.detailsContent}
     >
       <View style={styles.detailsHeader}>
-        <Text style={[styles.detailsName, fonts.heavy]}>{place.name}</Text>
+        <Text style={[styles.detailsName, fonts?.heavy]}>{place.name}</Text>
 
-        <View style={[styles.categoryPill, { backgroundColor: colors.border }]}>
-          <Text style={[styles.caption, fonts.bold, { color: colors.primary }]}>
+        <View
+          style={[styles.categoryPill, { backgroundColor: colors?.border }]}
+        >
+          <Text
+            style={[styles.caption, fonts?.bold, { color: colors?.primary }]}
+          >
             {place.category}
           </Text>
         </View>
@@ -426,25 +432,25 @@ const LocationDetailsScreen = ({
             key={info.label}
             style={[
               styles.detailsInfoItem,
-              { backgroundColor: colors.background },
+              { backgroundColor: colors?.background },
             ]}
           >
             <Text
               style={[
                 styles.detailsInfoLabel,
-                fonts.medium,
+                fonts?.medium,
                 { opacity: SECONDARY_OPACITY },
               ]}
             >
               {info.label}
             </Text>
-            <Text style={[styles.detailsText, fonts.bold]}>{info.value}</Text>
+            <Text style={[styles.detailsText, fonts?.bold]}>{info.value}</Text>
           </View>
         ))}
       </View>
 
-      <View style={[styles.detailsSection, { borderColor: colors.border }]}>
-        <Text style={[styles.detailsSectionTitle, fonts.bold]}>About</Text>
+      <View style={[styles.detailsSection, { borderColor: colors?.border }]}>
+        <Text style={[styles.detailsSectionTitle, fonts?.bold]}>About</Text>
         <Text style={[styles.bodyText, { opacity: 0.8 }]}>
           This location is managed by the National Park Service. Visitors are
           encouraged to follow Leave No Trace principles and stay on designated

--- a/example/src/Showcase/StackShowcase.tsx
+++ b/example/src/Showcase/StackShowcase.tsx
@@ -456,7 +456,7 @@ const PeriodBadge = ({ period }: { period: Period }) => {
     <View
       style={[styles.periodBadge, { backgroundColor: PERIOD_COLORS[period] }]}
     >
-      <Text style={[styles.periodBadgeText, fonts.medium]}>{period}</Text>
+      <Text style={[styles.periodBadgeText, fonts?.medium]}>{period}</Text>
     </View>
   );
 };
@@ -471,8 +471,8 @@ const SectionCard = ({
   const { colors, fonts } = useTheme();
 
   return (
-    <View style={[styles.sectionCard, { backgroundColor: colors.card }]}>
-      <Text style={[styles.sectionTitle, fonts.bold, { color: colors.text }]}>
+    <View style={[styles.sectionCard, { backgroundColor: colors?.card }]}>
+      <Text style={[styles.sectionTitle, fonts?.bold, { color: colors?.text }]}>
         {title}
       </Text>
       {children}
@@ -492,19 +492,19 @@ const DetailStat = ({
   const { colors, fonts } = useTheme();
 
   return (
-    <View style={[styles.detailStat, { backgroundColor: colors.background }]}>
-      <MaterialCommunityIcons name={icon} size={18} color={colors.primary} />
+    <View style={[styles.detailStat, { backgroundColor: colors?.background }]}>
+      <MaterialCommunityIcons name={icon} size={18} color={colors?.primary} />
       <Text
         style={[
           styles.detailStatLabel,
-          fonts.medium,
-          { color: colors.text, opacity: SECONDARY_OPACITY },
+          fonts?.medium,
+          { color: colors?.text, opacity: SECONDARY_OPACITY },
         ]}
       >
         {label}
       </Text>
       <Text
-        style={[styles.detailStatValue, fonts.bold, { color: colors.text }]}
+        style={[styles.detailStatValue, fonts?.bold, { color: colors?.text }]}
       >
         {value}
       </Text>
@@ -517,7 +517,7 @@ const CatalogHero = () => {
   const featured = DINOS[9];
 
   return (
-    <View style={[styles.heroCard, { backgroundColor: colors.card }]}>
+    <View style={[styles.heroCard, { backgroundColor: colors?.card }]}>
       <View
         style={[
           StyleSheet.absoluteFill,
@@ -532,12 +532,12 @@ const CatalogHero = () => {
       <View style={[StyleSheet.absoluteFill, styles.heroImageScrim]} />
 
       <View style={styles.heroHeaderRow}>
-        <Text style={[styles.heroEyebrow, fonts.medium]}>Exhibit guide</Text>
+        <Text style={[styles.heroEyebrow, fonts?.medium]}>Exhibit guide</Text>
         <PeriodBadge period={featured.period} />
       </View>
 
       <View style={styles.heroCopy}>
-        <Text style={[styles.heroTitle, fonts.heavy]}>
+        <Text style={[styles.heroTitle, fonts?.heavy]}>
           Dinosaurs of the Mesozoic
         </Text>
         <Text style={styles.heroDescription}>
@@ -553,17 +553,21 @@ const EmptyState = () => {
   const { colors, fonts } = useTheme();
 
   return (
-    <View style={[styles.emptyState, { backgroundColor: colors.card }]}>
-      <MaterialCommunityIcons name="magnify" size={28} color={colors.primary} />
+    <View style={[styles.emptyState, { backgroundColor: colors?.card }]}>
+      <MaterialCommunityIcons
+        name="magnify"
+        size={28}
+        color={colors?.primary}
+      />
       <Text
-        style={[styles.emptyStateTitle, fonts.bold, { color: colors.text }]}
+        style={[styles.emptyStateTitle, fonts?.bold, { color: colors?.text }]}
       >
         No specimens found
       </Text>
       <Text
         style={[
           styles.emptyStateText,
-          { color: colors.text, opacity: SECONDARY_OPACITY },
+          { color: colors?.text, opacity: SECONDARY_OPACITY },
         ]}
       >
         Try another search term or switch to a different period.
@@ -583,7 +587,7 @@ const DinoCard = React.memo(
         style={[
           styles.card,
           width !== undefined && { width },
-          { backgroundColor: colors.card },
+          { backgroundColor: colors?.card },
         ]}
         onPress={() => navigation.navigate('DinoDetail', { id: item.id })}
       >
@@ -604,11 +608,11 @@ const DinoCard = React.memo(
         <View style={styles.cardBody}>
           <PeriodBadge period={item.period} />
 
-          <Text style={[styles.cardName, fonts.bold]} numberOfLines={2}>
+          <Text style={[styles.cardName, fonts?.bold]} numberOfLines={2}>
             {item.name}
           </Text>
 
-          <Text style={[styles.cardMeta, fonts.medium]} numberOfLines={1}>
+          <Text style={[styles.cardMeta, fonts?.medium]} numberOfLines={1}>
             {item.diet} · {item.length} · {item.weight}
           </Text>
         </View>
@@ -675,7 +679,7 @@ const CatalogScreen = () => {
 
   return (
     <ScrollView
-      style={{ backgroundColor: colors.background }}
+      style={{ backgroundColor: colors?.background }}
       contentContainerStyle={[styles.catalogContent, { paddingTop: SPACING_M }]}
     >
       <CatalogHero />
@@ -684,8 +688,8 @@ const CatalogScreen = () => {
         <Text
           style={[
             styles.catalogSectionTitle,
-            fonts.bold,
-            { color: colors.text },
+            fonts?.bold,
+            { color: colors?.text },
           ]}
         >
           Specimens
@@ -693,7 +697,7 @@ const CatalogScreen = () => {
         <Text
           style={[
             styles.catalogSectionMeta,
-            { color: colors.text, opacity: SECONDARY_OPACITY },
+            { color: colors?.text, opacity: SECONDARY_OPACITY },
           ]}
         >
           {resultsLabel}
@@ -718,12 +722,12 @@ const DinoDetailScreen = ({ route }: StaticScreenProps<{ id: string }>) => {
 
   return (
     <ScrollView
-      style={{ backgroundColor: colors.background }}
+      style={{ backgroundColor: colors?.background }}
       contentContainerStyle={styles.detailContent}
     >
       <Pressable
         testID={OPEN_IMAGE_VIEWER_TEST_ID}
-        style={[styles.detailHero, { backgroundColor: colors.background }]}
+        style={[styles.detailHero, { backgroundColor: colors?.background }]}
         onPress={() => navigation.navigate('ImageViewer', { id: dino.id })}
       >
         <Image
@@ -736,7 +740,7 @@ const DinoDetailScreen = ({ route }: StaticScreenProps<{ id: string }>) => {
       <View style={styles.detailBody}>
         <View style={styles.detailIntro}>
           <PeriodBadge period={dino.period} />
-          <Text style={[styles.detailName, fonts.heavy]}>{dino.name}</Text>
+          <Text style={[styles.detailName, fonts?.heavy]}>{dino.name}</Text>
         </View>
 
         <SectionCard title="Quick facts">
@@ -753,7 +757,7 @@ const DinoDetailScreen = ({ route }: StaticScreenProps<{ id: string }>) => {
         </SectionCard>
 
         <SectionCard title="Field notes">
-          <Text style={[styles.bodyText, { color: colors.text }]}>
+          <Text style={[styles.bodyText, { color: colors?.text }]}>
             {dino.description}
           </Text>
         </SectionCard>
@@ -762,7 +766,7 @@ const DinoDetailScreen = ({ route }: StaticScreenProps<{ id: string }>) => {
           <Text
             style={[
               styles.bodyText,
-              { color: colors.text, opacity: SECONDARY_OPACITY },
+              { color: colors?.text, opacity: SECONDARY_OPACITY },
             ]}
           >
             {PERIOD_DESCRIPTIONS[dino.period]}
@@ -824,7 +828,7 @@ const ImageViewerScreen = ({ route }: StaticScreenProps<{ id: string }>) => {
         ]}
       >
         <View
-          style={[styles.viewerImageWrapper, { backgroundColor: colors.card }]}
+          style={[styles.viewerImageWrapper, { backgroundColor: colors?.card }]}
         >
           <Image
             source={dino.image}
@@ -833,17 +837,17 @@ const ImageViewerScreen = ({ route }: StaticScreenProps<{ id: string }>) => {
           />
         </View>
 
-        <View style={[styles.viewerCaption, { backgroundColor: colors.card }]}>
+        <View style={[styles.viewerCaption, { backgroundColor: colors?.card }]}>
           <PeriodBadge period={dino.period} />
           <Text
-            style={[styles.viewerTitle, fonts.heavy, { color: colors.text }]}
+            style={[styles.viewerTitle, fonts?.heavy, { color: colors?.text }]}
           >
             {dino.name}
           </Text>
           <Text
             style={[
               styles.viewerMeta,
-              { color: colors.text, opacity: SECONDARY_OPACITY },
+              { color: colors?.text, opacity: SECONDARY_OPACITY },
             ]}
           >
             {dino.diet} · {dino.length} · {dino.weight}
@@ -922,7 +926,7 @@ const StackShowcaseNavigator = createStackNavigator({
       options: ({ theme }) => ({
         headerTitle: '',
         headerBackTestID: DETAIL_BACK_TEST_ID,
-        headerStyle: { backgroundColor: theme.colors.background },
+        headerStyle: { backgroundColor: theme.colors?.background },
         headerShadowVisible: false,
         presentation: 'modal',
       }),

--- a/example/src/index.tsx
+++ b/example/src/index.tsx
@@ -20,7 +20,6 @@ import {
   DefaultTheme,
   MaterialDarkTheme,
   MaterialLightTheme,
-  SystemTheme,
   type Theme,
   useNavigation,
   useNavigationContainerRef,
@@ -93,7 +92,7 @@ if (Platform.OS === 'web') {
   }
 }
 
-type ThemeName = 'light' | 'dark' | 'material' | 'custom' | 'undefined';
+type ThemeName = 'light' | 'dark' | 'material' | 'custom';
 
 type AppState = {
   isReady: boolean;
@@ -148,7 +147,7 @@ function Examples() {
   }, [filter, navigation]);
 
   return (
-    <ScrollView style={{ backgroundColor: theme?.colors?.background }}>
+    <ScrollView style={{ backgroundColor: theme.colors?.background }}>
       <SafeAreaView edges={['right', 'bottom', 'left']}>
         {!filter.length ? (
           <ListGroupItem title="Settings">
@@ -161,7 +160,7 @@ function Examples() {
                     payload: value,
                   })
                 }
-                trackColor={{ true: theme?.colors?.primary }}
+                trackColor={{ true: theme.colors?.primary }}
                 style={{
                   // FIXME: On iOS, switch doesn't center vertically
                   marginVertical: 12,
@@ -177,7 +176,6 @@ function Examples() {
                     { label: 'Material', value: 'material' },
                     { label: 'Light', value: 'light' },
                     { label: 'Dark', value: 'dark' },
-                    { label: 'Undefined', value: 'undefined' },
                   ] as const
                 ).filter((choice) =>
                   Platform.OS !== 'android' ? choice.value !== 'material' : true
@@ -387,22 +385,20 @@ export function App() {
   const isLargeScreen = dimensions.width >= 1024;
 
   const theme =
-    themeName === 'undefined'
-      ? SystemTheme
-      : themeName === 'dark'
-        ? DarkTheme
-        : themeName === 'light'
-          ? DefaultTheme
-          : Platform.OS === 'android' && themeName === 'material'
-            ? colorScheme === 'dark'
-              ? MaterialDarkTheme
-              : MaterialLightTheme
-            : PlatformTheme;
+    themeName === 'dark'
+      ? DarkTheme
+      : themeName === 'light'
+        ? DefaultTheme
+        : Platform.OS === 'android' && themeName === 'material'
+          ? colorScheme === 'dark'
+            ? MaterialDarkTheme
+            : MaterialLightTheme
+          : PlatformTheme;
 
   return (
     <Providers>
       <StatusBar
-        style={Platform.OS === 'ios' ? 'auto' : theme?.dark ? 'light' : 'dark'}
+        style={Platform.OS === 'ios' ? 'auto' : theme.dark ? 'light' : 'dark'}
       />
       {Platform.OS === 'web' ? (
         <style>

--- a/example/src/index.tsx
+++ b/example/src/index.tsx
@@ -20,6 +20,7 @@ import {
   DefaultTheme,
   MaterialDarkTheme,
   MaterialLightTheme,
+  SystemTheme,
   type Theme,
   useNavigation,
   useNavigationContainerRef,
@@ -92,7 +93,7 @@ if (Platform.OS === 'web') {
   }
 }
 
-type ThemeName = 'light' | 'dark' | 'material' | 'custom';
+type ThemeName = 'light' | 'dark' | 'material' | 'custom' | 'undefined';
 
 type AppState = {
   isReady: boolean;
@@ -147,7 +148,7 @@ function Examples() {
   }, [filter, navigation]);
 
   return (
-    <ScrollView style={{ backgroundColor: theme.colors.background }}>
+    <ScrollView style={{ backgroundColor: theme?.colors?.background }}>
       <SafeAreaView edges={['right', 'bottom', 'left']}>
         {!filter.length ? (
           <ListGroupItem title="Settings">
@@ -160,7 +161,7 @@ function Examples() {
                     payload: value,
                   })
                 }
-                trackColor={{ true: theme.colors.primary }}
+                trackColor={{ true: theme?.colors?.primary }}
                 style={{
                   // FIXME: On iOS, switch doesn't center vertically
                   marginVertical: 12,
@@ -176,6 +177,7 @@ function Examples() {
                     { label: 'Material', value: 'material' },
                     { label: 'Light', value: 'light' },
                     { label: 'Dark', value: 'dark' },
+                    { label: 'Undefined', value: 'undefined' },
                   ] as const
                 ).filter((choice) =>
                   Platform.OS !== 'android' ? choice.value !== 'material' : true
@@ -385,20 +387,22 @@ export function App() {
   const isLargeScreen = dimensions.width >= 1024;
 
   const theme =
-    themeName === 'dark'
-      ? DarkTheme
-      : themeName === 'light'
-        ? DefaultTheme
-        : Platform.OS === 'android' && themeName === 'material'
-          ? colorScheme === 'dark'
-            ? MaterialDarkTheme
-            : MaterialLightTheme
-          : PlatformTheme;
+    themeName === 'undefined'
+      ? SystemTheme
+      : themeName === 'dark'
+        ? DarkTheme
+        : themeName === 'light'
+          ? DefaultTheme
+          : Platform.OS === 'android' && themeName === 'material'
+            ? colorScheme === 'dark'
+              ? MaterialDarkTheme
+              : MaterialLightTheme
+            : PlatformTheme;
 
   return (
     <Providers>
       <StatusBar
-        style={Platform.OS === 'ios' ? 'auto' : theme.dark ? 'light' : 'dark'}
+        style={Platform.OS === 'ios' ? 'auto' : theme?.dark ? 'light' : 'dark'}
       />
       {Platform.OS === 'web' ? (
         <style>

--- a/example/src/userinterface-bug.tsx
+++ b/example/src/userinterface-bug.tsx
@@ -11,16 +11,21 @@ import {
 
 const BlackWhiteScrollView = () => {
   return (
-    <ScrollView contentInsetAdjustmentBehavior="always">
-      <View style={{ padding: 10 }}>
+    <ScrollView
+      contentInsetAdjustmentBehavior="always"
+      contentContainerStyle={{ padding: 16 }}
+    >
+      <View style={{ paddingBottom: 20 }}>
         <Text>Current colorscheme: {useColorScheme()}</Text>
       </View>
-      <View style={{ height: 100, backgroundColor: 'black' }} />
-      <View style={{ height: 100, backgroundColor: 'white' }} />
-      <View style={{ height: 100, backgroundColor: 'black' }} />
-      <View style={{ height: 100, backgroundColor: 'white' }} />
-      <View style={{ height: 100, backgroundColor: 'black' }} />
-      <View style={{ height: 100, backgroundColor: 'white' }} />
+      <Text>View using DynamicColorIOS:</Text>
+      <View
+        style={{
+          height: 300,
+          width: 300,
+          backgroundColor: DynamicColorIOS({ dark: 'black', light: 'white' }),
+        }}
+      />
     </ScrollView>
   );
 };

--- a/example/src/userinterface-bug.tsx
+++ b/example/src/userinterface-bug.tsx
@@ -4,6 +4,7 @@ import { NavigationContainer, SystemTheme } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import {
   DynamicColorIOS,
+  Platform,
   ScrollView,
   useColorScheme,
   View,
@@ -18,14 +19,22 @@ const BlackWhiteScrollView = () => {
       <View style={{ paddingBottom: 20 }}>
         <Text>Current colorscheme: {useColorScheme()}</Text>
       </View>
-      <Text>View using DynamicColorIOS:</Text>
-      <View
-        style={{
-          height: 300,
-          width: 300,
-          backgroundColor: DynamicColorIOS({ dark: 'black', light: 'white' }),
-        }}
-      />
+      <View style={{ paddingBottom: 20 }}>
+        <Text>View using DynamicColorIOS:</Text>
+        <View
+          style={{
+            height: 300,
+            width: 300,
+            backgroundColor: DynamicColorIOS({ dark: 'black', light: 'white' }),
+          }}
+        />
+      </View>
+      <View style={{ height: 200, backgroundColor: 'black' }} />
+      <View style={{ height: 200, backgroundColor: 'white' }} />
+      <View style={{ height: 200, backgroundColor: 'black' }} />
+      <View style={{ height: 200, backgroundColor: 'white' }} />
+      <View style={{ height: 200, backgroundColor: 'black' }} />
+      <View style={{ height: 200, backgroundColor: 'white' }} />
     </ScrollView>
   );
 };
@@ -40,11 +49,14 @@ const StackScreen = () => {
         component={BlackWhiteScrollView}
         options={{
           headerTransparent: true,
-          headerBlurEffect: 'regular',
           headerTintColor: DynamicColorIOS({
             light: 'red',
             dark: 'green',
           }),
+          headerBlurEffect:
+            Platform.OS === 'ios' && parseInt(Platform.Version, 10) < 26
+              ? 'regular'
+              : undefined,
           unstable_headerRightItems: ({ tintColor }) => [
             {
               type: 'button',

--- a/example/src/userinterface-bug.tsx
+++ b/example/src/userinterface-bug.tsx
@@ -39,12 +39,12 @@ const StackScreen = () => {
             light: 'red',
             dark: 'green',
           }),
-          headerBlurEffect: 'regular',
-          unstable_headerRightItems: () => [
+          unstable_headerRightItems: ({ tintColor }) => [
             {
               type: 'button',
               label: 'Button',
               onPress: () => {},
+              tintColor,
             },
           ],
         }}

--- a/example/src/userinterface-bug.tsx
+++ b/example/src/userinterface-bug.tsx
@@ -1,0 +1,48 @@
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { DynamicColorIOS, PlatformColor, ScrollView, View } from 'react-native';
+
+const BlackWhiteScrollView = () => {
+  return (
+    <ScrollView
+      contentInsetAdjustmentBehavior="always"
+      style={{ backgroundColor: PlatformColor('systemBackground') }}
+    >
+      <View style={{ height: 100, backgroundColor: 'black' }} />
+      <View style={{ height: 100, backgroundColor: 'white' }} />
+      <View style={{ height: 100, backgroundColor: 'black' }} />
+      <View style={{ height: 100, backgroundColor: 'white' }} />
+      <View style={{ height: 100, backgroundColor: 'black' }} />
+      <View style={{ height: 100, backgroundColor: 'white' }} />
+    </ScrollView>
+  );
+};
+
+const Stack = createNativeStackNavigator();
+export const UserInterfaceBug = () => {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator>
+        <Stack.Screen
+          name="Home"
+          component={BlackWhiteScrollView}
+          options={{
+            headerTransparent: true,
+            headerTintColor: DynamicColorIOS({
+              light: 'red',
+              dark: 'green',
+            }),
+            headerBlurEffect: 'regular',
+            unstable_headerRightItems: () => [
+              {
+                type: 'button',
+                label: 'Button',
+                onPress: () => {},
+              },
+            ],
+          }}
+        />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+};

--- a/example/src/userinterface-bug.tsx
+++ b/example/src/userinterface-bug.tsx
@@ -1,6 +1,6 @@
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { Text } from '@react-navigation/elements';
-import { NavigationContainer } from '@react-navigation/native';
+import { NavigationContainer, SystemTheme } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import {
   DynamicColorIOS,
@@ -35,6 +35,7 @@ const StackScreen = () => {
         component={BlackWhiteScrollView}
         options={{
           headerTransparent: true,
+          headerBlurEffect: 'regular',
           headerTintColor: DynamicColorIOS({
             light: 'red',
             dark: 'green',
@@ -56,7 +57,7 @@ const Tabs = createBottomTabNavigator();
 
 export const UserInterfaceBug = () => {
   return (
-    <NavigationContainer>
+    <NavigationContainer theme={SystemTheme}>
       <Tabs.Navigator>
         <Tabs.Screen name="Stack" component={StackScreen} />
       </Tabs.Navigator>

--- a/example/src/userinterface-bug.tsx
+++ b/example/src/userinterface-bug.tsx
@@ -1,13 +1,20 @@
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import { Text } from '@react-navigation/elements';
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
-import { DynamicColorIOS, PlatformColor, ScrollView, View } from 'react-native';
+import {
+  DynamicColorIOS,
+  ScrollView,
+  useColorScheme,
+  View,
+} from 'react-native';
 
 const BlackWhiteScrollView = () => {
   return (
-    <ScrollView
-      contentInsetAdjustmentBehavior="always"
-      style={{ backgroundColor: PlatformColor('systemBackground') }}
-    >
+    <ScrollView contentInsetAdjustmentBehavior="always">
+      <View style={{ padding: 10 }}>
+        <Text>Current colorscheme: {useColorScheme()}</Text>
+      </View>
       <View style={{ height: 100, backgroundColor: 'black' }} />
       <View style={{ height: 100, backgroundColor: 'white' }} />
       <View style={{ height: 100, backgroundColor: 'black' }} />
@@ -19,30 +26,40 @@ const BlackWhiteScrollView = () => {
 };
 
 const Stack = createNativeStackNavigator();
+
+const StackScreen = () => {
+  return (
+    <Stack.Navigator>
+      <Stack.Screen
+        name="Home"
+        component={BlackWhiteScrollView}
+        options={{
+          headerTransparent: true,
+          headerTintColor: DynamicColorIOS({
+            light: 'red',
+            dark: 'green',
+          }),
+          headerBlurEffect: 'regular',
+          unstable_headerRightItems: () => [
+            {
+              type: 'button',
+              label: 'Button',
+              onPress: () => {},
+            },
+          ],
+        }}
+      />
+    </Stack.Navigator>
+  );
+};
+const Tabs = createBottomTabNavigator();
+
 export const UserInterfaceBug = () => {
   return (
     <NavigationContainer>
-      <Stack.Navigator>
-        <Stack.Screen
-          name="Home"
-          component={BlackWhiteScrollView}
-          options={{
-            headerTransparent: true,
-            headerTintColor: DynamicColorIOS({
-              light: 'red',
-              dark: 'green',
-            }),
-            headerBlurEffect: 'regular',
-            unstable_headerRightItems: () => [
-              {
-                type: 'button',
-                label: 'Button',
-                onPress: () => {},
-              },
-            ],
-          }}
-        />
-      </Stack.Navigator>
+      <Tabs.Navigator>
+        <Tabs.Screen name="Stack" component={StackScreen} />
+      </Tabs.Navigator>
     </NavigationContainer>
   );
 };

--- a/packages/bottom-tabs/src/types.tsx
+++ b/packages/bottom-tabs/src/types.tsx
@@ -460,7 +460,7 @@ export type BottomTabNavigationOptions = {
     | Icon
     | ((props: {
         focused: boolean;
-        color: ColorValue;
+        color: ColorValue | undefined;
         size: number;
       }) => Icon | React.ReactNode);
 

--- a/packages/bottom-tabs/src/views/BottomTabBar.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabBar.tsx
@@ -349,8 +349,10 @@ export function BottomTabBar({ state, navigation, descriptors, style }: Props) {
               : { borderTopWidth: StyleSheet.hairlineWidth },
         {
           backgroundColor:
-            tabBarBackgroundElement != null ? 'transparent' : colors.background,
-          borderColor: colors.border,
+            tabBarBackgroundElement != null
+              ? 'transparent'
+              : colors?.background,
+          borderColor: colors?.border,
         },
         sidebar
           ? {

--- a/packages/bottom-tabs/src/views/BottomTabItem.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabItem.tsx
@@ -189,14 +189,18 @@ export function BottomTabItem({
   const activeTintColor: ColorValue =
     customActiveTintColor ??
     (variant === 'uikit' && sidebar && horizontal
-      ? Color.foreground(colors.primary)
-      : colors.primary);
+      ? Color.foreground(colors?.primary ?? 'transparent')
+      : (colors?.primary ?? 'transparent'));
 
   const inactiveTintColor: ColorValue =
     customInactiveTintColor === undefined
       ? variant === 'material'
-        ? (Color(colors.text)?.alpha(0.68).string() ?? 'rgba(0, 0, 0, 0.68)')
-        : (Color(colors.text)?.alpha(0.5).string() ?? 'rgba(0, 0, 0, 0.5)')
+        ? (Color(colors?.text ?? 'transparent')
+            ?.alpha(0.68)
+            .string() ?? 'rgba(0, 0, 0, 0.68)')
+        : (Color(colors?.text ?? 'transparent')
+            ?.alpha(0.5)
+            .string() ?? 'rgba(0, 0, 0, 0.5)')
       : customInactiveTintColor;
 
   const activeBackgroundColor: ColorValue =
@@ -204,7 +208,7 @@ export function BottomTabItem({
     (variant === 'material'
       ? (Color(activeTintColor)?.alpha(0.12).string() ?? 'rgba(0, 0, 0, 0.06)')
       : sidebar && horizontal
-        ? colors.primary
+        ? (colors?.primary ?? 'transparent')
         : 'transparent');
 
   const { options } = descriptor;
@@ -228,8 +232,8 @@ export function BottomTabItem({
     horizontal &&
     customInactiveTintColor === undefined
   ) {
-    iconInactiveTintColor = colors.primary;
-    labelInactiveTintColor = colors.text;
+    iconInactiveTintColor = colors?.primary ?? 'transparent';
+    labelInactiveTintColor = colors?.text ?? 'transparent';
   }
 
   const renderLabel = ({ focused }: { focused: boolean }) => {
@@ -265,8 +269,8 @@ export function BottomTabItem({
               ]
             : styles.labelBeneath,
           compact || (variant === 'uikit' && sidebar && horizontal)
-            ? fonts.regular
-            : fonts.medium,
+            ? fonts?.regular
+            : fonts?.medium,
           labelStyle,
         ]}
         allowFontScaling={allowFontScaling}
@@ -345,8 +349,8 @@ export function BottomTabItem({
         pressColor: rippleColor,
         hoverEffect:
           (variant === 'material' || (sidebar && horizontal)) &&
-          typeof colors.text === 'string'
-            ? { color: colors.text }
+          typeof colors?.text === 'string'
+            ? { color: colors?.text }
             : undefined,
         pressOpacity: 1,
         style: [

--- a/packages/bottom-tabs/src/views/BottomTabViewNativeImpl.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabViewNativeImpl.tsx
@@ -118,12 +118,12 @@ export function BottomTabViewNative({
 
   const {
     fontFamily = Platform.select({
-      ios: fonts.medium.fontFamily,
-      default: fonts.regular.fontFamily,
+      ios: fonts?.medium.fontFamily,
+      default: fonts?.regular.fontFamily,
     }),
     fontWeight = Platform.select({
-      ios: fonts.medium.fontWeight,
-      default: fonts.regular.fontWeight,
+      ios: fonts?.medium.fontWeight,
+      default: fonts?.regular.fontWeight,
     }),
     fontSize,
     fontStyle,
@@ -131,7 +131,7 @@ export function BottomTabViewNative({
   } = currentOptions.tabBarLabelStyle || {};
 
   const backgroundColor =
-    currentOptions.tabBarStyle?.backgroundColor ?? colors.background;
+    currentOptions.tabBarStyle?.backgroundColor ?? colors?.background;
 
   const shouldHideTabBar = currentOptions.tabBarStyle?.display === 'none';
 
@@ -141,7 +141,7 @@ export function BottomTabViewNative({
 
   // Derive colors based on Material Design guidelines
   // https://m3.material.io/components/navigation-bar/specs
-  if (Platform.OS === 'android') {
+  if (Platform.OS === 'android' && backgroundColor) {
     switch (getAndroidColorName(backgroundColor)) {
       case 'system_surface_container_light':
       case 'system_surface_container_high_light':
@@ -178,14 +178,16 @@ export function BottomTabViewNative({
 
   inactiveTintColor =
     inactiveTintColor ??
-    Platform.select({ ios: PlatformColor('label'), default: colors.text });
+    Platform.select({ ios: PlatformColor('label'), default: colors?.text });
 
-  activeTintColor = activeTintColor ?? colors.primary;
+  activeTintColor = activeTintColor ?? colors?.primary;
 
   activeIndicatorColor =
     activeIndicatorColor ??
     Platform.select({
-      android: Color(activeTintColor)?.alpha(0.075).string(),
+      android: activeTintColor
+        ? Color(activeTintColor)?.alpha(0.075).string()
+        : undefined,
       default: undefined,
     });
 
@@ -341,9 +343,12 @@ export function BottomTabViewNative({
               : getLabel({ label: tabBarLabel, title }, route.name);
 
           const badgeBackgroundColor =
-            tabBarBadgeStyle?.backgroundColor ?? colors.notification;
+            tabBarBadgeStyle?.backgroundColor ?? colors?.notification;
           const badgeTextColor =
-            tabBarBadgeStyle?.color ?? Color.foreground(badgeBackgroundColor);
+            tabBarBadgeStyle?.color ??
+            (badgeBackgroundColor
+              ? Color.foreground(badgeBackgroundColor)
+              : undefined);
 
           const tabItemAppearance: TabsScreenItemStateAppearance = {
             tabBarItemTitleFontFamily: fontFamily,
@@ -468,7 +473,13 @@ export function BottomTabViewNative({
               overrideScrollViewContentInsetAdjustmentBehavior={
                 overrideScrollViewContentInsetAdjustmentBehavior
               }
-              experimental_userInterfaceStyle={dark ? 'dark' : 'light'}
+              experimental_userInterfaceStyle={
+                typeof dark === 'boolean'
+                  ? dark
+                    ? 'dark'
+                    : 'light'
+                  : undefined
+              }
             >
               {lazy &&
               !loaded.includes(route.key) &&

--- a/packages/drawer/src/views/DrawerItem.tsx
+++ b/packages/drawer/src/views/DrawerItem.tsx
@@ -118,7 +118,7 @@ export function DrawerItem(props: Props) {
     labelStyle,
     focused = false,
     allowFontScaling,
-    activeTintColor = colors.primary,
+    activeTintColor = colors?.primary ?? 'transparent',
     inactiveTintColor,
     activeBackgroundColor,
     inactiveBackgroundColor = 'transparent',
@@ -135,7 +135,9 @@ export function DrawerItem(props: Props) {
   const color: ColorValue = focused
     ? activeTintColor
     : (inactiveTintColor ??
-      Color(colors.text)?.alpha(0.68).string() ??
+      Color(colors?.text ?? 'transparent')
+        ?.alpha(0.68)
+        .string() ??
       'rgba(0, 0, 0, 0.68)');
   const backgroundColor: ColorValue = focused
     ? (activeBackgroundColor ??
@@ -222,7 +224,7 @@ export function DrawerItem(props: Props) {
               <Text
                 numberOfLines={1}
                 allowFontScaling={allowFontScaling}
-                style={[styles.labelText, { color }, fonts.medium, labelStyle]}
+                style={[styles.labelText, { color }, fonts?.medium, labelStyle]}
               >
                 {label}
               </Text>

--- a/packages/drawer/src/views/DrawerView.tsx
+++ b/packages/drawer/src/views/DrawerView.tsx
@@ -310,7 +310,7 @@ function DrawerViewBase({
         overlayAccessibilityLabel={overlayAccessibilityLabel}
         drawerPosition={drawerPosition}
         drawerStyle={[
-          { backgroundColor: colors.card },
+          { backgroundColor: colors?.card },
           drawerType === 'permanent' &&
             ((
               Platform.OS === 'web'
@@ -319,11 +319,11 @@ function DrawerViewBase({
                   (direction !== 'rtl' && drawerPosition === 'right')
             )
               ? {
-                  borderLeftColor: colors.border,
+                  borderLeftColor: colors?.border,
                   borderLeftWidth: StyleSheet.hairlineWidth,
                 }
               : {
-                  borderRightColor: colors.border,
+                  borderRightColor: colors?.border,
                   borderRightWidth: StyleSheet.hairlineWidth,
                 }),
 

--- a/packages/elements/src/Badge.tsx
+++ b/packages/elements/src/Badge.tsx
@@ -73,7 +73,7 @@ export function Badge({
   }
 
   // @ts-expect-error: backgroundColor definitely exists
-  const { backgroundColor = colors.notification, ...restStyle } =
+  const { backgroundColor = colors?.notification, ...restStyle } =
     StyleSheet.flatten(style) || {};
   const textColor = Color.foreground(backgroundColor);
 
@@ -103,7 +103,7 @@ export function Badge({
           borderRadius,
           borderCurve: 'continuous',
         },
-        fonts.regular,
+        fonts?.regular,
         styles.container,
         restStyle,
       ]}

--- a/packages/elements/src/Button.tsx
+++ b/packages/elements/src/Button.tsx
@@ -82,7 +82,7 @@ function ButtonBase({
 }: ButtonBaseProps) {
   const { dark, colors, fonts } = useTheme();
 
-  const color = customColor ?? colors.primary;
+  const color = customColor ?? colors?.primary ?? 'transparent';
 
   let backgroundColor: ColorValue;
   let textColor: ColorValue;
@@ -118,7 +118,7 @@ function ButtonBase({
       }
       style={[{ backgroundColor }, styles.button, style]}
     >
-      <Text style={[{ color: textColor }, fonts.regular, styles.text]}>
+      <Text style={[{ color: textColor }, fonts?.regular, styles.text]}>
         {children}
       </Text>
     </PlatformPressable>

--- a/packages/elements/src/Header/Header.tsx
+++ b/packages/elements/src/Header/Header.tsx
@@ -271,8 +271,8 @@ export function Header(props: Props) {
       ios:
         isLiquidGlassSupported && PlatformColor
           ? PlatformColor('label')
-          : colors.primary,
-      default: colors.text,
+          : (colors?.primary ?? 'transparent'),
+      default: colors?.text ?? 'transparent',
     });
 
   const leftButton = headerLeft

--- a/packages/elements/src/Header/HeaderBackButton.tsx
+++ b/packages/elements/src/Header/HeaderBackButton.tsx
@@ -49,7 +49,7 @@ export function HeaderBackButton({
   const isMinimal = displayMode === 'minimal' || measuredMinimal;
 
   const renderBackImage = () => {
-    const color = tintColor ?? colors.text;
+    const color = tintColor ?? colors?.text ?? 'transparent';
 
     if (typeof icon === 'function') {
       return icon({ tintColor: color });
@@ -181,7 +181,7 @@ function HeaderBackLabel({
   }, [isMinimal, onMeasureMinimal]);
 
   const commonStyle: Animated.WithAnimatedValue<StyleProp<TextStyle>> = [
-    fonts.regular,
+    fonts?.regular,
     styles.label,
     labelStyle,
   ];

--- a/packages/elements/src/Header/HeaderBackground.tsx
+++ b/packages/elements/src/Header/HeaderBackground.tsx
@@ -31,8 +31,8 @@ export function HeaderBackground({
       style={[
         styles.container,
         {
-          backgroundColor: colors.card,
-          borderBottomColor: colors.border,
+          backgroundColor: colors?.card,
+          borderBottomColor: colors?.border,
         },
         style,
       ]}

--- a/packages/elements/src/Header/HeaderSearchBar.tsx
+++ b/packages/elements/src/Header/HeaderSearchBar.tsx
@@ -164,7 +164,7 @@ export function HeaderSearchBar({
     [cancelSearch, clearText]
   );
 
-  const textColor = tintColor ?? colors.text;
+  const textColor = tintColor ?? colors?.text ?? 'transparent';
 
   // When status bar height is provided, add spacing below it
   // Otherwise, use a smaller top margin to align with the header content
@@ -196,7 +196,7 @@ export function HeaderSearchBar({
       {Platform.OS !== 'ios' ? (
         <HeaderBackButton
           accessibilityLabel={cancelButtonText}
-          tintColor={tintColor ?? colors.text}
+          tintColor={tintColor ?? colors?.text}
           pressColor={pressColor}
           pressOpacity={pressOpacity}
           onPress={cancelSearch}
@@ -228,13 +228,17 @@ export function HeaderSearchBar({
           enterKeyHint={enterKeyHint}
           placeholder={placeholder}
           placeholderTextColor={Color(textColor)?.alpha(0.5).string()}
-          cursorColor={colors.primary}
-          selectionHandleColor={colors.primary}
-          selectionColor={Color(colors.primary)?.alpha(0.3).string()}
+          cursorColor={colors?.primary ?? 'transparent'}
+          selectionHandleColor={colors?.primary ?? 'transparent'}
+          selectionColor={
+            Color(colors?.primary ?? 'transparent')
+              ?.alpha(0.3)
+              .string() ?? 'transparent'
+          }
           style={[
             Platform.select({
-              ios: isLiquidGlassSupported ? fonts.medium : fonts.regular,
-              default: fonts.regular,
+              ios: isLiquidGlassSupported ? fonts?.medium : fonts?.regular,
+              default: fonts?.regular,
             }),
             styles.searchbar,
             Platform.OS === 'ios' &&
@@ -307,8 +311,8 @@ export function HeaderSearchBar({
           >
             <Text
               style={[
-                fonts.regular,
-                { color: tintColor ?? colors.primary },
+                fonts?.regular,
+                { color: tintColor ?? colors?.primary },
                 styles.cancelText,
               ]}
             >

--- a/packages/elements/src/Header/HeaderTitle.tsx
+++ b/packages/elements/src/Header/HeaderTitle.tsx
@@ -25,8 +25,8 @@ export function HeaderTitle({ tintColor, style, ...rest }: Props) {
       numberOfLines={1}
       {...rest}
       style={[
-        { color: tintColor === undefined ? colors.text : tintColor },
-        Platform.select({ ios: fonts.bold, default: fonts.medium }),
+        { color: tintColor === undefined ? colors?.text : tintColor },
+        Platform.select({ ios: fonts?.bold, default: fonts?.medium }),
         styles.title,
         style,
       ]}

--- a/packages/elements/src/Screen.tsx
+++ b/packages/elements/src/Screen.tsx
@@ -71,7 +71,7 @@ export function Screen(props: Props) {
       inert={!focused}
       style={{
         ...styles.container,
-        backgroundColor: colors.background,
+        backgroundColor: colors?.background,
         ...style,
       }}
       // On Fabric we need to disable collapsing for the background to ensure

--- a/packages/elements/src/Text.tsx
+++ b/packages/elements/src/Text.tsx
@@ -8,7 +8,7 @@ export function Text({ style, ...rest }: TextProps) {
   return (
     <NativeText
       {...rest}
-      style={[{ color: colors.text }, fonts.regular, style]}
+      style={[{ color: colors?.text }, fonts?.regular, style]}
     />
   );
 }

--- a/packages/material-top-tabs/src/views/MaterialTopTabBar.tsx
+++ b/packages/material-top-tabs/src/views/MaterialTopTabBar.tsx
@@ -34,7 +34,7 @@ const MaterialLabel = ({
 
   return (
     <Text
-      style={[{ color }, fonts.medium, styles.label, style]}
+      style={[{ color }, fonts?.medium, styles.label, style]}
       allowFontScaling={allowFontScaling}
     >
       {labelText}
@@ -59,7 +59,7 @@ export function MaterialTopTabBar({
   const focusedOptions = descriptors[state.routes[state.index].key].options;
 
   const activeColor: ColorValue =
-    focusedOptions.tabBarActiveTintColor ?? colors.text;
+    focusedOptions.tabBarActiveTintColor ?? colors?.text ?? 'transparent';
   const inactiveColor: ColorValue =
     focusedOptions.tabBarInactiveTintColor ??
     Color(activeColor)?.alpha(0.5).string() ??
@@ -196,14 +196,14 @@ export function MaterialTopTabBar({
       pressOpacity={focusedOptions.tabBarPressOpacity}
       tabStyle={focusedOptions.tabBarItemStyle}
       indicatorStyle={[
-        { backgroundColor: colors.primary },
+        { backgroundColor: colors?.primary },
         focusedOptions.tabBarIndicatorStyle,
       ]}
       gap={focusedOptions.tabBarGap}
       android_ripple={focusedOptions.tabBarAndroidRipple}
       indicatorContainerStyle={focusedOptions.tabBarIndicatorContainerStyle}
       contentContainerStyle={focusedOptions.tabBarContentContainerStyle}
-      style={[{ backgroundColor: colors.card }, focusedOptions.tabBarStyle]}
+      style={[{ backgroundColor: colors?.card }, focusedOptions.tabBarStyle]}
       onTabPress={({ route, preventDefault }) => {
         const event = navigation.emit({
           type: 'tabPress',

--- a/packages/material-top-tabs/src/views/MaterialTopTabView.tsx
+++ b/packages/material-top-tabs/src/views/MaterialTopTabView.tsx
@@ -104,7 +104,7 @@ export function MaterialTopTabView({
             route.key,
             {
               sceneStyle: [
-                { backgroundColor: colors.background },
+                { backgroundColor: colors?.background },
                 options?.sceneStyle,
               ],
             },

--- a/packages/native-stack/src/views/NativeStackView.native.tsx
+++ b/packages/native-stack/src/views/NativeStackView.native.tsx
@@ -418,7 +418,7 @@ const SceneView = ({
         contentStyle={[
           presentation !== 'transparentModal' &&
             presentation !== 'containedTransparentModal' && {
-              backgroundColor: colors.background,
+              backgroundColor: colors?.background,
             },
           contentStyle,
         ]}

--- a/packages/native-stack/src/views/useHeaderConfigProps.tsx
+++ b/packages/native-stack/src/views/useHeaderConfigProps.tsx
@@ -43,8 +43,8 @@ const ICON_SIZE = 24;
 
 const processBarButtonItems = (
   items: NativeStackHeaderItem[] | undefined,
-  colors: Theme['colors'],
-  fonts: Theme['fonts']
+  colors?: Theme['colors'],
+  fonts?: Theme['fonts']
 ) => {
   return items
     ?.map((item, index) => {
@@ -81,7 +81,7 @@ const processBarButtonItems = (
           index,
           title: label,
           titleStyle: {
-            ...fonts.regular,
+            ...fonts?.regular,
             ...labelStyle,
           },
           icon: transformIcon(icon),
@@ -116,8 +116,10 @@ const processBarButtonItems = (
 
         if (badge) {
           const badgeBackgroundColor =
-            badge.style?.backgroundColor ?? colors.notification;
-          const badgeTextColor = Color.foreground(badgeBackgroundColor);
+            badge.style?.backgroundColor ?? colors?.notification;
+          const badgeTextColor = badgeBackgroundColor
+            ? Color.foreground(badgeBackgroundColor)
+            : undefined;
 
           processedItem = {
             ...processedItem,
@@ -127,7 +129,7 @@ const processBarButtonItems = (
               style: {
                 backgroundColor: badgeBackgroundColor,
                 color: badgeTextColor,
-                ...fonts.regular,
+                ...fonts?.regular,
                 ...badge.style,
               },
             },
@@ -222,31 +224,25 @@ export function useHeaderConfigProps({
   const { direction } = useLocale();
   const { colors, fonts, dark } = useTheme();
   const tintColor =
-    headerTintColor ?? (Platform.OS === 'ios' ? colors.primary : colors.text);
+    headerTintColor ?? (Platform.OS === 'ios' ? colors?.primary : colors?.text);
 
   const headerBackTitleStyleFlattened =
-    StyleSheet.flatten([fonts.regular, headerBackTitleStyle]) || {};
+    StyleSheet.flatten([fonts?.regular, headerBackTitleStyle]) || {};
   const headerLargeTitleStyleFlattened =
     StyleSheet.flatten([
-      Platform.select({ ios: fonts.heavy, default: fonts.medium }),
+      Platform.select({ ios: fonts?.heavy, default: fonts?.medium }),
       headerLargeTitleStyle,
     ]) || {};
   const headerTitleStyleFlattened =
     StyleSheet.flatten([
-      Platform.select({ ios: fonts.bold, default: fonts.medium }),
+      Platform.select({ ios: fonts?.bold, default: fonts?.medium }),
       headerTitleStyle,
     ]) || {};
   const headerStyleFlattened = StyleSheet.flatten(headerStyle) || {};
   const headerLargeStyleFlattened = StyleSheet.flatten(headerLargeStyle) || {};
 
   const headerBackgroundColor =
-    headerStyleFlattened.backgroundColor ??
-    (headerBackground != null ||
-    headerTransparent ||
-    // The title becomes invisible if background color is set with large title on iOS 26
-    (Platform.OS === 'ios' && headerLargeTitleEnabled)
-      ? 'transparent'
-      : colors.card);
+    headerStyleFlattened.backgroundColor ?? colors?.card;
 
   const backTitleFontSize =
     'fontSize' in headerBackTitleStyleFlattened
@@ -264,7 +260,8 @@ export function useHeaderConfigProps({
           // So we don't set an explicit color when header is transparent
           // Unless a custom tint color is explicitly provided
           headerTintColor
-        : (headerTintColor ?? colors.text);
+        : (headerTintColor ?? colors?.text);
+
   const titleFontSize =
     'fontSize' in headerTitleStyleFlattened
       ? headerTitleStyleFlattened.fontSize
@@ -553,6 +550,7 @@ export function useHeaderConfigProps({
     children,
     headerLeftBarButtonItems: processBarButtonItems(leftItems, colors, fonts),
     headerRightBarButtonItems: processBarButtonItems(rightItems, colors, fonts),
-    experimental_userInterfaceStyle: dark ? 'dark' : 'light',
+    experimental_userInterfaceStyle:
+      typeof dark === 'boolean' ? (dark ? 'dark' : 'light') : undefined,
   } as const;
 }

--- a/packages/native-stack/src/views/useHeaderConfigProps.tsx
+++ b/packages/native-stack/src/views/useHeaderConfigProps.tsx
@@ -242,7 +242,13 @@ export function useHeaderConfigProps({
   const headerLargeStyleFlattened = StyleSheet.flatten(headerLargeStyle) || {};
 
   const headerBackgroundColor =
-    headerStyleFlattened.backgroundColor ?? colors?.card;
+    headerStyleFlattened.backgroundColor ??
+    (headerBackground != null ||
+    headerTransparent ||
+    // The title becomes invisible if background color is set with large title on iOS 26
+    (Platform.OS === 'ios' && headerLargeTitleEnabled)
+      ? 'transparent'
+      : colors?.card);
 
   const backTitleFontSize =
     'fontSize' in headerBackTitleStyleFlattened

--- a/packages/native/src/Link.tsx
+++ b/packages/native/src/Link.tsx
@@ -67,6 +67,6 @@ export function Link<
       web: { onClick: onPress } as any,
       default: { onPress },
     }),
-    style: [{ color: colors.primary }, fonts.regular, style],
+    style: [{ color: colors?.primary }, fonts?.regular, style],
   });
 }

--- a/packages/native/src/index.tsx
+++ b/packages/native/src/index.tsx
@@ -17,6 +17,7 @@ export { ServerContainer } from './ServerContainer';
 export { DarkTheme } from './theming/DarkTheme';
 export { LightTheme as DefaultTheme } from './theming/LightTheme';
 export { MaterialDarkTheme, MaterialLightTheme } from './theming/MaterialTheme';
+export { SystemTheme } from './theming/SystemTheme';
 export * from './types';
 export { useLinkBuilder } from './useLinkBuilder';
 export { type LinkProps, useLinkProps } from './useLinkProps';

--- a/packages/native/src/theming/SystemTheme.tsx
+++ b/packages/native/src/theming/SystemTheme.tsx
@@ -1,0 +1,7 @@
+import type { Theme } from '@react-navigation/core';
+
+export const SystemTheme = {
+  dark: undefined,
+  colors: undefined,
+  fonts: undefined,
+} as const satisfies Theme;

--- a/packages/native/src/types.tsx
+++ b/packages/native/src/types.tsx
@@ -37,8 +37,8 @@ type FontStyle = {
 };
 
 interface NativeTheme {
-  dark: boolean;
-  colors: {
+  dark?: boolean;
+  colors?: {
     primary: ColorValue;
     background: ColorValue;
     card: ColorValue;
@@ -46,7 +46,7 @@ interface NativeTheme {
     border: ColorValue;
     notification: ColorValue;
   };
-  fonts: {
+  fonts?: {
     regular: FontStyle;
     medium: FontStyle;
     bold: FontStyle;

--- a/packages/stack/src/views/Stack/CardContainer.tsx
+++ b/packages/stack/src/views/Stack/CardContainer.tsx
@@ -270,7 +270,7 @@ function CardContainerInner({
             backgroundColor:
               presentation === 'transparentModal'
                 ? 'transparent'
-                : colors.background,
+                : colors?.background,
           },
           cardStyle,
         ]}


### PR DESCRIPTION
**Motivation**

Fixes https://github.com/react-navigation/react-navigation/issues/13069

Sometimes you want to use the system theme and not the default theme provided by react navigation. Also you might want to set `dark` to undefined so the header and bottom bar uses automatic UIUserInterfaceStyle and thereby gets expected support for DynamicColorIOS and PlatformColor.

**Test plan**

TBD but for know you can start the example app and see a custom screen that I've created with transparent header and that uses DynamicColorIOS in the headerTintColor. Toggle theme with Cmd + Shift + A when app is in foreground and in background. This custom screen should probably be removed before merging and instead we should create an example in the current example app. But I wanted to get an opinion of the purposed changes before updating the existing example screens.

When setting `dark`, `colors` and `fonts` to undefined by using `SystemTheme` DynamicColorIOS works as expected even though app is in background:
https://github.com/user-attachments/assets/de7ea3ec-3cc1-4d3b-b505-f133692d5428


