### PR TITLE
fix: preserve accessibility on android when header transparent is true

### DIFF
--- a/packages/elements/src/Screen.tsx
+++ b/packages/elements/src/Screen.tsx
@@ -88,7 +88,12 @@ export function Screen(props: Props) {
 
               setHeaderHeight(height);
             }}
-            style={[styles.header, headerTransparent ? styles.absolute : null]}
+            style={[
+              styles.header,
+              headerTransparent
+                ? [styles.absolute, { height: headerHeight }]
+                : null,
+            ]}
           >
             {header}
           </View>

--- a/packages/elements/src/Screen.tsx
+++ b/packages/elements/src/Screen.tsx
@@ -91,7 +91,11 @@ export function Screen(props: Props) {
             style={[
               styles.header,
               headerTransparent
-                ? [styles.absolute, { height: headerHeight }]
+                ? [
+                    styles.absolute,
+                    // Specify an explicit min height for Android screen readers
+                    { minHeight: headerHeight },
+                  ]
                 : null,
             ]}
           >

--- a/packages/elements/src/Screen.tsx
+++ b/packages/elements/src/Screen.tsx
@@ -82,12 +82,6 @@ export function Screen(props: Props) {
       {headerShown ? (
         <NavigationProvider navigation={navigation} route={route}>
           <View
-            ref={headerRef}
-            onLayout={(e) => {
-              const { height } = e.nativeEvent.layout;
-
-              setHeaderHeight(height);
-            }}
             style={[
               styles.header,
               headerTransparent
@@ -99,7 +93,17 @@ export function Screen(props: Props) {
                 : null,
             ]}
           >
-            {header}
+            <View
+              ref={headerRef}
+              onLayout={(e) => {
+                const { height } = e.nativeEvent.layout;
+
+                setHeaderHeight(height);
+              }}
+              style={{ pointerEvents: 'box-none' }}
+            >
+              {header}
+            </View>
           </View>
         </NavigationProvider>
       ) : null}

--- a/packages/native-stack/src/views/NativeStackView.native.tsx
+++ b/packages/native-stack/src/views/NativeStackView.native.tsx
@@ -339,7 +339,11 @@ const SceneView = ({
             style={[
               styles.header,
               headerTransparent
-                ? [styles.absolute, { height: headerHeight }]
+                ? [
+                    styles.absolute,
+                    // Specify an explicit min height for Android screen readers
+                    { minHeight: headerHeight },
+                  ]
                 : null,
             ]}
           >

--- a/packages/native-stack/src/views/NativeStackView.native.tsx
+++ b/packages/native-stack/src/views/NativeStackView.native.tsx
@@ -330,12 +330,6 @@ const SceneView = ({
         ) : null}
         {header != null && headerShown !== false ? (
           <View
-            onLayout={(e) => {
-              const headerHeight = e.nativeEvent.layout.height;
-
-              animatedHeaderHeight.setValue(headerHeight);
-              setHeaderHeight(headerHeight);
-            }}
             style={[
               styles.header,
               headerTransparent
@@ -347,12 +341,22 @@ const SceneView = ({
                 : null,
             ]}
           >
-            {header({
-              back: headerBack,
-              options,
-              route,
-              navigation,
-            })}
+            <View
+              onLayout={(e) => {
+                const headerHeight = e.nativeEvent.layout.height;
+
+                animatedHeaderHeight.setValue(headerHeight);
+                setHeaderHeight(headerHeight);
+              }}
+              style={{ pointerEvents: 'box-none' }}
+            >
+              {header({
+                back: headerBack,
+                options,
+                route,
+                navigation,
+              })}
+            </View>
           </View>
         ) : null}
         <HeaderShownContext.Provider

--- a/packages/native-stack/src/views/NativeStackView.native.tsx
+++ b/packages/native-stack/src/views/NativeStackView.native.tsx
@@ -336,7 +336,12 @@ const SceneView = ({
               animatedHeaderHeight.setValue(headerHeight);
               setHeaderHeight(headerHeight);
             }}
-            style={[styles.header, headerTransparent ? styles.absolute : null]}
+            style={[
+              styles.header,
+              headerTransparent
+                ? [styles.absolute, { height: headerHeight }]
+                : null,
+            ]}
           >
             {header({
               back: headerBack,

--- a/packages/stack/src/views/Header/HeaderContainer.tsx
+++ b/packages/stack/src/views/Header/HeaderContainer.tsx
@@ -61,7 +61,6 @@ export function HeaderContainer({
           header,
           headerMode,
           headerShown = true,
-          headerTransparent,
           headerStyleInterpolator,
         } = scene.descriptor.options;
 
@@ -160,9 +159,7 @@ export function HeaderContainer({
               style={[
                 // Avoid positioning the focused header absolutely
                 // Otherwise accessibility tools don't seem to be able to find it
-                (mode === 'float' && !isFocused) || headerTransparent
-                  ? styles.header
-                  : null,
+                mode === 'float' && !isFocused ? styles.header : null,
                 {
                   pointerEvents: isFocused ? 'box-none' : 'none',
                 },

--- a/packages/stack/src/views/Header/HeaderContainer.tsx
+++ b/packages/stack/src/views/Header/HeaderContainer.tsx
@@ -158,7 +158,6 @@ export function HeaderContainer({
               }
               style={[
                 // Avoid positioning the focused header absolutely
-                // Otherwise accessibility tools don't seem to be able to find it
                 mode === 'float' && !isFocused ? styles.header : null,
                 {
                   pointerEvents: isFocused ? 'box-none' : 'none',

--- a/packages/stack/src/views/Header/HeaderContainer.tsx
+++ b/packages/stack/src/views/Header/HeaderContainer.tsx
@@ -61,6 +61,7 @@ export function HeaderContainer({
           header,
           headerMode,
           headerShown = true,
+          headerTransparent,
           headerStyleInterpolator,
         } = scene.descriptor.options;
 
@@ -158,7 +159,10 @@ export function HeaderContainer({
               }
               style={[
                 // Avoid positioning the focused header absolutely
-                mode === 'float' && !isFocused ? styles.header : null,
+                // Otherwise accessibility tools don't seem to be able to find it
+                (mode === 'float' && !isFocused) || headerTransparent
+                  ? styles.header
+                  : null,
                 {
                   pointerEvents: isFocused ? 'box-none' : 'none',
                 },

--- a/packages/stack/src/views/Stack/CardContainer.tsx
+++ b/packages/stack/src/views/Stack/CardContainer.tsx
@@ -194,6 +194,7 @@ function CardContainerInner({
     gestureVelocityImpact,
     headerMode,
     headerShown,
+    headerTransparent,
     transitionSpec,
   } = scene.descriptor.options;
 
@@ -284,7 +285,10 @@ function CardContainerInner({
                   getPreviousScene,
                   getFocusedRoute,
                   onContentHeightChange: onHeaderHeightChange,
-                  style: styles.header,
+                  style: [
+                    styles.header,
+                    headerTransparent ? { height: headerHeight } : null,
+                  ],
                 })
               : null}
             <View style={styles.scene}>

--- a/packages/stack/src/views/Stack/CardContainer.tsx
+++ b/packages/stack/src/views/Stack/CardContainer.tsx
@@ -287,7 +287,12 @@ function CardContainerInner({
                   onContentHeightChange: onHeaderHeightChange,
                   style: [
                     styles.header,
-                    headerTransparent ? { height: headerHeight } : null,
+                    headerTransparent
+                      ? {
+                          // Specify an explicit min height for Android screen readers
+                          minHeight: headerHeight,
+                        }
+                      : null,
                   ],
                 })
               : null}


### PR DESCRIPTION
## Summary
The bug happens because when headerTransparent: true, the focused header is forced into absolute positioning, and on Android TalkBack this layer setup can make the back button and title hard to focus.
The fix removes this forced absolute positioning only for the focused header, so it stays in normal layout and remains accessible.
The change is limited to one condition in packages/stack/src/views/Header/HeaderContainer.tsx, with no API, gesture, routing, or render-structure changes.
So the impact is very small, while absolute positioning for non-focused headers and transition behavior is still preserved, keeping regression risk low.

## Related issue
https://github.com/react-navigation/react-navigation/issues/13043

## Current behavior
<img width="356" height="662" alt="20260416234149" src="https://github.com/user-attachments/assets/0fcb8554-1124-4807-a330-e878e9ab216e" />
