### PR TITLE
feat: add support for retaining screens in stack

### DIFF
--- a/example/e2e/maestro/stack-retain.yml
+++ b/example/e2e/maestro/stack-retain.yml
@@ -1,0 +1,36 @@
+appId: ${APP_ID}
+name: Stack - Retain
+---
+- runFlow:
+    file: ../launch.yml
+    env:
+      LINK: stack-retain
+      TEXT: "Let's Go!"
+- tapOn:
+    text: "Let's Go!"
+- assertVisible:
+    text: 'Retain'
+- extendedWaitUntil:
+    timeout: 5000
+    visible: '3'
+- tapOn:
+    text: 'Retain'
+- assertVisible:
+    text: '📌'
+- back
+- tapOn:
+    text: "Let's Go!"
+- extendedWaitUntil:
+    timeout: 5000
+    visible: '6'
+- assertVisible:
+    text: '📌'
+- tapOn:
+    text: 'Unretain'
+- back
+- tapOn:
+    text: "Let's Go!"
+- assertNotVisible:
+    text: '📌'
+- assertVisible:
+    text: 'Retain'

--- a/example/e2e/tests/maestro.test.ts
+++ b/example/e2e/tests/maestro.test.ts
@@ -277,6 +277,12 @@ async function runStep(page: Page, step: any) {
       break;
     }
 
+    case 'back': {
+      await page.goBack();
+
+      break;
+    }
+
     case 'stopApp': {
       // No-op on web
 

--- a/example/src/Screens/StackRetain.tsx
+++ b/example/src/Screens/StackRetain.tsx
@@ -1,0 +1,109 @@
+import { Button, Text } from '@react-navigation/elements';
+import {
+  useNavigation,
+  useNavigationState,
+  useRoute,
+  useTheme,
+} from '@react-navigation/native';
+import { createStackNavigator } from '@react-navigation/stack';
+import * as React from 'react';
+import { ScrollView, StyleSheet, View } from 'react-native';
+
+const HomeScreen = () => {
+  const navigation = useNavigation('RetainHome');
+  const { colors } = useTheme();
+
+  return (
+    <ScrollView
+      contentContainerStyle={styles.scrollContent}
+      style={[styles.screen, { backgroundColor: colors.background }]}
+    >
+      <Button
+        variant="filled"
+        onPress={() => navigation.navigate('RetainCounter')}
+      >
+        Let's Go!
+      </Button>
+    </ScrollView>
+  );
+};
+
+const CounterScreen = () => {
+  const [count, setCount] = React.useState(0);
+  const { colors } = useTheme();
+
+  const navigation = useNavigation('RetainCounter');
+
+  React.useEffect(() => {
+    const interval = setInterval(() => {
+      setCount((prev) => prev + 1);
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, []);
+
+  const route = useRoute('RetainCounter');
+  const isRetained = useNavigationState('RetainCounter', (state) =>
+    state.retainedRouteKeys.includes(route.key)
+  );
+
+  return (
+    <ScrollView
+      contentContainerStyle={styles.scrollContent}
+      style={[styles.screen, { backgroundColor: colors.background }]}
+    >
+      <View style={{ alignItems: 'center', gap: 16 }}>
+        <Text
+          style={{
+            fontSize: 24,
+            position: 'absolute',
+            bottom: 24,
+            right: 0,
+          }}
+        >
+          {isRetained ? '📌' : ''}
+        </Text>
+        <Text style={{ fontSize: 48, fontVariant: ['tabular-nums'] }}>
+          {count}
+        </Text>
+        <Button onPress={() => navigation.retain(isRetained ? false : true)}>
+          {isRetained ? 'Unretain' : 'Retain'}
+        </Button>
+      </View>
+    </ScrollView>
+  );
+};
+
+const StackRetainNavigator = createStackNavigator({
+  screens: {
+    RetainHome: {
+      screen: HomeScreen,
+      options: {
+        title: 'Home',
+      },
+    },
+    RetainCounter: {
+      screen: CounterScreen,
+      options: {
+        title: 'Counter',
+      },
+    },
+  },
+});
+
+export const StackRetain = {
+  screen: StackRetainNavigator,
+  title: 'Stack - Retain',
+};
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+  },
+  scrollContent: {
+    flexGrow: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 16,
+  },
+});

--- a/example/src/screens.tsx
+++ b/example/src/screens.tsx
@@ -31,6 +31,7 @@ import { StackHeaderCustomization } from './Screens/StackHeaderCustomization';
 import { StackModal } from './Screens/StackModal';
 import { StackPreloadFlow } from './Screens/StackPreloadFlow';
 import { StackPreventRemove } from './Screens/StackPreventRemove';
+import { StackRetain } from './Screens/StackRetain';
 import { StackTransparentModal } from './Screens/StackTransparentModal';
 import { StaticConfig as StaticConfigScreen } from './Screens/StaticConfig';
 import { BottomTabsShowcase } from './Showcase/BottomTabsShowcase';
@@ -72,6 +73,7 @@ export const SCREENS = {
   NavigatorLayout,
   ScreenLayout,
   StaticConfigScreen,
+  StackRetain,
   ActivityModes,
   BottomTabsShowcase,
   DrawerShowcase,

--- a/packages/core/src/__tests__/useOnAction.test.tsx
+++ b/packages/core/src/__tests__/useOnAction.test.tsx
@@ -606,6 +606,7 @@ test("prevents removing a screen with 'beforeRemove' event", () => {
     index: 1,
     key: 'stack-2',
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [
       { key: 'foo-3', name: 'foo' },
@@ -622,6 +623,7 @@ test("prevents removing a screen with 'beforeRemove' event", () => {
     index: 2,
     key: 'stack-2',
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [
       { key: 'foo-3', name: 'foo' },
@@ -644,6 +646,7 @@ test("prevents removing a screen with 'beforeRemove' event", () => {
     index: 2,
     key: 'stack-2',
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [
       { key: 'foo-3', name: 'foo' },
@@ -663,6 +666,7 @@ test("prevents removing a screen with 'beforeRemove' event", () => {
     index: 0,
     key: 'stack-2',
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [{ key: 'foo-3', name: 'foo' }],
     stale: false,
@@ -680,6 +684,7 @@ test("prevents removing a screen with 'beforeRemove' event", () => {
     index: 0,
     key: 'stack-2',
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [{ key: 'foo-3', name: 'foo' }],
     stale: false,
@@ -756,6 +761,7 @@ test("prevents removing a child screen with 'beforeRemove' event", () => {
     index: 1,
     key: 'stack-2',
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [
       { key: 'foo-3', name: 'foo' },
@@ -772,6 +778,7 @@ test("prevents removing a child screen with 'beforeRemove' event", () => {
     index: 2,
     key: 'stack-2',
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [
       { key: 'foo-3', name: 'foo' },
@@ -783,6 +790,7 @@ test("prevents removing a child screen with 'beforeRemove' event", () => {
           index: 0,
           key: 'stack-8',
           preloadedRoutes: [],
+          retainedRouteKeys: [],
           routeNames: ['qux', 'lex'],
           routes: [{ key: 'qux-9', name: 'qux' }],
           stale: false,
@@ -803,6 +811,7 @@ test("prevents removing a child screen with 'beforeRemove' event", () => {
     index: 2,
     key: 'stack-2',
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [
       { key: 'foo-3', name: 'foo' },
@@ -814,6 +823,7 @@ test("prevents removing a child screen with 'beforeRemove' event", () => {
           index: 0,
           key: 'stack-8',
           preloadedRoutes: [],
+          retainedRouteKeys: [],
           routeNames: ['qux', 'lex'],
           routes: [{ key: 'qux-9', name: 'qux' }],
           stale: false,
@@ -834,6 +844,7 @@ test("prevents removing a child screen with 'beforeRemove' event", () => {
     index: 0,
     key: 'stack-2',
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [{ key: 'foo-3', name: 'foo' }],
     stale: false,
@@ -851,6 +862,7 @@ test("prevents removing a child screen with 'beforeRemove' event", () => {
     index: 0,
     key: 'stack-2',
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [{ key: 'foo-3', name: 'foo' }],
     stale: false,
@@ -932,6 +944,7 @@ test("prevents removing a grand child screen with 'beforeRemove' event", () => {
     index: 1,
     key: 'stack-2',
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [
       { key: 'foo-3', name: 'foo' },
@@ -948,6 +961,7 @@ test("prevents removing a grand child screen with 'beforeRemove' event", () => {
     index: 2,
     key: 'stack-2',
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [
       { key: 'foo-3', name: 'foo' },
@@ -959,6 +973,7 @@ test("prevents removing a grand child screen with 'beforeRemove' event", () => {
           index: 0,
           key: 'stack-8',
           preloadedRoutes: [],
+          retainedRouteKeys: [],
           routeNames: ['qux'],
           routes: [
             {
@@ -968,6 +983,7 @@ test("prevents removing a grand child screen with 'beforeRemove' event", () => {
                 index: 0,
                 key: 'stack-12',
                 preloadedRoutes: [],
+                retainedRouteKeys: [],
                 routeNames: ['lex'],
                 routes: [{ key: 'lex-13', name: 'lex' }],
                 stale: false,
@@ -993,6 +1009,7 @@ test("prevents removing a grand child screen with 'beforeRemove' event", () => {
     index: 2,
     key: 'stack-2',
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [
       { key: 'foo-3', name: 'foo' },
@@ -1004,6 +1021,7 @@ test("prevents removing a grand child screen with 'beforeRemove' event", () => {
           index: 0,
           key: 'stack-8',
           preloadedRoutes: [],
+          retainedRouteKeys: [],
           routeNames: ['qux'],
           routes: [
             {
@@ -1013,6 +1031,7 @@ test("prevents removing a grand child screen with 'beforeRemove' event", () => {
                 index: 0,
                 key: 'stack-12',
                 preloadedRoutes: [],
+                retainedRouteKeys: [],
                 routeNames: ['lex'],
                 routes: [{ key: 'lex-13', name: 'lex' }],
                 stale: false,
@@ -1038,6 +1057,7 @@ test("prevents removing a grand child screen with 'beforeRemove' event", () => {
     index: 0,
     key: 'stack-2',
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [{ key: 'foo-3', name: 'foo' }],
     stale: false,
@@ -1055,6 +1075,7 @@ test("prevents removing a grand child screen with 'beforeRemove' event", () => {
     index: 0,
     key: 'stack-2',
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [{ key: 'foo-3', name: 'foo' }],
     stale: false,
@@ -1146,6 +1167,7 @@ test("prevents removing by multiple screens with 'beforeRemove' event", () => {
     index: 3,
     key: 'stack-2',
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz', 'bax'],
     routes: [
       { key: 'foo-3', name: 'foo' },
@@ -1158,6 +1180,7 @@ test("prevents removing by multiple screens with 'beforeRemove' event", () => {
           index: 0,
           key: 'stack-9',
           preloadedRoutes: [],
+          retainedRouteKeys: [],
           routeNames: ['qux'],
           routes: [
             {
@@ -1167,6 +1190,7 @@ test("prevents removing by multiple screens with 'beforeRemove' event", () => {
                 index: 0,
                 key: 'stack-13',
                 preloadedRoutes: [],
+                retainedRouteKeys: [],
                 routeNames: ['lex'],
                 routes: [{ key: 'lex-14', name: 'lex' }],
                 stale: false,
@@ -1220,6 +1244,7 @@ test("prevents removing by multiple screens with 'beforeRemove' event", () => {
     index: 0,
     key: 'stack-2',
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz', 'bax'],
     routes: [{ key: 'foo-3', name: 'foo' }],
     stale: false,
@@ -1296,6 +1321,7 @@ test("prevents removing a child screen with 'beforeRemove' event with 'resetRoot
     index: 1,
     key: 'stack-2',
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [
       { key: 'foo-3', name: 'foo' },
@@ -1306,6 +1332,7 @@ test("prevents removing a child screen with 'beforeRemove' event with 'resetRoot
           index: 0,
           key: 'stack-7',
           preloadedRoutes: [],
+          retainedRouteKeys: [],
           routeNames: ['qux', 'lex'],
           routes: [{ key: 'qux-8', name: 'qux' }],
           stale: false,
@@ -1324,6 +1351,7 @@ test("prevents removing a child screen with 'beforeRemove' event with 'resetRoot
       routeNames: ['foo', 'bar', 'baz'],
       routes: [{ key: 'foo-3', name: 'foo' }],
       preloadedRoutes: [],
+      retainedRouteKeys: [],
       stale: false,
       type: 'stack',
     };
@@ -1338,6 +1366,7 @@ test("prevents removing a child screen with 'beforeRemove' event with 'resetRoot
     index: 1,
     key: 'stack-2',
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [
       { key: 'foo-3', name: 'foo' },
@@ -1348,6 +1377,7 @@ test("prevents removing a child screen with 'beforeRemove' event with 'resetRoot
           index: 0,
           key: 'stack-7',
           preloadedRoutes: [],
+          retainedRouteKeys: [],
           routeNames: ['qux', 'lex'],
           routes: [{ key: 'qux-8', name: 'qux' }],
           stale: false,
@@ -1368,6 +1398,7 @@ test("prevents removing a child screen with 'beforeRemove' event with 'resetRoot
       routeNames: ['foo', 'bar', 'baz'],
       routes: [{ key: 'foo-3', name: 'foo' }],
       preloadedRoutes: [],
+      retainedRouteKeys: [],
       stale: false,
       type: 'stack',
     };
@@ -1382,6 +1413,7 @@ test("prevents removing a child screen with 'beforeRemove' event with 'resetRoot
     routeNames: ['foo', 'bar', 'baz'],
     routes: [{ key: 'foo-3', name: 'foo' }],
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     stale: false,
     type: 'stack',
   });

--- a/packages/core/src/__tests__/usePreventRemove.test.tsx
+++ b/packages/core/src/__tests__/usePreventRemove.test.tsx
@@ -77,6 +77,7 @@ test("prevents removing a screen with 'usePreventRemove' hook", () => {
     index: 1,
     key: 'stack-2',
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [
       { key: 'foo-3', name: 'foo' },
@@ -93,6 +94,7 @@ test("prevents removing a screen with 'usePreventRemove' hook", () => {
     index: 2,
     key: 'stack-2',
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [
       { key: 'foo-3', name: 'foo' },
@@ -112,6 +114,7 @@ test("prevents removing a screen with 'usePreventRemove' hook", () => {
     index: 2,
     key: 'stack-2',
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [
       { key: 'foo-3', name: 'foo' },
@@ -132,6 +135,7 @@ test("prevents removing a screen with 'usePreventRemove' hook", () => {
     index: 0,
     key: 'stack-2',
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [{ key: 'foo-3', name: 'foo' }],
     stale: false,
@@ -193,6 +197,7 @@ test("prevents removing a screen when 'usePreventRemove' hook is called multiple
     index: 1,
     key: 'stack-2',
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [
       { key: 'foo-3', name: 'foo' },
@@ -209,6 +214,7 @@ test("prevents removing a screen when 'usePreventRemove' hook is called multiple
     index: 2,
     key: 'stack-2',
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [
       { key: 'foo-3', name: 'foo' },
@@ -228,6 +234,7 @@ test("prevents removing a screen when 'usePreventRemove' hook is called multiple
     index: 2,
     key: 'stack-2',
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [
       { key: 'foo-3', name: 'foo' },
@@ -248,6 +255,7 @@ test("prevents removing a screen when 'usePreventRemove' hook is called multiple
     index: 0,
     key: 'stack-2',
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [{ key: 'foo-3', name: 'foo' }],
     stale: false,
@@ -302,6 +310,7 @@ test("should have no effect when 'usePreventRemove' hook is set to false", () =>
     index: 1,
     key: 'stack-2',
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [
       { key: 'foo-3', name: 'foo' },
@@ -318,6 +327,7 @@ test("should have no effect when 'usePreventRemove' hook is set to false", () =>
     index: 2,
     key: 'stack-2',
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [
       { key: 'foo-3', name: 'foo' },
@@ -336,6 +346,7 @@ test("should have no effect when 'usePreventRemove' hook is set to false", () =>
     index: 0,
     key: 'stack-2',
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [{ key: 'foo-3', name: 'foo' }],
     stale: false,
@@ -350,6 +361,7 @@ test("should have no effect when 'usePreventRemove' hook is set to false", () =>
     index: 0,
     key: 'stack-2',
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [{ key: 'foo-3', name: 'foo' }],
     stale: false,
@@ -417,6 +429,7 @@ test("prevents removing a child screen with 'usePreventRemove' hook", () => {
     index: 1,
     key: 'stack-2',
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [
       { key: 'foo-3', name: 'foo' },
@@ -433,6 +446,7 @@ test("prevents removing a child screen with 'usePreventRemove' hook", () => {
     index: 2,
     key: 'stack-2',
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [
       { key: 'foo-3', name: 'foo' },
@@ -444,6 +458,7 @@ test("prevents removing a child screen with 'usePreventRemove' hook", () => {
           index: 0,
           key: 'stack-8',
           preloadedRoutes: [],
+          retainedRouteKeys: [],
           routeNames: ['qux', 'lex'],
           routes: [{ key: 'qux-9', name: 'qux' }],
           stale: false,
@@ -464,6 +479,7 @@ test("prevents removing a child screen with 'usePreventRemove' hook", () => {
     index: 2,
     key: 'stack-2',
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [
       { key: 'foo-3', name: 'foo' },
@@ -475,6 +491,7 @@ test("prevents removing a child screen with 'usePreventRemove' hook", () => {
           index: 0,
           key: 'stack-8',
           preloadedRoutes: [],
+          retainedRouteKeys: [],
           routeNames: ['qux', 'lex'],
           routes: [{ key: 'qux-9', name: 'qux' }],
           stale: false,
@@ -493,6 +510,7 @@ test("prevents removing a child screen with 'usePreventRemove' hook", () => {
     index: 2,
     key: 'stack-2',
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [
       { key: 'foo-3', name: 'foo' },
@@ -504,6 +522,7 @@ test("prevents removing a child screen with 'usePreventRemove' hook", () => {
           index: 0,
           key: 'stack-8',
           preloadedRoutes: [],
+          retainedRouteKeys: [],
           routeNames: ['qux', 'lex'],
           routes: [{ key: 'qux-9', name: 'qux' }],
           stale: false,
@@ -525,6 +544,7 @@ test("prevents removing a child screen with 'usePreventRemove' hook", () => {
     index: 0,
     key: 'stack-2',
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [{ key: 'foo-3', name: 'foo' }],
     stale: false,
@@ -596,6 +616,7 @@ test("prevents removing a grand child screen with 'usePreventRemove' hook", () =
     index: 1,
     key: 'stack-2',
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [
       { key: 'foo-3', name: 'foo' },
@@ -612,6 +633,7 @@ test("prevents removing a grand child screen with 'usePreventRemove' hook", () =
     index: 2,
     key: 'stack-2',
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [
       { key: 'foo-3', name: 'foo' },
@@ -623,6 +645,7 @@ test("prevents removing a grand child screen with 'usePreventRemove' hook", () =
           index: 0,
           key: 'stack-8',
           preloadedRoutes: [],
+          retainedRouteKeys: [],
           routeNames: ['qux'],
           routes: [
             {
@@ -632,6 +655,7 @@ test("prevents removing a grand child screen with 'usePreventRemove' hook", () =
                 index: 0,
                 key: 'stack-12',
                 preloadedRoutes: [],
+                retainedRouteKeys: [],
                 routeNames: ['lex'],
                 routes: [{ key: 'lex-13', name: 'lex' }],
                 stale: false,
@@ -657,6 +681,7 @@ test("prevents removing a grand child screen with 'usePreventRemove' hook", () =
     index: 2,
     key: 'stack-2',
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [
       { key: 'foo-3', name: 'foo' },
@@ -668,6 +693,7 @@ test("prevents removing a grand child screen with 'usePreventRemove' hook", () =
           index: 0,
           key: 'stack-8',
           preloadedRoutes: [],
+          retainedRouteKeys: [],
           routeNames: ['qux'],
           routes: [
             {
@@ -677,6 +703,7 @@ test("prevents removing a grand child screen with 'usePreventRemove' hook", () =
                 index: 0,
                 key: 'stack-12',
                 preloadedRoutes: [],
+                retainedRouteKeys: [],
                 routeNames: ['lex'],
                 routes: [{ key: 'lex-13', name: 'lex' }],
                 stale: false,
@@ -703,6 +730,7 @@ test("prevents removing a grand child screen with 'usePreventRemove' hook", () =
     index: 0,
     key: 'stack-2',
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [{ key: 'foo-3', name: 'foo' }],
     stale: false,
@@ -789,6 +817,7 @@ test("prevents removing by multiple screens with 'usePreventRemove' hook", () =>
     index: 3,
     key: 'stack-2',
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz', 'bax'],
     routes: [
       { key: 'foo-3', name: 'foo' },
@@ -801,6 +830,7 @@ test("prevents removing by multiple screens with 'usePreventRemove' hook", () =>
           index: 0,
           key: 'stack-11',
           preloadedRoutes: [],
+          retainedRouteKeys: [],
           routeNames: ['qux'],
           routes: [
             {
@@ -810,6 +840,7 @@ test("prevents removing by multiple screens with 'usePreventRemove' hook", () =>
                 index: 0,
                 key: 'stack-15',
                 preloadedRoutes: [],
+                retainedRouteKeys: [],
                 routeNames: ['lex'],
                 routes: [{ key: 'lex-16', name: 'lex' }],
                 stale: false,
@@ -863,6 +894,7 @@ test("prevents removing by multiple screens with 'usePreventRemove' hook", () =>
     index: 0,
     key: 'stack-2',
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz', 'bax'],
     routes: [{ key: 'foo-3', name: 'foo' }],
     stale: false,
@@ -926,6 +958,7 @@ test("prevents removing a child screen with 'usePreventRemove' hook with 'resetR
     index: 1,
     key: 'stack-2',
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [
       { key: 'foo-3', name: 'foo' },
@@ -936,6 +969,7 @@ test("prevents removing a child screen with 'usePreventRemove' hook with 'resetR
           index: 0,
           key: 'stack-7',
           preloadedRoutes: [],
+          retainedRouteKeys: [],
           routeNames: ['qux', 'lex'],
           routes: [{ key: 'qux-8', name: 'qux' }],
           stale: false,
@@ -954,6 +988,7 @@ test("prevents removing a child screen with 'usePreventRemove' hook with 'resetR
       routeNames: ['foo', 'bar', 'baz'],
       routes: [{ key: 'foo-3', name: 'foo' }],
       preloadedRoutes: [],
+      retainedRouteKeys: [],
       stale: false,
       type: 'stack',
     };
@@ -967,6 +1002,7 @@ test("prevents removing a child screen with 'usePreventRemove' hook with 'resetR
     index: 1,
     key: 'stack-2',
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [
       { key: 'foo-3', name: 'foo' },
@@ -977,6 +1013,7 @@ test("prevents removing a child screen with 'usePreventRemove' hook with 'resetR
           index: 0,
           key: 'stack-7',
           preloadedRoutes: [],
+          retainedRouteKeys: [],
           routeNames: ['qux', 'lex'],
           routes: [{ key: 'qux-8', name: 'qux' }],
           stale: false,

--- a/packages/routers/src/StackRouter.tsx
+++ b/packages/routers/src/StackRouter.tsx
@@ -46,6 +46,12 @@ export type StackActionType =
       };
       source?: string | undefined;
       target?: string | undefined;
+    }
+  | {
+      type: 'RETAIN';
+      payload: { enable: boolean };
+      source?: string | undefined;
+      target?: string | undefined;
     };
 
 export type StackRouterOptions = DefaultRouterOptions;
@@ -60,6 +66,13 @@ export type StackNavigationState<ParamList extends ParamListBase> =
      * List of routes, which are supposed to be preloaded before navigating to.
      */
     preloadedRoutes: NavigationRoute<ParamList, keyof ParamList>[];
+    /**
+     * List of route keys to retain in the stack
+     * When a retained route gets removed from the stack,
+     * it'll be treated as preloaded route and not completely removed
+     * So it preserves the route and can be navigated back to
+     */
+    retainedRouteKeys: string[];
   };
 
 export type StackActionHelpers<ParamList extends ParamListBase> = {
@@ -124,6 +137,16 @@ export type StackActionHelpers<ParamList extends ParamListBase> = {
           ]
       : never
   ): void;
+
+  /**
+   * Enable or disable retaining the current route in the stack
+   * When a retained route gets removed from the stack,
+   * it'll be treated as preloaded route and not completely removed
+   * So it preserves the route and can be navigated back to
+   *
+   * @param enable Whether to retain the current route in the stack or not.
+   */
+  retain(enable: boolean): void;
 };
 
 export const StackActions = {
@@ -158,7 +181,46 @@ export const StackActions = {
       },
     } as const satisfies StackActionType;
   },
+  retain(enable: boolean) {
+    return {
+      type: 'RETAIN',
+      payload: { enable },
+    } as const satisfies StackActionType;
+  },
 };
+
+function retainRoutes<ParamList extends ParamListBase>(
+  previousState: StackNavigationState<ParamList>,
+  nextState: StackNavigationState<ParamList>
+) {
+  if (!nextState.retainedRouteKeys.length) {
+    return nextState;
+  }
+
+  const retainedRouteKeySet = new Set(nextState.retainedRouteKeys);
+  const nextRouteKeySet = new Set(nextState.routes.map((route) => route.key));
+  const retainedRoutes = previousState.routes.filter(
+    (route) =>
+      retainedRouteKeySet.has(route.key) && !nextRouteKeySet.has(route.key)
+  );
+
+  if (!retainedRoutes.length) {
+    return nextState;
+  }
+
+  const removedRetainedRouteKeys = new Set(
+    retainedRoutes.map((route) => route.key)
+  );
+
+  return {
+    ...nextState,
+    preloadedRoutes: retainedRoutes.concat(
+      nextState.preloadedRoutes.filter(
+        (route) => !removedRetainedRouteKeys.has(route.key)
+      )
+    ),
+  };
+}
 
 export function StackRouter(options: StackRouterOptions) {
   const router: Router<
@@ -183,6 +245,7 @@ export function StackRouter(options: StackRouterOptions) {
         index: 0,
         routeNames,
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routes: [
           {
             key: `${initialRouteName}-${nanoid()}`,
@@ -232,6 +295,11 @@ export function StackRouter(options: StackRouterOptions) {
               }) as Route<string>
           ) ?? [];
 
+      const retainedRouteKeys =
+        state.retainedRouteKeys?.filter((key) =>
+          [...routes, ...preloadedRoutes].some((route) => route.key === key)
+        ) ?? [];
+
       if (routes.length === 0) {
         const initialRouteName =
           options.initialRouteName !== undefined
@@ -253,6 +321,7 @@ export function StackRouter(options: StackRouterOptions) {
         routeNames,
         routes,
         preloadedRoutes,
+        retainedRouteKeys,
       };
     },
 
@@ -261,6 +330,12 @@ export function StackRouter(options: StackRouterOptions) {
       { routeNames, routeParamList, routeKeyChanges }
     ) {
       const routes = state.routes.filter(
+        (route) =>
+          routeNames.includes(route.name) &&
+          !routeKeyChanges.includes(route.name)
+      );
+
+      const preloadedRoutes = state.preloadedRoutes.filter(
         (route) =>
           routeNames.includes(route.name) &&
           !routeKeyChanges.includes(route.name)
@@ -280,10 +355,20 @@ export function StackRouter(options: StackRouterOptions) {
         });
       }
 
+      const routeKeys = new Set(
+        [...routes, ...preloadedRoutes].map((route) => route.key)
+      );
+
+      const retainedRouteKeys = state.retainedRouteKeys.filter((key) =>
+        routeKeys.has(key)
+      );
+
       return {
         ...state,
         routeNames,
         routes,
+        preloadedRoutes,
+        retainedRouteKeys,
         index: Math.min(state.index, routes.length - 1),
       };
     },
@@ -295,11 +380,11 @@ export function StackRouter(options: StackRouterOptions) {
         return state;
       }
 
-      return {
+      return retainRoutes(state, {
         ...state,
         index,
         routes: state.routes.slice(0, index + 1),
-      };
+      });
     },
 
     getStateForAction(state, action, options) {
@@ -334,7 +419,7 @@ export function StackRouter(options: StackRouterOptions) {
             route = createRouteFromAction({ action, routeParamList });
           }
 
-          return {
+          return retainRoutes(state, {
             ...state,
             routes: state.routes.map((r, i) =>
               i === currentIndex ? route : r
@@ -342,7 +427,7 @@ export function StackRouter(options: StackRouterOptions) {
             preloadedRoutes: state.preloadedRoutes.filter(
               (r) => r.key !== route.key
             ),
-          };
+          });
         }
 
         case 'PUSH':
@@ -482,14 +567,14 @@ export function StackRouter(options: StackRouterOptions) {
             ];
           }
 
-          return {
+          return retainRoutes(state, {
             ...state,
             index: routes.length - 1,
             preloadedRoutes: state.preloadedRoutes.filter(
               (route) => routes[routes.length - 1].key !== route.key
             ),
             routes,
-          };
+          });
         }
 
         case 'POP': {
@@ -547,11 +632,11 @@ export function StackRouter(options: StackRouterOptions) {
               }
             }
 
-            return {
+            return retainRoutes(state, {
               ...state,
               index: routes.length - 1,
               routes,
-            };
+            });
           }
 
           return null;
@@ -568,11 +653,11 @@ export function StackRouter(options: StackRouterOptions) {
               };
             }
 
-            return {
+            return retainRoutes(state, {
               ...state,
               index: 0,
               routes: [route],
-            };
+            });
           }
 
           return null;
@@ -655,14 +740,14 @@ export function StackRouter(options: StackRouterOptions) {
 
             const routes = state.routes.slice(0, currentIndex).concat(route);
 
-            return {
+            return retainRoutes(state, {
               ...state,
               index: routes.length - 1,
               routes,
               preloadedRoutes: state.preloadedRoutes.filter(
                 (r) => r.key !== route.key
               ),
-            };
+            });
           }
 
           const route = state.routes[index];
@@ -691,7 +776,7 @@ export function StackRouter(options: StackRouterOptions) {
             params = createParamsFromAction({ action, routeParamList });
           }
 
-          return {
+          return retainRoutes(state, {
             ...state,
             index,
             routes: [
@@ -700,7 +785,7 @@ export function StackRouter(options: StackRouterOptions) {
                 ? { ...route, params, history }
                 : state.routes[index],
             ],
-          };
+          });
         }
 
         case 'GO_BACK':
@@ -718,6 +803,42 @@ export function StackRouter(options: StackRouterOptions) {
           }
 
           return null;
+
+        case 'RETAIN': {
+          const routeKey = action.source ?? state.routes[state.index].key;
+
+          if (
+            !state.routes.some((route) => route.key === routeKey) &&
+            !state.preloadedRoutes.some((route) => route.key === routeKey)
+          ) {
+            return null;
+          }
+
+          if (action.payload.enable) {
+            if (state.retainedRouteKeys.includes(routeKey)) {
+              return state;
+            }
+
+            return {
+              ...state,
+              retainedRouteKeys: [...state.retainedRouteKeys, routeKey],
+            };
+          }
+
+          if (!state.retainedRouteKeys.includes(routeKey)) {
+            return state;
+          }
+
+          return {
+            ...state,
+            preloadedRoutes: state.preloadedRoutes.filter(
+              (route) => route.key !== routeKey
+            ),
+            retainedRouteKeys: state.retainedRouteKeys.filter(
+              (key) => key !== routeKey
+            ),
+          };
+        }
 
         case 'PRELOAD': {
           const getId = options.routeGetIdList[action.payload.name];

--- a/packages/routers/src/StackRouter.tsx
+++ b/packages/routers/src/StackRouter.tsx
@@ -67,10 +67,10 @@ export type StackNavigationState<ParamList extends ParamListBase> =
      */
     preloadedRoutes: NavigationRoute<ParamList, keyof ParamList>[];
     /**
-     * List of route keys to retain in the stack
+     * List of route keys to retain in the stack.
      * When a retained route gets removed from the stack,
      * it'll be treated as preloaded route and not completely removed
-     * So it preserves the route and can be navigated back to
+     * So it preserves the route and can be navigated to again.
      */
     retainedRouteKeys: string[];
   };
@@ -139,10 +139,10 @@ export type StackActionHelpers<ParamList extends ParamListBase> = {
   ): void;
 
   /**
-   * Enable or disable retaining the current route in the stack
+   * Enable or disable retaining the current route in the stack.
    * When a retained route gets removed from the stack,
    * it'll be treated as preloaded route and not completely removed
-   * So it preserves the route and can be navigated back to
+   * So it preserves the route and can be navigated to again.
    *
    * @param enable Whether to retain the current route in the stack or not.
    */

--- a/packages/routers/src/__tests__/StackRouter.test.tsx
+++ b/packages/routers/src/__tests__/StackRouter.test.tsx
@@ -27,6 +27,7 @@ test('gets initial state from route names and params with initialRouteName', () 
     index: 0,
     key: 'stack-test',
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['bar', 'baz', 'qux'],
     routes: [{ key: 'baz-test', name: 'baz', params: { answer: 42 } }],
     stale: false,
@@ -50,6 +51,7 @@ test('gets initial state from route names and params without initialRouteName', 
     index: 0,
     key: 'stack-test',
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['bar', 'baz', 'qux'],
     routes: [{ key: 'bar-test', name: 'bar' }],
     stale: false,
@@ -77,6 +79,7 @@ test('gets rehydrated state from partial state', () => {
           { key: 'qux-1', name: 'qux' },
         ],
         preloadedRoutes: [{ name: 'baz', key: 'baz-test' }],
+        retainedRouteKeys: [],
       },
       options
     )
@@ -84,6 +87,7 @@ test('gets rehydrated state from partial state', () => {
     index: 1,
     key: 'stack-test',
     preloadedRoutes: [{ name: 'baz', key: 'baz-test', params: { answer: 42 } }],
+    retainedRouteKeys: [],
     routeNames: ['bar', 'baz', 'qux'],
     routes: [
       { key: 'bar-0', name: 'bar' },
@@ -109,6 +113,7 @@ test('gets rehydrated state from partial state', () => {
     index: 2,
     key: 'stack-test',
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['bar', 'baz', 'qux'],
     routes: [
       { key: 'bar-0', name: 'bar' },
@@ -131,6 +136,7 @@ test('gets rehydrated state from partial state', () => {
     index: 0,
     key: 'stack-test',
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['bar', 'baz', 'qux'],
     routes: [{ key: 'bar-test', name: 'bar' }],
     stale: false,
@@ -145,6 +151,7 @@ test("doesn't rehydrate state if it's not stale", () => {
     index: 0,
     key: 'stack-test',
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['bar', 'baz', 'qux'],
     routes: [{ key: 'bar-test', name: 'bar' }],
     stale: false as const,
@@ -160,6 +167,234 @@ test("doesn't rehydrate state if it's not stale", () => {
   ).toBe(state);
 });
 
+test('adds and removes retained route keys with retain', () => {
+  const router = StackRouter({});
+  const options: RouterConfigOptions = {
+    routeNames: ['baz', 'bar', 'qux'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+
+  expect(
+    router.getStateForAction(
+      {
+        stale: false,
+        type: 'stack',
+        key: 'root',
+        index: 1,
+        preloadedRoutes: [],
+        retainedRouteKeys: [],
+        routeNames: ['baz', 'bar', 'qux'],
+        routes: [
+          { key: 'baz', name: 'baz' },
+          { key: 'bar', name: 'bar' },
+        ],
+      },
+      {
+        ...StackActions.retain(true),
+        source: 'bar',
+      },
+      options
+    )
+  ).toEqual({
+    stale: false,
+    type: 'stack',
+    key: 'root',
+    index: 1,
+    preloadedRoutes: [],
+    retainedRouteKeys: ['bar'],
+    routeNames: ['baz', 'bar', 'qux'],
+    routes: [
+      { key: 'baz', name: 'baz' },
+      { key: 'bar', name: 'bar' },
+    ],
+  });
+
+  expect(
+    router.getStateForAction(
+      {
+        stale: false,
+        type: 'stack',
+        key: 'root',
+        index: 1,
+        preloadedRoutes: [],
+        retainedRouteKeys: ['bar', 'qux'],
+        routeNames: ['baz', 'bar', 'qux'],
+        routes: [
+          { key: 'baz', name: 'baz' },
+          { key: 'bar', name: 'bar' },
+          { key: 'qux', name: 'qux' },
+        ],
+      },
+      {
+        ...StackActions.retain(false),
+        source: 'bar',
+      },
+      options
+    )
+  ).toEqual({
+    stale: false,
+    type: 'stack',
+    key: 'root',
+    index: 1,
+    preloadedRoutes: [],
+    retainedRouteKeys: ['qux'],
+    routeNames: ['baz', 'bar', 'qux'],
+    routes: [
+      { key: 'baz', name: 'baz' },
+      { key: 'bar', name: 'bar' },
+      { key: 'qux', name: 'qux' },
+    ],
+  });
+});
+
+test('falls back to focused route and validates source with retain', () => {
+  const router = StackRouter({});
+  const options: RouterConfigOptions = {
+    routeNames: ['baz', 'bar', 'qux'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+
+  expect(
+    router.getStateForAction(
+      {
+        stale: false,
+        type: 'stack',
+        key: 'root',
+        index: 1,
+        preloadedRoutes: [],
+        retainedRouteKeys: [],
+        routeNames: ['baz', 'bar', 'qux'],
+        routes: [
+          { key: 'baz', name: 'baz' },
+          { key: 'bar', name: 'bar' },
+        ],
+      },
+      StackActions.retain(true),
+      options
+    )
+  ).toEqual({
+    stale: false,
+    type: 'stack',
+    key: 'root',
+    index: 1,
+    preloadedRoutes: [],
+    retainedRouteKeys: ['bar'],
+    routeNames: ['baz', 'bar', 'qux'],
+    routes: [
+      { key: 'baz', name: 'baz' },
+      { key: 'bar', name: 'bar' },
+    ],
+  });
+
+  expect(
+    router.getStateForAction(
+      {
+        stale: false,
+        type: 'stack',
+        key: 'root',
+        index: 1,
+        preloadedRoutes: [],
+        retainedRouteKeys: [],
+        routeNames: ['baz', 'bar', 'qux'],
+        routes: [
+          { key: 'baz', name: 'baz' },
+          { key: 'bar', name: 'bar' },
+        ],
+      },
+      {
+        ...StackActions.retain(true),
+        source: 'qux',
+      },
+      options
+    )
+  ).toBeNull();
+});
+
+test('handles retain for preloaded routes', () => {
+  const router = StackRouter({});
+  const options: RouterConfigOptions = {
+    routeNames: ['baz', 'bar', 'qux'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+
+  const state: StackNavigationState<ParamListBase> = {
+    stale: false,
+    type: 'stack',
+    key: 'root',
+    index: 1,
+    preloadedRoutes: [{ key: 'qux', name: 'qux' }],
+    retainedRouteKeys: [],
+    routeNames: ['baz', 'bar', 'qux'],
+    routes: [
+      { key: 'baz', name: 'baz' },
+      { key: 'bar', name: 'bar' },
+    ],
+  };
+
+  expect(
+    router.getStateForAction(
+      state,
+      {
+        ...StackActions.retain(false),
+        source: 'qux',
+      },
+      options
+    )
+  ).toBe(state);
+
+  expect(
+    router.getStateForAction(
+      state,
+      {
+        ...StackActions.retain(true),
+        source: 'qux',
+      },
+      options
+    )
+  ).toEqual({
+    stale: false,
+    type: 'stack',
+    key: 'root',
+    index: 1,
+    preloadedRoutes: [{ key: 'qux', name: 'qux' }],
+    retainedRouteKeys: ['qux'],
+    routeNames: ['baz', 'bar', 'qux'],
+    routes: [
+      { key: 'baz', name: 'baz' },
+      { key: 'bar', name: 'bar' },
+    ],
+  });
+
+  expect(
+    router.getStateForAction(
+      {
+        ...state,
+        retainedRouteKeys: ['qux'],
+      },
+      {
+        ...StackActions.retain(false),
+        source: 'qux',
+      },
+      options
+    )
+  ).toEqual({
+    stale: false,
+    type: 'stack',
+    key: 'root',
+    index: 1,
+    preloadedRoutes: [],
+    retainedRouteKeys: [],
+    routeNames: ['baz', 'bar', 'qux'],
+    routes: [
+      { key: 'baz', name: 'baz' },
+      { key: 'bar', name: 'bar' },
+    ],
+  });
+});
+
 test('gets state on route names change', () => {
   const router = StackRouter({});
 
@@ -169,6 +404,7 @@ test('gets state on route names change', () => {
         index: 2,
         key: 'stack-test',
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['bar', 'baz', 'qux'],
         routes: [
           { key: 'bar-test', name: 'bar' },
@@ -192,6 +428,7 @@ test('gets state on route names change', () => {
     index: 1,
     key: 'stack-test',
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['qux', 'baz', 'foo', 'fiz'],
     routes: [
       { key: 'baz-test', name: 'baz', params: { answer: 42 } },
@@ -207,6 +444,7 @@ test('gets state on route names change', () => {
         index: 1,
         key: 'stack-test',
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['foo', 'bar'],
         routes: [
           { key: 'foo-test', name: 'foo' },
@@ -228,8 +466,50 @@ test('gets state on route names change', () => {
     index: 0,
     key: 'stack-test',
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'qux'],
     routes: [{ key: 'baz-test', name: 'baz', params: { name: 'John' } }],
+    stale: false,
+    type: 'stack',
+  });
+});
+
+test('cleans up preloaded routes and retained route keys on route names change', () => {
+  const router = StackRouter({});
+
+  expect(
+    router.getStateForRouteNamesChange(
+      {
+        index: 2,
+        key: 'stack-test',
+        preloadedRoutes: [
+          { key: 'foo-test', name: 'foo' },
+          { key: 'qux-preload', name: 'qux' },
+        ],
+        retainedRouteKeys: ['baz-test', 'foo-test', 'qux-preload'],
+        routeNames: ['bar', 'baz', 'qux', 'foo'],
+        routes: [
+          { key: 'bar-test', name: 'bar' },
+          { key: 'baz-test', name: 'baz', params: { answer: 42 } },
+          { key: 'qux-test', name: 'qux', params: { name: 'Jane' } },
+        ],
+        stale: false,
+        type: 'stack',
+      },
+      {
+        routeNames: ['baz', 'qux'],
+        routeParamList: {},
+        routeGetIdList: {},
+        routeKeyChanges: ['qux'],
+      }
+    )
+  ).toEqual({
+    index: 0,
+    key: 'stack-test',
+    preloadedRoutes: [],
+    retainedRouteKeys: ['baz-test'],
+    routeNames: ['baz', 'qux'],
+    routes: [{ key: 'baz-test', name: 'baz', params: { answer: 42 } }],
     stale: false,
     type: 'stack',
   });
@@ -244,6 +524,7 @@ test('gets state on route names change with initialRouteName', () => {
         index: 1,
         key: 'stack-test',
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['foo', 'bar'],
         routes: [
           { key: 'foo-test', name: 'foo' },
@@ -265,10 +546,44 @@ test('gets state on route names change with initialRouteName', () => {
     index: 0,
     key: 'stack-test',
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'qux'],
     routes: [{ key: 'qux-test', name: 'qux' }],
     stale: false,
     type: 'stack',
+  });
+});
+
+test('moves retained routes to preloadedRoutes on route focus', () => {
+  const router = StackRouter({});
+
+  expect(
+    router.getStateForRouteFocus(
+      {
+        stale: false,
+        type: 'stack',
+        key: 'root',
+        index: 2,
+        preloadedRoutes: [],
+        retainedRouteKeys: ['qux'],
+        routeNames: ['baz', 'bar', 'qux'],
+        routes: [
+          { key: 'baz', name: 'baz' },
+          { key: 'bar', name: 'bar' },
+          { key: 'qux', name: 'qux' },
+        ],
+      },
+      'baz'
+    )
+  ).toEqual({
+    stale: false,
+    type: 'stack',
+    key: 'root',
+    index: 0,
+    preloadedRoutes: [{ key: 'qux', name: 'qux' }],
+    retainedRouteKeys: ['qux'],
+    routeNames: ['baz', 'bar', 'qux'],
+    routes: [{ key: 'baz', name: 'baz' }],
   });
 });
 
@@ -288,6 +603,7 @@ test('handles navigate action', () => {
         key: 'root',
         index: 1,
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'baz', name: 'baz' },
@@ -303,6 +619,7 @@ test('handles navigate action', () => {
     key: 'root',
     index: 2,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'baz', name: 'baz' },
@@ -323,6 +640,7 @@ test('handles navigate action', () => {
         key: 'root',
         index: 1,
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'baz', name: 'baz' },
@@ -338,6 +656,7 @@ test('handles navigate action', () => {
     key: 'root',
     index: 2,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'baz', name: 'baz' },
@@ -363,6 +682,7 @@ test('updates params on navigate if already on the screen', () => {
         key: 'root',
         index: 1,
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'baz', name: 'baz' },
@@ -378,6 +698,7 @@ test('updates params on navigate if already on the screen', () => {
     key: 'root',
     index: 1,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'baz', name: 'baz' },
@@ -402,6 +723,7 @@ test('merges params on navigate when specified', () => {
         key: 'root',
         index: 1,
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'baz', name: 'baz' },
@@ -417,6 +739,7 @@ test('merges params on navigate when specified', () => {
     key: 'root',
     index: 1,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'baz', name: 'baz' },
@@ -441,6 +764,7 @@ test("doesn't navigate to nonexistent screen", () => {
         key: 'root',
         index: 1,
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'baz', name: 'baz' },
@@ -472,6 +796,7 @@ test('handles getId for navigate', () => {
         key: 'root',
         index: 0,
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [{ key: 'bar', name: 'bar' }],
       },
@@ -484,6 +809,7 @@ test('handles getId for navigate', () => {
     key: 'root',
     index: 1,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'bar', name: 'bar' },
@@ -499,6 +825,7 @@ test('handles getId for navigate', () => {
         key: 'root',
         index: 1,
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'bar', name: 'bar' },
@@ -514,6 +841,7 @@ test('handles getId for navigate', () => {
     key: 'root',
     index: 1,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'bar', name: 'bar' },
@@ -529,6 +857,7 @@ test('handles getId for navigate', () => {
         key: 'root',
         index: 1,
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'bar-test', name: 'bar', params: { foo: 'a' } },
@@ -544,6 +873,7 @@ test('handles getId for navigate', () => {
     key: 'root',
     index: 2,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'bar-test', name: 'bar', params: { foo: 'a' } },
@@ -560,6 +890,7 @@ test('handles getId for navigate', () => {
         key: 'root',
         index: 1,
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'bar', name: 'bar' },
@@ -575,6 +906,7 @@ test('handles getId for navigate', () => {
     key: 'root',
     index: 2,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'bar', name: 'bar' },
@@ -604,6 +936,7 @@ test('getId is scoped to route name for navigate', () => {
         key: 'root',
         index: 1,
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'qux-test', name: 'qux', params: { test: 'a' } },
@@ -619,6 +952,7 @@ test('getId is scoped to route name for navigate', () => {
     key: 'root',
     index: 2,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'qux-test', name: 'qux', params: { test: 'a' } },
@@ -644,6 +978,7 @@ test('goes back to matching screen for navigate if pop: true', () => {
         key: 'root',
         index: 1,
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'baz', name: 'baz' },
@@ -663,6 +998,7 @@ test('goes back to matching screen for navigate if pop: true', () => {
     key: 'root',
     index: 2,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'baz', name: 'baz' },
@@ -683,6 +1019,7 @@ test('goes back to matching screen for navigate if pop: true', () => {
         key: 'root',
         index: 1,
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'baz', name: 'baz' },
@@ -702,6 +1039,7 @@ test('goes back to matching screen for navigate if pop: true', () => {
     key: 'root',
     index: 0,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [{ key: 'baz', name: 'baz', params: { answer: 42 } }],
   });
@@ -714,6 +1052,7 @@ test('goes back to matching screen for navigate if pop: true', () => {
         key: 'root',
         index: 1,
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'baz', name: 'baz' },
@@ -733,10 +1072,56 @@ test('goes back to matching screen for navigate if pop: true', () => {
     key: 'root',
     index: 1,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'baz', name: 'baz' },
       { key: 'bar', name: 'bar', params: { answer: 96 } },
+    ],
+  });
+});
+
+test('moves retained routes to preloadedRoutes when navigate with pop removes them', () => {
+  const router = StackRouter({});
+  const options: RouterConfigOptions = {
+    routeNames: ['baz', 'bar', 'qux'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+
+  expect(
+    router.getStateForAction(
+      {
+        stale: false,
+        type: 'stack',
+        key: 'root',
+        index: 2,
+        preloadedRoutes: [],
+        retainedRouteKeys: ['qux'],
+        routeNames: ['baz', 'bar', 'qux'],
+        routes: [
+          { key: 'baz', name: 'baz' },
+          { key: 'bar', name: 'bar' },
+          { key: 'qux', name: 'qux' },
+        ],
+      },
+      CommonActions.navigate({
+        name: 'bar',
+        pop: true,
+      }),
+      options
+    )
+  ).toEqual({
+    stale: false,
+    type: 'stack',
+    key: 'root',
+    index: 1,
+    preloadedRoutes: [{ key: 'qux', name: 'qux' }],
+    retainedRouteKeys: ['qux'],
+    routeNames: ['baz', 'bar', 'qux'],
+    routes: [
+      { key: 'baz', name: 'baz' },
+      { key: 'bar', name: 'bar' },
     ],
   });
 });
@@ -760,6 +1145,7 @@ test('goes back to matching ID for navigate if pop: true', () => {
         key: 'root',
         index: 1,
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'bar', name: 'bar' },
@@ -779,6 +1165,7 @@ test('goes back to matching ID for navigate if pop: true', () => {
     key: 'root',
     index: 1,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'bar', name: 'bar' },
@@ -794,6 +1181,7 @@ test('goes back to matching ID for navigate if pop: true', () => {
         key: 'root',
         index: 1,
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'bar', name: 'bar' },
@@ -815,6 +1203,7 @@ test('goes back to matching ID for navigate if pop: true', () => {
     key: 'root',
     index: 2,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'bar', name: 'bar' },
@@ -842,6 +1231,7 @@ test('goes back to matching ID in route history for navigate if pop: true', () =
         key: 'root',
         index: 1,
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'baz', name: 'baz' },
@@ -869,6 +1259,7 @@ test('goes back to matching ID in route history for navigate if pop: true', () =
     key: 'root',
     index: 1,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'baz', name: 'baz' },
@@ -889,6 +1280,7 @@ test('goes back to matching ID in route history for navigate if pop: true', () =
         key: 'root',
         index: 1,
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'baz', name: 'baz' },
@@ -916,6 +1308,7 @@ test('goes back to matching ID in route history for navigate if pop: true', () =
     key: 'root',
     index: 1,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'baz', name: 'baz' },
@@ -945,6 +1338,7 @@ test('handles pop action', () => {
         key: 'root',
         index: 2,
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'baz', name: 'baz' },
@@ -961,6 +1355,7 @@ test('handles pop action', () => {
     key: 'root',
     index: 1,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'baz', name: 'baz' },
@@ -976,6 +1371,7 @@ test('handles pop action', () => {
         key: 'root',
         index: 2,
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'baz', name: 'baz' },
@@ -992,6 +1388,7 @@ test('handles pop action', () => {
     key: 'root',
     index: 0,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [{ key: 'baz', name: 'baz' }],
   });
@@ -1004,6 +1401,7 @@ test('handles pop action', () => {
         key: 'root',
         index: 2,
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'baz', name: 'baz' },
@@ -1020,6 +1418,7 @@ test('handles pop action', () => {
     key: 'root',
     index: 0,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [{ key: 'baz', name: 'baz' }],
   });
@@ -1032,6 +1431,7 @@ test('handles pop action', () => {
         key: 'root',
         index: 2,
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'baz-0', name: 'baz' },
@@ -1052,6 +1452,7 @@ test('handles pop action', () => {
     key: 'root',
     index: 1,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'baz-0', name: 'baz' },
@@ -1067,6 +1468,7 @@ test('handles pop action', () => {
         key: 'root',
         index: 4,
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'baz-0', name: 'baz' },
@@ -1089,6 +1491,7 @@ test('handles pop action', () => {
     key: 'root',
     index: 2,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'baz-0', name: 'baz' },
@@ -1105,6 +1508,7 @@ test('handles pop action', () => {
         key: 'root',
         index: 0,
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [{ key: 'baz-0', name: 'baz' }],
       },
@@ -1112,6 +1516,48 @@ test('handles pop action', () => {
       options
     )
   ).toBeNull();
+});
+
+test('moves retained routes to preloadedRoutes on pop', () => {
+  const router = StackRouter({});
+  const options: RouterConfigOptions = {
+    routeNames: ['baz', 'bar', 'qux'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+
+  expect(
+    router.getStateForAction(
+      {
+        stale: false,
+        type: 'stack',
+        key: 'root',
+        index: 2,
+        preloadedRoutes: [],
+        retainedRouteKeys: ['qux'],
+        routeNames: ['baz', 'bar', 'qux'],
+        routes: [
+          { key: 'baz', name: 'baz' },
+          { key: 'bar', name: 'bar' },
+          { key: 'qux', name: 'qux' },
+        ],
+      },
+      StackActions.pop(),
+      options
+    )
+  ).toEqual({
+    stale: false,
+    type: 'stack',
+    key: 'root',
+    index: 1,
+    preloadedRoutes: [{ key: 'qux', name: 'qux' }],
+    retainedRouteKeys: ['qux'],
+    routeNames: ['baz', 'bar', 'qux'],
+    routes: [
+      { key: 'baz', name: 'baz' },
+      { key: 'bar', name: 'bar' },
+    ],
+  });
 });
 
 test('handles pop to top action', () => {
@@ -1130,6 +1576,7 @@ test('handles pop to top action', () => {
         key: 'root',
         index: 0,
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [{ key: 'baz', name: 'baz' }],
       },
@@ -1146,6 +1593,7 @@ test('handles pop to top action', () => {
         key: 'root',
         index: 2,
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'baz', name: 'baz' },
@@ -1162,6 +1610,7 @@ test('handles pop to top action', () => {
     key: 'root',
     index: 0,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [{ key: 'baz', name: 'baz' }],
   });
@@ -1174,6 +1623,7 @@ test('handles pop to top action', () => {
         key: 'root',
         index: 2,
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           {
@@ -1192,6 +1642,7 @@ test('handles pop to top action', () => {
     key: 'root',
     index: 0,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [{ key: 'baz', name: 'baz' }],
   });
@@ -1204,6 +1655,7 @@ test('handles pop to top action', () => {
         key: 'root',
         index: 2,
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'baz', name: 'baz' },
@@ -1224,6 +1676,137 @@ test('handles pop to top action', () => {
     key: 'root',
     index: 0,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
+    routeNames: ['baz', 'bar', 'qux'],
+    routes: [{ key: 'baz', name: 'baz' }],
+  });
+});
+
+test('moves retained routes to preloadedRoutes on popToTop', () => {
+  const router = StackRouter({});
+  const options: RouterConfigOptions = {
+    routeNames: ['baz', 'bar', 'qux'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+
+  expect(
+    router.getStateForAction(
+      {
+        stale: false,
+        type: 'stack',
+        key: 'root',
+        index: 2,
+        preloadedRoutes: [],
+        retainedRouteKeys: ['bar', 'qux'],
+        routeNames: ['baz', 'bar', 'qux'],
+        routes: [
+          { key: 'baz', name: 'baz' },
+          { key: 'bar', name: 'bar' },
+          { key: 'qux', name: 'qux' },
+        ],
+      },
+      StackActions.popToTop(),
+      options
+    )
+  ).toEqual({
+    stale: false,
+    type: 'stack',
+    key: 'root',
+    index: 0,
+    preloadedRoutes: [
+      { key: 'bar', name: 'bar' },
+      { key: 'qux', name: 'qux' },
+    ],
+    retainedRouteKeys: ['bar', 'qux'],
+    routeNames: ['baz', 'bar', 'qux'],
+    routes: [{ key: 'baz', name: 'baz' }],
+  });
+});
+
+test('prepends retained routes before existing preloadedRoutes on pop', () => {
+  const router = StackRouter({});
+  const options: RouterConfigOptions = {
+    routeNames: ['baz', 'bar', 'qux'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+
+  expect(
+    router.getStateForAction(
+      {
+        stale: false,
+        type: 'stack',
+        key: 'root',
+        index: 2,
+        preloadedRoutes: [{ key: 'pre', name: 'baz' }],
+        retainedRouteKeys: ['qux'],
+        routeNames: ['baz', 'bar', 'qux'],
+        routes: [
+          { key: 'baz', name: 'baz' },
+          { key: 'bar', name: 'bar' },
+          { key: 'qux', name: 'qux' },
+        ],
+      },
+      StackActions.pop(),
+      options
+    )
+  ).toEqual({
+    stale: false,
+    type: 'stack',
+    key: 'root',
+    index: 1,
+    preloadedRoutes: [
+      { key: 'qux', name: 'qux' },
+      { key: 'pre', name: 'baz' },
+    ],
+    retainedRouteKeys: ['qux'],
+    routeNames: ['baz', 'bar', 'qux'],
+    routes: [
+      { key: 'baz', name: 'baz' },
+      { key: 'bar', name: 'bar' },
+    ],
+  });
+});
+
+test('preserves order of multiple retained routes before existing preloadedRoutes on popToTop', () => {
+  const router = StackRouter({});
+  const options: RouterConfigOptions = {
+    routeNames: ['baz', 'bar', 'qux'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+
+  expect(
+    router.getStateForAction(
+      {
+        stale: false,
+        type: 'stack',
+        key: 'root',
+        index: 2,
+        preloadedRoutes: [{ key: 'pre', name: 'baz' }],
+        retainedRouteKeys: ['bar', 'qux'],
+        routeNames: ['baz', 'bar', 'qux'],
+        routes: [
+          { key: 'baz', name: 'baz' },
+          { key: 'bar', name: 'bar' },
+          { key: 'qux', name: 'qux' },
+        ],
+      },
+      StackActions.popToTop(),
+      options
+    )
+  ).toEqual({
+    stale: false,
+    type: 'stack',
+    key: 'root',
+    index: 0,
+    preloadedRoutes: [
+      { key: 'bar', name: 'bar' },
+      { key: 'qux', name: 'qux' },
+      { key: 'pre', name: 'baz' },
+    ],
+    retainedRouteKeys: ['bar', 'qux'],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [{ key: 'baz', name: 'baz' }],
   });
@@ -1245,6 +1828,7 @@ test('handles pop action with route history', () => {
         key: 'root',
         index: 1,
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'baz', name: 'baz' },
@@ -1268,6 +1852,7 @@ test('handles pop action with route history', () => {
     key: 'root',
     index: 1,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'baz', name: 'baz' },
@@ -1297,6 +1882,7 @@ test('handles pop action with multiple history entries', () => {
         key: 'root',
         index: 1,
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'baz', name: 'baz' },
@@ -1321,6 +1907,7 @@ test('handles pop action with multiple history entries', () => {
     key: 'root',
     index: 1,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'baz', name: 'baz' },
@@ -1350,6 +1937,7 @@ test('handles pop action with history and route popping', () => {
         key: 'root',
         index: 2,
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'baz', name: 'baz' },
@@ -1374,6 +1962,7 @@ test('handles pop action with history and route popping', () => {
     key: 'root',
     index: 0,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [{ key: 'baz', name: 'baz' }],
   });
@@ -1395,6 +1984,7 @@ test('handles pop action to restore params from history', () => {
         key: 'root',
         index: 1,
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'baz', name: 'baz' },
@@ -1417,6 +2007,7 @@ test('handles pop action to restore params from history', () => {
     key: 'root',
     index: 1,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'baz', name: 'baz' },
@@ -1446,6 +2037,7 @@ test('handles pop action with undefined params in history', () => {
         key: 'root',
         index: 1,
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'baz', name: 'baz' },
@@ -1466,6 +2058,7 @@ test('handles pop action with undefined params in history', () => {
     key: 'root',
     index: 1,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'baz', name: 'baz' },
@@ -1493,6 +2086,7 @@ test('handles pop action with route.history', () => {
     key: 'root',
     index: 1,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'baz', name: 'baz' },
@@ -1520,6 +2114,7 @@ test('handles pop action with route.history', () => {
     key: 'root',
     index: 1,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'baz', name: 'baz' },
@@ -1544,6 +2139,7 @@ test('handles pop action with route.history', () => {
     key: 'root',
     index: 1,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'baz', name: 'baz' },
@@ -1568,6 +2164,7 @@ test('handles pop action with route.history', () => {
     key: 'root',
     index: 0,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [{ key: 'baz', name: 'baz' }],
   });
@@ -1589,6 +2186,7 @@ test('handles pop(n) with route.history', () => {
         key: 'root',
         index: 2,
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'baz', name: 'baz' },
@@ -1615,6 +2213,7 @@ test('handles pop(n) with route.history', () => {
     key: 'root',
     index: 2,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'baz', name: 'baz' },
@@ -1636,6 +2235,7 @@ test('handles pop(n) with route.history', () => {
         key: 'root',
         index: 1,
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'baz', name: 'baz' },
@@ -1659,6 +2259,7 @@ test('handles pop(n) with route.history', () => {
     key: 'root',
     index: 0,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [{ key: 'baz', name: 'baz' }],
   });
@@ -1678,6 +2279,7 @@ test('handles pop action with route.history on a single route', () => {
     key: 'root',
     index: 0,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       {
@@ -1704,6 +2306,7 @@ test('handles pop action with route.history on a single route', () => {
     key: 'root',
     index: 0,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       {
@@ -1727,6 +2330,7 @@ test('handles pop action with route.history on a single route', () => {
     key: 'root',
     index: 0,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       {
@@ -1753,6 +2357,7 @@ test('handles goBack with route.history', () => {
     key: 'root',
     index: 1,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'baz', name: 'baz' },
@@ -1780,6 +2385,7 @@ test('handles goBack with route.history', () => {
     key: 'root',
     index: 1,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'baz', name: 'baz' },
@@ -1804,6 +2410,7 @@ test('handles goBack with route.history', () => {
     key: 'root',
     index: 1,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'baz', name: 'baz' },
@@ -1828,8 +2435,51 @@ test('handles goBack with route.history', () => {
     key: 'root',
     index: 0,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [{ key: 'baz', name: 'baz' }],
+  });
+});
+
+test('moves retained routes to preloadedRoutes on goBack', () => {
+  const router = StackRouter({});
+  const options: RouterConfigOptions = {
+    routeNames: ['baz', 'bar', 'qux'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+
+  expect(
+    router.getStateForAction(
+      {
+        stale: false,
+        type: 'stack',
+        key: 'root',
+        index: 2,
+        preloadedRoutes: [],
+        retainedRouteKeys: ['qux'],
+        routeNames: ['baz', 'bar', 'qux'],
+        routes: [
+          { key: 'baz', name: 'baz' },
+          { key: 'bar', name: 'bar' },
+          { key: 'qux', name: 'qux' },
+        ],
+      },
+      CommonActions.goBack(),
+      options
+    )
+  ).toEqual({
+    stale: false,
+    type: 'stack',
+    key: 'root',
+    index: 1,
+    preloadedRoutes: [{ key: 'qux', name: 'qux' }],
+    retainedRouteKeys: ['qux'],
+    routeNames: ['baz', 'bar', 'qux'],
+    routes: [
+      { key: 'baz', name: 'baz' },
+      { key: 'bar', name: 'bar' },
+    ],
   });
 });
 
@@ -1847,6 +2497,7 @@ test('handles goBack action with route.history on a single route', () => {
     key: 'root',
     index: 0,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       {
@@ -1873,6 +2524,7 @@ test('handles goBack action with route.history on a single route', () => {
     key: 'root',
     index: 0,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       {
@@ -1896,6 +2548,7 @@ test('handles goBack action with route.history on a single route', () => {
     key: 'root',
     index: 0,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       {
@@ -1929,6 +2582,7 @@ test('replaces focused screen with replace', () => {
           { key: 'baz', name: 'baz' },
         ],
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['foo', 'bar', 'baz', 'qux'],
       },
       StackActions.replace('qux', { answer: 42 }),
@@ -1945,6 +2599,7 @@ test('replaces focused screen with replace', () => {
       { key: 'baz', name: 'baz' },
     ],
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz', 'qux'],
   });
 });
@@ -1970,6 +2625,7 @@ test('replaces active screen with replace', () => {
           { key: 'baz', name: 'baz' },
         ],
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['foo', 'bar', 'baz', 'qux'],
       },
       {
@@ -1989,6 +2645,50 @@ test('replaces active screen with replace', () => {
       { key: 'baz', name: 'baz' },
     ],
     preloadedRoutes: [],
+    retainedRouteKeys: [],
+    routeNames: ['foo', 'bar', 'baz', 'qux'],
+  });
+});
+
+test('moves retained routes to preloadedRoutes on replace', () => {
+  const router = StackRouter({});
+  const options: RouterConfigOptions = {
+    routeNames: ['foo', 'bar', 'baz', 'qux'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+
+  expect(
+    router.getStateForAction(
+      {
+        stale: false,
+        type: 'stack',
+        key: 'root',
+        index: 1,
+        routes: [
+          { key: 'foo', name: 'foo' },
+          { key: 'bar', name: 'bar' },
+          { key: 'baz', name: 'baz' },
+        ],
+        preloadedRoutes: [],
+        retainedRouteKeys: ['bar'],
+        routeNames: ['foo', 'bar', 'baz', 'qux'],
+      },
+      StackActions.replace('qux', { answer: 42 }),
+      options
+    )
+  ).toEqual({
+    stale: false,
+    type: 'stack',
+    key: 'root',
+    index: 1,
+    routes: [
+      { key: 'foo', name: 'foo' },
+      { key: 'qux-test', name: 'qux', params: { answer: 42 } },
+      { key: 'baz', name: 'baz' },
+    ],
+    preloadedRoutes: [{ key: 'bar', name: 'bar' }],
+    retainedRouteKeys: ['bar'],
     routeNames: ['foo', 'bar', 'baz', 'qux'],
   });
 });
@@ -2014,6 +2714,7 @@ test("handles replace if source key isn't present but target is not specified", 
           { key: 'baz', name: 'baz' },
         ],
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['foo', 'bar', 'baz', 'qux'],
       },
       {
@@ -2026,6 +2727,7 @@ test("handles replace if source key isn't present but target is not specified", 
     index: 1,
     key: 'root',
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz', 'qux'],
     routes: [
       { key: 'foo', name: 'foo' },
@@ -2058,6 +2760,7 @@ test("doesn't handle replace if source key isn't present when target is specifie
           { key: 'baz', name: 'baz' },
         ],
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['foo', 'bar', 'baz', 'qux'],
       },
       {
@@ -2091,6 +2794,7 @@ test("doesn't handle replace if screen to replace with isn't present", () => {
           { key: 'baz', name: 'baz' },
         ],
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['foo', 'bar', 'baz', 'qux'],
       },
       {
@@ -2120,6 +2824,7 @@ test('handles push action', () => {
         key: 'root',
         index: 2,
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [{ key: 'bar', name: 'bar' }],
       },
@@ -2132,6 +2837,7 @@ test('handles push action', () => {
     key: 'root',
     index: 1,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'bar', name: 'bar' },
@@ -2147,6 +2853,7 @@ test('handles push action', () => {
         key: 'root',
         index: 2,
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [{ key: 'bar', name: 'bar' }],
       },
@@ -2159,6 +2866,7 @@ test('handles push action', () => {
     key: 'root',
     index: 1,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'bar', name: 'bar' },
@@ -2174,6 +2882,7 @@ test('handles push action', () => {
         key: 'root',
         index: 2,
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [{ key: 'bar', name: 'bar' }],
       },
@@ -2199,6 +2908,7 @@ test("doesn't push nonexistent screen", () => {
         key: 'root',
         index: 1,
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'baz', name: 'baz' },
@@ -2230,6 +2940,7 @@ test('handles getId for push', () => {
         key: 'root',
         index: 0,
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [{ key: 'bar', name: 'bar' }],
       },
@@ -2242,6 +2953,7 @@ test('handles getId for push', () => {
     key: 'root',
     index: 1,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'bar', name: 'bar' },
@@ -2257,6 +2969,7 @@ test('handles getId for push', () => {
         key: 'root',
         index: 1,
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'bar', name: 'bar' },
@@ -2272,6 +2985,7 @@ test('handles getId for push', () => {
     key: 'root',
     index: 2,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'bar', name: 'bar' },
@@ -2288,6 +3002,7 @@ test('handles getId for push', () => {
         key: 'root',
         index: 1,
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'bar', name: 'bar' },
@@ -2303,6 +3018,7 @@ test('handles getId for push', () => {
     key: 'root',
     index: 2,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'bar', name: 'bar' },
@@ -2332,6 +3048,7 @@ test('getId is scoped to route name for push', () => {
         key: 'root',
         index: 1,
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'qux-test', name: 'qux', params: { test: 'a' } },
@@ -2347,6 +3064,7 @@ test('getId is scoped to route name for push', () => {
     key: 'root',
     index: 2,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'qux-test', name: 'qux', params: { test: 'a' } },
@@ -2372,6 +3090,7 @@ test('adds path on navigate if provided', () => {
         key: 'root',
         index: 1,
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'baz', name: 'baz' },
@@ -2391,6 +3110,7 @@ test('adds path on navigate if provided', () => {
     key: 'root',
     index: 1,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'baz', name: 'baz' },
@@ -2406,6 +3126,7 @@ test('adds path on navigate if provided', () => {
         key: 'root',
         index: 1,
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'baz', name: 'baz' },
@@ -2425,6 +3146,7 @@ test('adds path on navigate if provided', () => {
     key: 'root',
     index: 1,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'baz', name: 'baz' },
@@ -2445,6 +3167,7 @@ test('adds path on navigate if provided', () => {
         key: 'root',
         index: 0,
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [{ key: 'bar', name: 'bar', params: { answer: 42 } }],
       },
@@ -2460,6 +3183,7 @@ test('adds path on navigate if provided', () => {
     key: 'root',
     index: 1,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'bar', name: 'bar', params: { answer: 42 } },
@@ -2488,6 +3212,7 @@ test("doesn't remove existing path on navigate if not provided", () => {
         key: 'root',
         index: 1,
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'baz', name: 'baz' },
@@ -2507,6 +3232,7 @@ test("doesn't remove existing path on navigate if not provided", () => {
     key: 'root',
     index: 1,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'baz', name: 'baz' },
@@ -2531,6 +3257,7 @@ test('handles popTo action', () => {
         key: 'root',
         index: 1,
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'baz', name: 'baz' },
@@ -2546,6 +3273,7 @@ test('handles popTo action', () => {
     key: 'root',
     index: 1,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'baz', name: 'baz' },
@@ -2565,6 +3293,7 @@ test('handles popTo action', () => {
         key: 'root',
         index: 1,
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'baz', name: 'baz' },
@@ -2580,6 +3309,7 @@ test('handles popTo action', () => {
     key: 'root',
     index: 0,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [{ key: 'baz', name: 'baz', params: { answer: 42 } }],
   });
@@ -2592,6 +3322,7 @@ test('handles popTo action', () => {
         key: 'root',
         index: 1,
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'baz', name: 'baz' },
@@ -2607,10 +3338,85 @@ test('handles popTo action', () => {
     key: 'root',
     index: 1,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'baz', name: 'baz' },
       { key: 'bar', name: 'bar', params: { answer: 96 } },
+    ],
+  });
+});
+
+test('moves retained routes to preloadedRoutes on popTo', () => {
+  const router = StackRouter({});
+  const options: RouterConfigOptions = {
+    routeNames: ['baz', 'bar', 'qux'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+
+  expect(
+    router.getStateForAction(
+      {
+        stale: false,
+        type: 'stack',
+        key: 'root',
+        index: 2,
+        preloadedRoutes: [],
+        retainedRouteKeys: ['qux'],
+        routeNames: ['baz', 'bar', 'qux'],
+        routes: [
+          { key: 'baz', name: 'baz' },
+          { key: 'bar', name: 'bar' },
+          { key: 'qux', name: 'qux' },
+        ],
+      },
+      StackActions.popTo('bar'),
+      options
+    )
+  ).toEqual({
+    stale: false,
+    type: 'stack',
+    key: 'root',
+    index: 1,
+    preloadedRoutes: [{ key: 'qux', name: 'qux' }],
+    retainedRouteKeys: ['qux'],
+    routeNames: ['baz', 'bar', 'qux'],
+    routes: [
+      { key: 'baz', name: 'baz' },
+      { key: 'bar', name: 'bar' },
+    ],
+  });
+
+  expect(
+    router.getStateForAction(
+      {
+        stale: false,
+        type: 'stack',
+        key: 'root',
+        index: 1,
+        preloadedRoutes: [],
+        retainedRouteKeys: ['bar'],
+        routeNames: ['baz', 'bar', 'qux'],
+        routes: [
+          { key: 'baz', name: 'baz' },
+          { key: 'bar', name: 'bar' },
+        ],
+      },
+      StackActions.popTo('qux'),
+      options
+    )
+  ).toEqual({
+    stale: false,
+    type: 'stack',
+    key: 'root',
+    index: 1,
+    preloadedRoutes: [{ key: 'bar', name: 'bar' }],
+    retainedRouteKeys: ['bar'],
+    routeNames: ['baz', 'bar', 'qux'],
+    routes: [
+      { key: 'baz', name: 'baz' },
+      { key: 'qux-test', name: 'qux' },
     ],
   });
 });
@@ -2631,6 +3437,7 @@ test("doesn't popTo to nonexistent screen", () => {
         key: 'root',
         index: 1,
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'baz', name: 'baz' },
@@ -2661,6 +3468,7 @@ test("doesn't merge params on popTo to an existing screen", () => {
         key: 'root',
         index: 2,
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'baz', name: 'baz' },
@@ -2677,6 +3485,7 @@ test("doesn't merge params on popTo to an existing screen", () => {
     key: 'root',
     index: 1,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'baz', name: 'baz' },
@@ -2692,6 +3501,7 @@ test("doesn't merge params on popTo to an existing screen", () => {
         key: 'root',
         index: 1,
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'baz', name: 'baz' },
@@ -2707,6 +3517,7 @@ test("doesn't merge params on popTo to an existing screen", () => {
     key: 'root',
     index: 1,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'baz', name: 'baz' },
@@ -2734,6 +3545,7 @@ test('merges params on popTo to an existing screen if merge: true', () => {
         key: 'root',
         index: 2,
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'baz', name: 'baz' },
@@ -2751,6 +3563,7 @@ test('merges params on popTo to an existing screen if merge: true', () => {
     key: 'root',
     index: 1,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'baz', name: 'baz' },
@@ -2766,6 +3579,7 @@ test('merges params on popTo to an existing screen if merge: true', () => {
         key: 'root',
         index: 1,
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'baz', name: 'baz' },
@@ -2781,6 +3595,7 @@ test('merges params on popTo to an existing screen if merge: true', () => {
     key: 'root',
     index: 1,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'baz', name: 'baz' },
@@ -2800,6 +3615,7 @@ test('merges params on popTo to an existing screen if merge: true', () => {
         key: 'root',
         index: 1,
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'baz', name: 'baz', params: { test: 99 } },
@@ -2815,6 +3631,7 @@ test('merges params on popTo to an existing screen if merge: true', () => {
     key: 'root',
     index: 0,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       {
@@ -2847,6 +3664,7 @@ test("handles popTo if source key isn't present but target is not specified", ()
           { key: 'baz', name: 'baz' },
         ],
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['foo', 'bar', 'baz', 'qux'],
       },
       {
@@ -2859,6 +3677,7 @@ test("handles popTo if source key isn't present but target is not specified", ()
     index: 1,
     key: 'root',
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz', 'qux'],
     routes: [
       { key: 'foo', name: 'foo' },
@@ -2890,6 +3709,7 @@ test('handles popTo when source and target match a route', () => {
           { key: 'baz', name: 'baz' },
         ],
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['foo', 'bar', 'baz', 'qux'],
       },
       {
@@ -2903,6 +3723,7 @@ test('handles popTo when source and target match a route', () => {
     index: 1,
     key: 'root',
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz', 'qux'],
     routes: [
       { key: 'foo', name: 'foo' },
@@ -2931,6 +3752,7 @@ test('handles popTo with getId matching route history', () => {
         key: 'root',
         index: 2,
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           {
@@ -2955,6 +3777,7 @@ test('handles popTo with getId matching route history', () => {
     key: 'root',
     index: 0,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       {
@@ -2974,6 +3797,7 @@ test('handles popTo with getId matching route history', () => {
         key: 'root',
         index: 1,
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           {
@@ -2997,6 +3821,7 @@ test('handles popTo with getId matching route history', () => {
     key: 'root',
     index: 0,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       {
@@ -3016,6 +3841,7 @@ test('handles popTo with getId matching route history', () => {
         key: 'root',
         index: 1,
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           {
@@ -3036,6 +3862,7 @@ test('handles popTo with getId matching route history', () => {
     key: 'root',
     index: 0,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       {
@@ -3069,6 +3896,7 @@ test("doesn't handle popTo if source key isn't present when target is specified"
           { key: 'baz', name: 'baz' },
         ],
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['foo', 'bar', 'baz', 'qux'],
       },
       {
@@ -3102,6 +3930,7 @@ test('adds route to preloaded list with preload', () => {
         key: 'root',
         index: 2,
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'baz', name: 'baz' },
@@ -3120,6 +3949,7 @@ test('adds route to preloaded list with preload', () => {
     preloadedRoutes: [
       { key: 'bar-test', name: 'bar', params: { color: 'test' } },
     ],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'baz', name: 'baz' },
@@ -3150,6 +3980,7 @@ test('updates an existing route with preload when the ID matches', () => {
         key: 'root',
         index: 1,
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           {
@@ -3169,6 +4000,7 @@ test('updates an existing route with preload when the ID matches', () => {
     key: 'root',
     index: 1,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       {
@@ -3202,6 +4034,7 @@ test('updates the last matching route with preload when the ID matches', () => {
         key: 'root',
         index: 2,
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           {
@@ -3226,6 +4059,7 @@ test('updates the last matching route with preload when the ID matches', () => {
     key: 'root',
     index: 2,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       {
@@ -3264,6 +4098,7 @@ test('adds preloaded route with preload when the ID changes', () => {
         key: 'root',
         index: 1,
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           {
@@ -3285,6 +4120,7 @@ test('adds preloaded route with preload when the ID changes', () => {
     preloadedRoutes: [
       { key: 'bar-test', name: 'bar', params: { answer: 43, color: 'test' } },
     ],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       {
@@ -3308,6 +4144,7 @@ test('updates the last matching route by name with preload and reuse when getId 
         key: 'root',
         index: 2,
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           {
@@ -3342,6 +4179,7 @@ test('updates the last matching route by name with preload and reuse when getId 
     key: 'root',
     index: 2,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       {
@@ -3380,6 +4218,7 @@ test('updates the last matching route with preload and reuse', () => {
         key: 'root',
         index: 2,
         preloadedRoutes: [],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           {
@@ -3408,6 +4247,7 @@ test('updates the last matching route with preload and reuse', () => {
     key: 'root',
     index: 2,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       {
@@ -3457,6 +4297,7 @@ test('updates the last matching preloaded route with preload and reuse', () => {
             params: { answer: 42, toBe: 'last' },
           },
         ],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [{ key: 'baz', name: 'baz' }],
       },
@@ -3484,6 +4325,7 @@ test('updates the last matching preloaded route with preload and reuse', () => {
         params: { answer: 42, color: 'test', something: 'else' },
       },
     ],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [{ key: 'baz', name: 'baz' }],
   });
@@ -3516,6 +4358,7 @@ test('prefers a matching preloaded route over matching routes with preload and r
             params: { answer: 42, toBe: 'preloaded' },
           },
         ],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           {
@@ -3545,6 +4388,7 @@ test('prefers a matching preloaded route over matching routes with preload and r
         params: { answer: 42, color: 'test', something: 'else' },
       },
     ],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       {
@@ -3579,6 +4423,7 @@ test('uses preloaded route when pushing a route with the same name', () => {
           },
           { key: 'qux-some', name: 'qux' },
         ],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           {
@@ -3602,6 +4447,7 @@ test('uses preloaded route when pushing a route with the same name', () => {
         name: 'bar',
       },
     ],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       {
@@ -3626,6 +4472,7 @@ test('uses preloaded route when pushing a route with the same name', () => {
           },
           { key: 'qux-some', name: 'qux' },
         ],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'qux-some', name: 'qux' },
@@ -3650,6 +4497,7 @@ test('uses preloaded route when pushing a route with the same name', () => {
         name: 'bar',
       },
     ],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       {
@@ -3690,6 +4538,7 @@ test('uses preloaded route when pushing a route with the same ID', () => {
             name: 'bar',
           },
         ],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           {
@@ -3708,6 +4557,7 @@ test('uses preloaded route when pushing a route with the same ID', () => {
     key: 'root',
     index: 1,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'qux-test', name: 'qux' },
@@ -3753,6 +4603,7 @@ test('does not use preloaded route when pushing a route with different ID', () =
             name: 'bar',
           },
         ],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           {
@@ -3780,6 +4631,7 @@ test('does not use preloaded route when pushing a route with different ID', () =
         name: 'bar',
       },
     ],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'qux-test', name: 'qux' },
@@ -3819,6 +4671,7 @@ test('uses preloaded route when replacing current route', () => {
             params: { answer: 42 },
           },
         ],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'baz', name: 'baz' },
@@ -3834,6 +4687,7 @@ test('uses preloaded route when replacing current route', () => {
     key: 'root',
     index: 1,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'baz', name: 'baz' },
@@ -3872,6 +4726,7 @@ test('uses preloaded route with the same ID when replacing current route', () =>
             params: { answer: 42 },
           },
         ],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'baz', name: 'baz' },
@@ -3887,6 +4742,7 @@ test('uses preloaded route with the same ID when replacing current route', () =>
     key: 'root',
     index: 1,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'baz', name: 'baz' },
@@ -3925,6 +4781,7 @@ test('does not use preloaded route with different ID when replacing current rout
             params: { answer: 99 },
           },
         ],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'baz', name: 'baz' },
@@ -3946,6 +4803,7 @@ test('does not use preloaded route with different ID when replacing current rout
         params: { answer: 99 },
       },
     ],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'baz', name: 'baz' },
@@ -3982,6 +4840,7 @@ test('uses preloaded route with the same name when popTo replaces current route'
             params: { answer: 42 },
           },
         ],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'baz', name: 'baz' },
@@ -3997,6 +4856,7 @@ test('uses preloaded route with the same name when popTo replaces current route'
     key: 'root',
     index: 1,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'baz', name: 'baz' },
@@ -4035,6 +4895,7 @@ test('uses preloaded route with the same ID when popTo replaces current route', 
             params: { answer: 42 },
           },
         ],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'baz', name: 'baz' },
@@ -4050,6 +4911,7 @@ test('uses preloaded route with the same ID when popTo replaces current route', 
     key: 'root',
     index: 1,
     preloadedRoutes: [],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'baz', name: 'baz' },
@@ -4088,6 +4950,7 @@ test('does not use preloaded route with different ID when popTo replaces current
             params: { answer: 99 },
           },
         ],
+        retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'baz', name: 'baz' },
@@ -4109,6 +4972,7 @@ test('does not use preloaded route with different ID when popTo replaces current
         params: { answer: 99 },
       },
     ],
+    retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'baz', name: 'baz' },

--- a/packages/stack/src/views/Stack/__tests__/StackView.test.tsx
+++ b/packages/stack/src/views/Stack/__tests__/StackView.test.tsx
@@ -29,6 +29,7 @@ const createNavigationState = (
   routeNames: routes.map((r) => r.name),
   routes,
   preloadedRoutes: options.preloadedRoutes ?? [],
+  retainedRouteKeys: [],
 });
 
 const createDescriptors = (


### PR DESCRIPTION
This adds support for retaining screens in stack.

Calling `navigation.retain(true)` in a Stack will mark it as retained. Retained screens stay alive and are not unmounted when you go back from them or replace them. Next time you navigate to the screen, it'll animate in the existing instance.

Calling `navigation.retain(false)` unmarks the screen from being retained. If it was already loaded, but not present in history, it'll be removed.

Currently, this will only work for JS stack. It'll work in Native Stack in the future with React native Screens 5.

https://github.com/user-attachments/assets/82e8c481-c34e-4070-b02b-607331bf8fad

**Use cases**:

- Keep frequently visited heavy screens rendered without unmounting/remounting
- Keep elements such as video players alive for picture-in-picture modes