### PR TITLE
refactor: simplify types for custom navigators

### DIFF
--- a/packages/bottom-tabs/src/index.tsx
+++ b/packages/bottom-tabs/src/index.tsx
@@ -11,6 +11,7 @@ export { SceneStyleInterpolators, TransitionPresets, TransitionSpecs };
  * Navigators
  */
 export {
+  type BottomTabTypeBag,
   createBottomTabNavigator,
   createBottomTabScreen,
 } from './navigators/createBottomTabNavigator';

--- a/packages/bottom-tabs/src/navigators/createBottomTabNavigator.tsx
+++ b/packages/bottom-tabs/src/navigators/createBottomTabNavigator.tsx
@@ -1,6 +1,6 @@
 import {
   createNavigatorFactory,
-  createStaticScreenFactory,
+  createScreenFactory,
   type NavigatorTypeBagFactory,
   type ParamListBase,
   type TabActionHelpers,
@@ -71,5 +71,4 @@ export interface BottomTabTypeBag extends NavigatorTypeBagFactory {
 export const createBottomTabNavigator =
   createNavigatorFactory<BottomTabTypeBag>(BottomTabNavigator);
 
-export const createBottomTabScreen =
-  createStaticScreenFactory<BottomTabTypeBag>();
+export const createBottomTabScreen = createScreenFactory<BottomTabTypeBag>();

--- a/packages/bottom-tabs/src/navigators/createBottomTabNavigator.tsx
+++ b/packages/bottom-tabs/src/navigators/createBottomTabNavigator.tsx
@@ -1,16 +1,12 @@
 import {
   createNavigatorFactory,
+  createStaticScreenFactory,
+  type NavigatorTypeBagFactory,
   type ParamListBase,
-  type StaticConfig,
-  type StaticParamList,
-  type StaticScreenConfig,
-  type StaticScreenConfigLinking,
-  type StaticScreenConfigScreen,
   type TabActionHelpers,
   type TabNavigationState,
   TabRouter,
   type TabRouterOptions,
-  type TypedNavigator,
   useNavigationBuilder,
 } from '@react-navigation/native';
 
@@ -65,47 +61,22 @@ function BottomTabNavigator({
   );
 }
 
-type BottomTabTypeBag<ParamList extends {}> = {
-  ParamList: ParamList;
-  State: TabNavigationState<ParamList>;
+export interface BottomTabTypeBag extends NavigatorTypeBagFactory {
+  ParamList: this['input'];
+  State: TabNavigationState<this['input']>;
   ScreenOptions: BottomTabNavigationOptions;
   EventMap: BottomTabNavigationEventMap;
   NavigationList: {
-    [RouteName in keyof ParamList]: BottomTabNavigationProp<
-      ParamList,
+    [RouteName in keyof this['input']]: BottomTabNavigationProp<
+      this['input'],
       RouteName
     >;
   };
   Navigator: typeof BottomTabNavigator;
-};
-
-export function createBottomTabNavigator<
-  const ParamList extends ParamListBase,
->(): TypedNavigator<BottomTabTypeBag<ParamList>, undefined>;
-export function createBottomTabNavigator<
-  const Config extends StaticConfig<BottomTabTypeBag<ParamListBase>>,
->(
-  config: Config
-): TypedNavigator<
-  BottomTabTypeBag<StaticParamList<{ config: Config }>>,
-  Config
->;
-export function createBottomTabNavigator(config?: unknown) {
-  return createNavigatorFactory(BottomTabNavigator)(config);
 }
 
-export function createBottomTabScreen<
-  const Linking extends StaticScreenConfigLinking,
-  const Screen extends StaticScreenConfigScreen,
->(
-  config: StaticScreenConfig<
-    Linking,
-    Screen,
-    TabNavigationState<ParamListBase>,
-    BottomTabNavigationOptions,
-    BottomTabNavigationEventMap,
-    BottomTabNavigationProp<ParamListBase>
-  >
-) {
-  return config;
-}
+export const createBottomTabNavigator =
+  createNavigatorFactory<BottomTabTypeBag>(BottomTabNavigator);
+
+export const createBottomTabScreen =
+  createStaticScreenFactory<BottomTabTypeBag>();

--- a/packages/bottom-tabs/src/navigators/createBottomTabNavigator.tsx
+++ b/packages/bottom-tabs/src/navigators/createBottomTabNavigator.tsx
@@ -1,7 +1,7 @@
 import {
   createNavigatorFactory,
   createScreenFactory,
-  type NavigatorTypeBagFactory,
+  type NavigatorTypeBagBase,
   type ParamListBase,
   type TabActionHelpers,
   type TabNavigationState,
@@ -60,7 +60,7 @@ function BottomTabNavigator({
   );
 }
 
-export interface BottomTabTypeBag extends NavigatorTypeBagFactory {
+export interface BottomTabTypeBag extends NavigatorTypeBagBase {
   State: TabNavigationState<this['ParamList']>;
   ScreenOptions: BottomTabNavigationOptions;
   EventMap: BottomTabNavigationEventMap;

--- a/packages/bottom-tabs/src/navigators/createBottomTabNavigator.tsx
+++ b/packages/bottom-tabs/src/navigators/createBottomTabNavigator.tsx
@@ -13,7 +13,6 @@ import {
 import type {
   BottomTabNavigationEventMap,
   BottomTabNavigationOptions,
-  BottomTabNavigationProp,
   BottomTabNavigatorProps,
 } from '../types';
 import { BottomTabView } from '../views/BottomTabViewCommon';
@@ -62,16 +61,10 @@ function BottomTabNavigator({
 }
 
 export interface BottomTabTypeBag extends NavigatorTypeBagFactory {
-  ParamList: this['input'];
   State: TabNavigationState<this['input']>;
   ScreenOptions: BottomTabNavigationOptions;
   EventMap: BottomTabNavigationEventMap;
-  NavigationList: {
-    [RouteName in keyof this['input']]: BottomTabNavigationProp<
-      this['input'],
-      RouteName
-    >;
-  };
+  ActionHelpers: TabActionHelpers<this['input']>;
   Navigator: typeof BottomTabNavigator;
 }
 

--- a/packages/bottom-tabs/src/navigators/createBottomTabNavigator.tsx
+++ b/packages/bottom-tabs/src/navigators/createBottomTabNavigator.tsx
@@ -61,10 +61,10 @@ function BottomTabNavigator({
 }
 
 export interface BottomTabTypeBag extends NavigatorTypeBagFactory {
-  State: TabNavigationState<this['input']>;
+  State: TabNavigationState<this['ParamList']>;
   ScreenOptions: BottomTabNavigationOptions;
   EventMap: BottomTabNavigationEventMap;
-  ActionHelpers: TabActionHelpers<this['input']>;
+  ActionHelpers: TabActionHelpers<this['ParamList']>;
   Navigator: typeof BottomTabNavigator;
 }
 

--- a/packages/core/src/StaticNavigation.tsx
+++ b/packages/core/src/StaticNavigation.tsx
@@ -385,7 +385,7 @@ export type StaticScreenCreator<
  * Used by navigator authors to expose a `createXScreen` identity function
  * that types the screen config for their navigator.
  */
-export function createStaticScreenFactory<
+export function createScreenFactory<
   F extends NavigatorTypeBagFactory,
 >(): ApplyNavigatorTypeBagFactory<F, ParamListBase> extends infer B extends
   NavigatorTypeBagBase

--- a/packages/core/src/StaticNavigation.tsx
+++ b/packages/core/src/StaticNavigation.tsx
@@ -353,7 +353,7 @@ export type StaticScreenConfig<
   navigationKey?: string;
 };
 
-export type StaticScreenCreator<Bag extends NavigatorTypeBagBase> = <
+export type StaticScreenFactory<Bag extends NavigatorTypeBagBase> = <
   const Linking extends StaticScreenConfigLinking,
   const Screen extends StaticScreenConfigScreen,
 >(
@@ -375,13 +375,11 @@ export type StaticScreenCreator<Bag extends NavigatorTypeBagBase> = <
 >;
 
 /**
- * Factory to create a typed `createScreen` helper for a navigator.
- * Used by navigator authors to expose a `createXScreen` identity function
- * that types the screen config for their navigator.
+ * Helper to create a typed `createXScreen` for static configuration.
  */
 export function createScreenFactory<
-  F extends NavigatorTypeBagBase,
->(): StaticScreenCreator<NavigatorTypeBagFor<F, ParamListBase>> {
+  TypeBag extends NavigatorTypeBagBase,
+>(): StaticScreenFactory<NavigatorTypeBagFor<TypeBag, ParamListBase>> {
   return ((config: unknown) => config) as never;
 }
 

--- a/packages/core/src/StaticNavigation.tsx
+++ b/packages/core/src/StaticNavigation.tsx
@@ -7,13 +7,12 @@ import * as React from 'react';
 import { isValidElementType } from 'react-is';
 
 import type {
-  ApplyNavigatorTypeBagFactory,
   DefaultNavigatorOptions,
   EventMapBase,
   NavigationListBase,
   NavigatorScreenParams,
   NavigatorTypeBagBase,
-  NavigatorTypeBagFactory,
+  NavigatorTypeBagFor,
   PathConfig,
   PathConfigMap,
   RouteGroupConfig,
@@ -386,14 +385,14 @@ export type StaticScreenCreator<
  * that types the screen config for their navigator.
  */
 export function createScreenFactory<
-  F extends NavigatorTypeBagFactory,
->(): ApplyNavigatorTypeBagFactory<F, ParamListBase> extends infer B extends
+  F extends NavigatorTypeBagBase,
+>(): NavigatorTypeBagFor<F, ParamListBase> extends infer B extends
   NavigatorTypeBagBase
   ? StaticScreenCreator<
       B['State'],
       B['ScreenOptions'],
       B['EventMap'],
-      B['NavigationList'][keyof ParamListBase]
+      B['NavigationList'][keyof B['ParamList']]
     >
   : never {
   return ((config: unknown) => config) as never;

--- a/packages/core/src/StaticNavigation.tsx
+++ b/packages/core/src/StaticNavigation.tsx
@@ -353,30 +353,25 @@ export type StaticScreenConfig<
   navigationKey?: string;
 };
 
-export type StaticScreenCreator<
-  State extends NavigationState,
-  ScreenOptions extends {},
-  EventMap extends EventMapBase,
-  Navigation,
-> = <
+export type StaticScreenCreator<Bag extends NavigatorTypeBagBase> = <
   const Linking extends StaticScreenConfigLinking,
   const Screen extends StaticScreenConfigScreen,
 >(
   config: StaticScreenConfig<
     Linking,
     Screen,
-    State,
-    ScreenOptions,
-    EventMap,
-    Navigation
+    Bag['State'],
+    Bag['ScreenOptions'],
+    Bag['EventMap'],
+    Bag['NavigationList'][keyof Bag['ParamList']]
   >
 ) => StaticScreenConfig<
   Linking,
   Screen,
-  State,
-  ScreenOptions,
-  EventMap,
-  Navigation
+  Bag['State'],
+  Bag['ScreenOptions'],
+  Bag['EventMap'],
+  Bag['NavigationList'][keyof Bag['ParamList']]
 >;
 
 /**
@@ -386,15 +381,7 @@ export type StaticScreenCreator<
  */
 export function createScreenFactory<
   F extends NavigatorTypeBagBase,
->(): NavigatorTypeBagFor<F, ParamListBase> extends infer B extends
-  NavigatorTypeBagBase
-  ? StaticScreenCreator<
-      B['State'],
-      B['ScreenOptions'],
-      B['EventMap'],
-      B['NavigationList'][keyof B['ParamList']]
-    >
-  : never {
+>(): StaticScreenCreator<NavigatorTypeBagFor<F, ParamListBase>> {
   return ((config: unknown) => config) as never;
 }
 

--- a/packages/core/src/StaticNavigation.tsx
+++ b/packages/core/src/StaticNavigation.tsx
@@ -7,11 +7,13 @@ import * as React from 'react';
 import { isValidElementType } from 'react-is';
 
 import type {
+  ApplyNavigatorTypeBagFactory,
   DefaultNavigatorOptions,
   EventMapBase,
   NavigationListBase,
   NavigatorScreenParams,
   NavigatorTypeBagBase,
+  NavigatorTypeBagFactory,
   PathConfig,
   PathConfigMap,
   RouteGroupConfig,
@@ -351,6 +353,51 @@ export type StaticScreenConfig<
    */
   navigationKey?: string;
 };
+
+export type StaticScreenCreator<
+  State extends NavigationState,
+  ScreenOptions extends {},
+  EventMap extends EventMapBase,
+  Navigation,
+> = <
+  const Linking extends StaticScreenConfigLinking,
+  const Screen extends StaticScreenConfigScreen,
+>(
+  config: StaticScreenConfig<
+    Linking,
+    Screen,
+    State,
+    ScreenOptions,
+    EventMap,
+    Navigation
+  >
+) => StaticScreenConfig<
+  Linking,
+  Screen,
+  State,
+  ScreenOptions,
+  EventMap,
+  Navigation
+>;
+
+/**
+ * Factory to create a typed `createScreen` helper for a navigator.
+ * Used by navigator authors to expose a `createXScreen` identity function
+ * that types the screen config for their navigator.
+ */
+export function createStaticScreenFactory<
+  F extends NavigatorTypeBagFactory,
+>(): ApplyNavigatorTypeBagFactory<F, ParamListBase> extends infer B extends
+  NavigatorTypeBagBase
+  ? StaticScreenCreator<
+      B['State'],
+      B['ScreenOptions'],
+      B['EventMap'],
+      B['NavigationList'][keyof ParamListBase]
+    >
+  : never {
+  return ((config: unknown) => config) as never;
+}
 
 type StaticConfigScreens<
   ParamList extends ParamListBase,

--- a/packages/core/src/__tests__/StaticNavigation.test.tsx
+++ b/packages/core/src/__tests__/StaticNavigation.test.tsx
@@ -10,15 +10,11 @@ import * as React from 'react';
 import { BaseNavigationContainer } from '../BaseNavigationContainer';
 import { createNavigatorFactory } from '../createNavigatorFactory';
 import { getStateFromPath } from '../getStateFromPath';
-import {
-  createPathConfigForStaticNavigation,
-  type StaticConfig,
-  type StaticParamList,
-} from '../StaticNavigation';
+import { createPathConfigForStaticNavigation } from '../StaticNavigation';
 import type {
   DefaultNavigatorOptions,
   EventMapBase,
-  TypedNavigator,
+  NavigatorTypeBagFactory,
 } from '../types';
 import { useIsFocused } from '../useIsFocused';
 import { useNavigationBuilder } from '../useNavigationBuilder';
@@ -68,31 +64,19 @@ const TestNavigator = (props: TestNavigatorProps) => {
   );
 };
 
-type TestNavigatorTypeBag<ParamList extends {}> = {
-  ParamList: ParamList;
+interface TestNavigatorTypeBag extends NavigatorTypeBagFactory {
+  ParamList: this['input'];
   State: NavigationState;
   ScreenOptions: TestNavigatorScreenOptions;
   EventMap: EventMapBase;
   NavigationList: {
-    [RouteName in keyof ParamList]: unknown;
+    [RouteName in keyof this['input']]: unknown;
   };
   Navigator: typeof TestNavigator;
-};
-
-function createTestNavigator<
-  const ParamList extends ParamListBase,
->(): TypedNavigator<TestNavigatorTypeBag<ParamList>, undefined>;
-function createTestNavigator<
-  const Config extends StaticConfig<TestNavigatorTypeBag<ParamListBase>>,
->(
-  config: Config
-): TypedNavigator<
-  TestNavigatorTypeBag<StaticParamList<{ config: Config }>>,
-  Config
->;
-function createTestNavigator(config?: unknown) {
-  return createNavigatorFactory(TestNavigator)(config);
 }
+
+const createTestNavigator =
+  createNavigatorFactory<TestNavigatorTypeBag>(TestNavigator);
 
 const TestScreen = ({ route }: any) => {
   const isFocused = useIsFocused();

--- a/packages/core/src/__tests__/StaticNavigation.test.tsx
+++ b/packages/core/src/__tests__/StaticNavigation.test.tsx
@@ -14,7 +14,7 @@ import { createPathConfigForStaticNavigation } from '../StaticNavigation';
 import type {
   DefaultNavigatorOptions,
   EventMapBase,
-  NavigatorTypeBagFactory,
+  NavigatorTypeBagBase,
 } from '../types';
 import { useIsFocused } from '../useIsFocused';
 import { useNavigationBuilder } from '../useNavigationBuilder';
@@ -64,7 +64,7 @@ const TestNavigator = (props: TestNavigatorProps) => {
   );
 };
 
-interface TestNavigatorTypeBag extends NavigatorTypeBagFactory {
+interface TestNavigatorTypeBag extends NavigatorTypeBagBase {
   ScreenOptions: TestNavigatorScreenOptions;
   Navigator: typeof TestNavigator;
 }

--- a/packages/core/src/__tests__/StaticNavigation.test.tsx
+++ b/packages/core/src/__tests__/StaticNavigation.test.tsx
@@ -65,13 +65,7 @@ const TestNavigator = (props: TestNavigatorProps) => {
 };
 
 interface TestNavigatorTypeBag extends NavigatorTypeBagFactory {
-  ParamList: this['input'];
-  State: NavigationState;
   ScreenOptions: TestNavigatorScreenOptions;
-  EventMap: EventMapBase;
-  NavigationList: {
-    [RouteName in keyof this['input']]: unknown;
-  };
   Navigator: typeof TestNavigator;
 }
 

--- a/packages/core/src/createNavigatorFactory.tsx
+++ b/packages/core/src/createNavigatorFactory.tsx
@@ -14,29 +14,35 @@ import type {
   TypedNavigator,
 } from './types';
 
-export type TypedNavigatorCreator<F extends NavigatorTypeBagBase> = {
+export type TypedNavigatorFactory<TypeBag extends NavigatorTypeBagBase> = {
   <const ParamList extends ParamListBase>(): TypedNavigator<
-    NavigatorTypeBagFor<F, ParamList>,
+    NavigatorTypeBagFor<TypeBag, ParamList>,
     undefined
   >;
-  <const Config extends StaticConfig<NavigatorTypeBagFor<F, ParamListBase>>>(
+  <
+    const Config extends StaticConfig<
+      NavigatorTypeBagFor<TypeBag, ParamListBase>
+    >,
+  >(
     config: Config
   ): TypedNavigator<
-    NavigatorTypeBagFor<F, StaticParamList<{ config: Config }>>,
+    NavigatorTypeBagFor<TypeBag, StaticParamList<{ config: Config }>>,
     Config
   >;
 };
 
 /**
- * Higher order component to create a `Navigator` and `Screen` pair.
- * Custom navigators should wrap the navigator component in `createNavigator` before exporting.
+ * Higher order function to create a navigator factory
+ * A navigator factory creates a navigator:
+ * - `Navigator` and `Screen` pairs for dynamic configuration
+ * - Static navigator object for static configuration
  *
  * @param Navigator The navigator component to wrap.
- * @returns Factory method to create a `Navigator` and `Screen` pair.
+ * @returns Factory method to create a navigator
  */
-export function createNavigatorFactory<
-  F extends NavigatorTypeBagBase = NavigatorTypeBagBase,
->(Navigator: React.ComponentType<any>): TypedNavigatorCreator<F> {
+export function createNavigatorFactory<TypeBag extends NavigatorTypeBagBase>(
+  Navigator: React.ComponentType<any>
+): TypedNavigatorFactory<TypeBag> {
   const displayName = Navigator.displayName ?? Navigator.name ?? 'Navigator';
 
   function createNavigator(config?: any): any {
@@ -84,5 +90,5 @@ export function createNavigatorFactory<
     };
   }
 
-  return createNavigator as never;
+  return createNavigator;
 }

--- a/packages/core/src/createNavigatorFactory.tsx
+++ b/packages/core/src/createNavigatorFactory.tsx
@@ -9,24 +9,20 @@ import {
   type StaticParamList,
 } from './StaticNavigation';
 import type {
-  ApplyNavigatorTypeBagFactory,
-  NavigatorTypeBagFactory,
+  NavigatorTypeBagBase,
+  NavigatorTypeBagFor,
   TypedNavigator,
 } from './types';
 
-export type TypedNavigatorCreator<F extends NavigatorTypeBagFactory> = {
+export type TypedNavigatorCreator<F extends NavigatorTypeBagBase> = {
   <const ParamList extends ParamListBase>(): TypedNavigator<
-    ApplyNavigatorTypeBagFactory<F, ParamList>,
+    NavigatorTypeBagFor<F, ParamList>,
     undefined
   >;
-  <
-    const Config extends StaticConfig<
-      ApplyNavigatorTypeBagFactory<F, ParamListBase>
-    >,
-  >(
+  <const Config extends StaticConfig<NavigatorTypeBagFor<F, ParamListBase>>>(
     config: Config
   ): TypedNavigator<
-    ApplyNavigatorTypeBagFactory<F, StaticParamList<{ config: Config }>>,
+    NavigatorTypeBagFor<F, StaticParamList<{ config: Config }>>,
     Config
   >;
 };
@@ -39,7 +35,7 @@ export type TypedNavigatorCreator<F extends NavigatorTypeBagFactory> = {
  * @returns Factory method to create a `Navigator` and `Screen` pair.
  */
 export function createNavigatorFactory<
-  F extends NavigatorTypeBagFactory = NavigatorTypeBagFactory,
+  F extends NavigatorTypeBagBase = NavigatorTypeBagBase,
 >(Navigator: React.ComponentType<any>): TypedNavigatorCreator<F> {
   const displayName = Navigator.displayName ?? Navigator.name ?? 'Navigator';
 

--- a/packages/core/src/createNavigatorFactory.tsx
+++ b/packages/core/src/createNavigatorFactory.tsx
@@ -1,8 +1,35 @@
+import type { ParamListBase } from '@react-navigation/routers';
 import * as React from 'react';
 
 import { Group } from './Group';
 import { Screen } from './Screen';
-import { createComponentForStaticConfig } from './StaticNavigation';
+import {
+  createComponentForStaticConfig,
+  type StaticConfig,
+  type StaticParamList,
+} from './StaticNavigation';
+import type {
+  ApplyNavigatorTypeBagFactory,
+  NavigatorTypeBagFactory,
+  TypedNavigator,
+} from './types';
+
+export type TypedNavigatorCreator<F extends NavigatorTypeBagFactory> = {
+  <const ParamList extends ParamListBase>(): TypedNavigator<
+    ApplyNavigatorTypeBagFactory<F, ParamList>,
+    undefined
+  >;
+  <
+    const Config extends StaticConfig<
+      ApplyNavigatorTypeBagFactory<F, ParamListBase>
+    >,
+  >(
+    config: Config
+  ): TypedNavigator<
+    ApplyNavigatorTypeBagFactory<F, StaticParamList<{ config: Config }>>,
+    Config
+  >;
+};
 
 /**
  * Higher order component to create a `Navigator` and `Screen` pair.
@@ -11,7 +38,9 @@ import { createComponentForStaticConfig } from './StaticNavigation';
  * @param Navigator The navigator component to wrap.
  * @returns Factory method to create a `Navigator` and `Screen` pair.
  */
-export function createNavigatorFactory(Navigator: React.ComponentType<any>) {
+export function createNavigatorFactory<
+  F extends NavigatorTypeBagFactory = NavigatorTypeBagFactory,
+>(Navigator: React.ComponentType<any>): TypedNavigatorCreator<F> {
   const displayName = Navigator.displayName ?? Navigator.name ?? 'Navigator';
 
   function createNavigator(config?: any): any {
@@ -59,5 +88,5 @@ export function createNavigatorFactory(Navigator: React.ComponentType<any>) {
     };
   }
 
-  return createNavigator;
+  return createNavigator as never;
 }

--- a/packages/core/src/index.tsx
+++ b/packages/core/src/index.tsx
@@ -23,7 +23,7 @@ export { PreventRemoveContext } from './PreventRemoveContext';
 export { PreventRemoveProvider } from './PreventRemoveProvider';
 export {
   createPathConfigForStaticNavigation,
-  createStaticScreenFactory,
+  createScreenFactory,
   type StaticConfig,
   type StaticNavigation,
   type StaticParamList,

--- a/packages/core/src/index.tsx
+++ b/packages/core/src/index.tsx
@@ -2,7 +2,7 @@ export { BaseNavigationContainer } from './BaseNavigationContainer';
 export { createNavigationContainerRef } from './createNavigationContainerRef';
 export {
   createNavigatorFactory,
-  type TypedNavigatorCreator,
+  type TypedNavigatorFactory,
 } from './createNavigatorFactory';
 export { CurrentRenderContext } from './CurrentRenderContext';
 export { findFocusedRoute } from './findFocusedRoute';
@@ -30,7 +30,7 @@ export {
   type StaticScreenConfig,
   type StaticScreenConfigLinking,
   type StaticScreenConfigScreen,
-  type StaticScreenCreator,
+  type StaticScreenFactory,
   type StaticScreenProps,
 } from './StaticNavigation';
 export { ThemeContext } from './theming/ThemeContext';

--- a/packages/core/src/index.tsx
+++ b/packages/core/src/index.tsx
@@ -1,6 +1,9 @@
 export { BaseNavigationContainer } from './BaseNavigationContainer';
 export { createNavigationContainerRef } from './createNavigationContainerRef';
-export { createNavigatorFactory } from './createNavigatorFactory';
+export {
+  createNavigatorFactory,
+  type TypedNavigatorCreator,
+} from './createNavigatorFactory';
 export { CurrentRenderContext } from './CurrentRenderContext';
 export { findFocusedRoute } from './findFocusedRoute';
 export { getActionFromState } from './getActionFromState';
@@ -20,12 +23,14 @@ export { PreventRemoveContext } from './PreventRemoveContext';
 export { PreventRemoveProvider } from './PreventRemoveProvider';
 export {
   createPathConfigForStaticNavigation,
+  createStaticScreenFactory,
   type StaticConfig,
   type StaticNavigation,
   type StaticParamList,
   type StaticScreenConfig,
   type StaticScreenConfigLinking,
   type StaticScreenConfigScreen,
+  type StaticScreenCreator,
   type StaticScreenProps,
 } from './StaticNavigation';
 export { ThemeContext } from './theming/ThemeContext';

--- a/packages/core/src/types.tsx
+++ b/packages/core/src/types.tsx
@@ -1183,6 +1183,9 @@ export type NavigationListBase<ParamList extends ParamListBase> = {
  * navigator authors only need to override `State`, `ScreenOptions`,
  * `EventMap`, `ActionHelpers`, and `Navigator`.
  */
+type ActionHelpersOf<T> =
+  T extends Record<string, (...args: any) => void> ? T : {};
+
 export interface NavigatorTypeBagBase {
   ParamList: {};
   State: NavigationState;
@@ -1196,9 +1199,7 @@ export interface NavigatorTypeBagBase {
       this['State'],
       this['ScreenOptions'],
       this['EventMap'],
-      this['ActionHelpers'] extends Record<string, (...args: any) => void>
-        ? this['ActionHelpers']
-        : {}
+      ActionHelpersOf<this['ActionHelpers']>
     >;
   };
   Navigator: React.ComponentType<any>;

--- a/packages/core/src/types.tsx
+++ b/packages/core/src/types.tsx
@@ -1186,16 +1186,29 @@ export type NavigatorTypeBagBase = {
  * Navigator authors extend this and reference `this['input']` (the
  * param list) in the bag fields to express how they depend on it.
  *
- * The defaults are a permissive bag used when the factory is called
- * without a generic — any string is a valid screen name.
+ * `ParamList` and `NavigationList` default to derivations of the other
+ * fields, so navigator authors only need to override `State`,
+ * `ScreenOptions`, `EventMap`, `ActionHelpers`, and `Navigator`.
  */
 export interface NavigatorTypeBagFactory {
   input: {};
-  ParamList: ParamListBase;
+  ParamList: this['input'];
   State: NavigationState;
   ScreenOptions: {};
   EventMap: {};
-  NavigationList: NavigationListBase<ParamListBase>;
+  ActionHelpers: {};
+  NavigationList: {
+    [RouteName in keyof this['input']]: NavigationProp<
+      this['input'],
+      RouteName,
+      this['State'],
+      this['ScreenOptions'],
+      this['EventMap'],
+      this['ActionHelpers'] extends Record<string, (...args: any) => void>
+        ? this['ActionHelpers']
+        : {}
+    >;
+  };
   Navigator: React.ComponentType<any>;
 }
 

--- a/packages/core/src/types.tsx
+++ b/packages/core/src/types.tsx
@@ -1183,23 +1183,24 @@ export type NavigatorTypeBagBase = {
 
 /**
  * Higher-kinded encoding of a navigator type bag.
- * Navigator authors extend this and reference `this['input']` (the
- * param list) in the bag fields to express how they depend on it.
+ * Navigator authors extend this and reference `this['ParamList']` in
+ * the other bag fields to express how they depend on it.
+ * `ApplyNavigatorTypeBagFactory` overrides `ParamList` at the call
+ * site, and TS's `this`-resolution threads the new value through.
  *
- * `ParamList` and `NavigationList` default to derivations of the other
- * fields, so navigator authors only need to override `State`,
- * `ScreenOptions`, `EventMap`, `ActionHelpers`, and `Navigator`.
+ * `NavigationList` defaults to a derivation of the other fields, so
+ * navigator authors only need to override `State`, `ScreenOptions`,
+ * `EventMap`, `ActionHelpers`, and `Navigator`.
  */
 export interface NavigatorTypeBagFactory {
-  input: {};
-  ParamList: this['input'];
+  ParamList: {};
   State: NavigationState;
   ScreenOptions: {};
   EventMap: {};
   ActionHelpers: {};
   NavigationList: {
-    [RouteName in keyof this['input']]: NavigationProp<
-      this['input'],
+    [RouteName in keyof this['ParamList']]: NavigationProp<
+      this['ParamList'],
       RouteName,
       this['State'],
       this['ScreenOptions'],
@@ -1217,8 +1218,8 @@ export interface NavigatorTypeBagFactory {
  */
 export type ApplyNavigatorTypeBagFactory<
   F extends NavigatorTypeBagFactory,
-  Input extends {},
-> = Omit<F & { input: Input }, 'input'>;
+  ParamList extends {},
+> = F & { ParamList: ParamList };
 
 type TypedNavigatorComponent<Bag extends NavigatorTypeBagBase> =
   React.ComponentType<

--- a/packages/core/src/types.tsx
+++ b/packages/core/src/types.tsx
@@ -1172,27 +1172,18 @@ export type NavigationListBase<ParamList extends ParamListBase> = {
   [RouteName in keyof ParamList]: unknown;
 };
 
-export type NavigatorTypeBagBase = {
-  ParamList: {};
-  State: NavigationState;
-  ScreenOptions: {};
-  EventMap: {};
-  NavigationList: NavigationListBase<ParamListBase>;
-  Navigator: React.ComponentType<any>;
-};
-
 /**
  * Higher-kinded encoding of a navigator type bag.
  * Navigator authors extend this and reference `this['ParamList']` in
  * the other bag fields to express how they depend on it.
- * `ApplyNavigatorTypeBagFactory` overrides `ParamList` at the call
+ * `NavigatorTypeBagFor` overrides `ParamList` at the call
  * site, and TS's `this`-resolution threads the new value through.
  *
  * `NavigationList` defaults to a derivation of the other fields, so
  * navigator authors only need to override `State`, `ScreenOptions`,
  * `EventMap`, `ActionHelpers`, and `Navigator`.
  */
-export interface NavigatorTypeBagFactory {
+export interface NavigatorTypeBagBase {
   ParamList: {};
   State: NavigationState;
   ScreenOptions: {};
@@ -1214,10 +1205,10 @@ export interface NavigatorTypeBagFactory {
 }
 
 /**
- * Applies a navigator type bag factory to a param list.
+ * Resolves a navigator type bag for a specific param list.
  */
-export type ApplyNavigatorTypeBagFactory<
-  F extends NavigatorTypeBagFactory,
+export type NavigatorTypeBagFor<
+  F extends NavigatorTypeBagBase,
   ParamList extends {},
 > = F & { ParamList: ParamList };
 

--- a/packages/core/src/types.tsx
+++ b/packages/core/src/types.tsx
@@ -1172,17 +1172,7 @@ export type NavigationListBase<ParamList extends ParamListBase> = {
   [RouteName in keyof ParamList]: unknown;
 };
 
-/**
- * Higher-kinded encoding of a navigator type bag.
- * Navigator authors extend this and reference `this['ParamList']` in
- * the other bag fields to express how they depend on it.
- * `NavigatorTypeBagFor` overrides `ParamList` at the call
- * site, and TS's `this`-resolution threads the new value through.
- *
- * `NavigationList` defaults to a derivation of the other fields, so
- * navigator authors only need to override `State`, `ScreenOptions`,
- * `EventMap`, `ActionHelpers`, and `Navigator`.
- */
+// Only use action helpers if all values are functions
 type ActionHelpersOf<T> =
   T extends Record<string, (...args: any) => void> ? T : {};
 
@@ -1206,12 +1196,13 @@ export interface NavigatorTypeBagBase {
 }
 
 /**
- * Resolves a navigator type bag for a specific param list.
+ * Adds a proper `ParamList` to a type bag interface
+ * So it can be used as `this['ParamList']`
  */
 export type NavigatorTypeBagFor<
-  F extends NavigatorTypeBagBase,
+  TypeBag extends NavigatorTypeBagBase,
   ParamList extends {},
-> = F & { ParamList: ParamList };
+> = TypeBag & { ParamList: ParamList };
 
 type TypedNavigatorComponent<Bag extends NavigatorTypeBagBase> =
   React.ComponentType<

--- a/packages/core/src/types.tsx
+++ b/packages/core/src/types.tsx
@@ -1181,6 +1181,32 @@ export type NavigatorTypeBagBase = {
   Navigator: React.ComponentType<any>;
 };
 
+/**
+ * Higher-kinded encoding of a navigator type bag.
+ * Navigator authors extend this and reference `this['input']` (the
+ * param list) in the bag fields to express how they depend on it.
+ *
+ * The defaults are a permissive bag used when the factory is called
+ * without a generic — any string is a valid screen name.
+ */
+export interface NavigatorTypeBagFactory {
+  input: {};
+  ParamList: ParamListBase;
+  State: NavigationState;
+  ScreenOptions: {};
+  EventMap: {};
+  NavigationList: NavigationListBase<ParamListBase>;
+  Navigator: React.ComponentType<any>;
+}
+
+/**
+ * Applies a navigator type bag factory to a param list.
+ */
+export type ApplyNavigatorTypeBagFactory<
+  F extends NavigatorTypeBagFactory,
+  Input extends {},
+> = Omit<F & { input: Input }, 'input'>;
+
 type TypedNavigatorComponent<Bag extends NavigatorTypeBagBase> =
   React.ComponentType<
     Omit<

--- a/packages/drawer/src/index.tsx
+++ b/packages/drawer/src/index.tsx
@@ -4,6 +4,7 @@
 export {
   createDrawerNavigator,
   createDrawerScreen,
+  type DrawerTypeBag,
 } from './navigators/createDrawerNavigator';
 
 /**

--- a/packages/drawer/src/navigators/createDrawerNavigator.tsx
+++ b/packages/drawer/src/navigators/createDrawerNavigator.tsx
@@ -64,10 +64,10 @@ function DrawerNavigator({
 }
 
 export interface DrawerTypeBag extends NavigatorTypeBagFactory {
-  State: DrawerNavigationState<this['input']>;
+  State: DrawerNavigationState<this['ParamList']>;
   ScreenOptions: DrawerNavigationOptions;
   EventMap: DrawerNavigationEventMap;
-  ActionHelpers: DrawerActionHelpers<this['input']>;
+  ActionHelpers: DrawerActionHelpers<this['ParamList']>;
   Navigator: typeof DrawerNavigator;
 }
 

--- a/packages/drawer/src/navigators/createDrawerNavigator.tsx
+++ b/packages/drawer/src/navigators/createDrawerNavigator.tsx
@@ -13,7 +13,6 @@ import {
 import type {
   DrawerNavigationEventMap,
   DrawerNavigationOptions,
-  DrawerNavigationProp,
   DrawerNavigatorProps,
 } from '../types';
 import { DrawerView } from '../views/DrawerView';
@@ -65,16 +64,10 @@ function DrawerNavigator({
 }
 
 export interface DrawerTypeBag extends NavigatorTypeBagFactory {
-  ParamList: this['input'];
   State: DrawerNavigationState<this['input']>;
   ScreenOptions: DrawerNavigationOptions;
   EventMap: DrawerNavigationEventMap;
-  NavigationList: {
-    [RouteName in keyof this['input']]: DrawerNavigationProp<
-      this['input'],
-      RouteName
-    >;
-  };
+  ActionHelpers: DrawerActionHelpers<this['input']>;
   Navigator: typeof DrawerNavigator;
 }
 

--- a/packages/drawer/src/navigators/createDrawerNavigator.tsx
+++ b/packages/drawer/src/navigators/createDrawerNavigator.tsx
@@ -1,6 +1,6 @@
 import {
   createNavigatorFactory,
-  createStaticScreenFactory,
+  createScreenFactory,
   type DrawerActionHelpers,
   type DrawerNavigationState,
   DrawerRouter,
@@ -74,4 +74,4 @@ export interface DrawerTypeBag extends NavigatorTypeBagFactory {
 export const createDrawerNavigator =
   createNavigatorFactory<DrawerTypeBag>(DrawerNavigator);
 
-export const createDrawerScreen = createStaticScreenFactory<DrawerTypeBag>();
+export const createDrawerScreen = createScreenFactory<DrawerTypeBag>();

--- a/packages/drawer/src/navigators/createDrawerNavigator.tsx
+++ b/packages/drawer/src/navigators/createDrawerNavigator.tsx
@@ -5,7 +5,7 @@ import {
   type DrawerNavigationState,
   DrawerRouter,
   type DrawerRouterOptions,
-  type NavigatorTypeBagFactory,
+  type NavigatorTypeBagBase,
   type ParamListBase,
   useNavigationBuilder,
 } from '@react-navigation/native';
@@ -63,7 +63,7 @@ function DrawerNavigator({
   );
 }
 
-export interface DrawerTypeBag extends NavigatorTypeBagFactory {
+export interface DrawerTypeBag extends NavigatorTypeBagBase {
   State: DrawerNavigationState<this['ParamList']>;
   ScreenOptions: DrawerNavigationOptions;
   EventMap: DrawerNavigationEventMap;

--- a/packages/drawer/src/navigators/createDrawerNavigator.tsx
+++ b/packages/drawer/src/navigators/createDrawerNavigator.tsx
@@ -1,16 +1,12 @@
 import {
   createNavigatorFactory,
+  createStaticScreenFactory,
   type DrawerActionHelpers,
   type DrawerNavigationState,
   DrawerRouter,
   type DrawerRouterOptions,
+  type NavigatorTypeBagFactory,
   type ParamListBase,
-  type StaticConfig,
-  type StaticParamList,
-  type StaticScreenConfig,
-  type StaticScreenConfigLinking,
-  type StaticScreenConfigScreen,
-  type TypedNavigator,
   useNavigationBuilder,
 } from '@react-navigation/native';
 
@@ -68,41 +64,21 @@ function DrawerNavigator({
   );
 }
 
-type DrawerTypeBag<ParamList extends {}> = {
-  ParamList: ParamList;
-  State: DrawerNavigationState<ParamList>;
+export interface DrawerTypeBag extends NavigatorTypeBagFactory {
+  ParamList: this['input'];
+  State: DrawerNavigationState<this['input']>;
   ScreenOptions: DrawerNavigationOptions;
   EventMap: DrawerNavigationEventMap;
   NavigationList: {
-    [RouteName in keyof ParamList]: DrawerNavigationProp<ParamList, RouteName>;
+    [RouteName in keyof this['input']]: DrawerNavigationProp<
+      this['input'],
+      RouteName
+    >;
   };
   Navigator: typeof DrawerNavigator;
-};
-
-export function createDrawerNavigator<
-  const ParamList extends ParamListBase,
->(): TypedNavigator<DrawerTypeBag<ParamList>, undefined>;
-export function createDrawerNavigator<
-  const Config extends StaticConfig<DrawerTypeBag<ParamListBase>>,
->(
-  config: Config
-): TypedNavigator<DrawerTypeBag<StaticParamList<{ config: Config }>>, Config>;
-export function createDrawerNavigator(config?: unknown) {
-  return createNavigatorFactory(DrawerNavigator)(config);
 }
 
-export function createDrawerScreen<
-  const Linking extends StaticScreenConfigLinking,
-  const Screen extends StaticScreenConfigScreen,
->(
-  config: StaticScreenConfig<
-    Linking,
-    Screen,
-    DrawerNavigationState<ParamListBase>,
-    DrawerNavigationOptions,
-    DrawerNavigationEventMap,
-    DrawerNavigationProp<ParamListBase>
-  >
-) {
-  return config;
-}
+export const createDrawerNavigator =
+  createNavigatorFactory<DrawerTypeBag>(DrawerNavigator);
+
+export const createDrawerScreen = createStaticScreenFactory<DrawerTypeBag>();

--- a/packages/material-top-tabs/src/index.tsx
+++ b/packages/material-top-tabs/src/index.tsx
@@ -4,6 +4,7 @@
 export {
   createMaterialTopTabNavigator,
   createMaterialTopTabScreen,
+  type MaterialTopTabTypeBag,
 } from './navigators/createMaterialTopTabNavigator';
 
 /**

--- a/packages/material-top-tabs/src/navigators/createMaterialTopTabNavigator.tsx
+++ b/packages/material-top-tabs/src/navigators/createMaterialTopTabNavigator.tsx
@@ -1,7 +1,7 @@
 import {
   createNavigatorFactory,
   createScreenFactory,
-  type NavigatorTypeBagFactory,
+  type NavigatorTypeBagBase,
   type ParamListBase,
   type TabActionHelpers,
   type TabNavigationState,
@@ -60,7 +60,7 @@ function MaterialTopTabNavigator({
   );
 }
 
-export interface MaterialTopTabTypeBag extends NavigatorTypeBagFactory {
+export interface MaterialTopTabTypeBag extends NavigatorTypeBagBase {
   State: TabNavigationState<this['ParamList']>;
   ScreenOptions: MaterialTopTabNavigationOptions;
   EventMap: MaterialTopTabNavigationEventMap;

--- a/packages/material-top-tabs/src/navigators/createMaterialTopTabNavigator.tsx
+++ b/packages/material-top-tabs/src/navigators/createMaterialTopTabNavigator.tsx
@@ -1,16 +1,12 @@
 import {
   createNavigatorFactory,
+  createStaticScreenFactory,
+  type NavigatorTypeBagFactory,
   type ParamListBase,
-  type StaticConfig,
-  type StaticParamList,
-  type StaticScreenConfig,
-  type StaticScreenConfigLinking,
-  type StaticScreenConfigScreen,
   type TabActionHelpers,
   type TabNavigationState,
   TabRouter,
   type TabRouterOptions,
-  type TypedNavigator,
   useNavigationBuilder,
 } from '@react-navigation/native';
 
@@ -65,47 +61,22 @@ function MaterialTopTabNavigator({
   );
 }
 
-type MaterialTopTabTypeBag<ParamList extends {}> = {
-  ParamList: ParamList;
-  State: TabNavigationState<ParamList>;
+export interface MaterialTopTabTypeBag extends NavigatorTypeBagFactory {
+  ParamList: this['input'];
+  State: TabNavigationState<this['input']>;
   ScreenOptions: MaterialTopTabNavigationOptions;
   EventMap: MaterialTopTabNavigationEventMap;
   NavigationList: {
-    [RouteName in keyof ParamList]: MaterialTopTabNavigationProp<
-      ParamList,
+    [RouteName in keyof this['input']]: MaterialTopTabNavigationProp<
+      this['input'],
       RouteName
     >;
   };
   Navigator: typeof MaterialTopTabNavigator;
-};
-
-export function createMaterialTopTabNavigator<
-  const ParamList extends ParamListBase,
->(): TypedNavigator<MaterialTopTabTypeBag<ParamList>, undefined>;
-export function createMaterialTopTabNavigator<
-  const Config extends StaticConfig<MaterialTopTabTypeBag<ParamListBase>>,
->(
-  config: Config
-): TypedNavigator<
-  MaterialTopTabTypeBag<StaticParamList<{ config: Config }>>,
-  Config
->;
-export function createMaterialTopTabNavigator(config?: unknown) {
-  return createNavigatorFactory(MaterialTopTabNavigator)(config);
 }
 
-export function createMaterialTopTabScreen<
-  const Linking extends StaticScreenConfigLinking,
-  const Screen extends StaticScreenConfigScreen,
->(
-  config: StaticScreenConfig<
-    Linking,
-    Screen,
-    TabNavigationState<ParamListBase>,
-    MaterialTopTabNavigationOptions,
-    MaterialTopTabNavigationEventMap,
-    MaterialTopTabNavigationProp<ParamListBase>
-  >
-) {
-  return config;
-}
+export const createMaterialTopTabNavigator =
+  createNavigatorFactory<MaterialTopTabTypeBag>(MaterialTopTabNavigator);
+
+export const createMaterialTopTabScreen =
+  createStaticScreenFactory<MaterialTopTabTypeBag>();

--- a/packages/material-top-tabs/src/navigators/createMaterialTopTabNavigator.tsx
+++ b/packages/material-top-tabs/src/navigators/createMaterialTopTabNavigator.tsx
@@ -13,7 +13,6 @@ import {
 import type {
   MaterialTopTabNavigationEventMap,
   MaterialTopTabNavigationOptions,
-  MaterialTopTabNavigationProp,
   MaterialTopTabNavigatorProps,
 } from '../types';
 import { MaterialTopTabView } from '../views/MaterialTopTabView';
@@ -62,16 +61,10 @@ function MaterialTopTabNavigator({
 }
 
 export interface MaterialTopTabTypeBag extends NavigatorTypeBagFactory {
-  ParamList: this['input'];
   State: TabNavigationState<this['input']>;
   ScreenOptions: MaterialTopTabNavigationOptions;
   EventMap: MaterialTopTabNavigationEventMap;
-  NavigationList: {
-    [RouteName in keyof this['input']]: MaterialTopTabNavigationProp<
-      this['input'],
-      RouteName
-    >;
-  };
+  ActionHelpers: TabActionHelpers<this['input']>;
   Navigator: typeof MaterialTopTabNavigator;
 }
 

--- a/packages/material-top-tabs/src/navigators/createMaterialTopTabNavigator.tsx
+++ b/packages/material-top-tabs/src/navigators/createMaterialTopTabNavigator.tsx
@@ -61,10 +61,10 @@ function MaterialTopTabNavigator({
 }
 
 export interface MaterialTopTabTypeBag extends NavigatorTypeBagFactory {
-  State: TabNavigationState<this['input']>;
+  State: TabNavigationState<this['ParamList']>;
   ScreenOptions: MaterialTopTabNavigationOptions;
   EventMap: MaterialTopTabNavigationEventMap;
-  ActionHelpers: TabActionHelpers<this['input']>;
+  ActionHelpers: TabActionHelpers<this['ParamList']>;
   Navigator: typeof MaterialTopTabNavigator;
 }
 

--- a/packages/material-top-tabs/src/navigators/createMaterialTopTabNavigator.tsx
+++ b/packages/material-top-tabs/src/navigators/createMaterialTopTabNavigator.tsx
@@ -1,6 +1,6 @@
 import {
   createNavigatorFactory,
-  createStaticScreenFactory,
+  createScreenFactory,
   type NavigatorTypeBagFactory,
   type ParamListBase,
   type TabActionHelpers,
@@ -72,4 +72,4 @@ export const createMaterialTopTabNavigator =
   createNavigatorFactory<MaterialTopTabTypeBag>(MaterialTopTabNavigator);
 
 export const createMaterialTopTabScreen =
-  createStaticScreenFactory<MaterialTopTabTypeBag>();
+  createScreenFactory<MaterialTopTabTypeBag>();

--- a/packages/native-stack/src/index.tsx
+++ b/packages/native-stack/src/index.tsx
@@ -4,6 +4,7 @@
 export {
   createNativeStackNavigator,
   createNativeStackScreen,
+  type NativeStackTypeBag,
 } from './navigators/createNativeStackNavigator';
 
 /**

--- a/packages/native-stack/src/navigators/createNativeStackNavigator.tsx
+++ b/packages/native-stack/src/navigators/createNativeStackNavigator.tsx
@@ -95,10 +95,10 @@ function NativeStackNavigator({
 }
 
 export interface NativeStackTypeBag extends NavigatorTypeBagFactory {
-  State: StackNavigationState<this['input']>;
+  State: StackNavigationState<this['ParamList']>;
   ScreenOptions: NativeStackNavigationOptions;
   EventMap: NativeStackNavigationEventMap;
-  ActionHelpers: StackActionHelpers<this['input']>;
+  ActionHelpers: StackActionHelpers<this['ParamList']>;
   Navigator: typeof NativeStackNavigator;
 }
 

--- a/packages/native-stack/src/navigators/createNativeStackNavigator.tsx
+++ b/packages/native-stack/src/navigators/createNativeStackNavigator.tsx
@@ -17,7 +17,6 @@ import * as React from 'react';
 import type {
   NativeStackNavigationEventMap,
   NativeStackNavigationOptions,
-  NativeStackNavigationProp,
   NativeStackNavigatorProps,
 } from '../types';
 import { NativeStackView } from '../views/NativeStackView';
@@ -96,16 +95,10 @@ function NativeStackNavigator({
 }
 
 export interface NativeStackTypeBag extends NavigatorTypeBagFactory {
-  ParamList: this['input'];
   State: StackNavigationState<this['input']>;
   ScreenOptions: NativeStackNavigationOptions;
   EventMap: NativeStackNavigationEventMap;
-  NavigationList: {
-    [RouteName in keyof this['input']]: NativeStackNavigationProp<
-      this['input'],
-      RouteName
-    >;
-  };
+  ActionHelpers: StackActionHelpers<this['input']>;
   Navigator: typeof NativeStackNavigator;
 }
 

--- a/packages/native-stack/src/navigators/createNativeStackNavigator.tsx
+++ b/packages/native-stack/src/navigators/createNativeStackNavigator.tsx
@@ -1,6 +1,6 @@
 import {
   createNavigatorFactory,
-  createStaticScreenFactory,
+  createScreenFactory,
   type EventArg,
   NavigationMetaContext,
   type NavigatorTypeBagFactory,
@@ -106,4 +106,4 @@ export const createNativeStackNavigator =
   createNavigatorFactory<NativeStackTypeBag>(NativeStackNavigator);
 
 export const createNativeStackScreen =
-  createStaticScreenFactory<NativeStackTypeBag>();
+  createScreenFactory<NativeStackTypeBag>();

--- a/packages/native-stack/src/navigators/createNativeStackNavigator.tsx
+++ b/packages/native-stack/src/navigators/createNativeStackNavigator.tsx
@@ -3,7 +3,7 @@ import {
   createScreenFactory,
   type EventArg,
   NavigationMetaContext,
-  type NavigatorTypeBagFactory,
+  type NavigatorTypeBagBase,
   type ParamListBase,
   type StackActionHelpers,
   StackActions,
@@ -94,7 +94,7 @@ function NativeStackNavigator({
   );
 }
 
-export interface NativeStackTypeBag extends NavigatorTypeBagFactory {
+export interface NativeStackTypeBag extends NavigatorTypeBagBase {
   State: StackNavigationState<this['ParamList']>;
   ScreenOptions: NativeStackNavigationOptions;
   EventMap: NativeStackNavigationEventMap;

--- a/packages/native-stack/src/navigators/createNativeStackNavigator.tsx
+++ b/packages/native-stack/src/navigators/createNativeStackNavigator.tsx
@@ -1,19 +1,15 @@
 import {
   createNavigatorFactory,
+  createStaticScreenFactory,
   type EventArg,
   NavigationMetaContext,
+  type NavigatorTypeBagFactory,
   type ParamListBase,
   type StackActionHelpers,
   StackActions,
   type StackNavigationState,
   StackRouter,
   type StackRouterOptions,
-  type StaticConfig,
-  type StaticParamList,
-  type StaticScreenConfig,
-  type StaticScreenConfigLinking,
-  type StaticScreenConfigScreen,
-  type TypedNavigator,
   useNavigationBuilder,
 } from '@react-navigation/native';
 import * as React from 'react';
@@ -99,47 +95,22 @@ function NativeStackNavigator({
   );
 }
 
-type NativeStackTypeBag<ParamList extends {}> = {
-  ParamList: ParamList;
-  State: StackNavigationState<ParamList>;
+export interface NativeStackTypeBag extends NavigatorTypeBagFactory {
+  ParamList: this['input'];
+  State: StackNavigationState<this['input']>;
   ScreenOptions: NativeStackNavigationOptions;
   EventMap: NativeStackNavigationEventMap;
   NavigationList: {
-    [RouteName in keyof ParamList]: NativeStackNavigationProp<
-      ParamList,
+    [RouteName in keyof this['input']]: NativeStackNavigationProp<
+      this['input'],
       RouteName
     >;
   };
   Navigator: typeof NativeStackNavigator;
-};
-
-export function createNativeStackNavigator<
-  const ParamList extends ParamListBase,
->(): TypedNavigator<NativeStackTypeBag<ParamList>, undefined>;
-export function createNativeStackNavigator<
-  const Config extends StaticConfig<NativeStackTypeBag<ParamListBase>>,
->(
-  config: Config
-): TypedNavigator<
-  NativeStackTypeBag<StaticParamList<{ config: Config }>>,
-  Config
->;
-export function createNativeStackNavigator(config?: unknown) {
-  return createNavigatorFactory(NativeStackNavigator)(config);
 }
 
-export function createNativeStackScreen<
-  const Linking extends StaticScreenConfigLinking,
-  const Screen extends StaticScreenConfigScreen,
->(
-  config: StaticScreenConfig<
-    Linking,
-    Screen,
-    StackNavigationState<ParamListBase>,
-    NativeStackNavigationOptions,
-    NativeStackNavigationEventMap,
-    NativeStackNavigationProp<ParamListBase>
-  >
-) {
-  return config;
-}
+export const createNativeStackNavigator =
+  createNavigatorFactory<NativeStackTypeBag>(NativeStackNavigator);
+
+export const createNativeStackScreen =
+  createStaticScreenFactory<NativeStackTypeBag>();

--- a/packages/native/src/__stubs__/createStackNavigator.tsx
+++ b/packages/native/src/__stubs__/createStackNavigator.tsx
@@ -30,7 +30,7 @@ const StackNavigator = (
 };
 
 interface StubStackTypeBag extends NavigatorTypeBagFactory {
-  State: StackNavigationState<this['input']>;
+  State: StackNavigationState<this['ParamList']>;
   Navigator: typeof StackNavigator;
 }
 

--- a/packages/native/src/__stubs__/createStackNavigator.tsx
+++ b/packages/native/src/__stubs__/createStackNavigator.tsx
@@ -2,10 +2,10 @@ import {
   createNavigatorFactory,
   type DefaultNavigatorOptions,
   type NavigationListBase,
+  type NavigatorTypeBagFactory,
   type ParamListBase,
   type StackNavigationState,
   StackRouter,
-  type TypedNavigator,
   useNavigationBuilder,
 } from '@react-navigation/core';
 
@@ -30,15 +30,14 @@ const StackNavigator = (
   );
 };
 
-export function createStackNavigator<
-  ParamList extends ParamListBase,
->(): TypedNavigator<{
-  ParamList: ParamList;
-  State: StackNavigationState<ParamList>;
+interface StubStackTypeBag extends NavigatorTypeBagFactory {
+  ParamList: this['input'];
+  State: StackNavigationState<this['input']>;
   ScreenOptions: {};
   EventMap: {};
-  NavigationList: NavigationListBase<ParamList>;
+  NavigationList: NavigationListBase<this['input']>;
   Navigator: typeof StackNavigator;
-}> {
-  return createNavigatorFactory(StackNavigator)();
 }
+
+export const createStackNavigator =
+  createNavigatorFactory<StubStackTypeBag>(StackNavigator);

--- a/packages/native/src/__stubs__/createStackNavigator.tsx
+++ b/packages/native/src/__stubs__/createStackNavigator.tsx
@@ -1,7 +1,7 @@
 import {
   createNavigatorFactory,
   type DefaultNavigatorOptions,
-  type NavigatorTypeBagFactory,
+  type NavigatorTypeBagBase,
   type ParamListBase,
   type StackNavigationState,
   StackRouter,
@@ -29,7 +29,7 @@ const StackNavigator = (
   );
 };
 
-interface StubStackTypeBag extends NavigatorTypeBagFactory {
+interface StubStackTypeBag extends NavigatorTypeBagBase {
   State: StackNavigationState<this['ParamList']>;
   Navigator: typeof StackNavigator;
 }

--- a/packages/native/src/__stubs__/createStackNavigator.tsx
+++ b/packages/native/src/__stubs__/createStackNavigator.tsx
@@ -1,7 +1,6 @@
 import {
   createNavigatorFactory,
   type DefaultNavigatorOptions,
-  type NavigationListBase,
   type NavigatorTypeBagFactory,
   type ParamListBase,
   type StackNavigationState,
@@ -31,11 +30,7 @@ const StackNavigator = (
 };
 
 interface StubStackTypeBag extends NavigatorTypeBagFactory {
-  ParamList: this['input'];
   State: StackNavigationState<this['input']>;
-  ScreenOptions: {};
-  EventMap: {};
-  NavigationList: NavigationListBase<this['input']>;
   Navigator: typeof StackNavigator;
 }
 

--- a/packages/native/src/__tests__/ServerContainer.test.tsx
+++ b/packages/native/src/__tests__/ServerContainer.test.tsx
@@ -2,7 +2,6 @@ import { expect, jest, test } from '@jest/globals';
 import {
   createNavigatorFactory,
   type DefaultNavigatorOptions,
-  type NavigationListBase,
   type NavigatorScreenParams,
   type NavigatorTypeBagFactory,
   type ParamListBase,
@@ -68,11 +67,7 @@ test('renders correct state with location', () => {
   };
 
   interface StackTypeBag extends NavigatorTypeBagFactory {
-    ParamList: this['input'];
     State: StackNavigationState<this['input']>;
-    ScreenOptions: {};
-    EventMap: {};
-    NavigationList: NavigationListBase<this['input']>;
     Navigator: typeof StackNavigator;
   }
 

--- a/packages/native/src/__tests__/ServerContainer.test.tsx
+++ b/packages/native/src/__tests__/ServerContainer.test.tsx
@@ -4,11 +4,11 @@ import {
   type DefaultNavigatorOptions,
   type NavigationListBase,
   type NavigatorScreenParams,
+  type NavigatorTypeBagFactory,
   type ParamListBase,
   type StackNavigationState,
   StackRouter,
   TabRouter,
-  type TypedNavigator,
   useNavigationBuilder,
 } from '@react-navigation/core';
 import * as React from 'react';
@@ -67,16 +67,17 @@ test('renders correct state with location', () => {
     );
   };
 
-  function createStackNavigator<ParamList extends {}>(): TypedNavigator<{
-    ParamList: ParamList;
-    State: StackNavigationState<ParamList>;
+  interface StackTypeBag extends NavigatorTypeBagFactory {
+    ParamList: this['input'];
+    State: StackNavigationState<this['input']>;
     ScreenOptions: {};
     EventMap: {};
-    NavigationList: NavigationListBase<ParamList>;
+    NavigationList: NavigationListBase<this['input']>;
     Navigator: typeof StackNavigator;
-  }> {
-    return createNavigatorFactory(StackNavigator)();
   }
+
+  const createStackNavigator =
+    createNavigatorFactory<StackTypeBag>(StackNavigator);
 
   type StackAParamList = {
     Home: NavigatorScreenParams<StackBParamList>;

--- a/packages/native/src/__tests__/ServerContainer.test.tsx
+++ b/packages/native/src/__tests__/ServerContainer.test.tsx
@@ -67,7 +67,7 @@ test('renders correct state with location', () => {
   };
 
   interface StackTypeBag extends NavigatorTypeBagFactory {
-    State: StackNavigationState<this['input']>;
+    State: StackNavigationState<this['ParamList']>;
     Navigator: typeof StackNavigator;
   }
 

--- a/packages/native/src/__tests__/ServerContainer.test.tsx
+++ b/packages/native/src/__tests__/ServerContainer.test.tsx
@@ -3,7 +3,7 @@ import {
   createNavigatorFactory,
   type DefaultNavigatorOptions,
   type NavigatorScreenParams,
-  type NavigatorTypeBagFactory,
+  type NavigatorTypeBagBase,
   type ParamListBase,
   type StackNavigationState,
   StackRouter,
@@ -66,7 +66,7 @@ test('renders correct state with location', () => {
     );
   };
 
-  interface StackTypeBag extends NavigatorTypeBagFactory {
+  interface StackTypeBag extends NavigatorTypeBagBase {
     State: StackNavigationState<this['ParamList']>;
     Navigator: typeof StackNavigator;
   }

--- a/packages/stack/src/index.tsx
+++ b/packages/stack/src/index.tsx
@@ -9,6 +9,7 @@ import * as TransitionSpecs from './TransitionConfigs/TransitionSpecs';
 export {
   createStackNavigator,
   createStackScreen,
+  type StackTypeBag,
 } from './navigators/createStackNavigator';
 
 /**

--- a/packages/stack/src/navigators/createStackNavigator.tsx
+++ b/packages/stack/src/navigators/createStackNavigator.tsx
@@ -92,10 +92,10 @@ function StackNavigator({
 }
 
 export interface StackTypeBag extends NavigatorTypeBagFactory {
-  State: StackNavigationState<this['input']>;
+  State: StackNavigationState<this['ParamList']>;
   ScreenOptions: StackNavigationOptions;
   EventMap: StackNavigationEventMap;
-  ActionHelpers: StackActionHelpers<this['input']>;
+  ActionHelpers: StackActionHelpers<this['ParamList']>;
   Navigator: typeof StackNavigator;
 }
 

--- a/packages/stack/src/navigators/createStackNavigator.tsx
+++ b/packages/stack/src/navigators/createStackNavigator.tsx
@@ -17,7 +17,6 @@ import * as React from 'react';
 import type {
   StackNavigationEventMap,
   StackNavigationOptions,
-  StackNavigationProp,
   StackNavigatorProps,
 } from '../types';
 import { StackView } from '../views/Stack/StackView';
@@ -93,16 +92,10 @@ function StackNavigator({
 }
 
 export interface StackTypeBag extends NavigatorTypeBagFactory {
-  ParamList: this['input'];
   State: StackNavigationState<this['input']>;
   ScreenOptions: StackNavigationOptions;
   EventMap: StackNavigationEventMap;
-  NavigationList: {
-    [RouteName in keyof this['input']]: StackNavigationProp<
-      this['input'],
-      RouteName
-    >;
-  };
+  ActionHelpers: StackActionHelpers<this['input']>;
   Navigator: typeof StackNavigator;
 }
 

--- a/packages/stack/src/navigators/createStackNavigator.tsx
+++ b/packages/stack/src/navigators/createStackNavigator.tsx
@@ -2,7 +2,7 @@ import {
   createNavigatorFactory,
   createScreenFactory,
   type EventArg,
-  type NavigatorTypeBagFactory,
+  type NavigatorTypeBagBase,
   type ParamListBase,
   type StackActionHelpers,
   StackActions,
@@ -91,7 +91,7 @@ function StackNavigator({
   );
 }
 
-export interface StackTypeBag extends NavigatorTypeBagFactory {
+export interface StackTypeBag extends NavigatorTypeBagBase {
   State: StackNavigationState<this['ParamList']>;
   ScreenOptions: StackNavigationOptions;
   EventMap: StackNavigationEventMap;

--- a/packages/stack/src/navigators/createStackNavigator.tsx
+++ b/packages/stack/src/navigators/createStackNavigator.tsx
@@ -1,6 +1,6 @@
 import {
   createNavigatorFactory,
-  createStaticScreenFactory,
+  createScreenFactory,
   type EventArg,
   type NavigatorTypeBagFactory,
   type ParamListBase,
@@ -102,4 +102,4 @@ export interface StackTypeBag extends NavigatorTypeBagFactory {
 export const createStackNavigator =
   createNavigatorFactory<StackTypeBag>(StackNavigator);
 
-export const createStackScreen = createStaticScreenFactory<StackTypeBag>();
+export const createStackScreen = createScreenFactory<StackTypeBag>();

--- a/packages/stack/src/navigators/createStackNavigator.tsx
+++ b/packages/stack/src/navigators/createStackNavigator.tsx
@@ -1,18 +1,14 @@
 import {
   createNavigatorFactory,
+  createStaticScreenFactory,
   type EventArg,
+  type NavigatorTypeBagFactory,
   type ParamListBase,
   type StackActionHelpers,
   StackActions,
   type StackNavigationState,
   StackRouter,
   type StackRouterOptions,
-  type StaticConfig,
-  type StaticParamList,
-  type StaticScreenConfig,
-  type StaticScreenConfigLinking,
-  type StaticScreenConfigScreen,
-  type TypedNavigator,
   useLocale,
   useNavigationBuilder,
 } from '@react-navigation/native';
@@ -96,41 +92,21 @@ function StackNavigator({
   );
 }
 
-type StackTypeBag<ParamList extends {}> = {
-  ParamList: ParamList;
-  State: StackNavigationState<ParamList>;
+export interface StackTypeBag extends NavigatorTypeBagFactory {
+  ParamList: this['input'];
+  State: StackNavigationState<this['input']>;
   ScreenOptions: StackNavigationOptions;
   EventMap: StackNavigationEventMap;
   NavigationList: {
-    [RouteName in keyof ParamList]: StackNavigationProp<ParamList, RouteName>;
+    [RouteName in keyof this['input']]: StackNavigationProp<
+      this['input'],
+      RouteName
+    >;
   };
   Navigator: typeof StackNavigator;
-};
-
-export function createStackNavigator<
-  const ParamList extends ParamListBase,
->(): TypedNavigator<StackTypeBag<ParamList>, undefined>;
-export function createStackNavigator<
-  const Config extends StaticConfig<StackTypeBag<ParamListBase>>,
->(
-  config: Config
-): TypedNavigator<StackTypeBag<StaticParamList<{ config: Config }>>, Config>;
-export function createStackNavigator(config?: unknown) {
-  return createNavigatorFactory(StackNavigator)(config);
 }
 
-export function createStackScreen<
-  const Linking extends StaticScreenConfigLinking,
-  const Screen extends StaticScreenConfigScreen,
->(
-  config: StaticScreenConfig<
-    Linking,
-    Screen,
-    StackNavigationState<ParamListBase>,
-    StackNavigationOptions,
-    StackNavigationEventMap,
-    StackNavigationProp<ParamListBase>
-  >
-) {
-  return config;
-}
+export const createStackNavigator =
+  createNavigatorFactory<StackTypeBag>(StackNavigator);
+
+export const createStackScreen = createStaticScreenFactory<StackTypeBag>();


### PR DESCRIPTION
The custom navigator types were quite verbose in React Navigation 8. This is an attempt to simplify them.

**Before**

```ts
type MyTypeBag<ParamList extends {}> = {
  ParamList: ParamList;
  State: TabNavigationState<ParamList>;
  ScreenOptions: MyNavigationOptions;
  EventMap: MyNavigationEventMap;
  NavigationList: {
    [RouteName in keyof ParamList]: MyNavigationProp<ParamList, RouteName>;
  };
  Navigator: typeof MyNavigator;
};

export function createMyNavigator<
  const ParamList extends ParamListBase,
>(): TypedNavigator<MyTypeBag<ParamList>, undefined>;
export function createMyNavigator<
  const Config extends StaticConfig<MyTypeBag<ParamListBase>>,
>(
  config: Config
): TypedNavigator<MyTypeBag<StaticParamList<{ config: Config }>>, Config>;
export function createMyNavigator(config?: unknown) {
  return createNavigatorFactory(MyNavigator)(config);
}

export function createMyScreen<
  const Linking extends StaticScreenConfigLinking,
  const Screen extends StaticScreenConfigScreen,
>(
  config: StaticScreenConfig<
    Linking,
    Screen,
    TabNavigationState<ParamListBase>,
    MyNavigationOptions,
    MyNavigationEventMap,
    MyNavigationProp<ParamListBase>
  >
) {
  return config;
}
```

**After**

```ts
export interface MyTypeBag extends NavigatorTypeBagBase {
  State: TabNavigationState<this['ParamList']>;
  ScreenOptions: MyNavigationOptions;
  EventMap: MyNavigationEventMap;
  ActionHelpers: TabActionHelpers<this['ParamList']>;
  Navigator: typeof MyNavigator;
}

export const createMyNavigator =
  createNavigatorFactory<MyTypeBag>(MyNavigator);

export const createMyScreen = createScreenFactory<MyTypeBag>();
```
