### PR TITLE
fix(bottom-tabs): disable touch events on unfocused tab screens

### DIFF
--- a/packages/bottom-tabs/src/views/BottomTabViewCustom.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabViewCustom.tsx
@@ -323,6 +323,7 @@ export function BottomTabViewCustom({
               mode={isFocused ? 'normal' : isActive ? 'inert' : 'paused'}
               visible={isFocused || isAnimatingRoute}
               style={{ ...StyleSheet.absoluteFill, zIndex: isFocused ? 0 : -1 }}
+              pointerEvents={isFocused ? 'box-none' : 'none'}
             >
               {content}
             </ActivityView>

--- a/packages/elements/src/ActivityView.native.tsx
+++ b/packages/elements/src/ActivityView.native.tsx
@@ -41,7 +41,8 @@ export function ActivityView({
     <Activity mode={activityMode}>
       <ActivityContentView style={{ display: 'contents' }}>
         <Container
-          inert={mode !== 'normal'} pointerEvents={pointerEvents}
+          inert={mode !== 'normal'}
+          pointerEvents={pointerEvents}
           style={{
             ...style,
             /**

--- a/packages/elements/src/ActivityView.native.tsx
+++ b/packages/elements/src/ActivityView.native.tsx
@@ -14,6 +14,7 @@ export function ActivityView({
   visible,
   delay = 500,
   style,
+  pointerEvents,
   children,
 }: Props) {
   const [delayedMode, setDelayedMode] = useState(mode);
@@ -40,7 +41,7 @@ export function ActivityView({
     <Activity mode={activityMode}>
       <ActivityContentView style={{ display: 'contents' }}>
         <Container
-          inert={mode !== 'normal'}
+          inert={mode !== 'normal'} pointerEvents={pointerEvents}
           style={{
             ...style,
             /**

--- a/packages/elements/src/ActivityView.tsx
+++ b/packages/elements/src/ActivityView.tsx
@@ -125,7 +125,11 @@ export function ActivityView({
   return (
     <Container ref={onRef} style={{ display: 'contents' }}>
       <Activity mode={activityMode}>
-        <Container inert={mode !== 'normal'} pointerEvents={pointerEvents} style={{ ...style, display }}>
+        <Container
+          inert={mode !== 'normal'}
+          pointerEvents={pointerEvents}
+          style={{ ...style, display }}
+        >
           {children}
         </Container>
       </Activity>

--- a/packages/elements/src/ActivityView.tsx
+++ b/packages/elements/src/ActivityView.tsx
@@ -1,5 +1,5 @@
 import { Activity, useCallback, useEffect, useState } from 'react';
-import { Platform, View, type ViewStyle } from 'react-native';
+import { Platform, View, type ViewProps, type ViewStyle } from 'react-native';
 
 import { Container } from './Container';
 
@@ -27,6 +27,10 @@ export type Props = {
    */
   style?: Omit<React.CSSProperties & ViewStyle, 'display'> | undefined;
   /**
+   * Controls whether the view can be the target of touch events.
+   */
+  pointerEvents?: ViewProps['pointerEvents'];
+  /**
    * The content of the activity view
    */
   children: React.ReactNode;
@@ -37,6 +41,7 @@ export function ActivityView({
   visible,
   delay = 500,
   style,
+  pointerEvents,
   children,
 }: Props) {
   const [delayedMode, setDelayedMode] = useState(mode);
@@ -120,7 +125,7 @@ export function ActivityView({
   return (
     <Container ref={onRef} style={{ display: 'contents' }}>
       <Activity mode={activityMode}>
-        <Container inert={mode !== 'normal'} style={{ ...style, display }}>
+        <Container inert={mode !== 'normal'} pointerEvents={pointerEvents} style={{ ...style, display }}>
           {children}
         </Container>
       </Activity>

--- a/packages/elements/src/Container.tsx
+++ b/packages/elements/src/Container.tsx
@@ -1,8 +1,9 @@
-import { Platform, View, type ViewStyle } from 'react-native';
+import { Platform, View, type ViewProps, type ViewStyle } from 'react-native';
 
 export type Props = {
   ref?: React.Ref<HTMLDivElement | View> | undefined;
   inert?: boolean | undefined;
+  pointerEvents?: ViewProps['pointerEvents'];
   style?:
     | (ViewStyle &
         Omit<React.CSSProperties, 'backgroundColor'> & {
@@ -12,7 +13,7 @@ export type Props = {
   children: React.ReactNode;
 };
 
-export function Container({ ref, inert, children, style }: Props) {
+export function Container({ ref, inert, pointerEvents, children, style }: Props) {
   if (Platform.OS === 'web') {
     const { backgroundColor, ...rest } = style ?? {};
 
@@ -38,7 +39,7 @@ export function Container({ ref, inert, children, style }: Props) {
     <View
       ref={ref as React.Ref<View> | undefined}
       aria-hidden={inert}
-      style={[{ pointerEvents: inert ? 'none' : 'box-none' }, style]}
+      style={[{ pointerEvents: pointerEvents ?? (inert ? 'none' : 'box-none') }, style]}
       collapsable={false}
     >
       {children}

--- a/packages/elements/src/Container.tsx
+++ b/packages/elements/src/Container.tsx
@@ -13,7 +13,13 @@ export type Props = {
   children: React.ReactNode;
 };
 
-export function Container({ ref, inert, pointerEvents, children, style }: Props) {
+export function Container({
+  ref,
+  inert,
+  pointerEvents,
+  children,
+  style,
+}: Props) {
   if (Platform.OS === 'web') {
     const { backgroundColor, ...rest } = style ?? {};
 
@@ -39,7 +45,10 @@ export function Container({ ref, inert, pointerEvents, children, style }: Props)
     <View
       ref={ref as React.Ref<View> | undefined}
       aria-hidden={inert}
-      style={[{ pointerEvents: pointerEvents ?? (inert ? 'none' : 'box-none') }, style]}
+      style={[
+        { pointerEvents: pointerEvents ?? (inert ? 'none' : 'box-none') },
+        style,
+      ]}
       collapsable={false}
     >
       {children}


### PR DESCRIPTION
## Summary

Disable touch events on unfocused tab screens in the custom (JS) bottom tab view.

## Problem

When using bottom tabs, unfocused tab screens are kept alive for performance (via `ActivityView`). However, these inactive screens can still intercept touch events, causing "ghost taps" — where a user taps on content in the focused tab but the tap is received by an element in an unfocused tab behind it.

## Precedent

The same fix was applied to expo-router's native tabs implementation in [expo/expo#44778](https://github.com/expo/expo/pull/44778).

## Fix

Add `pointerEvents={isFocused ? 'box-none' : 'none'}` to the `ActivityView` wrapping each tab screen in `BottomTabViewCustom.tsx`.

- `'box-none'` (focused): the container doesn't block touches, children receive them normally
- `'none'` (unfocused): all touch interaction is disabled on the inactive tab's view tree

This is a 1-line change affecting only `BottomTabViewCustom.tsx`. The native implementation (`BottomTabViewNativeImpl.tsx`) is not affected as touch handling is managed natively there.

## Test Plan

- [x] Taps on focused tab content work as expected
- [x] Taps no longer pass through to unfocused tab content behind the focused tab
- [x] Tab switching continues to work correctly