### PR TITLE
fix(bottom-tabs): disable pointer events on inactive tab screens

### DIFF
--- a/packages/bottom-tabs/src/views/BottomTabView.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabView.tsx
@@ -323,6 +323,7 @@ export function BottomTabView(props: Props) {
               enabled={detachInactiveScreens}
               freezeOnBlur={freezeOnBlur}
               shouldFreeze={activityState === STATE_INACTIVE && !isPreloaded}
+              pointerEvents={isFocused ? 'box-none' : 'none'}
             >
               <BottomTabBarHeightContext.Provider
                 value={tabBarPosition === 'bottom' ? tabBarHeight : 0}


### PR DESCRIPTION
**Motivation**

Inactive tab screens are rendered as full-screen overlays with `StyleSheet.absoluteFill`. Without explicit `pointerEvents` handling, these invisible screens intercept touch events meant for the focused tab, blocking user interaction.

Set `pointerEvents` to `'none'` on unfocused screens so touches pass through, and `'box-none'` on the focused screen so the container itself doesn't block events but its children remain interactive.

Please provide enough information so that others can review your pull request.

cc @jorge-cab

**Test plan**

Essentially the same patch as:
- https://github.com/expo/expo/pull/44778