### PR TITLE
fix(bottom-tabs): disable touch events on unfocused tab screens [v7]

### DIFF
--- a/packages/bottom-tabs/src/views/BottomTabView.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabView.tsx
@@ -323,6 +323,7 @@ export function BottomTabView(props: Props) {
               enabled={detachInactiveScreens}
               freezeOnBlur={freezeOnBlur}
               shouldFreeze={activityState === STATE_INACTIVE && !isPreloaded}
+              pointerEvents={isFocused ? 'box-none' : 'none'}
             >
               <BottomTabBarHeightContext.Provider
                 value={tabBarPosition === 'bottom' ? tabBarHeight : 0}


### PR DESCRIPTION
## Summary

Disable touch events on unfocused tab screens in `BottomTabView` (v7).

## Problem

When using bottom tabs, unfocused tab screens are kept alive for performance (via `MaybeScreen`). However, these inactive screens can still intercept touch events, causing "ghost taps" — where a user taps on content in the focused tab but the tap is received by an element in an unfocused tab behind it.

## Precedent

This issue is already fixed on `main` (v8) via the `inert` mechanism introduced in #12998 (Feb 2026), where `Container` sets `pointerEvents: 'none'` when `inert={true}`. This PR backports an equivalent fix to v7, which doesn't have the `Container`/`ActivityView`/`inert` architecture.

The same fix was also applied to expo-router's native tabs in [expo/expo#44778](https://github.com/expo/expo/pull/44778).

## Fix

Add `pointerEvents={isFocused ? 'box-none' : 'none'}` to the `MaybeScreen` wrapping each tab screen.

- `'box-none'` (focused): the container doesn't block touches, children receive them normally
- `'none'` (unfocused): all touch interaction is disabled on the inactive tab's view tree

This is a **1-line change** to a single file (`BottomTabView.tsx`). `MaybeScreen` extends `ViewProps`, so `pointerEvents` is already accepted.

## Test Plan

- [x] Taps on focused tab content work as expected
- [x] Taps no longer pass through to unfocused tab content behind the focused tab
- [x] Tab switching continues to work correctly
