### PR TITLE
feat: treat preloaded screens similar to regular screens

### DIFF
--- a/packages/core/src/SceneView.tsx
+++ b/packages/core/src/SceneView.tsx
@@ -8,7 +8,6 @@ import * as React from 'react';
 
 import { ConsumedParamsContext } from './ConsumedParamsContext';
 import { EnsureSingleNavigator } from './EnsureSingleNavigator';
-import { isArrayEqual } from './isArrayEqual';
 import {
   type FocusedRouteState,
   NavigationFocusedRouteStateContext,
@@ -23,8 +22,13 @@ type Props<State extends NavigationState, ScreenOptions extends {}> = {
   navigation: NavigationProp<ParamListBase, string, State, ScreenOptions>;
   route: Route<string>;
   routeState: NavigationState | PartialState<NavigationState> | undefined;
-  getState: () => State;
-  setState: (state: State) => void;
+  getRouteState: (
+    routeKey: string
+  ) => NavigationState | PartialState<NavigationState> | undefined;
+  setRouteState: (
+    routeKey: string,
+    state: NavigationState | PartialState<NavigationState> | undefined
+  ) => void;
   options: object;
   clearOptions: () => void;
 };
@@ -41,8 +45,8 @@ export function SceneView<
   route,
   navigation,
   routeState,
-  getState,
-  setState,
+  getRouteState,
+  setRouteState,
   options,
   clearOptions,
 }: Props<State, ScreenOptions>) {
@@ -60,35 +64,14 @@ export function SceneView<
   }, []);
 
   const getCurrentState = React.useCallback(() => {
-    const state = getState();
-    const currentRoute = state.routes.find((r) => r.key === route.key);
-
-    return currentRoute ? currentRoute.state : undefined;
-  }, [getState, route.key]);
+    return getRouteState(route.key);
+  }, [getRouteState, route.key]);
 
   const setCurrentState = React.useCallback(
     (child: NavigationState | PartialState<NavigationState> | undefined) => {
-      const state = getState();
-
-      const routes = state.routes.map((r) => {
-        if (r.key === route.key && r.state !== child) {
-          return {
-            ...r,
-            state: child,
-          };
-        }
-
-        return r;
-      });
-
-      if (!isArrayEqual(state.routes, routes)) {
-        setState({
-          ...state,
-          routes,
-        });
-      }
+      setRouteState(route.key, child);
     },
-    [getState, route.key, setState]
+    [route.key, setRouteState]
   );
 
   const isInitialRef = React.useRef(true);

--- a/packages/core/src/__tests__/index.test.tsx
+++ b/packages/core/src/__tests__/index.test.tsx
@@ -5,6 +5,7 @@ import {
   type NavigationState,
   type ParamListBase,
   type Router,
+  StackRouter,
 } from '@react-navigation/routers';
 import { act, render, renderAsync } from '@testing-library/react-native';
 import * as React from 'react';
@@ -1569,6 +1570,156 @@ test('navigates to nested child in a navigator with initial: false', () => {
     stale: false,
     type: 'test',
   });
+});
+
+test('preserves navigation state changes for preloaded screens', () => {
+  const TestNavigator = (props: any): any => {
+    const { state, descriptors, NavigationContent } = useNavigationBuilder(
+      StackRouter,
+      props
+    );
+
+    return (
+      <NavigationContent>
+        {[...state.routes, ...state.preloadedRoutes].map((route) =>
+          descriptors[route.key].render()
+        )}
+      </NavigationContent>
+    );
+  };
+
+  const ChildNavigator = (props: any): any => {
+    const { state, descriptors, NavigationContent } = useNavigationBuilder(
+      StackRouter,
+      props
+    );
+
+    return (
+      <NavigationContent>
+        {descriptors[state.routes[state.index].key].render()}
+      </NavigationContent>
+    );
+  };
+
+  let navigate: any;
+
+  const BazScreen = ({ navigation }: any) => {
+    React.useEffect(() => {
+      navigate = navigation.navigate;
+    }, [navigation]);
+
+    return 'baz';
+  };
+
+  const TestScreen = ({ route }: any): any =>
+    `[${route.name}, ${JSON.stringify(route.params)}]`;
+
+  const navigation = createNavigationContainerRef<ParamListBase>();
+
+  const element = render(
+    <BaseNavigationContainer ref={navigation}>
+      <TestNavigator>
+        <Screen name="foo" component={TestScreen} />
+        <Screen name="bar">
+          {() => (
+            <ChildNavigator>
+              <Screen name="baz" component={BazScreen} />
+              <Screen name="qux" component={TestScreen} />
+            </ChildNavigator>
+          )}
+        </Screen>
+      </TestNavigator>
+    </BaseNavigationContainer>
+  );
+
+  expect(element).toMatchInlineSnapshot(`"[foo, undefined]"`);
+
+  act(() => navigation.preload('bar'));
+
+  expect(element).toMatchInlineSnapshot(`
+[
+  "[foo, undefined]",
+  "baz",
+]
+`);
+
+  act(() => navigate('qux', { answer: 42 }));
+
+  act(() => navigation.navigate('bar'));
+
+  expect(element).toMatchInlineSnapshot(`
+[
+  "[foo, undefined]",
+  "[qux, {"answer":42}]",
+]
+`);
+});
+
+test('includes child state for preloaded screens in root state', () => {
+  const TestNavigator = (props: any): any => {
+    const { state, descriptors, NavigationContent } = useNavigationBuilder(
+      StackRouter,
+      props
+    );
+
+    return (
+      <NavigationContent>
+        {[...state.routes, ...state.preloadedRoutes].map((route) =>
+          descriptors[route.key].render()
+        )}
+      </NavigationContent>
+    );
+  };
+
+  const ChildNavigator = (props: any): any => {
+    const { state, descriptors, NavigationContent } = useNavigationBuilder(
+      StackRouter,
+      props
+    );
+
+    return (
+      <NavigationContent>
+        {descriptors[state.routes[state.index].key].render()}
+      </NavigationContent>
+    );
+  };
+
+  const navigation = createNavigationContainerRef<ParamListBase>();
+
+  render(
+    <BaseNavigationContainer ref={navigation}>
+      <TestNavigator>
+        <Screen name="foo">{() => null}</Screen>
+        <Screen name="bar">
+          {() => (
+            <ChildNavigator>
+              <Screen name="baz">{() => null}</Screen>
+              <Screen name="qux">{() => null}</Screen>
+            </ChildNavigator>
+          )}
+        </Screen>
+      </TestNavigator>
+    </BaseNavigationContainer>
+  );
+
+  act(() => navigation.preload('bar'));
+
+  expect(navigation.getRootState()).toEqual(
+    expect.objectContaining({
+      preloadedRoutes: [
+        expect.objectContaining({
+          name: 'bar',
+          state: expect.objectContaining({
+            index: 0,
+            routeNames: ['baz', 'qux'],
+            routes: [expect.objectContaining({ name: 'baz' })],
+            stale: false,
+            type: 'stack',
+          }),
+        }),
+      ],
+    })
+  );
 });
 
 test('resets to nested child in a navigator', () => {

--- a/packages/core/src/__tests__/useEventEmitter.test.tsx
+++ b/packages/core/src/__tests__/useEventEmitter.test.tsx
@@ -1,5 +1,9 @@
 import { beforeEach, expect, jest, test } from '@jest/globals';
-import type { NavigationState, Router } from '@react-navigation/routers';
+import {
+  type NavigationState,
+  type Router,
+  StackRouter,
+} from '@react-navigation/routers';
 import { act, render } from '@testing-library/react-native';
 import * as React from 'react';
 
@@ -531,6 +535,67 @@ test('fires custom events added with addListener', () => {
   expect(firstCallback).toHaveBeenCalledTimes(1);
   expect(secondCallback).toHaveBeenCalledTimes(1);
   expect(thirdCallback).toHaveBeenCalledTimes(2);
+});
+
+test('fires targeted custom events for preloaded routes', () => {
+  const eventName = 'someSuperCoolEvent';
+
+  function TestNavigator({ ref, ...props }: any): any {
+    const { state, navigation, descriptors, NavigationContent } =
+      useNavigationBuilder(StackRouter, props);
+
+    React.useImperativeHandle(ref, () => ({ navigation, state }), [
+      navigation,
+      state,
+    ]);
+
+    return (
+      <NavigationContent>
+        {[...state.routes, ...state.preloadedRoutes].map((route) =>
+          descriptors[route.key].render()
+        )}
+      </NavigationContent>
+    );
+  }
+
+  const callback: any = jest.fn();
+
+  const Test = ({ navigation }: any) => {
+    React.useEffect(
+      () => navigation.addListener(eventName, callback),
+      [navigation]
+    );
+
+    return null;
+  };
+
+  const ref = React.createRef<any>();
+
+  render(
+    <BaseNavigationContainer>
+      <TestNavigator ref={ref}>
+        <Screen name="first">{() => null}</Screen>
+        <Screen name="second" component={Test} />
+      </TestNavigator>
+    </BaseNavigationContainer>
+  );
+
+  act(() => ref.current.navigation.preload('second'));
+
+  const target = ref.current.state.preloadedRoutes[0].key;
+
+  act(() => {
+    ref.current.navigation.emit({
+      type: eventName,
+      target,
+      data: 42,
+    });
+  });
+
+  expect(callback).toHaveBeenCalledTimes(1);
+  expect(callback.mock.calls[0][0].type).toBe(eventName);
+  expect(callback.mock.calls[0][0].data).toBe(42);
+  expect(callback.mock.calls[0][0].target).toBe(target);
 });
 
 test("doesn't call same listener multiple times with addListener", () => {

--- a/packages/core/src/__tests__/usePreventRemove.test.tsx
+++ b/packages/core/src/__tests__/usePreventRemove.test.tsx
@@ -263,6 +263,56 @@ test("prevents removing a screen when 'usePreventRemove' hook is called multiple
   });
 });
 
+test("doesn't prevent retaining a screen in preloaded routes", () => {
+  const TestNavigator = (props: any) => {
+    const { state, descriptors, NavigationContent } = useNavigationBuilder(
+      StackRouter,
+      props
+    );
+
+    return (
+      <NavigationContent>
+        {state.routes.map((route) => descriptors[route.key].render())}
+      </NavigationContent>
+    );
+  };
+
+  const onPreventRemove = jest.fn();
+
+  const TestScreen = () => {
+    usePreventRemove(true, onPreventRemove);
+
+    return null;
+  };
+
+  const ref = createNavigationContainerRef<ParamListBase>();
+
+  render(
+    <BaseNavigationContainer ref={ref}>
+      <TestNavigator>
+        <Screen name="foo">{() => null}</Screen>
+        <Screen name="bar" component={TestScreen} />
+        <Screen name="baz">{() => null}</Screen>
+      </TestNavigator>
+    </BaseNavigationContainer>
+  );
+
+  act(() => ref.current?.navigate('bar'));
+  act(() => ref.current?.dispatch(StackActions.retain(true)));
+  act(() => ref.current?.navigate('baz'));
+  act(() => ref.current?.dispatch(StackActions.popTo('foo')));
+
+  expect(onPreventRemove).not.toHaveBeenCalled();
+
+  expect(ref.current?.getRootState()).toEqual(
+    expect.objectContaining({
+      routes: [{ key: 'foo-3', name: 'foo' }],
+      preloadedRoutes: [{ key: 'bar-5', name: 'bar' }],
+      retainedRouteKeys: ['bar-5'],
+    })
+  );
+});
+
 test("should have no effect when 'usePreventRemove' hook is set to false", () => {
   const TestNavigator = (props: any) => {
     const { state, descriptors, NavigationContent } = useNavigationBuilder(

--- a/packages/core/src/useDescriptors.tsx
+++ b/packages/core/src/useDescriptors.tsx
@@ -77,7 +77,13 @@ type Options<
   screenLayout: ScreenLayout<ScreenOptions> | undefined;
   onAction: (action: NavigationAction) => boolean;
   getState: () => State;
-  setState: (state: State) => void;
+  getRouteState: (
+    routeKey: string
+  ) => NavigationState | PartialState<NavigationState> | undefined;
+  setRouteState: (
+    routeKey: string,
+    state: NavigationState | PartialState<NavigationState> | undefined
+  ) => void;
   addListener: AddListener;
   addKeyedListener: AddKeyedListener;
   onRouteFocus: (key: string) => void;
@@ -106,7 +112,8 @@ export function useDescriptors<
   screenLayout,
   onAction,
   getState,
-  setState,
+  getRouteState,
+  setRouteState,
   addListener,
   addKeyedListener,
   onRouteFocus,
@@ -249,8 +256,8 @@ export function useDescriptors<
         route={route}
         screen={screen}
         routeState={routeState}
-        getState={getState}
-        setState={setState}
+        getRouteState={getRouteState}
+        setRouteState={setRouteState}
         options={customOptions}
         clearOptions={clearOptions}
       />

--- a/packages/core/src/useNavigationBuilder.tsx
+++ b/packages/core/src/useNavigationBuilder.tsx
@@ -810,6 +810,14 @@ export function useNavigationBuilder<
     );
   });
 
+  const getRoutesFromState = React.useCallback(
+    (state: State) =>
+      router.getRoutesFromState
+        ? router.getRoutesFromState(state)
+        : state.routes,
+    [router]
+  );
+
   const { onEmitEvent } = React.use(NavigationBuilderContext);
 
   const emitter = useEventEmitter<EventMapCore<State>>((e) => {
@@ -818,7 +826,7 @@ export function useNavigationBuilder<
     let route: Route<string> | undefined;
 
     if (e.target) {
-      route = state.routes.find((route) => route.key === e.target);
+      route = getRoutesFromState(state).find((route) => route.key === e.target);
 
       if (route?.name) {
         routeNames.push(route.name);
@@ -886,6 +894,7 @@ export function useNavigationBuilder<
     router,
     getState,
     setState,
+    getRoutesFromState,
     key: route?.key,
     actionListeners: childListeners.action,
     beforeRemoveListeners: keyedListeners.beforeRemove,
@@ -961,8 +970,65 @@ export function useNavigationBuilder<
 
   useOnGetState({
     getState,
+    getRoutesFromState,
+    getStateForRouteUpdate: router.getStateForRouteUpdate,
     getStateListeners: keyedListeners.getState,
   });
+
+  const getRouteState = React.useCallback(
+    (routeKey: string) => {
+      const state = getState();
+      const route = getRoutesFromState(state).find((r) => r.key === routeKey);
+
+      return route?.state;
+    },
+    [getState, getRoutesFromState]
+  );
+
+  const setRouteState = React.useCallback(
+    (
+      routeKey: string,
+      routeState: NavigationState | PartialState<NavigationState> | undefined
+    ) => {
+      const state = getState();
+
+      if (router.getStateForRouteUpdate) {
+        const route = getRoutesFromState(state).find((r) => r.key === routeKey);
+
+        if (route == null) {
+          return;
+        }
+
+        const nextState = router.getStateForRouteUpdate(state, {
+          ...route,
+          state: routeState,
+        });
+
+        if (nextState !== null) {
+          setState(nextState);
+        }
+      } else {
+        const routes = state.routes.map((r) => {
+          if (r.key === routeKey && r.state !== routeState) {
+            return {
+              ...r,
+              state: routeState,
+            };
+          }
+
+          return r;
+        });
+
+        if (!isArrayEqual(state.routes, routes)) {
+          setState({
+            ...state,
+            routes,
+          });
+        }
+      }
+    },
+    [getRoutesFromState, getState, router, setState]
+  );
 
   const descriptors = useDescriptors<
     State,
@@ -970,9 +1036,9 @@ export function useNavigationBuilder<
     ScreenOptions,
     EventMap
   >({
-    routes: router.getRoutesFromState
-      ? router.getRoutesFromState(state)
-      : state.routes,
+    routes: getRoutesFromState(state),
+    getRouteState,
+    setRouteState,
     screens,
     navigation,
     screenOptions,

--- a/packages/core/src/useOnAction.tsx
+++ b/packages/core/src/useOnAction.tsx
@@ -21,6 +21,7 @@ type Options<State extends NavigationState> = {
   key?: string | undefined;
   getState: () => State;
   setState: (state: State | PartialState<State>) => void;
+  getRoutesFromState: (state: State) => State['routes'];
   actionListeners: ChildActionListener[];
   beforeRemoveListeners: Record<string, ChildBeforeRemoveListener | undefined>;
   routerConfigOptions: RouterConfigOptions;
@@ -40,6 +41,7 @@ export function useOnAction<State extends NavigationState>({
   router,
   getState,
   setState,
+  getRoutesFromState,
   key,
   actionListeners,
   beforeRemoveListeners,
@@ -94,8 +96,10 @@ export function useOnAction<State extends NavigationState>({
             const isPrevented = shouldPreventRemove(
               emitter,
               beforeRemoveListeners,
-              state.routes,
-              result.routes,
+              getRoutesFromState(state),
+              result.stale === false
+                ? getRoutesFromState(result)
+                : result.routes,
               action
             );
 
@@ -144,6 +148,7 @@ export function useOnAction<State extends NavigationState>({
       actionListeners,
       beforeRemoveListeners,
       emitter,
+      getRoutesFromState,
       getState,
       key,
       onActionParent,
@@ -156,6 +161,7 @@ export function useOnAction<State extends NavigationState>({
 
   useOnPreventRemove({
     getState,
+    getRoutesFromState,
     emitter,
     beforeRemoveListeners,
   });

--- a/packages/core/src/useOnGetState.tsx
+++ b/packages/core/src/useOnGetState.tsx
@@ -8,18 +8,51 @@ import {
 } from './NavigationBuilderContext';
 import { NavigationRouteContext } from './NavigationProvider';
 
-type Options = {
-  getState: () => NavigationState;
+type Options<State extends NavigationState> = {
+  getState: () => State;
+  getRoutesFromState: (state: State) => State['routes'];
+  getStateForRouteUpdate?: (
+    state: State,
+    route: State['routes'][number]
+  ) => State | null;
   getStateListeners: Record<string, GetStateListener | undefined>;
 };
 
-export function useOnGetState({ getState, getStateListeners }: Options) {
+export function useOnGetState<State extends NavigationState>({
+  getState,
+  getRoutesFromState,
+  getStateForRouteUpdate,
+  getStateListeners,
+}: Options<State>) {
   const { addKeyedListener } = React.use(NavigationBuilderContext);
   const route = React.use(NavigationRouteContext);
   const key = route ? route.key : 'root';
 
   const getRehydratedState = React.useCallback(() => {
     const state = getState();
+
+    if (getStateForRouteUpdate) {
+      let nextState = state;
+
+      for (const route of getRoutesFromState(state)) {
+        const childState = getStateListeners[route.key]?.();
+
+        if (route.state === childState) {
+          continue;
+        }
+
+        const updatedState = getStateForRouteUpdate(nextState, {
+          ...route,
+          state: childState,
+        });
+
+        if (updatedState !== null) {
+          nextState = updatedState;
+        }
+      }
+
+      return nextState;
+    }
 
     // Avoid returning new route objects if we don't need to
     const routes = state.routes.map((route) => {
@@ -37,7 +70,7 @@ export function useOnGetState({ getState, getStateListeners }: Options) {
     }
 
     return { ...state, routes };
-  }, [getState, getStateListeners]);
+  }, [getRoutesFromState, getState, getStateForRouteUpdate, getStateListeners]);
 
   React.useEffect(() => {
     return addKeyedListener?.('getState', key, getRehydratedState);

--- a/packages/core/src/useOnPreventRemove.tsx
+++ b/packages/core/src/useOnPreventRemove.tsx
@@ -12,8 +12,9 @@ import { NavigationRouteContext } from './NavigationProvider';
 import type { EventMapCore } from './types';
 import type { NavigationEventEmitter } from './useEventEmitter';
 
-type Options = {
-  getState: () => NavigationState;
+type Options<State extends NavigationState> = {
+  getState: () => State;
+  getRoutesFromState: (state: State) => State['routes'];
   emitter: NavigationEventEmitter<EventMapCore<any>>;
   beforeRemoveListeners: Record<string, ChildBeforeRemoveListener | undefined>;
 };
@@ -73,11 +74,12 @@ export const shouldPreventRemove = (
   return false;
 };
 
-export function useOnPreventRemove({
+export function useOnPreventRemove<State extends NavigationState>({
   getState,
+  getRoutesFromState,
   emitter,
   beforeRemoveListeners,
-}: Options) {
+}: Options<State>) {
   const { addKeyedListener } = React.use(NavigationBuilderContext);
   const route = React.use(NavigationRouteContext);
   const routeKey = route?.key;
@@ -90,11 +92,18 @@ export function useOnPreventRemove({
         return shouldPreventRemove(
           emitter,
           beforeRemoveListeners,
-          state.routes,
+          getRoutesFromState(state),
           [],
           action
         );
       });
     }
-  }, [addKeyedListener, beforeRemoveListeners, emitter, getState, routeKey]);
+  }, [
+    addKeyedListener,
+    beforeRemoveListeners,
+    emitter,
+    getRoutesFromState,
+    getState,
+    routeKey,
+  ]);
 }

--- a/packages/routers/src/BaseRouter.tsx
+++ b/packages/routers/src/BaseRouter.tsx
@@ -1,10 +1,45 @@
 import { nanoid } from 'nanoid/non-secure';
 
 import type {
+  PushParamsAction,
+  ReplaceParamsAction,
+  SetParamsAction,
+} from './CommonActions';
+import type {
   CommonNavigationAction,
   NavigationState,
   PartialState,
+  Route,
 } from './types';
+
+export function getRouteForParamsAction<T extends Route<string>>(
+  route: T,
+  action: SetParamsAction | ReplaceParamsAction | PushParamsAction
+): T {
+  switch (action.type) {
+    case 'SET_PARAMS':
+      return {
+        ...route,
+        params: { ...route.params, ...action.payload.params },
+      };
+
+    case 'REPLACE_PARAMS':
+      return {
+        ...route,
+        params: action.payload.params,
+      };
+
+    case 'PUSH_PARAMS':
+      return {
+        ...route,
+        params: action.payload.params,
+        history: [
+          ...(route.history ?? []),
+          { type: 'params', params: route.params },
+        ],
+      };
+  }
+}
 
 /**
  * Base router object that can be used when writing custom routers.
@@ -17,31 +52,7 @@ export const BaseRouter = {
   ): State | PartialState<State> | null {
     switch (action.type) {
       case 'SET_PARAMS':
-      case 'REPLACE_PARAMS': {
-        const index = action.source
-          ? state.routes.findIndex((r) => r.key === action.source)
-          : state.index;
-
-        if (index === -1) {
-          return null;
-        }
-
-        return {
-          ...state,
-          routes: state.routes.map((r, i) =>
-            i === index
-              ? {
-                  ...r,
-                  params:
-                    action.type === 'REPLACE_PARAMS'
-                      ? action.payload.params
-                      : { ...r.params, ...action.payload.params },
-                }
-              : r
-          ),
-        };
-      }
-
+      case 'REPLACE_PARAMS':
       case 'PUSH_PARAMS': {
         const index = action.source
           ? state.routes.findIndex((r) => r.key === action.source)
@@ -51,20 +62,11 @@ export const BaseRouter = {
           return null;
         }
 
+        const route = getRouteForParamsAction(state.routes[index], action);
+
         return {
           ...state,
-          routes: state.routes.map((r, i) =>
-            i === index
-              ? {
-                  ...r,
-                  params: action.payload.params,
-                  history: [
-                    ...(r.history ?? []),
-                    { type: 'params', params: r.params },
-                  ],
-                }
-              : r
-          ),
+          routes: state.routes.map((r, i) => (i === index ? route : r)),
         };
       }
 

--- a/packages/routers/src/CommonActions.tsx
+++ b/packages/routers/src/CommonActions.tsx
@@ -7,13 +7,13 @@ type ResetState =
       routes: Omit<Route<string>, 'key'>[];
     });
 
-type GoBackAction = {
+export type GoBackAction = {
   type: 'GO_BACK';
   source?: string | undefined;
   target?: string | undefined;
 };
 
-type NavigateAction = {
+export type NavigateAction = {
   type: 'NAVIGATE';
   payload: {
     name: string;
@@ -26,35 +26,35 @@ type NavigateAction = {
   target?: string | undefined;
 };
 
-type ResetAction = {
+export type ResetAction = {
   type: 'RESET';
   payload: ResetState;
   source?: string | undefined;
   target?: string | undefined;
 };
 
-type SetParamsAction = {
+export type SetParamsAction = {
   type: 'SET_PARAMS';
   payload: { params?: object | undefined };
   source?: string | undefined;
   target?: string | undefined;
 };
 
-type ReplaceParamsAction = {
+export type ReplaceParamsAction = {
   type: 'REPLACE_PARAMS';
   payload: { params?: object | undefined };
   source?: string | undefined;
   target?: string | undefined;
 };
 
-type PushParamsAction = {
+export type PushParamsAction = {
   type: 'PUSH_PARAMS';
   payload: { params?: object | undefined };
   source?: string | undefined;
   target?: string | undefined;
 };
 
-type PreloadAction = {
+export type PreloadAction = {
   type: 'PRELOAD';
   payload: {
     name: string;

--- a/packages/routers/src/StackRouter.tsx
+++ b/packages/routers/src/StackRouter.tsx
@@ -1,6 +1,6 @@
 import { nanoid } from 'nanoid/non-secure';
 
-import { BaseRouter } from './BaseRouter';
+import { BaseRouter, getRouteForParamsAction } from './BaseRouter';
 import { createParamsFromAction } from './createParamsFromAction';
 import { createRouteFromAction } from './createRouteFromAction';
 import type {
@@ -385,6 +385,38 @@ export function StackRouter(options: StackRouterOptions) {
         index,
         routes: state.routes.slice(0, index + 1),
       });
+    },
+
+    getStateForRouteUpdate(state, route) {
+      const index = state.routes.findIndex((r) => r.key === route.key);
+
+      if (index > -1) {
+        const routes = [...state.routes];
+
+        routes[index] = route;
+
+        return {
+          ...state,
+          routes,
+        };
+      }
+
+      const preloadedIndex = state.preloadedRoutes.findIndex(
+        (r) => r.key === route.key
+      );
+
+      if (preloadedIndex > -1) {
+        const preloadedRoutes = [...state.preloadedRoutes];
+
+        preloadedRoutes[preloadedIndex] = route;
+
+        return {
+          ...state,
+          preloadedRoutes,
+        };
+      }
+
+      return null;
     },
 
     getStateForAction(state, action, options) {
@@ -899,6 +931,33 @@ export function StackRouter(options: StackRouterOptions) {
                 .concat(createRouteFromAction({ action, routeParamList })),
             };
           }
+        }
+
+        case 'SET_PARAMS':
+        case 'REPLACE_PARAMS':
+        case 'PUSH_PARAMS': {
+          const result = BaseRouter.getStateForAction(state, action);
+
+          if (result != null || action.source == null) {
+            return result;
+          }
+
+          const route = state.preloadedRoutes.find(
+            (route) => route.key === action.source
+          );
+
+          if (route == null) {
+            return null;
+          }
+
+          const updatedRoute = getRouteForParamsAction(route, action);
+
+          return {
+            ...state,
+            preloadedRoutes: state.preloadedRoutes.map((route) =>
+              route.key === updatedRoute.key ? updatedRoute : route
+            ),
+          };
         }
 
         default:

--- a/packages/routers/src/__tests__/StackRouter.test.tsx
+++ b/packages/routers/src/__tests__/StackRouter.test.tsx
@@ -395,6 +395,77 @@ test('handles retain for preloaded routes', () => {
   });
 });
 
+test('handles param actions for preloaded routes', () => {
+  const router = StackRouter({});
+  const options: RouterConfigOptions = {
+    routeNames: ['baz', 'bar', 'qux'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+
+  const state: StackNavigationState<ParamListBase> = {
+    stale: false,
+    type: 'stack',
+    key: 'root',
+    index: 0,
+    preloadedRoutes: [{ key: 'bar', name: 'bar', params: { answer: 42 } }],
+    retainedRouteKeys: [],
+    routeNames: ['baz', 'bar', 'qux'],
+    routes: [{ key: 'baz', name: 'baz' }],
+  };
+
+  expect(
+    router.getStateForAction(
+      state,
+      {
+        ...CommonActions.setParams({ name: 'Jane' }),
+        source: 'bar',
+      },
+      options
+    )
+  ).toEqual({
+    ...state,
+    preloadedRoutes: [
+      { key: 'bar', name: 'bar', params: { answer: 42, name: 'Jane' } },
+    ],
+  });
+
+  expect(
+    router.getStateForAction(
+      state,
+      {
+        ...CommonActions.replaceParams({ name: 'Jane' }),
+        source: 'bar',
+      },
+      options
+    )
+  ).toEqual({
+    ...state,
+    preloadedRoutes: [{ key: 'bar', name: 'bar', params: { name: 'Jane' } }],
+  });
+
+  expect(
+    router.getStateForAction(
+      state,
+      {
+        ...CommonActions.pushParams({ name: 'Jane' }),
+        source: 'bar',
+      },
+      options
+    )
+  ).toEqual({
+    ...state,
+    preloadedRoutes: [
+      {
+        key: 'bar',
+        name: 'bar',
+        params: { name: 'Jane' },
+        history: [{ type: 'params', params: { answer: 42 } }],
+      },
+    ],
+  });
+});
+
 test('gets state on route names change', () => {
   const router = StackRouter({});
 

--- a/packages/routers/src/types.tsx
+++ b/packages/routers/src/types.tsx
@@ -85,7 +85,7 @@ export type Route<
     /**
      * History of param changes for this route.
      */
-    history?: { type: 'params'; params: object }[] | undefined;
+    history?: { type: 'params'; params: object | undefined }[] | undefined;
   } & Readonly<
     undefined extends Params
       ? {
@@ -211,6 +211,22 @@ export type Router<
   getStateForRouteFocus(state: State, key: string): State;
 
   /**
+   * Take the current state and a route object, and return a new state with the route updated.
+   * Necessary to update route objects not in `state.routes` (e.g. `preloadedRoutes` in stack)
+   *
+   * Returns `null` if the route cannot be found.
+   *
+   * Also specify `getRoutesFromState` when this is specified.
+   *
+   * @param state State object to apply the action on.
+   * @param route Route object to update.
+   */
+  getStateForRouteUpdate?(
+    state: State,
+    route: State['routes'][number]
+  ): State | null;
+
+  /**
    * Take the current state and action, and return a new state.
    * If the action cannot be handled, return `null`.
    *
@@ -236,12 +252,13 @@ export type Router<
    * Get the list of routes from the navigation state.
    *
    * By default, `state.routes` is used.
-   * But in some cases (like `preloadedRoutes` in stack),
-   * the actual list of routes may be different.
+   * But the actual routes can be different in some cases (e.g. `preloadedRoutes` in stack).
+   *
+   * Also specify `getStateForRouteUpdate` when this is specified.
    *
    * @param state Navigation state to get the routes from.
    */
-  getRoutesFromState?(state: State): Route<string>[];
+  getRoutesFromState?(state: State): State['routes'];
 
   /**
    * Action creators for the router.


### PR DESCRIPTION
- receive events from parent navigator
- allow param updates
- allow navigation in nested navigators
- include nested navigator state in getRootState
- don't treat screen as being removed for `preventRemove`