### PR TITLE
feat: rework preload handling in stack

### DIFF
--- a/example/src/Screens/NativeStackPreloadFlow.tsx
+++ b/example/src/Screens/NativeStackPreloadFlow.tsx
@@ -16,9 +16,13 @@ const DetailsScreen = () => {
   const route = useRoute('NativeStackPreloadFlowDetails');
 
   const [isPreloaded] = useState(
-    useNavigationState('NativeStackPreloadFlowDetails', (state) =>
-      state.preloadedRoutes.some((r) => r.key === route.key)
-    )
+    useNavigationState('NativeStackPreloadFlowDetails', (state) => {
+      const index = state.routes.findIndex((r) => r.key === route.key);
+
+      return (
+        index > state.index && !state.retainedRouteKeys.includes(route.key)
+      );
+    })
   );
 
   const [loadingCountdown, setLoadingCountdown] = useState(3);

--- a/example/src/Screens/StackPreloadFlow.tsx
+++ b/example/src/Screens/StackPreloadFlow.tsx
@@ -16,9 +16,13 @@ const DetailsScreen = () => {
   const route = useRoute('StackPreloadFlowDetails');
 
   const [isPreloaded] = useState(
-    useNavigationState('StackPreloadFlowDetails', (state) =>
-      state.preloadedRoutes.some((r) => r.key === route.key)
-    )
+    useNavigationState('StackPreloadFlowDetails', (state) => {
+      const index = state.routes.findIndex((r) => r.key === route.key);
+
+      return (
+        index > state.index && !state.retainedRouteKeys.includes(route.key)
+      );
+    })
   );
 
   const [loadingCountdown, setLoadingCountdown] = useState(3);

--- a/packages/core/src/__tests__/getPathFromState.test.tsx
+++ b/packages/core/src/__tests__/getPathFromState.test.tsx
@@ -110,6 +110,30 @@ test('converts state to path string with config', () => {
   ).toBe(path);
 });
 
+test('converts stack state with preloaded routes to path from focused route', () => {
+  const config = {
+    screens: {
+      Foo: 'foo',
+      Bar: 'bar/:id',
+      Baz: 'baz',
+    },
+  };
+
+  const state = {
+    type: 'stack',
+    key: 'stack-test',
+    index: 1,
+    routeNames: ['Foo', 'Bar', 'Baz'],
+    routes: [
+      { key: 'Foo-test', name: 'Foo' },
+      { key: 'Bar-test', name: 'Bar', params: { id: 42 } },
+      { key: 'Baz-test', name: 'Baz' },
+    ],
+  };
+
+  expect(getPathFromState<object>(state, config)).toBe('/bar/42');
+});
+
 test('prepends trailing slash to path', () => {
   expect(
     getPathFromState<object>({

--- a/packages/core/src/__tests__/index.test.tsx
+++ b/packages/core/src/__tests__/index.test.tsx
@@ -5,6 +5,7 @@ import {
   type NavigationState,
   type ParamListBase,
   type Router,
+  StackRouter,
 } from '@react-navigation/routers';
 import { act, render, renderAsync } from '@testing-library/react-native';
 import * as React from 'react';
@@ -1569,6 +1570,154 @@ test('navigates to nested child in a navigator with initial: false', () => {
     stale: false,
     type: 'test',
   });
+});
+
+test('preserves navigation state changes for preloaded screens', () => {
+  const TestNavigator = (props: any): any => {
+    const { state, descriptors, NavigationContent } = useNavigationBuilder(
+      StackRouter,
+      props
+    );
+
+    return (
+      <NavigationContent>
+        {state.routes.map((route) => descriptors[route.key].render())}
+      </NavigationContent>
+    );
+  };
+
+  const ChildNavigator = (props: any): any => {
+    const { state, descriptors, NavigationContent } = useNavigationBuilder(
+      StackRouter,
+      props
+    );
+
+    return (
+      <NavigationContent>
+        {descriptors[state.routes[state.index].key].render()}
+      </NavigationContent>
+    );
+  };
+
+  let navigate: any;
+
+  const BazScreen = ({ navigation }: any) => {
+    React.useEffect(() => {
+      navigate = navigation.navigate;
+    }, [navigation]);
+
+    return 'baz';
+  };
+
+  const TestScreen = ({ route }: any): any =>
+    `[${route.name}, ${JSON.stringify(route.params)}]`;
+
+  const navigation = createNavigationContainerRef<ParamListBase>();
+
+  const element = render(
+    <BaseNavigationContainer ref={navigation}>
+      <TestNavigator>
+        <Screen name="foo" component={TestScreen} />
+        <Screen name="bar">
+          {() => (
+            <ChildNavigator>
+              <Screen name="baz" component={BazScreen} />
+              <Screen name="qux" component={TestScreen} />
+            </ChildNavigator>
+          )}
+        </Screen>
+      </TestNavigator>
+    </BaseNavigationContainer>
+  );
+
+  expect(element).toMatchInlineSnapshot(`"[foo, undefined]"`);
+
+  act(() => navigation.preload('bar'));
+
+  expect(element).toMatchInlineSnapshot(`
+[
+  "[foo, undefined]",
+  "baz",
+]
+`);
+
+  act(() => navigate('qux', { answer: 42 }));
+
+  act(() => navigation.navigate('bar'));
+
+  expect(element).toMatchInlineSnapshot(`
+[
+  "[foo, undefined]",
+  "[qux, {"answer":42}]",
+]
+`);
+});
+
+test('includes child state for preloaded screens in root state', () => {
+  const TestNavigator = (props: any): any => {
+    const { state, descriptors, NavigationContent } = useNavigationBuilder(
+      StackRouter,
+      props
+    );
+
+    return (
+      <NavigationContent>
+        {state.routes.map((route) => descriptors[route.key].render())}
+      </NavigationContent>
+    );
+  };
+
+  const ChildNavigator = (props: any): any => {
+    const { state, descriptors, NavigationContent } = useNavigationBuilder(
+      StackRouter,
+      props
+    );
+
+    return (
+      <NavigationContent>
+        {descriptors[state.routes[state.index].key].render()}
+      </NavigationContent>
+    );
+  };
+
+  const navigation = createNavigationContainerRef<ParamListBase>();
+
+  render(
+    <BaseNavigationContainer ref={navigation}>
+      <TestNavigator>
+        <Screen name="foo">{() => null}</Screen>
+        <Screen name="bar">
+          {() => (
+            <ChildNavigator>
+              <Screen name="baz">{() => null}</Screen>
+              <Screen name="qux">{() => null}</Screen>
+            </ChildNavigator>
+          )}
+        </Screen>
+      </TestNavigator>
+    </BaseNavigationContainer>
+  );
+
+  act(() => navigation.preload('bar'));
+
+  expect(navigation.getRootState()).toEqual(
+    expect.objectContaining({
+      index: 0,
+      routes: [
+        expect.objectContaining({ name: 'foo' }),
+        expect.objectContaining({
+          name: 'bar',
+          state: expect.objectContaining({
+            index: 0,
+            routeNames: ['baz', 'qux'],
+            routes: [expect.objectContaining({ name: 'baz' })],
+            stale: false,
+            type: 'stack',
+          }),
+        }),
+      ],
+    })
+  );
 });
 
 test('resets to nested child in a navigator', () => {

--- a/packages/core/src/__tests__/useEventEmitter.test.tsx
+++ b/packages/core/src/__tests__/useEventEmitter.test.tsx
@@ -1,9 +1,16 @@
 import { beforeEach, expect, jest, test } from '@jest/globals';
-import type { NavigationState, Router } from '@react-navigation/routers';
+import {
+  CommonActions,
+  type NavigationState,
+  type ParamListBase,
+  type Router,
+  StackRouter,
+} from '@react-navigation/routers';
 import { act, render } from '@testing-library/react-native';
 import * as React from 'react';
 
 import { BaseNavigationContainer } from '../BaseNavigationContainer';
+import { createNavigationContainerRef } from '../createNavigationContainerRef';
 import { Screen } from '../Screen';
 import { useNavigationBuilder } from '../useNavigationBuilder';
 import { MockRouter, MockRouterKey } from './__fixtures__/MockRouter';
@@ -531,6 +538,81 @@ test('fires custom events added with addListener', () => {
   expect(firstCallback).toHaveBeenCalledTimes(1);
   expect(secondCallback).toHaveBeenCalledTimes(1);
   expect(thirdCallback).toHaveBeenCalledTimes(2);
+});
+
+test('fires custom events for preloaded routes', () => {
+  const eventName = 'someSuperCoolEvent';
+
+  function TestNavigator({ ref, ...props }: any): any {
+    const { state, navigation, descriptors, NavigationContent } =
+      useNavigationBuilder(StackRouter, props);
+
+    React.useImperativeHandle(ref, () => ({ navigation, state }), [
+      navigation,
+      state,
+    ]);
+
+    return (
+      <NavigationContent>
+        {state.routes.map((route) => descriptors[route.key].render())}
+      </NavigationContent>
+    );
+  }
+
+  const callback: any = jest.fn();
+
+  const Test = ({ navigation }: any) => {
+    React.useEffect(
+      () => navigation.addListener(eventName, callback),
+      [navigation]
+    );
+
+    return null;
+  };
+
+  const ref = React.createRef<any>();
+  const navigation = createNavigationContainerRef<ParamListBase>();
+
+  render(
+    <BaseNavigationContainer ref={navigation}>
+      <TestNavigator ref={ref}>
+        <Screen name="first">{() => null}</Screen>
+        <Screen name="second" component={Test} />
+      </TestNavigator>
+    </BaseNavigationContainer>
+  );
+
+  act(() => navigation.dispatch(CommonActions.preload('second')));
+
+  const target = ref.current.state.routes[1].key;
+
+  ref.current.navigation.emit({
+    type: eventName,
+    target,
+    data: 42,
+  });
+
+  expect(callback).toHaveBeenCalledTimes(1);
+  expect(callback).toHaveBeenCalledWith(
+    expect.objectContaining({
+      type: eventName,
+      target,
+      data: 42,
+    })
+  );
+
+  ref.current.navigation.emit({
+    type: eventName,
+    data: 21,
+  });
+
+  expect(callback).toHaveBeenCalledTimes(2);
+  expect(callback).toHaveBeenLastCalledWith(
+    expect.objectContaining({
+      type: eventName,
+      data: 21,
+    })
+  );
 });
 
 test("doesn't call same listener multiple times with addListener", () => {

--- a/packages/core/src/__tests__/useNavigation.test.tsx
+++ b/packages/core/src/__tests__/useNavigation.test.tsx
@@ -244,7 +244,6 @@ test('gets navigation in preloaded screen', () => {
     return (
       <NavigationContent>
         {state.routes.map((route) => descriptors[route.key].render())}
-        {state.preloadedRoutes?.map((route) => descriptors[route.key].render())}
       </NavigationContent>
     );
   };

--- a/packages/core/src/__tests__/useOnAction.test.tsx
+++ b/packages/core/src/__tests__/useOnAction.test.tsx
@@ -605,7 +605,6 @@ test("prevents removing a screen with 'beforeRemove' event", () => {
   expect(onStateChange).toHaveBeenCalledWith({
     index: 1,
     key: 'stack-2',
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [
@@ -622,7 +621,6 @@ test("prevents removing a screen with 'beforeRemove' event", () => {
   expect(onStateChange).toHaveBeenCalledWith({
     index: 2,
     key: 'stack-2',
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [
@@ -645,7 +643,6 @@ test("prevents removing a screen with 'beforeRemove' event", () => {
   expect(ref.current?.getRootState()).toEqual({
     index: 2,
     key: 'stack-2',
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [
@@ -665,7 +662,6 @@ test("prevents removing a screen with 'beforeRemove' event", () => {
   expect(onStateChange).toHaveBeenCalledWith({
     index: 0,
     key: 'stack-2',
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [{ key: 'foo-3', name: 'foo' }],
@@ -683,7 +679,6 @@ test("prevents removing a screen with 'beforeRemove' event", () => {
   expect(onStateChange).toHaveBeenCalledWith({
     index: 0,
     key: 'stack-2',
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [{ key: 'foo-3', name: 'foo' }],
@@ -760,7 +755,6 @@ test("prevents removing a child screen with 'beforeRemove' event", () => {
   expect(onStateChange).toHaveBeenCalledWith({
     index: 1,
     key: 'stack-2',
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [
@@ -777,7 +771,6 @@ test("prevents removing a child screen with 'beforeRemove' event", () => {
   expect(onStateChange).toHaveBeenCalledWith({
     index: 2,
     key: 'stack-2',
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [
@@ -789,7 +782,6 @@ test("prevents removing a child screen with 'beforeRemove' event", () => {
         state: {
           index: 0,
           key: 'stack-8',
-          preloadedRoutes: [],
           retainedRouteKeys: [],
           routeNames: ['qux', 'lex'],
           routes: [{ key: 'qux-9', name: 'qux' }],
@@ -810,7 +802,6 @@ test("prevents removing a child screen with 'beforeRemove' event", () => {
   expect(ref.current?.getRootState()).toEqual({
     index: 2,
     key: 'stack-2',
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [
@@ -822,7 +813,6 @@ test("prevents removing a child screen with 'beforeRemove' event", () => {
         state: {
           index: 0,
           key: 'stack-8',
-          preloadedRoutes: [],
           retainedRouteKeys: [],
           routeNames: ['qux', 'lex'],
           routes: [{ key: 'qux-9', name: 'qux' }],
@@ -843,7 +833,6 @@ test("prevents removing a child screen with 'beforeRemove' event", () => {
   expect(onStateChange).toHaveBeenCalledWith({
     index: 0,
     key: 'stack-2',
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [{ key: 'foo-3', name: 'foo' }],
@@ -861,7 +850,6 @@ test("prevents removing a child screen with 'beforeRemove' event", () => {
   expect(onStateChange).toHaveBeenCalledWith({
     index: 0,
     key: 'stack-2',
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [{ key: 'foo-3', name: 'foo' }],
@@ -943,7 +931,6 @@ test("prevents removing a grand child screen with 'beforeRemove' event", () => {
   expect(onStateChange).toHaveBeenCalledWith({
     index: 1,
     key: 'stack-2',
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [
@@ -960,7 +947,6 @@ test("prevents removing a grand child screen with 'beforeRemove' event", () => {
   expect(onStateChange).toHaveBeenCalledWith({
     index: 2,
     key: 'stack-2',
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [
@@ -972,7 +958,6 @@ test("prevents removing a grand child screen with 'beforeRemove' event", () => {
         state: {
           index: 0,
           key: 'stack-8',
-          preloadedRoutes: [],
           retainedRouteKeys: [],
           routeNames: ['qux'],
           routes: [
@@ -982,7 +967,6 @@ test("prevents removing a grand child screen with 'beforeRemove' event", () => {
               state: {
                 index: 0,
                 key: 'stack-12',
-                preloadedRoutes: [],
                 retainedRouteKeys: [],
                 routeNames: ['lex'],
                 routes: [{ key: 'lex-13', name: 'lex' }],
@@ -1008,7 +992,6 @@ test("prevents removing a grand child screen with 'beforeRemove' event", () => {
   expect(ref.current?.getRootState()).toEqual({
     index: 2,
     key: 'stack-2',
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [
@@ -1020,7 +1003,6 @@ test("prevents removing a grand child screen with 'beforeRemove' event", () => {
         state: {
           index: 0,
           key: 'stack-8',
-          preloadedRoutes: [],
           retainedRouteKeys: [],
           routeNames: ['qux'],
           routes: [
@@ -1030,7 +1012,6 @@ test("prevents removing a grand child screen with 'beforeRemove' event", () => {
               state: {
                 index: 0,
                 key: 'stack-12',
-                preloadedRoutes: [],
                 retainedRouteKeys: [],
                 routeNames: ['lex'],
                 routes: [{ key: 'lex-13', name: 'lex' }],
@@ -1056,7 +1037,6 @@ test("prevents removing a grand child screen with 'beforeRemove' event", () => {
   expect(onStateChange).toHaveBeenCalledWith({
     index: 0,
     key: 'stack-2',
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [{ key: 'foo-3', name: 'foo' }],
@@ -1074,7 +1054,6 @@ test("prevents removing a grand child screen with 'beforeRemove' event", () => {
   expect(onStateChange).toHaveBeenCalledWith({
     index: 0,
     key: 'stack-2',
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [{ key: 'foo-3', name: 'foo' }],
@@ -1166,7 +1145,6 @@ test("prevents removing by multiple screens with 'beforeRemove' event", () => {
   const preventedState = {
     index: 3,
     key: 'stack-2',
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz', 'bax'],
     routes: [
@@ -1179,7 +1157,6 @@ test("prevents removing by multiple screens with 'beforeRemove' event", () => {
         state: {
           index: 0,
           key: 'stack-9',
-          preloadedRoutes: [],
           retainedRouteKeys: [],
           routeNames: ['qux'],
           routes: [
@@ -1189,7 +1166,6 @@ test("prevents removing by multiple screens with 'beforeRemove' event", () => {
               state: {
                 index: 0,
                 key: 'stack-13',
-                preloadedRoutes: [],
                 retainedRouteKeys: [],
                 routeNames: ['lex'],
                 routes: [{ key: 'lex-14', name: 'lex' }],
@@ -1243,7 +1219,6 @@ test("prevents removing by multiple screens with 'beforeRemove' event", () => {
   expect(onStateChange).toHaveBeenCalledWith({
     index: 0,
     key: 'stack-2',
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz', 'bax'],
     routes: [{ key: 'foo-3', name: 'foo' }],
@@ -1320,7 +1295,6 @@ test("prevents removing a child screen with 'beforeRemove' event with 'resetRoot
   expect(onStateChange).toHaveBeenCalledWith({
     index: 1,
     key: 'stack-2',
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [
@@ -1331,7 +1305,6 @@ test("prevents removing a child screen with 'beforeRemove' event with 'resetRoot
         state: {
           index: 0,
           key: 'stack-7',
-          preloadedRoutes: [],
           retainedRouteKeys: [],
           routeNames: ['qux', 'lex'],
           routes: [{ key: 'qux-8', name: 'qux' }],
@@ -1350,7 +1323,6 @@ test("prevents removing a child screen with 'beforeRemove' event with 'resetRoot
       key: 'stack-2',
       routeNames: ['foo', 'bar', 'baz'],
       routes: [{ key: 'foo-3', name: 'foo' }],
-      preloadedRoutes: [],
       retainedRouteKeys: [],
       stale: false,
       type: 'stack',
@@ -1365,7 +1337,6 @@ test("prevents removing a child screen with 'beforeRemove' event with 'resetRoot
   expect(ref.current?.getRootState()).toEqual({
     index: 1,
     key: 'stack-2',
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [
@@ -1376,7 +1347,6 @@ test("prevents removing a child screen with 'beforeRemove' event with 'resetRoot
         state: {
           index: 0,
           key: 'stack-7',
-          preloadedRoutes: [],
           retainedRouteKeys: [],
           routeNames: ['qux', 'lex'],
           routes: [{ key: 'qux-8', name: 'qux' }],
@@ -1397,7 +1367,6 @@ test("prevents removing a child screen with 'beforeRemove' event with 'resetRoot
       key: 'stack-2',
       routeNames: ['foo', 'bar', 'baz'],
       routes: [{ key: 'foo-3', name: 'foo' }],
-      preloadedRoutes: [],
       retainedRouteKeys: [],
       stale: false,
       type: 'stack',
@@ -1412,7 +1381,6 @@ test("prevents removing a child screen with 'beforeRemove' event with 'resetRoot
     key: 'stack-2',
     routeNames: ['foo', 'bar', 'baz'],
     routes: [{ key: 'foo-3', name: 'foo' }],
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     stale: false,
     type: 'stack',

--- a/packages/core/src/__tests__/usePreventRemove.test.tsx
+++ b/packages/core/src/__tests__/usePreventRemove.test.tsx
@@ -76,7 +76,6 @@ test("prevents removing a screen with 'usePreventRemove' hook", () => {
   expect(onStateChange).toHaveBeenCalledWith({
     index: 1,
     key: 'stack-2',
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [
@@ -93,7 +92,6 @@ test("prevents removing a screen with 'usePreventRemove' hook", () => {
   expect(onStateChange).toHaveBeenCalledWith({
     index: 2,
     key: 'stack-2',
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [
@@ -113,7 +111,6 @@ test("prevents removing a screen with 'usePreventRemove' hook", () => {
   expect(ref.current?.getRootState()).toEqual({
     index: 2,
     key: 'stack-2',
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [
@@ -134,7 +131,6 @@ test("prevents removing a screen with 'usePreventRemove' hook", () => {
   expect(onStateChange).toHaveBeenCalledWith({
     index: 0,
     key: 'stack-2',
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [{ key: 'foo-3', name: 'foo' }],
@@ -196,7 +192,6 @@ test("prevents removing a screen when 'usePreventRemove' hook is called multiple
   expect(onStateChange).toHaveBeenCalledWith({
     index: 1,
     key: 'stack-2',
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [
@@ -213,7 +208,6 @@ test("prevents removing a screen when 'usePreventRemove' hook is called multiple
   expect(onStateChange).toHaveBeenCalledWith({
     index: 2,
     key: 'stack-2',
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [
@@ -233,7 +227,6 @@ test("prevents removing a screen when 'usePreventRemove' hook is called multiple
   expect(ref.current?.getRootState()).toEqual({
     index: 2,
     key: 'stack-2',
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [
@@ -254,13 +247,65 @@ test("prevents removing a screen when 'usePreventRemove' hook is called multiple
   expect(onStateChange).toHaveBeenCalledWith({
     index: 0,
     key: 'stack-2',
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [{ key: 'foo-3', name: 'foo' }],
     stale: false,
     type: 'stack',
   });
+});
+
+test("doesn't prevent retaining a screen in inactive routes", () => {
+  const TestNavigator = (props: any) => {
+    const { state, descriptors, NavigationContent } = useNavigationBuilder(
+      StackRouter,
+      props
+    );
+
+    return (
+      <NavigationContent>
+        {state.routes.map((route) => descriptors[route.key].render())}
+      </NavigationContent>
+    );
+  };
+
+  const onPreventRemove = jest.fn();
+
+  const TestScreen = () => {
+    usePreventRemove(true, onPreventRemove);
+
+    return null;
+  };
+
+  const ref = createNavigationContainerRef<ParamListBase>();
+
+  render(
+    <BaseNavigationContainer ref={ref}>
+      <TestNavigator>
+        <Screen name="foo">{() => null}</Screen>
+        <Screen name="bar" component={TestScreen} />
+        <Screen name="baz">{() => null}</Screen>
+      </TestNavigator>
+    </BaseNavigationContainer>
+  );
+
+  act(() => ref.current?.navigate('bar'));
+  act(() => ref.current?.dispatch(StackActions.retain(true)));
+  act(() => ref.current?.navigate('baz'));
+  act(() => ref.current?.dispatch(StackActions.popTo('foo')));
+
+  expect(onPreventRemove).not.toHaveBeenCalled();
+
+  expect(ref.current?.getRootState()).toEqual(
+    expect.objectContaining({
+      index: 0,
+      routes: [
+        { key: 'foo-3', name: 'foo' },
+        { key: 'bar-5', name: 'bar' },
+      ],
+      retainedRouteKeys: ['bar-5'],
+    })
+  );
 });
 
 test("should have no effect when 'usePreventRemove' hook is set to false", () => {
@@ -309,7 +354,6 @@ test("should have no effect when 'usePreventRemove' hook is set to false", () =>
   expect(onStateChange).toHaveBeenCalledWith({
     index: 1,
     key: 'stack-2',
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [
@@ -326,7 +370,6 @@ test("should have no effect when 'usePreventRemove' hook is set to false", () =>
   expect(onStateChange).toHaveBeenCalledWith({
     index: 2,
     key: 'stack-2',
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [
@@ -345,7 +388,6 @@ test("should have no effect when 'usePreventRemove' hook is set to false", () =>
   expect(ref.current?.getRootState()).toEqual({
     index: 0,
     key: 'stack-2',
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [{ key: 'foo-3', name: 'foo' }],
@@ -360,7 +402,6 @@ test("should have no effect when 'usePreventRemove' hook is set to false", () =>
   expect(onStateChange).toHaveBeenCalledWith({
     index: 0,
     key: 'stack-2',
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [{ key: 'foo-3', name: 'foo' }],
@@ -428,7 +469,6 @@ test("prevents removing a child screen with 'usePreventRemove' hook", () => {
   expect(onStateChange).toHaveBeenCalledWith({
     index: 1,
     key: 'stack-2',
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [
@@ -445,7 +485,6 @@ test("prevents removing a child screen with 'usePreventRemove' hook", () => {
   expect(onStateChange).toHaveBeenCalledWith({
     index: 2,
     key: 'stack-2',
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [
@@ -457,7 +496,6 @@ test("prevents removing a child screen with 'usePreventRemove' hook", () => {
         state: {
           index: 0,
           key: 'stack-8',
-          preloadedRoutes: [],
           retainedRouteKeys: [],
           routeNames: ['qux', 'lex'],
           routes: [{ key: 'qux-9', name: 'qux' }],
@@ -478,7 +516,6 @@ test("prevents removing a child screen with 'usePreventRemove' hook", () => {
   expect(ref.current?.getRootState()).toEqual({
     index: 2,
     key: 'stack-2',
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [
@@ -490,7 +527,6 @@ test("prevents removing a child screen with 'usePreventRemove' hook", () => {
         state: {
           index: 0,
           key: 'stack-8',
-          preloadedRoutes: [],
           retainedRouteKeys: [],
           routeNames: ['qux', 'lex'],
           routes: [{ key: 'qux-9', name: 'qux' }],
@@ -509,7 +545,6 @@ test("prevents removing a child screen with 'usePreventRemove' hook", () => {
   expect(ref.current?.getRootState()).toEqual({
     index: 2,
     key: 'stack-2',
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [
@@ -521,7 +556,6 @@ test("prevents removing a child screen with 'usePreventRemove' hook", () => {
         state: {
           index: 0,
           key: 'stack-8',
-          preloadedRoutes: [],
           retainedRouteKeys: [],
           routeNames: ['qux', 'lex'],
           routes: [{ key: 'qux-9', name: 'qux' }],
@@ -543,7 +577,6 @@ test("prevents removing a child screen with 'usePreventRemove' hook", () => {
   expect(onStateChange).toHaveBeenCalledWith({
     index: 0,
     key: 'stack-2',
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [{ key: 'foo-3', name: 'foo' }],
@@ -615,7 +648,6 @@ test("prevents removing a grand child screen with 'usePreventRemove' hook", () =
   expect(onStateChange).toHaveBeenCalledWith({
     index: 1,
     key: 'stack-2',
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [
@@ -632,7 +664,6 @@ test("prevents removing a grand child screen with 'usePreventRemove' hook", () =
   expect(onStateChange).toHaveBeenCalledWith({
     index: 2,
     key: 'stack-2',
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [
@@ -644,7 +675,6 @@ test("prevents removing a grand child screen with 'usePreventRemove' hook", () =
         state: {
           index: 0,
           key: 'stack-8',
-          preloadedRoutes: [],
           retainedRouteKeys: [],
           routeNames: ['qux'],
           routes: [
@@ -654,7 +684,6 @@ test("prevents removing a grand child screen with 'usePreventRemove' hook", () =
               state: {
                 index: 0,
                 key: 'stack-12',
-                preloadedRoutes: [],
                 retainedRouteKeys: [],
                 routeNames: ['lex'],
                 routes: [{ key: 'lex-13', name: 'lex' }],
@@ -680,7 +709,6 @@ test("prevents removing a grand child screen with 'usePreventRemove' hook", () =
   expect(ref.current?.getRootState()).toEqual({
     index: 2,
     key: 'stack-2',
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [
@@ -692,7 +720,6 @@ test("prevents removing a grand child screen with 'usePreventRemove' hook", () =
         state: {
           index: 0,
           key: 'stack-8',
-          preloadedRoutes: [],
           retainedRouteKeys: [],
           routeNames: ['qux'],
           routes: [
@@ -702,7 +729,6 @@ test("prevents removing a grand child screen with 'usePreventRemove' hook", () =
               state: {
                 index: 0,
                 key: 'stack-12',
-                preloadedRoutes: [],
                 retainedRouteKeys: [],
                 routeNames: ['lex'],
                 routes: [{ key: 'lex-13', name: 'lex' }],
@@ -729,7 +755,6 @@ test("prevents removing a grand child screen with 'usePreventRemove' hook", () =
   expect(onStateChange).toHaveBeenCalledWith({
     index: 0,
     key: 'stack-2',
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [{ key: 'foo-3', name: 'foo' }],
@@ -816,7 +841,6 @@ test("prevents removing by multiple screens with 'usePreventRemove' hook", () =>
   const preventedState = {
     index: 3,
     key: 'stack-2',
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz', 'bax'],
     routes: [
@@ -829,7 +853,6 @@ test("prevents removing by multiple screens with 'usePreventRemove' hook", () =>
         state: {
           index: 0,
           key: 'stack-11',
-          preloadedRoutes: [],
           retainedRouteKeys: [],
           routeNames: ['qux'],
           routes: [
@@ -839,7 +862,6 @@ test("prevents removing by multiple screens with 'usePreventRemove' hook", () =>
               state: {
                 index: 0,
                 key: 'stack-15',
-                preloadedRoutes: [],
                 retainedRouteKeys: [],
                 routeNames: ['lex'],
                 routes: [{ key: 'lex-16', name: 'lex' }],
@@ -893,7 +915,6 @@ test("prevents removing by multiple screens with 'usePreventRemove' hook", () =>
   expect(onStateChange).toHaveBeenCalledWith({
     index: 0,
     key: 'stack-2',
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz', 'bax'],
     routes: [{ key: 'foo-3', name: 'foo' }],
@@ -957,7 +978,6 @@ test("prevents removing a child screen with 'usePreventRemove' hook with 'resetR
   expect(onStateChange).toHaveBeenCalledWith({
     index: 1,
     key: 'stack-2',
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [
@@ -968,7 +988,6 @@ test("prevents removing a child screen with 'usePreventRemove' hook with 'resetR
         state: {
           index: 0,
           key: 'stack-7',
-          preloadedRoutes: [],
           retainedRouteKeys: [],
           routeNames: ['qux', 'lex'],
           routes: [{ key: 'qux-8', name: 'qux' }],
@@ -987,7 +1006,6 @@ test("prevents removing a child screen with 'usePreventRemove' hook with 'resetR
       key: 'stack-2',
       routeNames: ['foo', 'bar', 'baz'],
       routes: [{ key: 'foo-3', name: 'foo' }],
-      preloadedRoutes: [],
       retainedRouteKeys: [],
       stale: false,
       type: 'stack',
@@ -1001,7 +1019,6 @@ test("prevents removing a child screen with 'usePreventRemove' hook with 'resetR
   expect(ref.current?.getRootState()).toEqual({
     index: 1,
     key: 'stack-2',
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz'],
     routes: [
@@ -1012,7 +1029,6 @@ test("prevents removing a child screen with 'usePreventRemove' hook with 'resetR
         state: {
           index: 0,
           key: 'stack-7',
-          preloadedRoutes: [],
           retainedRouteKeys: [],
           routeNames: ['qux', 'lex'],
           routes: [{ key: 'qux-8', name: 'qux' }],

--- a/packages/core/src/useNavigationBuilder.tsx
+++ b/packages/core/src/useNavigationBuilder.tsx
@@ -970,9 +970,7 @@ export function useNavigationBuilder<
     ScreenOptions,
     EventMap
   >({
-    routes: router.getRoutesFromState
-      ? router.getRoutesFromState(state)
-      : state.routes,
+    routes: state.routes,
     screens,
     navigation,
     screenOptions,

--- a/packages/native-stack/src/views/NativeStackView.native.tsx
+++ b/packages/native-stack/src/views/NativeStackView.native.tsx
@@ -55,7 +55,7 @@ type SceneViewProps = {
   nextDescriptor?: NativeStackDescriptor | undefined;
   isPresentationModal: boolean;
   isNextScreenTransparent: boolean;
-  isPreloaded: boolean;
+  isInactive: boolean;
   isBeforeLast: boolean;
   onWillDisappear: () => void;
   onWillAppear: () => void;
@@ -82,7 +82,7 @@ const SceneView = ({
   previousDescriptor,
   isPresentationModal,
   isNextScreenTransparent,
-  isPreloaded,
+  isInactive,
   isBeforeLast,
   onWillDisappear,
   onWillAppear,
@@ -294,12 +294,12 @@ const SceneView = ({
 
   const activityMode =
     // Render focused screens normally
-    // Unpause preloaded screens so updates are visible
-    // This lets effects on preloaded screens run
+    // Unpause preloaded and retained screens so updates are visible
+    // This lets effects on those screens run
     // We don't need to handle inert as it'll be handled natively
     inactiveBehavior === 'none' ||
     focused ||
-    isPreloaded ||
+    isInactive ||
     isNextScreenTransparent
       ? 'normal'
       : inactiveBehavior === 'unmount' &&
@@ -375,7 +375,7 @@ const SceneView = ({
       <ScreenStackItem
         key={route.key}
         screenId={route.key}
-        activityState={isPreloaded ? 0 : 2}
+        activityState={isInactive ? 0 : 2}
         style={StyleSheet.absoluteFill}
         aria-hidden={!focused}
         customAnimationOnSwipe={animationMatchesGesture}
@@ -468,16 +468,17 @@ export function NativeStackView({ state, navigation, descriptors }: Props) {
 
   useInvalidPreventRemoveError(descriptors);
 
-  const modalRouteKeys = getModalRouteKeys(state.routes, descriptors);
+  const activeRoutes = state.routes.slice(0, state.index + 1);
+  const modalRouteKeys = getModalRouteKeys(activeRoutes, descriptors);
 
   return (
     <SafeAreaProviderCompat>
       <ScreenStack style={styles.container}>
-        {state.routes.concat(state.preloadedRoutes).map((route, index) => {
+        {state.routes.map((route, index) => {
           const descriptor = descriptors[route.key];
           const isFocused = state.index === index;
-          const previousKey = state.routes[index - 1]?.key;
-          const nextKey = state.routes[index + 1]?.key;
+          const previousKey = activeRoutes[index - 1]?.key;
+          const nextKey = activeRoutes[index + 1]?.key;
           const previousDescriptor = previousKey
             ? descriptors[previousKey]
             : undefined;
@@ -491,10 +492,6 @@ export function NativeStackView({ state, navigation, descriptors }: Props) {
 
           const isModal = modalRouteKeys.includes(route.key);
 
-          const isPreloaded = state.preloadedRoutes.some(
-            (r) => r.key === route.key
-          );
-
           return (
             <SceneView
               key={route.key}
@@ -505,8 +502,8 @@ export function NativeStackView({ state, navigation, descriptors }: Props) {
               nextDescriptor={nextDescriptor}
               isPresentationModal={isModal}
               isNextScreenTransparent={isNextScreenTransparent}
-              isPreloaded={isPreloaded}
-              isBeforeLast={index === state.routes.length - 2}
+              isInactive={index > state.index}
+              isBeforeLast={index === activeRoutes.length - 2}
               onWillDisappear={() => {
                 navigation.emit({
                   type: 'transitionStart',

--- a/packages/native-stack/src/views/NativeStackView.tsx
+++ b/packages/native-stack/src/views/NativeStackView.tsx
@@ -39,12 +39,14 @@ export function NativeStackView({ state, descriptors }: Props) {
   const parentHeaderBack = React.use(HeaderBackContext);
   const { buildHref } = useLinkBuilder();
 
+  const activeRoutes = state.routes.slice(0, state.index + 1);
+
   return (
     <SafeAreaProviderCompat>
-      {state.routes.concat(state.preloadedRoutes).map((route, i) => {
+      {state.routes.map((route, i) => {
         const isFocused = state.index === i;
-        const previousKey = state.routes[i - 1]?.key;
-        const nextKey = state.routes[i + 1]?.key;
+        const previousKey = activeRoutes[i - 1]?.key;
+        const nextKey = activeRoutes[i + 1]?.key;
         const previousDescriptor = previousKey
           ? descriptors[previousKey]
           : undefined;
@@ -85,20 +87,18 @@ export function NativeStackView({ state, descriptors }: Props) {
           nextPresentation != null &&
           TRANSPARENT_PRESENTATIONS.includes(nextPresentation);
 
-        const isPreloaded = state.preloadedRoutes.some(
-          (r) => r.key === route.key
-        );
+        const isInactive = i > state.index;
 
-        const isBeforeLast = i === state.routes.length - 2;
+        const isBeforeLast = i === activeRoutes.length - 2;
 
         const activityMode =
           // Render focused screens normally
           isFocused
             ? 'normal'
-            : // Unpause preloaded screens so updates are visible
-              // This lets effects on preloaded screens run
+            : // Unpause preloaded and retained screens so updates are visible
+              // This lets effects on those screens run
               inactiveBehavior === 'none' ||
-                isPreloaded ||
+                isInactive ||
                 isNextScreenTransparent
               ? 'inert'
               : inactiveBehavior === 'unmount' && !isBeforeLast && !route.state

--- a/packages/routers/src/StackRouter.tsx
+++ b/packages/routers/src/StackRouter.tsx
@@ -6,7 +6,6 @@ import { createRouteFromAction } from './createRouteFromAction';
 import type {
   CommonNavigationAction,
   DefaultRouterOptions,
-  NavigationRoute,
   NavigationState,
   ParamListBase,
   Route,
@@ -63,14 +62,9 @@ export type StackNavigationState<ParamList extends ParamListBase> =
      */
     type: 'stack';
     /**
-     * List of routes, which are supposed to be preloaded before navigating to.
-     */
-    preloadedRoutes: NavigationRoute<ParamList, keyof ParamList>[];
-    /**
      * List of route keys to retain in the stack.
      * When a retained route gets removed from the stack,
-     * it'll be treated as preloaded route and not completely removed
-     * So it preserves the route and can be navigated to again.
+     * it'll be kept in routes and can be navigated to again.
      */
     retainedRouteKeys: string[];
   };
@@ -141,8 +135,7 @@ export type StackActionHelpers<ParamList extends ParamListBase> = {
   /**
    * Enable or disable retaining the current route in the stack.
    * When a retained route gets removed from the stack,
-   * it'll be treated as preloaded route and not completely removed
-   * So it preserves the route and can be navigated to again.
+   * it'll be kept in routes and can be navigated to again.
    *
    * @param enable Whether to retain the current route in the stack or not.
    */
@@ -199,7 +192,7 @@ function retainRoutes<ParamList extends ParamListBase>(
 
   const retainedRouteKeySet = new Set(nextState.retainedRouteKeys);
   const nextRouteKeySet = new Set(nextState.routes.map((route) => route.key));
-  const retainedRoutes = previousState.routes.filter(
+  const retainedRoutes = getActiveRoutes(previousState).filter(
     (route) =>
       retainedRouteKeySet.has(route.key) && !nextRouteKeySet.has(route.key)
   );
@@ -212,15 +205,73 @@ function retainRoutes<ParamList extends ParamListBase>(
     retainedRoutes.map((route) => route.key)
   );
 
-  return {
-    ...nextState,
-    preloadedRoutes: retainedRoutes.concat(
-      nextState.preloadedRoutes.filter(
+  return getStateWithRoutes(
+    nextState,
+    getActiveRoutes(nextState),
+    getPreloadedRoutes(nextState),
+    retainedRoutes.concat(
+      getRetainedRoutes(nextState).filter(
         (route) => !removedRetainedRouteKeys.has(route.key)
       )
+    )
+  );
+}
+
+const getActiveRoutes = <ParamList extends ParamListBase>(
+  state: StackNavigationState<ParamList>
+) => state.routes.slice(0, state.index + 1);
+
+const getInactiveRoutes = <ParamList extends ParamListBase>(
+  state: StackNavigationState<ParamList>
+) => state.routes.slice(state.index + 1);
+
+const getPreloadedRoutes = <ParamList extends ParamListBase>(
+  state: StackNavigationState<ParamList>
+) => {
+  const retainedRouteKeySet = new Set(state.retainedRouteKeys);
+
+  return getInactiveRoutes(state).filter(
+    (route) => !retainedRouteKeySet.has(route.key)
+  );
+};
+
+const getRetainedRoutes = <ParamList extends ParamListBase>(
+  state: StackNavigationState<ParamList>
+) => {
+  const retainedRouteKeySet = new Set(state.retainedRouteKeys);
+
+  return getInactiveRoutes(state).filter((route) =>
+    retainedRouteKeySet.has(route.key)
+  );
+};
+
+const getStateWithRoutes = <ParamList extends ParamListBase>(
+  state: StackNavigationState<ParamList>,
+  activeRoutes: Route<string>[],
+  preloadedRoutes = getPreloadedRoutes(state),
+  retainedRoutes = getRetainedRoutes(state)
+) => {
+  const routeKeySet = new Set(activeRoutes.map((route) => route.key));
+  const retainedRouteKeySet = new Set(state.retainedRouteKeys);
+
+  const filteredRetainedRoutes = retainedRoutes.filter(
+    (route) => !routeKeySet.has(route.key)
+  );
+
+  const filteredPreloadedRoutes = preloadedRoutes.filter(
+    (route) =>
+      !retainedRouteKeySet.has(route.key) && !routeKeySet.has(route.key)
+  );
+
+  return {
+    ...state,
+    index: activeRoutes.length - 1,
+    routes: activeRoutes.concat(
+      filteredRetainedRoutes,
+      filteredPreloadedRoutes
     ),
   };
-}
+};
 
 export function StackRouter(options: StackRouterOptions) {
   const router: Router<
@@ -244,7 +295,6 @@ export function StackRouter(options: StackRouterOptions) {
         key: `stack-${nanoid()}`,
         index: 0,
         routeNames,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routes: [
           {
@@ -277,29 +327,6 @@ export function StackRouter(options: StackRouterOptions) {
               : route.params,
         }));
 
-      const preloadedRoutes =
-        state.preloadedRoutes
-          ?.filter((route) => routeNames.includes(route.name))
-          .map(
-            (route) =>
-              ({
-                ...route,
-                key: route.key || `${route.name}-${nanoid()}`,
-                params:
-                  routeParamList[route.name] !== undefined
-                    ? {
-                        ...routeParamList[route.name],
-                        ...route.params,
-                      }
-                    : route.params,
-              }) as Route<string>
-          ) ?? [];
-
-      const retainedRouteKeys =
-        state.retainedRouteKeys?.filter((key) =>
-          [...routes, ...preloadedRoutes].some((route) => route.key === key)
-        ) ?? [];
-
       if (routes.length === 0) {
         const initialRouteName =
           options.initialRouteName !== undefined
@@ -313,14 +340,22 @@ export function StackRouter(options: StackRouterOptions) {
         });
       }
 
+      const index = Math.min(
+        Math.max(state.index ?? routes.length - 1, 0),
+        routes.length - 1
+      );
+
+      const routeKeys = new Set(routes.map((route) => route.key));
+      const retainedRouteKeys =
+        state.retainedRouteKeys?.filter((key) => routeKeys.has(key)) ?? [];
+
       return {
         stale: false,
         type: 'stack',
         key: `stack-${nanoid()}`,
-        index: routes.length - 1,
+        index,
         routeNames,
         routes,
-        preloadedRoutes,
         retainedRouteKeys,
       };
     },
@@ -329,13 +364,19 @@ export function StackRouter(options: StackRouterOptions) {
       state,
       { routeNames, routeParamList, routeKeyChanges }
     ) {
-      const routes = state.routes.filter(
+      const routes = getActiveRoutes(state).filter(
         (route) =>
           routeNames.includes(route.name) &&
           !routeKeyChanges.includes(route.name)
       );
 
-      const preloadedRoutes = state.preloadedRoutes.filter(
+      const preloadedRoutes = getPreloadedRoutes(state).filter(
+        (route) =>
+          routeNames.includes(route.name) &&
+          !routeKeyChanges.includes(route.name)
+      );
+
+      const retainedRoutes = getRetainedRoutes(state).filter(
         (route) =>
           routeNames.includes(route.name) &&
           !routeKeyChanges.includes(route.name)
@@ -356,45 +397,53 @@ export function StackRouter(options: StackRouterOptions) {
       }
 
       const routeKeys = new Set(
-        [...routes, ...preloadedRoutes].map((route) => route.key)
+        [...routes, ...preloadedRoutes, ...retainedRoutes].map(
+          (route) => route.key
+        )
       );
 
       const retainedRouteKeys = state.retainedRouteKeys.filter((key) =>
         routeKeys.has(key)
       );
 
-      return {
-        ...state,
-        routeNames,
+      return getStateWithRoutes(
+        {
+          ...state,
+          routeNames,
+          retainedRouteKeys,
+        },
         routes,
         preloadedRoutes,
-        retainedRouteKeys,
-        index: Math.min(state.index, routes.length - 1),
-      };
+        retainedRoutes
+      );
     },
 
     getStateForRouteFocus(state, key) {
-      const index = state.routes.findIndex((r) => r.key === key);
+      const routes = getActiveRoutes(state);
+      const index = routes.findIndex((r) => r.key === key);
 
       if (index === -1 || index === state.index) {
         return state;
       }
 
-      return retainRoutes(state, {
-        ...state,
-        index,
-        routes: state.routes.slice(0, index + 1),
-      });
+      return retainRoutes(
+        state,
+        getStateWithRoutes(state, routes.slice(0, index + 1))
+      );
     },
 
     getStateForAction(state, action, options) {
       const { routeParamList } = options;
 
+      const routes = getActiveRoutes(state);
+      const preloadedRoutes = getPreloadedRoutes(state);
+      const inactiveRoutes = getInactiveRoutes(state);
+
       switch (action.type) {
         case 'REPLACE': {
           const currentIndex =
             action.target === state.key && action.source
-              ? state.routes.findIndex((r) => r.key === action.source)
+              ? routes.findIndex((r) => r.key === action.source)
               : state.index;
 
           if (currentIndex === -1) {
@@ -408,8 +457,8 @@ export function StackRouter(options: StackRouterOptions) {
           const getId = options.routeGetIdList[action.payload.name];
           const id = getId?.({ params: action.payload.params });
 
-          // Re-use preloaded route if available
-          let route = state.preloadedRoutes.find(
+          // Re-use inactive route if available
+          let route = inactiveRoutes.find(
             (route) =>
               route.name === action.payload.name &&
               id === getId?.({ params: route.params })
@@ -419,15 +468,14 @@ export function StackRouter(options: StackRouterOptions) {
             route = createRouteFromAction({ action, routeParamList });
           }
 
-          return retainRoutes(state, {
-            ...state,
-            routes: state.routes.map((r, i) =>
-              i === currentIndex ? route : r
-            ),
-            preloadedRoutes: state.preloadedRoutes.filter(
-              (r) => r.key !== route.key
-            ),
-          });
+          return retainRoutes(
+            state,
+            getStateWithRoutes(
+              state,
+              routes.map((r, i) => (i === currentIndex ? route : r)),
+              preloadedRoutes.filter((r) => r.key !== route.key)
+            )
+          );
         }
 
         case 'PUSH':
@@ -442,7 +490,7 @@ export function StackRouter(options: StackRouterOptions) {
           let route: Route<string> | undefined;
 
           if (action.type === 'NAVIGATE') {
-            const currentRoute = state.routes[state.index];
+            const currentRoute = routes[state.index];
 
             if (id !== undefined) {
               if (
@@ -451,8 +499,8 @@ export function StackRouter(options: StackRouterOptions) {
               ) {
                 route = currentRoute;
               } else if (action.payload.pop) {
-                for (let i = state.routes.length - 1; i >= 0; i--) {
-                  const r = state.routes[i];
+                for (let i = routes.length - 1; i >= 0; i--) {
+                  const r = routes[i];
 
                   if (r.name !== action.payload.name) {
                     continue;
@@ -489,7 +537,7 @@ export function StackRouter(options: StackRouterOptions) {
               if (action.payload.name === currentRoute.name) {
                 route = currentRoute;
               } else if (action.payload.pop) {
-                route = state.routes.findLast(
+                route = routes.findLast(
                   (route) => route.name === action.payload.name
                 );
               }
@@ -497,7 +545,7 @@ export function StackRouter(options: StackRouterOptions) {
           }
 
           if (!route) {
-            route = state.preloadedRoutes.find(
+            route = inactiveRoutes.find(
               (route) =>
                 route.name === action.payload.name &&
                 id === getId?.({ params: route.params })
@@ -520,16 +568,16 @@ export function StackRouter(options: StackRouterOptions) {
             params = createParamsFromAction({ action, routeParamList });
           }
 
-          let routes: Route<string>[];
+          let nextRoutes: Route<string>[];
 
           if (route) {
             if (action.type === 'NAVIGATE' && action.payload.pop) {
-              routes = [];
+              nextRoutes = [];
 
               // Get all routes until the matching one
-              for (const r of state.routes) {
+              for (const r of routes) {
                 if (r.key === route.key) {
-                  routes.push({
+                  nextRoutes.push({
                     ...route,
                     path:
                       action.payload.path !== undefined
@@ -540,11 +588,22 @@ export function StackRouter(options: StackRouterOptions) {
                   break;
                 }
 
-                routes.push(r);
+                nextRoutes.push(r);
+              }
+
+              if (!nextRoutes.some((r) => r.key === route.key)) {
+                nextRoutes.push({
+                  ...route,
+                  path:
+                    action.payload.path !== undefined
+                      ? action.payload.path
+                      : route.path,
+                  params,
+                });
               }
             } else {
-              routes = state.routes.filter((r) => r.key !== route.key);
-              routes.push({
+              nextRoutes = routes.filter((r) => r.key !== route.key);
+              nextRoutes.push({
                 ...route,
                 path:
                   action.type === 'NAVIGATE' &&
@@ -555,8 +614,8 @@ export function StackRouter(options: StackRouterOptions) {
               });
             }
           } else {
-            routes = [
-              ...state.routes,
+            nextRoutes = [
+              ...routes,
               {
                 key: `${action.payload.name}-${nanoid()}`,
                 name: action.payload.name,
@@ -567,23 +626,25 @@ export function StackRouter(options: StackRouterOptions) {
             ];
           }
 
-          return retainRoutes(state, {
-            ...state,
-            index: routes.length - 1,
-            preloadedRoutes: state.preloadedRoutes.filter(
-              (route) => routes[routes.length - 1].key !== route.key
-            ),
-            routes,
-          });
+          return retainRoutes(
+            state,
+            getStateWithRoutes(
+              state,
+              nextRoutes,
+              preloadedRoutes.filter(
+                (route) => nextRoutes[nextRoutes.length - 1].key !== route.key
+              )
+            )
+          );
         }
 
         case 'POP': {
           let currentIndex =
             action.target === state.key && action.source
-              ? state.routes.findIndex((r) => r.key === action.source)
+              ? routes.findIndex((r) => r.key === action.source)
               : state.index;
 
-          let route = state.routes[currentIndex];
+          let route = routes[currentIndex];
 
           /**
            * When popping entries,
@@ -596,11 +657,11 @@ export function StackRouter(options: StackRouterOptions) {
            */
           if (route.history?.length || currentIndex > 0) {
             let count = action.payload.count;
-            let routes = state.routes;
+            let nextRoutes = routes;
 
             while (count > 0 && (route.history?.length || currentIndex > 0)) {
               if (route.history?.length) {
-                routes = [...routes];
+                nextRoutes = [...nextRoutes];
 
                 const end = Math.min(count, route.history.length);
                 const last = route.history.at(-end);
@@ -609,7 +670,7 @@ export function StackRouter(options: StackRouterOptions) {
 
                 count = count - removed;
 
-                routes[currentIndex] = {
+                nextRoutes[currentIndex] = {
                   ...route,
                   params: last?.type === 'params' ? last.params : route.params,
                   history,
@@ -617,33 +678,29 @@ export function StackRouter(options: StackRouterOptions) {
               }
 
               if (currentIndex > 0 && count > 0) {
-                const length = routes.length;
+                const length = nextRoutes.length;
                 const end = Math.max(currentIndex - count + 1, 1);
 
-                routes = routes
+                nextRoutes = nextRoutes
                   .slice(0, end)
-                  .concat(routes.slice(currentIndex + 1));
+                  .concat(nextRoutes.slice(currentIndex + 1));
 
-                const removed = length - routes.length;
+                const removed = length - nextRoutes.length;
 
                 count = count - removed;
-                currentIndex = routes.length - 1;
-                route = routes[currentIndex];
+                currentIndex = nextRoutes.length - 1;
+                route = nextRoutes[currentIndex];
               }
             }
 
-            return retainRoutes(state, {
-              ...state,
-              index: routes.length - 1,
-              routes,
-            });
+            return retainRoutes(state, getStateWithRoutes(state, nextRoutes));
           }
 
           return null;
         }
 
         case 'POP_TO_TOP': {
-          let route = state.routes[0];
+          let route = routes[0];
 
           if (state.index > 0 || route.history?.length) {
             if (route.history?.length) {
@@ -653,11 +710,7 @@ export function StackRouter(options: StackRouterOptions) {
               };
             }
 
-            return retainRoutes(state, {
-              ...state,
-              index: 0,
-              routes: [route],
-            });
+            return retainRoutes(state, getStateWithRoutes(state, [route]));
           }
 
           return null;
@@ -666,7 +719,7 @@ export function StackRouter(options: StackRouterOptions) {
         case 'POP_TO': {
           const currentIndex =
             action.target === state.key && action.source
-              ? state.routes.findLastIndex((r) => r.key === action.source)
+              ? routes.findLastIndex((r) => r.key === action.source)
               : state.index;
 
           if (currentIndex === -1) {
@@ -686,7 +739,7 @@ export function StackRouter(options: StackRouterOptions) {
 
           if (id !== undefined) {
             for (let i = currentIndex; i >= 0; i--) {
-              const r = state.routes[i];
+              const r = routes[i];
 
               if (r.name !== action.payload.name) {
                 continue;
@@ -714,11 +767,11 @@ export function StackRouter(options: StackRouterOptions) {
                 }
               }
             }
-          } else if (state.routes[currentIndex].name === action.payload.name) {
+          } else if (routes[currentIndex].name === action.payload.name) {
             index = currentIndex;
           } else {
             for (let i = currentIndex; i >= 0; i--) {
-              if (state.routes[i].name === action.payload.name) {
+              if (routes[i].name === action.payload.name) {
                 index = i;
                 break;
               }
@@ -727,8 +780,8 @@ export function StackRouter(options: StackRouterOptions) {
 
           // If the route doesn't exist, remove the current route and add the new one
           if (index === -1) {
-            // Re-use preloaded route if available
-            let route = state.preloadedRoutes.find(
+            // Re-use inactive route if available
+            let route = inactiveRoutes.find(
               (route) =>
                 route.name === action.payload.name &&
                 id === getId?.({ params: route.params })
@@ -738,19 +791,19 @@ export function StackRouter(options: StackRouterOptions) {
               route = createRouteFromAction({ action, routeParamList });
             }
 
-            const routes = state.routes.slice(0, currentIndex).concat(route);
+            const nextRoutes = routes.slice(0, currentIndex).concat(route);
 
-            return retainRoutes(state, {
-              ...state,
-              index: routes.length - 1,
-              routes,
-              preloadedRoutes: state.preloadedRoutes.filter(
-                (r) => r.key !== route.key
-              ),
-            });
+            return retainRoutes(
+              state,
+              getStateWithRoutes(
+                state,
+                nextRoutes,
+                preloadedRoutes.filter((r) => r.key !== route.key)
+              )
+            );
           }
 
-          const route = state.routes[index];
+          const route = routes[index];
 
           let baseParams = route.params;
           let history = route.history;
@@ -776,20 +829,19 @@ export function StackRouter(options: StackRouterOptions) {
             params = createParamsFromAction({ action, routeParamList });
           }
 
-          return retainRoutes(state, {
-            ...state,
-            index,
-            routes: [
-              ...state.routes.slice(0, index),
+          return retainRoutes(
+            state,
+            getStateWithRoutes(state, [
+              ...routes.slice(0, index),
               params !== baseParams || historyIndex !== undefined
                 ? { ...route, params, history }
-                : state.routes[index],
-            ],
-          });
+                : routes[index],
+            ])
+          );
         }
 
         case 'GO_BACK':
-          if (state.index > 0 || state.routes[state.index].history?.length) {
+          if (state.index > 0 || routes[state.index].history?.length) {
             return router.getStateForAction(
               state,
               {
@@ -805,12 +857,9 @@ export function StackRouter(options: StackRouterOptions) {
           return null;
 
         case 'RETAIN': {
-          const routeKey = action.source ?? state.routes[state.index].key;
+          const routeKey = action.source ?? routes[state.index].key;
 
-          if (
-            !state.routes.some((route) => route.key === routeKey) &&
-            !state.preloadedRoutes.some((route) => route.key === routeKey)
-          ) {
+          if (!state.routes.some((route) => route.key === routeKey)) {
             return null;
           }
 
@@ -829,15 +878,16 @@ export function StackRouter(options: StackRouterOptions) {
             return state;
           }
 
-          return {
-            ...state,
-            preloadedRoutes: state.preloadedRoutes.filter(
-              (route) => route.key !== routeKey
-            ),
-            retainedRouteKeys: state.retainedRouteKeys.filter(
-              (key) => key !== routeKey
-            ),
-          };
+          return getStateWithRoutes(
+            {
+              ...state,
+              retainedRouteKeys: state.retainedRouteKeys.filter(
+                (key) => key !== routeKey
+              ),
+            },
+            routes,
+            preloadedRoutes.filter((route) => route.key !== routeKey)
+          );
         }
 
         case 'PRELOAD': {
@@ -848,66 +898,65 @@ export function StackRouter(options: StackRouterOptions) {
           let route: Route<string> | undefined;
 
           if (action.payload.reuse) {
-            route = state.preloadedRoutes.findLast(
+            route = preloadedRoutes.findLast(
               (route) =>
                 route.name === action.payload.name &&
                 (id === undefined || id === getId?.({ params: route.params }))
             );
 
             if (route) {
-              return {
-                ...state,
-                preloadedRoutes: state.preloadedRoutes.map((r) =>
+              return getStateWithRoutes(
+                state,
+                routes,
+                preloadedRoutes.map((r) =>
                   r.key === route?.key && r.params !== params
                     ? { ...r, params }
                     : r
-                ),
-              };
+                )
+              );
             }
           }
 
           if (id !== undefined) {
-            route = state.routes.findLast(
+            route = routes.findLast(
               (route) =>
                 route.name === action.payload.name &&
                 id === getId?.({ params: route.params })
             );
           } else if (action.payload.reuse) {
-            route = state.routes.findLast(
+            route = routes.findLast(
               (route) => route.name === action.payload.name
             );
           }
 
           if (route) {
-            return {
-              ...state,
-              routes: state.routes.map((r) =>
+            return getStateWithRoutes(
+              state,
+              routes.map((r) =>
                 r.key === route.key && r.params !== params
                   ? { ...r, params }
                   : r
               ),
-            };
+              preloadedRoutes
+            );
           } else {
-            return {
-              ...state,
-              preloadedRoutes: state.preloadedRoutes
+            return getStateWithRoutes(
+              state,
+              routes,
+              preloadedRoutes
                 .filter(
                   (r) =>
                     r.name !== action.payload.name ||
                     id !== getId?.({ params: r.params })
                 )
-                .concat(createRouteFromAction({ action, routeParamList })),
-            };
+                .concat(createRouteFromAction({ action, routeParamList }))
+            );
           }
         }
 
         default:
           return BaseRouter.getStateForAction(state, action);
       }
-    },
-
-    getRoutesFromState(state) {
-      return [...state.routes, ...state.preloadedRoutes];
     },
 
     actionCreators: StackActions,

--- a/packages/routers/src/__tests__/StackRouter.test.tsx
+++ b/packages/routers/src/__tests__/StackRouter.test.tsx
@@ -34,7 +34,6 @@ test('gets initial state from route names and params with initialRouteName', () 
   ).toEqual({
     index: 0,
     key: 'stack-1',
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['bar', 'baz', 'qux'],
     routes: [{ key: 'baz-2', name: 'baz', params: { answer: 42 } }],
@@ -58,7 +57,6 @@ test('gets initial state from route names and params without initialRouteName', 
   ).toEqual({
     index: 0,
     key: 'stack-1',
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['bar', 'baz', 'qux'],
     routes: [{ key: 'bar-2', name: 'bar' }],
@@ -82,11 +80,12 @@ test('gets rehydrated state from partial state', () => {
   expect(
     router.getRehydratedState(
       {
+        index: 1,
         routes: [
           { key: 'bar-0', name: 'bar' },
           { key: 'qux-1', name: 'qux' },
+          { name: 'baz', key: 'baz-test' },
         ],
-        preloadedRoutes: [{ name: 'baz', key: 'baz-test' }],
         retainedRouteKeys: [],
       },
       options
@@ -94,12 +93,41 @@ test('gets rehydrated state from partial state', () => {
   ).toEqual({
     index: 1,
     key: 'stack-1',
-    preloadedRoutes: [{ name: 'baz', key: 'baz-test', params: { answer: 42 } }],
     retainedRouteKeys: [],
     routeNames: ['bar', 'baz', 'qux'],
     routes: [
       { key: 'bar-0', name: 'bar' },
       { key: 'qux-1', name: 'qux', params: { name: 'Jane' } },
+      { name: 'baz', key: 'baz-test', params: { answer: 42 } },
+    ],
+    stale: false,
+    type: 'stack',
+  });
+
+  expect(
+    router.getRehydratedState(
+      {
+        index: 1,
+        routes: [
+          { key: 'bar-0', name: 'bar' },
+          { key: 'qux-1', name: 'qux' },
+          { key: 'qux-retained', name: 'qux' },
+          { name: 'baz', key: 'baz-test' },
+        ],
+        retainedRouteKeys: ['qux-1', 'qux-retained', 'missing'],
+      },
+      options
+    )
+  ).toEqual({
+    index: 1,
+    key: 'stack-2',
+    retainedRouteKeys: ['qux-1', 'qux-retained'],
+    routeNames: ['bar', 'baz', 'qux'],
+    routes: [
+      { key: 'bar-0', name: 'bar' },
+      { key: 'qux-1', name: 'qux', params: { name: 'Jane' } },
+      { key: 'qux-retained', name: 'qux', params: { name: 'Jane' } },
+      { name: 'baz', key: 'baz-test', params: { answer: 42 } },
     ],
     stale: false,
     type: 'stack',
@@ -119,8 +147,7 @@ test('gets rehydrated state from partial state', () => {
     )
   ).toEqual({
     index: 2,
-    key: 'stack-2',
-    preloadedRoutes: [],
+    key: 'stack-3',
     retainedRouteKeys: [],
     routeNames: ['bar', 'baz', 'qux'],
     routes: [
@@ -142,11 +169,10 @@ test('gets rehydrated state from partial state', () => {
     )
   ).toEqual({
     index: 0,
-    key: 'stack-4',
-    preloadedRoutes: [],
+    key: 'stack-5',
     retainedRouteKeys: [],
     routeNames: ['bar', 'baz', 'qux'],
-    routes: [{ key: 'bar-3', name: 'bar' }],
+    routes: [{ key: 'bar-4', name: 'bar' }],
     stale: false,
     type: 'stack',
   });
@@ -158,7 +184,6 @@ test("doesn't rehydrate state if it's not stale", () => {
   const state = {
     index: 0,
     key: 'stack-test',
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['bar', 'baz', 'qux'],
     routes: [{ key: 'bar-test', name: 'bar' }],
@@ -190,7 +215,6 @@ test('adds and removes retained route keys with retain', () => {
         type: 'stack',
         key: 'root',
         index: 1,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -209,7 +233,6 @@ test('adds and removes retained route keys with retain', () => {
     type: 'stack',
     key: 'root',
     index: 1,
-    preloadedRoutes: [],
     retainedRouteKeys: ['bar'],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -225,7 +248,6 @@ test('adds and removes retained route keys with retain', () => {
         type: 'stack',
         key: 'root',
         index: 1,
-        preloadedRoutes: [],
         retainedRouteKeys: ['bar', 'qux'],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -245,7 +267,6 @@ test('adds and removes retained route keys with retain', () => {
     type: 'stack',
     key: 'root',
     index: 1,
-    preloadedRoutes: [],
     retainedRouteKeys: ['qux'],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -271,7 +292,6 @@ test('falls back to focused route and validates source with retain', () => {
         type: 'stack',
         key: 'root',
         index: 1,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -287,7 +307,6 @@ test('falls back to focused route and validates source with retain', () => {
     type: 'stack',
     key: 'root',
     index: 1,
-    preloadedRoutes: [],
     retainedRouteKeys: ['bar'],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -303,7 +322,6 @@ test('falls back to focused route and validates source with retain', () => {
         type: 'stack',
         key: 'root',
         index: 1,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -333,12 +351,12 @@ test('handles retain for preloaded routes', () => {
     type: 'stack',
     key: 'root',
     index: 1,
-    preloadedRoutes: [{ key: 'qux', name: 'qux' }],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'baz', name: 'baz' },
       { key: 'bar', name: 'bar' },
+      { key: 'qux', name: 'qux' },
     ],
   };
 
@@ -367,12 +385,12 @@ test('handles retain for preloaded routes', () => {
     type: 'stack',
     key: 'root',
     index: 1,
-    preloadedRoutes: [{ key: 'qux', name: 'qux' }],
     retainedRouteKeys: ['qux'],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'baz', name: 'baz' },
       { key: 'bar', name: 'bar' },
+      { key: 'qux', name: 'qux' },
     ],
   });
 
@@ -393,12 +411,89 @@ test('handles retain for preloaded routes', () => {
     type: 'stack',
     key: 'root',
     index: 1,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'baz', name: 'baz' },
       { key: 'bar', name: 'bar' },
+    ],
+  });
+});
+
+test('handles param actions for preloaded routes', () => {
+  const router = StackRouter({});
+  const options: RouterConfigOptions = {
+    routeNames: ['baz', 'bar', 'qux'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+
+  const state: StackNavigationState<ParamListBase> = {
+    stale: false,
+    type: 'stack',
+    key: 'root',
+    index: 0,
+    retainedRouteKeys: [],
+    routeNames: ['baz', 'bar', 'qux'],
+    routes: [
+      { key: 'baz', name: 'baz' },
+      { key: 'bar', name: 'bar', params: { answer: 42 } },
+    ],
+  };
+
+  expect(
+    router.getStateForAction(
+      state,
+      {
+        ...CommonActions.setParams({ name: 'Jane' }),
+        source: 'bar',
+      },
+      options
+    )
+  ).toEqual({
+    ...state,
+    routes: [
+      { key: 'baz', name: 'baz' },
+      { key: 'bar', name: 'bar', params: { answer: 42, name: 'Jane' } },
+    ],
+  });
+
+  expect(
+    router.getStateForAction(
+      state,
+      {
+        ...CommonActions.replaceParams({ name: 'Jane' }),
+        source: 'bar',
+      },
+      options
+    )
+  ).toEqual({
+    ...state,
+    routes: [
+      { key: 'baz', name: 'baz' },
+      { key: 'bar', name: 'bar', params: { name: 'Jane' } },
+    ],
+  });
+
+  expect(
+    router.getStateForAction(
+      state,
+      {
+        ...CommonActions.pushParams({ name: 'Jane' }),
+        source: 'bar',
+      },
+      options
+    )
+  ).toEqual({
+    ...state,
+    routes: [
+      { key: 'baz', name: 'baz' },
+      {
+        key: 'bar',
+        name: 'bar',
+        params: { name: 'Jane' },
+        history: [{ type: 'params', params: { answer: 42 } }],
+      },
     ],
   });
 });
@@ -411,7 +506,6 @@ test('gets state on route names change', () => {
       {
         index: 2,
         key: 'stack-test',
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['bar', 'baz', 'qux'],
         routes: [
@@ -435,7 +529,6 @@ test('gets state on route names change', () => {
   ).toEqual({
     index: 1,
     key: 'stack-test',
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['qux', 'baz', 'foo', 'fiz'],
     routes: [
@@ -451,7 +544,6 @@ test('gets state on route names change', () => {
       {
         index: 1,
         key: 'stack-test',
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['foo', 'bar'],
         routes: [
@@ -473,7 +565,6 @@ test('gets state on route names change', () => {
   ).toEqual({
     index: 0,
     key: 'stack-test',
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'qux'],
     routes: [{ key: 'baz-1', name: 'baz', params: { name: 'John' } }],
@@ -490,16 +581,14 @@ test('cleans up preloaded routes and retained route keys on route names change',
       {
         index: 2,
         key: 'stack-test',
-        preloadedRoutes: [
-          { key: 'foo-test', name: 'foo' },
-          { key: 'qux-preload', name: 'qux' },
-        ],
-        retainedRouteKeys: ['baz-test', 'foo-test', 'qux-preload'],
+        retainedRouteKeys: ['baz-test', 'qux-preload'],
         routeNames: ['bar', 'baz', 'qux', 'foo'],
         routes: [
           { key: 'bar-test', name: 'bar' },
           { key: 'baz-test', name: 'baz', params: { answer: 42 } },
           { key: 'qux-test', name: 'qux', params: { name: 'Jane' } },
+          { key: 'foo-test', name: 'foo' },
+          { key: 'qux-preload', name: 'qux' },
         ],
         stale: false,
         type: 'stack',
@@ -514,7 +603,6 @@ test('cleans up preloaded routes and retained route keys on route names change',
   ).toEqual({
     index: 0,
     key: 'stack-test',
-    preloadedRoutes: [],
     retainedRouteKeys: ['baz-test'],
     routeNames: ['baz', 'qux'],
     routes: [{ key: 'baz-test', name: 'baz', params: { answer: 42 } }],
@@ -531,7 +619,6 @@ test('gets state on route names change with initialRouteName', () => {
       {
         index: 1,
         key: 'stack-test',
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['foo', 'bar'],
         routes: [
@@ -553,7 +640,6 @@ test('gets state on route names change with initialRouteName', () => {
   ).toEqual({
     index: 0,
     key: 'stack-test',
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'qux'],
     routes: [{ key: 'qux-1', name: 'qux' }],
@@ -562,7 +648,7 @@ test('gets state on route names change with initialRouteName', () => {
   });
 });
 
-test('moves retained routes to preloadedRoutes on route focus', () => {
+test('moves retained routes to inactive routes on route focus', () => {
   const router = StackRouter({});
 
   expect(
@@ -572,7 +658,6 @@ test('moves retained routes to preloadedRoutes on route focus', () => {
         type: 'stack',
         key: 'root',
         index: 2,
-        preloadedRoutes: [],
         retainedRouteKeys: ['qux'],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -588,10 +673,12 @@ test('moves retained routes to preloadedRoutes on route focus', () => {
     type: 'stack',
     key: 'root',
     index: 0,
-    preloadedRoutes: [{ key: 'qux', name: 'qux' }],
     retainedRouteKeys: ['qux'],
     routeNames: ['baz', 'bar', 'qux'],
-    routes: [{ key: 'baz', name: 'baz' }],
+    routes: [
+      { key: 'baz', name: 'baz' },
+      { key: 'qux', name: 'qux' },
+    ],
   });
 });
 
@@ -610,7 +697,6 @@ test('handles navigate action', () => {
         type: 'stack',
         key: 'root',
         index: 1,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -626,7 +712,6 @@ test('handles navigate action', () => {
     type: 'stack',
     key: 'root',
     index: 2,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -647,7 +732,6 @@ test('handles navigate action', () => {
         type: 'stack',
         key: 'root',
         index: 1,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -663,7 +747,6 @@ test('handles navigate action', () => {
     type: 'stack',
     key: 'root',
     index: 2,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -689,7 +772,6 @@ test('updates params on navigate if already on the screen', () => {
         type: 'stack',
         key: 'root',
         index: 1,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -705,7 +787,6 @@ test('updates params on navigate if already on the screen', () => {
     type: 'stack',
     key: 'root',
     index: 1,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -730,7 +811,6 @@ test('merges params on navigate when specified', () => {
         type: 'stack',
         key: 'root',
         index: 1,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -746,7 +826,6 @@ test('merges params on navigate when specified', () => {
     type: 'stack',
     key: 'root',
     index: 1,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -771,7 +850,6 @@ test("doesn't navigate to nonexistent screen", () => {
         type: 'stack',
         key: 'root',
         index: 1,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -803,7 +881,6 @@ test('handles getId for navigate', () => {
         type: 'stack',
         key: 'root',
         index: 0,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [{ key: 'bar', name: 'bar' }],
@@ -816,7 +893,6 @@ test('handles getId for navigate', () => {
     type: 'stack',
     key: 'root',
     index: 1,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -832,7 +908,6 @@ test('handles getId for navigate', () => {
         type: 'stack',
         key: 'root',
         index: 1,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -848,7 +923,6 @@ test('handles getId for navigate', () => {
     type: 'stack',
     key: 'root',
     index: 1,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -864,7 +938,6 @@ test('handles getId for navigate', () => {
         type: 'stack',
         key: 'root',
         index: 1,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -880,7 +953,6 @@ test('handles getId for navigate', () => {
     type: 'stack',
     key: 'root',
     index: 2,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -897,7 +969,6 @@ test('handles getId for navigate', () => {
         type: 'stack',
         key: 'root',
         index: 1,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -913,7 +984,6 @@ test('handles getId for navigate', () => {
     type: 'stack',
     key: 'root',
     index: 2,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -943,7 +1013,6 @@ test('getId is scoped to route name for navigate', () => {
         type: 'stack',
         key: 'root',
         index: 1,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -959,7 +1028,6 @@ test('getId is scoped to route name for navigate', () => {
     type: 'stack',
     key: 'root',
     index: 2,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -985,7 +1053,6 @@ test('goes back to matching screen for navigate if pop: true', () => {
         type: 'stack',
         key: 'root',
         index: 1,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -1005,7 +1072,6 @@ test('goes back to matching screen for navigate if pop: true', () => {
     type: 'stack',
     key: 'root',
     index: 2,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -1026,7 +1092,6 @@ test('goes back to matching screen for navigate if pop: true', () => {
         type: 'stack',
         key: 'root',
         index: 1,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -1046,7 +1111,6 @@ test('goes back to matching screen for navigate if pop: true', () => {
     type: 'stack',
     key: 'root',
     index: 0,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [{ key: 'baz', name: 'baz', params: { answer: 42 } }],
@@ -1059,7 +1123,6 @@ test('goes back to matching screen for navigate if pop: true', () => {
         type: 'stack',
         key: 'root',
         index: 1,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -1079,7 +1142,6 @@ test('goes back to matching screen for navigate if pop: true', () => {
     type: 'stack',
     key: 'root',
     index: 1,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -1089,7 +1151,97 @@ test('goes back to matching screen for navigate if pop: true', () => {
   });
 });
 
-test('moves retained routes to preloadedRoutes when navigate with pop removes them', () => {
+test('navigates to a preloaded route with navigate if pop: true', () => {
+  const router = StackRouter({});
+  const options: RouterConfigOptions = {
+    routeNames: ['baz', 'bar', 'qux'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+
+  expect(
+    router.getStateForAction(
+      {
+        stale: false,
+        type: 'stack',
+        key: 'root',
+        index: 1,
+        retainedRouteKeys: [],
+        routeNames: ['baz', 'bar', 'qux'],
+        routes: [
+          { key: 'baz', name: 'baz' },
+          { key: 'bar', name: 'bar' },
+          { key: 'qux-preload', name: 'qux' },
+        ],
+      },
+      CommonActions.navigate({
+        name: 'qux',
+        params: { answer: 42 },
+        pop: true,
+      }),
+      options
+    )
+  ).toEqual({
+    stale: false,
+    type: 'stack',
+    key: 'root',
+    index: 2,
+    retainedRouteKeys: [],
+    routeNames: ['baz', 'bar', 'qux'],
+    routes: [
+      { key: 'baz', name: 'baz' },
+      { key: 'bar', name: 'bar' },
+      { key: 'qux-preload', name: 'qux', params: { answer: 42 } },
+    ],
+  });
+});
+
+test('navigates to a retained route with navigate if pop: true', () => {
+  const router = StackRouter({});
+  const options: RouterConfigOptions = {
+    routeNames: ['baz', 'bar', 'qux'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+
+  expect(
+    router.getStateForAction(
+      {
+        stale: false,
+        type: 'stack',
+        key: 'root',
+        index: 1,
+        retainedRouteKeys: ['qux-retained'],
+        routeNames: ['baz', 'bar', 'qux'],
+        routes: [
+          { key: 'baz', name: 'baz' },
+          { key: 'bar', name: 'bar' },
+          { key: 'qux-retained', name: 'qux' },
+        ],
+      },
+      CommonActions.navigate({
+        name: 'qux',
+        params: { answer: 42 },
+        pop: true,
+      }),
+      options
+    )
+  ).toEqual({
+    stale: false,
+    type: 'stack',
+    key: 'root',
+    index: 2,
+    retainedRouteKeys: ['qux-retained'],
+    routeNames: ['baz', 'bar', 'qux'],
+    routes: [
+      { key: 'baz', name: 'baz' },
+      { key: 'bar', name: 'bar' },
+      { key: 'qux-retained', name: 'qux', params: { answer: 42 } },
+    ],
+  });
+});
+
+test('moves retained routes to inactive routes when navigate with pop removes them', () => {
   const router = StackRouter({});
   const options: RouterConfigOptions = {
     routeNames: ['baz', 'bar', 'qux'],
@@ -1104,7 +1256,6 @@ test('moves retained routes to preloadedRoutes when navigate with pop removes th
         type: 'stack',
         key: 'root',
         index: 2,
-        preloadedRoutes: [],
         retainedRouteKeys: ['qux'],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -1124,12 +1275,12 @@ test('moves retained routes to preloadedRoutes when navigate with pop removes th
     type: 'stack',
     key: 'root',
     index: 1,
-    preloadedRoutes: [{ key: 'qux', name: 'qux' }],
     retainedRouteKeys: ['qux'],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'baz', name: 'baz' },
       { key: 'bar', name: 'bar' },
+      { key: 'qux', name: 'qux' },
     ],
   });
 });
@@ -1152,7 +1303,6 @@ test('goes back to matching ID for navigate if pop: true', () => {
         type: 'stack',
         key: 'root',
         index: 1,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -1172,7 +1322,6 @@ test('goes back to matching ID for navigate if pop: true', () => {
     type: 'stack',
     key: 'root',
     index: 1,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -1187,8 +1336,7 @@ test('goes back to matching ID for navigate if pop: true', () => {
         stale: false,
         type: 'stack',
         key: 'root',
-        index: 1,
-        preloadedRoutes: [],
+        index: 3,
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -1210,7 +1358,6 @@ test('goes back to matching ID for navigate if pop: true', () => {
     type: 'stack',
     key: 'root',
     index: 2,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -1238,7 +1385,6 @@ test('goes back to matching ID in route history for navigate if pop: true', () =
         type: 'stack',
         key: 'root',
         index: 1,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -1266,7 +1412,6 @@ test('goes back to matching ID in route history for navigate if pop: true', () =
     type: 'stack',
     key: 'root',
     index: 1,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -1287,7 +1432,6 @@ test('goes back to matching ID in route history for navigate if pop: true', () =
         type: 'stack',
         key: 'root',
         index: 1,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -1315,7 +1459,6 @@ test('goes back to matching ID in route history for navigate if pop: true', () =
     type: 'stack',
     key: 'root',
     index: 1,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -1345,7 +1488,6 @@ test('handles pop action', () => {
         type: 'stack',
         key: 'root',
         index: 2,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -1362,7 +1504,6 @@ test('handles pop action', () => {
     type: 'stack',
     key: 'root',
     index: 1,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -1378,7 +1519,6 @@ test('handles pop action', () => {
         type: 'stack',
         key: 'root',
         index: 2,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -1395,7 +1535,6 @@ test('handles pop action', () => {
     type: 'stack',
     key: 'root',
     index: 0,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [{ key: 'baz', name: 'baz' }],
@@ -1408,7 +1547,6 @@ test('handles pop action', () => {
         type: 'stack',
         key: 'root',
         index: 2,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -1425,7 +1563,6 @@ test('handles pop action', () => {
     type: 'stack',
     key: 'root',
     index: 0,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [{ key: 'baz', name: 'baz' }],
@@ -1438,7 +1575,6 @@ test('handles pop action', () => {
         type: 'stack',
         key: 'root',
         index: 2,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -1459,7 +1595,6 @@ test('handles pop action', () => {
     type: 'stack',
     key: 'root',
     index: 1,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -1475,7 +1610,6 @@ test('handles pop action', () => {
         type: 'stack',
         key: 'root',
         index: 4,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -1498,7 +1632,6 @@ test('handles pop action', () => {
     type: 'stack',
     key: 'root',
     index: 2,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -1515,7 +1648,6 @@ test('handles pop action', () => {
         type: 'stack',
         key: 'root',
         index: 0,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [{ key: 'baz-0', name: 'baz' }],
@@ -1526,7 +1658,7 @@ test('handles pop action', () => {
   ).toBeNull();
 });
 
-test('moves retained routes to preloadedRoutes on pop', () => {
+test('moves retained routes to inactive routes on pop', () => {
   const router = StackRouter({});
   const options: RouterConfigOptions = {
     routeNames: ['baz', 'bar', 'qux'],
@@ -1541,7 +1673,6 @@ test('moves retained routes to preloadedRoutes on pop', () => {
         type: 'stack',
         key: 'root',
         index: 2,
-        preloadedRoutes: [],
         retainedRouteKeys: ['qux'],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -1558,12 +1689,12 @@ test('moves retained routes to preloadedRoutes on pop', () => {
     type: 'stack',
     key: 'root',
     index: 1,
-    preloadedRoutes: [{ key: 'qux', name: 'qux' }],
     retainedRouteKeys: ['qux'],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'baz', name: 'baz' },
       { key: 'bar', name: 'bar' },
+      { key: 'qux', name: 'qux' },
     ],
   });
 });
@@ -1583,7 +1714,6 @@ test('handles pop to top action', () => {
         type: 'stack',
         key: 'root',
         index: 0,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [{ key: 'baz', name: 'baz' }],
@@ -1600,7 +1730,6 @@ test('handles pop to top action', () => {
         type: 'stack',
         key: 'root',
         index: 2,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -1617,7 +1746,6 @@ test('handles pop to top action', () => {
     type: 'stack',
     key: 'root',
     index: 0,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [{ key: 'baz', name: 'baz' }],
@@ -1630,7 +1758,6 @@ test('handles pop to top action', () => {
         type: 'stack',
         key: 'root',
         index: 2,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -1649,7 +1776,6 @@ test('handles pop to top action', () => {
     type: 'stack',
     key: 'root',
     index: 0,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [{ key: 'baz', name: 'baz' }],
@@ -1662,7 +1788,6 @@ test('handles pop to top action', () => {
         type: 'stack',
         key: 'root',
         index: 2,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -1683,14 +1808,13 @@ test('handles pop to top action', () => {
     type: 'stack',
     key: 'root',
     index: 0,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [{ key: 'baz', name: 'baz' }],
   });
 });
 
-test('moves retained routes to preloadedRoutes on popToTop', () => {
+test('moves retained routes to inactive routes on popToTop', () => {
   const router = StackRouter({});
   const options: RouterConfigOptions = {
     routeNames: ['baz', 'bar', 'qux'],
@@ -1705,7 +1829,6 @@ test('moves retained routes to preloadedRoutes on popToTop', () => {
         type: 'stack',
         key: 'root',
         index: 2,
-        preloadedRoutes: [],
         retainedRouteKeys: ['bar', 'qux'],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -1722,17 +1845,17 @@ test('moves retained routes to preloadedRoutes on popToTop', () => {
     type: 'stack',
     key: 'root',
     index: 0,
-    preloadedRoutes: [
+    retainedRouteKeys: ['bar', 'qux'],
+    routeNames: ['baz', 'bar', 'qux'],
+    routes: [
+      { key: 'baz', name: 'baz' },
       { key: 'bar', name: 'bar' },
       { key: 'qux', name: 'qux' },
     ],
-    retainedRouteKeys: ['bar', 'qux'],
-    routeNames: ['baz', 'bar', 'qux'],
-    routes: [{ key: 'baz', name: 'baz' }],
   });
 });
 
-test('prepends retained routes before existing preloadedRoutes on pop', () => {
+test('keeps retained routes before existing preloaded routes on pop', () => {
   const router = StackRouter({});
   const options: RouterConfigOptions = {
     routeNames: ['baz', 'bar', 'qux'],
@@ -1747,13 +1870,13 @@ test('prepends retained routes before existing preloadedRoutes on pop', () => {
         type: 'stack',
         key: 'root',
         index: 2,
-        preloadedRoutes: [{ key: 'pre', name: 'baz' }],
         retainedRouteKeys: ['qux'],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'baz', name: 'baz' },
           { key: 'bar', name: 'bar' },
           { key: 'qux', name: 'qux' },
+          { key: 'pre', name: 'baz' },
         ],
       },
       StackActions.pop(),
@@ -1764,20 +1887,18 @@ test('prepends retained routes before existing preloadedRoutes on pop', () => {
     type: 'stack',
     key: 'root',
     index: 1,
-    preloadedRoutes: [
-      { key: 'qux', name: 'qux' },
-      { key: 'pre', name: 'baz' },
-    ],
     retainedRouteKeys: ['qux'],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'baz', name: 'baz' },
       { key: 'bar', name: 'bar' },
+      { key: 'qux', name: 'qux' },
+      { key: 'pre', name: 'baz' },
     ],
   });
 });
 
-test('preserves order of multiple retained routes before existing preloadedRoutes on popToTop', () => {
+test('preserves order of multiple retained routes before existing preloaded routes on popToTop', () => {
   const router = StackRouter({});
   const options: RouterConfigOptions = {
     routeNames: ['baz', 'bar', 'qux'],
@@ -1792,13 +1913,13 @@ test('preserves order of multiple retained routes before existing preloadedRoute
         type: 'stack',
         key: 'root',
         index: 2,
-        preloadedRoutes: [{ key: 'pre', name: 'baz' }],
-        retainedRouteKeys: ['bar', 'qux'],
+        retainedRouteKeys: ['qux', 'bar'],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'baz', name: 'baz' },
           { key: 'bar', name: 'bar' },
           { key: 'qux', name: 'qux' },
+          { key: 'pre', name: 'baz' },
         ],
       },
       StackActions.popToTop(),
@@ -1809,14 +1930,14 @@ test('preserves order of multiple retained routes before existing preloadedRoute
     type: 'stack',
     key: 'root',
     index: 0,
-    preloadedRoutes: [
+    retainedRouteKeys: ['qux', 'bar'],
+    routeNames: ['baz', 'bar', 'qux'],
+    routes: [
+      { key: 'baz', name: 'baz' },
       { key: 'bar', name: 'bar' },
       { key: 'qux', name: 'qux' },
       { key: 'pre', name: 'baz' },
     ],
-    retainedRouteKeys: ['bar', 'qux'],
-    routeNames: ['baz', 'bar', 'qux'],
-    routes: [{ key: 'baz', name: 'baz' }],
   });
 });
 
@@ -1835,7 +1956,6 @@ test('handles pop action with route history', () => {
         type: 'stack',
         key: 'root',
         index: 1,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -1859,7 +1979,6 @@ test('handles pop action with route history', () => {
     type: 'stack',
     key: 'root',
     index: 1,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -1889,7 +2008,6 @@ test('handles pop action with multiple history entries', () => {
         type: 'stack',
         key: 'root',
         index: 1,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -1914,7 +2032,6 @@ test('handles pop action with multiple history entries', () => {
     type: 'stack',
     key: 'root',
     index: 1,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -1944,7 +2061,6 @@ test('handles pop action with history and route popping', () => {
         type: 'stack',
         key: 'root',
         index: 2,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -1969,7 +2085,6 @@ test('handles pop action with history and route popping', () => {
     type: 'stack',
     key: 'root',
     index: 0,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [{ key: 'baz', name: 'baz' }],
@@ -1991,7 +2106,6 @@ test('handles pop action to restore params from history', () => {
         type: 'stack',
         key: 'root',
         index: 1,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -2014,7 +2128,6 @@ test('handles pop action to restore params from history', () => {
     type: 'stack',
     key: 'root',
     index: 1,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -2044,7 +2157,6 @@ test('handles pop action with undefined params in history', () => {
         type: 'stack',
         key: 'root',
         index: 1,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -2065,7 +2177,6 @@ test('handles pop action with undefined params in history', () => {
     type: 'stack',
     key: 'root',
     index: 1,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -2093,7 +2204,6 @@ test('handles pop action with route.history', () => {
     type: 'stack',
     key: 'root',
     index: 1,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -2121,7 +2231,6 @@ test('handles pop action with route.history', () => {
     type: 'stack',
     key: 'root',
     index: 1,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -2146,7 +2255,6 @@ test('handles pop action with route.history', () => {
     type: 'stack',
     key: 'root',
     index: 1,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -2171,7 +2279,6 @@ test('handles pop action with route.history', () => {
     type: 'stack',
     key: 'root',
     index: 0,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [{ key: 'baz', name: 'baz' }],
@@ -2193,7 +2300,6 @@ test('handles pop(n) with route.history', () => {
         type: 'stack',
         key: 'root',
         index: 2,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -2220,7 +2326,6 @@ test('handles pop(n) with route.history', () => {
     type: 'stack',
     key: 'root',
     index: 2,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -2242,7 +2347,6 @@ test('handles pop(n) with route.history', () => {
         type: 'stack',
         key: 'root',
         index: 1,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -2266,7 +2370,6 @@ test('handles pop(n) with route.history', () => {
     type: 'stack',
     key: 'root',
     index: 0,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [{ key: 'baz', name: 'baz' }],
@@ -2286,7 +2389,6 @@ test('handles pop action with route.history on a single route', () => {
     type: 'stack',
     key: 'root',
     index: 0,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -2313,7 +2415,6 @@ test('handles pop action with route.history on a single route', () => {
     type: 'stack',
     key: 'root',
     index: 0,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -2337,7 +2438,6 @@ test('handles pop action with route.history on a single route', () => {
     type: 'stack',
     key: 'root',
     index: 0,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -2364,7 +2464,6 @@ test('handles goBack with route.history', () => {
     type: 'stack',
     key: 'root',
     index: 1,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -2392,7 +2491,6 @@ test('handles goBack with route.history', () => {
     type: 'stack',
     key: 'root',
     index: 1,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -2417,7 +2515,6 @@ test('handles goBack with route.history', () => {
     type: 'stack',
     key: 'root',
     index: 1,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -2442,14 +2539,13 @@ test('handles goBack with route.history', () => {
     type: 'stack',
     key: 'root',
     index: 0,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [{ key: 'baz', name: 'baz' }],
   });
 });
 
-test('moves retained routes to preloadedRoutes on goBack', () => {
+test('moves retained routes to inactive routes on goBack', () => {
   const router = StackRouter({});
   const options: RouterConfigOptions = {
     routeNames: ['baz', 'bar', 'qux'],
@@ -2464,7 +2560,6 @@ test('moves retained routes to preloadedRoutes on goBack', () => {
         type: 'stack',
         key: 'root',
         index: 2,
-        preloadedRoutes: [],
         retainedRouteKeys: ['qux'],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -2481,12 +2576,12 @@ test('moves retained routes to preloadedRoutes on goBack', () => {
     type: 'stack',
     key: 'root',
     index: 1,
-    preloadedRoutes: [{ key: 'qux', name: 'qux' }],
     retainedRouteKeys: ['qux'],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'baz', name: 'baz' },
       { key: 'bar', name: 'bar' },
+      { key: 'qux', name: 'qux' },
     ],
   });
 });
@@ -2504,7 +2599,6 @@ test('handles goBack action with route.history on a single route', () => {
     type: 'stack',
     key: 'root',
     index: 0,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -2531,7 +2625,6 @@ test('handles goBack action with route.history on a single route', () => {
     type: 'stack',
     key: 'root',
     index: 0,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -2555,7 +2648,6 @@ test('handles goBack action with route.history on a single route', () => {
     type: 'stack',
     key: 'root',
     index: 0,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -2589,7 +2681,6 @@ test('replaces focused screen with replace', () => {
           { key: 'bar', name: 'bar', params: { fruit: 'orange' } },
           { key: 'baz', name: 'baz' },
         ],
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['foo', 'bar', 'baz', 'qux'],
       },
@@ -2606,7 +2697,6 @@ test('replaces focused screen with replace', () => {
       { key: 'qux-1', name: 'qux', params: { answer: 42 } },
       { key: 'baz', name: 'baz' },
     ],
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz', 'qux'],
   });
@@ -2632,7 +2722,6 @@ test('replaces active screen with replace', () => {
           { key: 'bar', name: 'bar', params: { fruit: 'orange' } },
           { key: 'baz', name: 'baz' },
         ],
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['foo', 'bar', 'baz', 'qux'],
       },
@@ -2652,13 +2741,12 @@ test('replaces active screen with replace', () => {
       { key: 'qux-1', name: 'qux', params: { answer: 42 } },
       { key: 'baz', name: 'baz' },
     ],
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz', 'qux'],
   });
 });
 
-test('moves retained routes to preloadedRoutes on replace', () => {
+test('moves retained routes to inactive routes on replace', () => {
   const router = StackRouter({});
   const options: RouterConfigOptions = {
     routeNames: ['foo', 'bar', 'baz', 'qux'],
@@ -2678,7 +2766,6 @@ test('moves retained routes to preloadedRoutes on replace', () => {
           { key: 'bar', name: 'bar' },
           { key: 'baz', name: 'baz' },
         ],
-        preloadedRoutes: [],
         retainedRouteKeys: ['bar'],
         routeNames: ['foo', 'bar', 'baz', 'qux'],
       },
@@ -2693,9 +2780,9 @@ test('moves retained routes to preloadedRoutes on replace', () => {
     routes: [
       { key: 'foo', name: 'foo' },
       { key: 'qux-1', name: 'qux', params: { answer: 42 } },
+      { key: 'bar', name: 'bar' },
       { key: 'baz', name: 'baz' },
     ],
-    preloadedRoutes: [{ key: 'bar', name: 'bar' }],
     retainedRouteKeys: ['bar'],
     routeNames: ['foo', 'bar', 'baz', 'qux'],
   });
@@ -2721,7 +2808,6 @@ test("handles replace if source key isn't present but target is not specified", 
           { key: 'bar', name: 'bar', params: { fruit: 'orange' } },
           { key: 'baz', name: 'baz' },
         ],
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['foo', 'bar', 'baz', 'qux'],
       },
@@ -2734,7 +2820,6 @@ test("handles replace if source key isn't present but target is not specified", 
   ).toEqual({
     index: 1,
     key: 'root',
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz', 'qux'],
     routes: [
@@ -2767,7 +2852,6 @@ test("doesn't handle replace if source key isn't present when target is specifie
           { key: 'bar', name: 'bar', params: { fruit: 'orange' } },
           { key: 'baz', name: 'baz' },
         ],
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['foo', 'bar', 'baz', 'qux'],
       },
@@ -2801,7 +2885,6 @@ test("doesn't handle replace if screen to replace with isn't present", () => {
           { key: 'bar', name: 'bar', params: { fruit: 'orange' } },
           { key: 'baz', name: 'baz' },
         ],
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['foo', 'bar', 'baz', 'qux'],
       },
@@ -2831,7 +2914,6 @@ test('handles push action', () => {
         type: 'stack',
         key: 'root',
         index: 2,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [{ key: 'bar', name: 'bar' }],
@@ -2844,7 +2926,6 @@ test('handles push action', () => {
     type: 'stack',
     key: 'root',
     index: 1,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -2860,7 +2941,6 @@ test('handles push action', () => {
         type: 'stack',
         key: 'root',
         index: 2,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [{ key: 'bar', name: 'bar' }],
@@ -2873,7 +2953,6 @@ test('handles push action', () => {
     type: 'stack',
     key: 'root',
     index: 1,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -2889,7 +2968,6 @@ test('handles push action', () => {
         type: 'stack',
         key: 'root',
         index: 2,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [{ key: 'bar', name: 'bar' }],
@@ -2915,7 +2993,6 @@ test("doesn't push nonexistent screen", () => {
         type: 'stack',
         key: 'root',
         index: 1,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -2947,7 +3024,6 @@ test('handles getId for push', () => {
         type: 'stack',
         key: 'root',
         index: 0,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [{ key: 'bar', name: 'bar' }],
@@ -2960,7 +3036,6 @@ test('handles getId for push', () => {
     type: 'stack',
     key: 'root',
     index: 1,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -2976,7 +3051,6 @@ test('handles getId for push', () => {
         type: 'stack',
         key: 'root',
         index: 1,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -2992,7 +3066,6 @@ test('handles getId for push', () => {
     type: 'stack',
     key: 'root',
     index: 2,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -3009,7 +3082,6 @@ test('handles getId for push', () => {
         type: 'stack',
         key: 'root',
         index: 1,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -3025,7 +3097,6 @@ test('handles getId for push', () => {
     type: 'stack',
     key: 'root',
     index: 2,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -3055,7 +3126,6 @@ test('getId is scoped to route name for push', () => {
         type: 'stack',
         key: 'root',
         index: 1,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -3071,7 +3141,6 @@ test('getId is scoped to route name for push', () => {
     type: 'stack',
     key: 'root',
     index: 2,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -3097,7 +3166,6 @@ test('adds path on navigate if provided', () => {
         type: 'stack',
         key: 'root',
         index: 1,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -3117,7 +3185,6 @@ test('adds path on navigate if provided', () => {
     type: 'stack',
     key: 'root',
     index: 1,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -3133,7 +3200,6 @@ test('adds path on navigate if provided', () => {
         type: 'stack',
         key: 'root',
         index: 1,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -3153,7 +3219,6 @@ test('adds path on navigate if provided', () => {
     type: 'stack',
     key: 'root',
     index: 1,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -3174,7 +3239,6 @@ test('adds path on navigate if provided', () => {
         type: 'stack',
         key: 'root',
         index: 0,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [{ key: 'bar', name: 'bar', params: { answer: 42 } }],
@@ -3190,7 +3254,6 @@ test('adds path on navigate if provided', () => {
     type: 'stack',
     key: 'root',
     index: 1,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -3219,7 +3282,6 @@ test("doesn't remove existing path on navigate if not provided", () => {
         type: 'stack',
         key: 'root',
         index: 1,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -3239,7 +3301,6 @@ test("doesn't remove existing path on navigate if not provided", () => {
     type: 'stack',
     key: 'root',
     index: 1,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -3264,7 +3325,6 @@ test('handles popTo action', () => {
         type: 'stack',
         key: 'root',
         index: 1,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -3280,7 +3340,6 @@ test('handles popTo action', () => {
     type: 'stack',
     key: 'root',
     index: 1,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -3300,7 +3359,6 @@ test('handles popTo action', () => {
         type: 'stack',
         key: 'root',
         index: 1,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -3316,7 +3374,6 @@ test('handles popTo action', () => {
     type: 'stack',
     key: 'root',
     index: 0,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [{ key: 'baz', name: 'baz', params: { answer: 42 } }],
@@ -3329,7 +3386,6 @@ test('handles popTo action', () => {
         type: 'stack',
         key: 'root',
         index: 1,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -3345,7 +3401,6 @@ test('handles popTo action', () => {
     type: 'stack',
     key: 'root',
     index: 1,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -3355,7 +3410,7 @@ test('handles popTo action', () => {
   });
 });
 
-test('moves retained routes to preloadedRoutes on popTo', () => {
+test('moves retained routes to inactive routes on popTo', () => {
   const router = StackRouter({});
   const options: RouterConfigOptions = {
     routeNames: ['baz', 'bar', 'qux'],
@@ -3370,7 +3425,6 @@ test('moves retained routes to preloadedRoutes on popTo', () => {
         type: 'stack',
         key: 'root',
         index: 2,
-        preloadedRoutes: [],
         retainedRouteKeys: ['qux'],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -3387,12 +3441,12 @@ test('moves retained routes to preloadedRoutes on popTo', () => {
     type: 'stack',
     key: 'root',
     index: 1,
-    preloadedRoutes: [{ key: 'qux', name: 'qux' }],
     retainedRouteKeys: ['qux'],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'baz', name: 'baz' },
       { key: 'bar', name: 'bar' },
+      { key: 'qux', name: 'qux' },
     ],
   });
 
@@ -3403,7 +3457,6 @@ test('moves retained routes to preloadedRoutes on popTo', () => {
         type: 'stack',
         key: 'root',
         index: 1,
-        preloadedRoutes: [],
         retainedRouteKeys: ['bar'],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -3419,12 +3472,12 @@ test('moves retained routes to preloadedRoutes on popTo', () => {
     type: 'stack',
     key: 'root',
     index: 1,
-    preloadedRoutes: [{ key: 'bar', name: 'bar' }],
     retainedRouteKeys: ['bar'],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'baz', name: 'baz' },
       { key: 'qux-1', name: 'qux' },
+      { key: 'bar', name: 'bar' },
     ],
   });
 });
@@ -3444,7 +3497,6 @@ test("doesn't popTo to nonexistent screen", () => {
         type: 'stack',
         key: 'root',
         index: 1,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -3475,7 +3527,6 @@ test("doesn't merge params on popTo to an existing screen", () => {
         type: 'stack',
         key: 'root',
         index: 2,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -3492,7 +3543,6 @@ test("doesn't merge params on popTo to an existing screen", () => {
     type: 'stack',
     key: 'root',
     index: 1,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -3508,7 +3558,6 @@ test("doesn't merge params on popTo to an existing screen", () => {
         type: 'stack',
         key: 'root',
         index: 1,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -3524,7 +3573,6 @@ test("doesn't merge params on popTo to an existing screen", () => {
     type: 'stack',
     key: 'root',
     index: 1,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -3552,7 +3600,6 @@ test('merges params on popTo to an existing screen if merge: true', () => {
         type: 'stack',
         key: 'root',
         index: 2,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -3570,7 +3617,6 @@ test('merges params on popTo to an existing screen if merge: true', () => {
     type: 'stack',
     key: 'root',
     index: 1,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -3586,7 +3632,6 @@ test('merges params on popTo to an existing screen if merge: true', () => {
         type: 'stack',
         key: 'root',
         index: 1,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -3602,7 +3647,6 @@ test('merges params on popTo to an existing screen if merge: true', () => {
     type: 'stack',
     key: 'root',
     index: 1,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -3622,7 +3666,6 @@ test('merges params on popTo to an existing screen if merge: true', () => {
         type: 'stack',
         key: 'root',
         index: 1,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -3638,7 +3681,6 @@ test('merges params on popTo to an existing screen if merge: true', () => {
     type: 'stack',
     key: 'root',
     index: 0,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -3671,7 +3713,6 @@ test("handles popTo if source key isn't present but target is not specified", ()
           { key: 'bar', name: 'bar', params: { fruit: 'orange' } },
           { key: 'baz', name: 'baz' },
         ],
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['foo', 'bar', 'baz', 'qux'],
       },
@@ -3684,12 +3725,12 @@ test("handles popTo if source key isn't present but target is not specified", ()
   ).toEqual({
     index: 1,
     key: 'root',
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz', 'qux'],
     routes: [
       { key: 'foo', name: 'foo' },
       { key: 'qux-1', name: 'qux', params: { answer: 42 } },
+      { key: 'baz', name: 'baz' },
     ],
     stale: false,
     type: 'stack',
@@ -3716,7 +3757,6 @@ test('handles popTo when source and target match a route', () => {
           { key: 'bar', name: 'bar', params: { fruit: 'orange' } },
           { key: 'baz', name: 'baz' },
         ],
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['foo', 'bar', 'baz', 'qux'],
       },
@@ -3730,7 +3770,6 @@ test('handles popTo when source and target match a route', () => {
   ).toEqual({
     index: 1,
     key: 'root',
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['foo', 'bar', 'baz', 'qux'],
     routes: [
@@ -3759,7 +3798,6 @@ test('handles popTo with getId matching route history', () => {
         type: 'stack',
         key: 'root',
         index: 2,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -3784,7 +3822,6 @@ test('handles popTo with getId matching route history', () => {
     type: 'stack',
     key: 'root',
     index: 0,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -3804,7 +3841,6 @@ test('handles popTo with getId matching route history', () => {
         type: 'stack',
         key: 'root',
         index: 1,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -3828,7 +3864,6 @@ test('handles popTo with getId matching route history', () => {
     type: 'stack',
     key: 'root',
     index: 0,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -3848,7 +3883,6 @@ test('handles popTo with getId matching route history', () => {
         type: 'stack',
         key: 'root',
         index: 1,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -3869,7 +3903,6 @@ test('handles popTo with getId matching route history', () => {
     type: 'stack',
     key: 'root',
     index: 0,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -3903,7 +3936,6 @@ test("doesn't handle popTo if source key isn't present when target is specified"
           { key: 'bar', name: 'bar', params: { fruit: 'orange' } },
           { key: 'baz', name: 'baz' },
         ],
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['foo', 'bar', 'baz', 'qux'],
       },
@@ -3917,7 +3949,7 @@ test("doesn't handle popTo if source key isn't present when target is specified"
   ).toBeNull();
 });
 
-test('adds route to preloaded list with preload', () => {
+test('adds preloaded route with preload', () => {
   const router = StackRouter({});
   const options: RouterConfigOptions = {
     routeNames: ['baz', 'bar', 'qux'],
@@ -3937,7 +3969,6 @@ test('adds route to preloaded list with preload', () => {
         type: 'stack',
         key: 'root',
         index: 2,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -3954,13 +3985,13 @@ test('adds route to preloaded list with preload', () => {
     type: 'stack',
     key: 'root',
     index: 2,
-    preloadedRoutes: [{ key: 'bar-1', name: 'bar', params: { color: 'test' } }],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       { key: 'baz', name: 'baz' },
       { key: 'bar', name: 'bar', params: { answer: 42 } },
       { key: 'qux', name: 'qux' },
+      { key: 'bar-1', name: 'bar', params: { color: 'test' } },
     ],
   });
 });
@@ -3985,7 +4016,6 @@ test('updates an existing route with preload when the ID matches', () => {
         type: 'stack',
         key: 'root',
         index: 1,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -4005,7 +4035,6 @@ test('updates an existing route with preload when the ID matches', () => {
     type: 'stack',
     key: 'root',
     index: 1,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -4039,7 +4068,6 @@ test('updates the last matching route with preload when the ID matches', () => {
         type: 'stack',
         key: 'root',
         index: 2,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -4064,7 +4092,6 @@ test('updates the last matching route with preload when the ID matches', () => {
     type: 'stack',
     key: 'root',
     index: 2,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -4103,7 +4130,6 @@ test('adds preloaded route with preload when the ID changes', () => {
         type: 'stack',
         key: 'root',
         index: 1,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -4123,9 +4149,6 @@ test('adds preloaded route with preload when the ID changes', () => {
     type: 'stack',
     key: 'root',
     index: 1,
-    preloadedRoutes: [
-      { key: 'bar-1', name: 'bar', params: { answer: 43, color: 'test' } },
-    ],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -4135,6 +4158,7 @@ test('adds preloaded route with preload when the ID changes', () => {
         params: { answer: 42, toBe: 'notMerged' },
       },
       { key: 'baz', name: 'baz' },
+      { key: 'bar-1', name: 'bar', params: { answer: 43, color: 'test' } },
     ],
   });
 });
@@ -4149,7 +4173,6 @@ test('updates the last matching route by name with preload and reuse when getId 
         type: 'stack',
         key: 'root',
         index: 2,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -4184,7 +4207,6 @@ test('updates the last matching route by name with preload and reuse when getId 
     type: 'stack',
     key: 'root',
     index: 2,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -4223,7 +4245,6 @@ test('updates the last matching route with preload and reuse', () => {
         type: 'stack',
         key: 'root',
         index: 2,
-        preloadedRoutes: [],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -4252,7 +4273,6 @@ test('updates the last matching route with preload and reuse', () => {
     type: 'stack',
     key: 'root',
     index: 2,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -4290,8 +4310,11 @@ test('updates the last matching preloaded route with preload and reuse', () => {
         stale: false,
         type: 'stack',
         key: 'root',
-        index: 1,
-        preloadedRoutes: [
+        index: 0,
+        retainedRouteKeys: [],
+        routeNames: ['baz', 'bar', 'qux'],
+        routes: [
+          { key: 'baz', name: 'baz' },
           {
             key: 'bar-first',
             name: 'bar',
@@ -4303,9 +4326,6 @@ test('updates the last matching preloaded route with preload and reuse', () => {
             params: { answer: 42, toBe: 'last' },
           },
         ],
-        retainedRouteKeys: [],
-        routeNames: ['baz', 'bar', 'qux'],
-        routes: [{ key: 'baz', name: 'baz' }],
       },
       CommonActions.preload(
         'bar',
@@ -4318,8 +4338,11 @@ test('updates the last matching preloaded route with preload and reuse', () => {
     stale: false,
     type: 'stack',
     key: 'root',
-    index: 1,
-    preloadedRoutes: [
+    index: 0,
+    retainedRouteKeys: [],
+    routeNames: ['baz', 'bar', 'qux'],
+    routes: [
+      { key: 'baz', name: 'baz' },
       {
         key: 'bar-first',
         name: 'bar',
@@ -4331,9 +4354,6 @@ test('updates the last matching preloaded route with preload and reuse', () => {
         params: { answer: 42, color: 'test', something: 'else' },
       },
     ],
-    retainedRouteKeys: [],
-    routeNames: ['baz', 'bar', 'qux'],
-    routes: [{ key: 'baz', name: 'baz' }],
   });
 });
 
@@ -4357,13 +4377,6 @@ test('prefers a matching preloaded route over matching routes with preload and r
         type: 'stack',
         key: 'root',
         index: 1,
-        preloadedRoutes: [
-          {
-            key: 'bar-preloaded',
-            name: 'bar',
-            params: { answer: 42, toBe: 'preloaded' },
-          },
-        ],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
@@ -4373,6 +4386,11 @@ test('prefers a matching preloaded route over matching routes with preload and r
             params: { answer: 42, toBe: 'route' },
           },
           { key: 'baz', name: 'baz' },
+          {
+            key: 'bar-preloaded',
+            name: 'bar',
+            params: { answer: 42, toBe: 'preloaded' },
+          },
         ],
       },
       CommonActions.preload(
@@ -4387,13 +4405,6 @@ test('prefers a matching preloaded route over matching routes with preload and r
     type: 'stack',
     key: 'root',
     index: 1,
-    preloadedRoutes: [
-      {
-        key: 'bar-preloaded',
-        name: 'bar',
-        params: { answer: 42, color: 'test', something: 'else' },
-      },
-    ],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -4403,6 +4414,11 @@ test('prefers a matching preloaded route over matching routes with preload and r
         params: { answer: 42, toBe: 'route' },
       },
       { key: 'baz', name: 'baz' },
+      {
+        key: 'bar-preloaded',
+        name: 'bar',
+        params: { answer: 42, color: 'test', something: 'else' },
+      },
     ],
   });
 });
@@ -4422,24 +4438,22 @@ test('uses preloaded route when pushing a route with the same name', () => {
         type: 'stack',
         key: 'root',
         index: 0,
-        preloadedRoutes: [
-          {
-            key: 'bar-test',
-            name: 'bar',
-          },
-          { key: 'qux-some', name: 'qux' },
-        ],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           {
-            key: 'bar-test',
+            key: 'bar-active',
             name: 'bar',
           },
+          {
+            key: 'bar-preloaded',
+            name: 'bar',
+          },
+          { key: 'qux-preloaded', name: 'qux', path: 'qux' },
         ],
       },
 
-      StackActions.push('qux'),
+      StackActions.push('qux', { answer: 42 }),
       options
     )
   ).toEqual({
@@ -4447,20 +4461,23 @@ test('uses preloaded route when pushing a route with the same name', () => {
     type: 'stack',
     key: 'root',
     index: 1,
-    preloadedRoutes: [
-      {
-        key: 'bar-test',
-        name: 'bar',
-      },
-    ],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
       {
-        key: 'bar-test',
+        key: 'bar-active',
         name: 'bar',
       },
-      { key: 'qux-some', name: 'qux' },
+      {
+        key: 'qux-preloaded',
+        name: 'qux',
+        path: 'qux',
+        params: { answer: 42 },
+      },
+      {
+        key: 'bar-preloaded',
+        name: 'bar',
+      },
     ],
   });
 
@@ -4471,46 +4488,48 @@ test('uses preloaded route when pushing a route with the same name', () => {
         type: 'stack',
         key: 'root',
         index: 1,
-        preloadedRoutes: [
-          {
-            key: 'bar-test',
-            name: 'bar',
-          },
-          { key: 'qux-some', name: 'qux' },
-        ],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
-          { key: 'qux-some', name: 'qux' },
+          { key: 'qux-active', name: 'qux' },
           {
-            key: 'bar-test',
+            key: 'bar-active',
             name: 'bar',
           },
+          {
+            key: 'bar-preloaded',
+            name: 'bar',
+          },
+          { key: 'qux-preloaded', name: 'qux', path: 'qux' },
         ],
       },
 
-      StackActions.push('qux'),
+      StackActions.push('qux', { answer: 42 }),
       options
     )
   ).toEqual({
     stale: false,
     type: 'stack',
     key: 'root',
-    index: 1,
-    preloadedRoutes: [
-      {
-        key: 'bar-test',
-        name: 'bar',
-      },
-    ],
+    index: 2,
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
+      { key: 'qux-active', name: 'qux' },
       {
-        key: 'bar-test',
+        key: 'bar-active',
         name: 'bar',
       },
-      { key: 'qux-some', name: 'qux' },
+      {
+        key: 'qux-preloaded',
+        name: 'qux',
+        path: 'qux',
+        params: { answer: 42 },
+      },
+      {
+        key: 'bar-preloaded',
+        name: 'bar',
+      },
     ],
   });
 });
@@ -4535,21 +4554,19 @@ test('uses preloaded route when pushing a route with the same ID', () => {
         type: 'stack',
         key: 'root',
         index: 0,
-        preloadedRoutes: [
-          {
-            key: 'bar-test',
-            params: {
-              answer: 41,
-            },
-            name: 'bar',
-          },
-        ],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           {
             key: 'qux-test',
             name: 'qux',
+          },
+          {
+            key: 'bar-test',
+            params: {
+              answer: 41,
+            },
+            name: 'bar',
           },
         ],
       },
@@ -4562,7 +4579,6 @@ test('uses preloaded route when pushing a route with the same ID', () => {
     type: 'stack',
     key: 'root',
     index: 1,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -4599,7 +4615,13 @@ test('does not use preloaded route when pushing a route with different ID', () =
         type: 'stack',
         key: 'root',
         index: 0,
-        preloadedRoutes: [
+        retainedRouteKeys: [],
+        routeNames: ['baz', 'bar', 'qux'],
+        routes: [
+          {
+            key: 'qux-test',
+            name: 'qux',
+          },
           {
             key: 'bar-some',
             params: {
@@ -4607,14 +4629,6 @@ test('does not use preloaded route when pushing a route with different ID', () =
               toBe: 'notMerged',
             },
             name: 'bar',
-          },
-        ],
-        retainedRouteKeys: [],
-        routeNames: ['baz', 'bar', 'qux'],
-        routes: [
-          {
-            key: 'qux-test',
-            name: 'qux',
           },
         ],
       },
@@ -4627,16 +4641,6 @@ test('does not use preloaded route when pushing a route with different ID', () =
     type: 'stack',
     key: 'root',
     index: 1,
-    preloadedRoutes: [
-      {
-        key: 'bar-some',
-        params: {
-          answer: 42,
-          toBe: 'notMerged',
-        },
-        name: 'bar',
-      },
-    ],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -4646,6 +4650,14 @@ test('does not use preloaded route when pushing a route with different ID', () =
         params: {
           color: 'test',
           answer: 41,
+        },
+        name: 'bar',
+      },
+      {
+        key: 'bar-some',
+        params: {
+          answer: 42,
+          toBe: 'notMerged',
         },
         name: 'bar',
       },
@@ -4670,18 +4682,16 @@ test('uses preloaded route when replacing current route', () => {
         type: 'stack',
         key: 'root',
         index: 1,
-        preloadedRoutes: [
-          {
-            key: 'bar-preloaded',
-            name: 'bar',
-            params: { answer: 42 },
-          },
-        ],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'baz', name: 'baz' },
           { key: 'qux', name: 'qux' },
+          {
+            key: 'bar-preloaded',
+            name: 'bar',
+            params: { answer: 42 },
+          },
         ],
       },
       StackActions.replace('bar'),
@@ -4692,7 +4702,6 @@ test('uses preloaded route when replacing current route', () => {
     type: 'stack',
     key: 'root',
     index: 1,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -4725,18 +4734,16 @@ test('uses preloaded route with the same ID when replacing current route', () =>
         type: 'stack',
         key: 'root',
         index: 1,
-        preloadedRoutes: [
-          {
-            key: 'bar-preloaded',
-            name: 'bar',
-            params: { answer: 42 },
-          },
-        ],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'baz', name: 'baz' },
           { key: 'qux', name: 'qux' },
+          {
+            key: 'bar-preloaded',
+            name: 'bar',
+            params: { answer: 42 },
+          },
         ],
       },
       StackActions.replace('bar', { answer: 42 }),
@@ -4747,7 +4754,6 @@ test('uses preloaded route with the same ID when replacing current route', () =>
     type: 'stack',
     key: 'root',
     index: 1,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -4780,18 +4786,16 @@ test('does not use preloaded route with different ID when replacing current rout
         type: 'stack',
         key: 'root',
         index: 1,
-        preloadedRoutes: [
-          {
-            key: 'bar-preloaded',
-            name: 'bar',
-            params: { answer: 99 },
-          },
-        ],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'baz', name: 'baz' },
           { key: 'qux', name: 'qux' },
+          {
+            key: 'bar-preloaded',
+            name: 'bar',
+            params: { answer: 99 },
+          },
         ],
       },
       StackActions.popTo('bar', { answer: 42 }),
@@ -4802,13 +4806,6 @@ test('does not use preloaded route with different ID when replacing current rout
     type: 'stack',
     key: 'root',
     index: 1,
-    preloadedRoutes: [
-      {
-        key: 'bar-preloaded',
-        name: 'bar',
-        params: { answer: 99 },
-      },
-    ],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -4817,6 +4814,11 @@ test('does not use preloaded route with different ID when replacing current rout
         key: 'bar-1',
         name: 'bar',
         params: { color: 'test', answer: 42 },
+      },
+      {
+        key: 'bar-preloaded',
+        name: 'bar',
+        params: { answer: 99 },
       },
     ],
   });
@@ -4839,18 +4841,16 @@ test('uses preloaded route with the same name when popTo replaces current route'
         type: 'stack',
         key: 'root',
         index: 1,
-        preloadedRoutes: [
-          {
-            key: 'bar-preloaded',
-            name: 'bar',
-            params: { answer: 42 },
-          },
-        ],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'baz', name: 'baz' },
           { key: 'qux', name: 'qux' },
+          {
+            key: 'bar-preloaded',
+            name: 'bar',
+            params: { answer: 42 },
+          },
         ],
       },
       StackActions.popTo('bar'),
@@ -4861,7 +4861,6 @@ test('uses preloaded route with the same name when popTo replaces current route'
     type: 'stack',
     key: 'root',
     index: 1,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -4894,18 +4893,16 @@ test('uses preloaded route with the same ID when popTo replaces current route', 
         type: 'stack',
         key: 'root',
         index: 1,
-        preloadedRoutes: [
-          {
-            key: 'bar-preloaded',
-            name: 'bar',
-            params: { answer: 42 },
-          },
-        ],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'baz', name: 'baz' },
           { key: 'qux', name: 'qux' },
+          {
+            key: 'bar-preloaded',
+            name: 'bar',
+            params: { answer: 42 },
+          },
         ],
       },
       StackActions.popTo('bar', { answer: 42 }),
@@ -4916,7 +4913,6 @@ test('uses preloaded route with the same ID when popTo replaces current route', 
     type: 'stack',
     key: 'root',
     index: 1,
-    preloadedRoutes: [],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -4949,18 +4945,16 @@ test('does not use preloaded route with different ID when popTo replaces current
         type: 'stack',
         key: 'root',
         index: 1,
-        preloadedRoutes: [
-          {
-            key: 'bar-preloaded',
-            name: 'bar',
-            params: { answer: 99 },
-          },
-        ],
         retainedRouteKeys: [],
         routeNames: ['baz', 'bar', 'qux'],
         routes: [
           { key: 'baz', name: 'baz' },
           { key: 'qux', name: 'qux' },
+          {
+            key: 'bar-preloaded',
+            name: 'bar',
+            params: { answer: 99 },
+          },
         ],
       },
       StackActions.popTo('bar', { answer: 42 }),
@@ -4971,13 +4965,6 @@ test('does not use preloaded route with different ID when popTo replaces current
     type: 'stack',
     key: 'root',
     index: 1,
-    preloadedRoutes: [
-      {
-        key: 'bar-preloaded',
-        name: 'bar',
-        params: { answer: 99 },
-      },
-    ],
     retainedRouteKeys: [],
     routeNames: ['baz', 'bar', 'qux'],
     routes: [
@@ -4986,6 +4973,11 @@ test('does not use preloaded route with different ID when popTo replaces current
         key: 'bar-1',
         name: 'bar',
         params: { color: 'test', answer: 42 },
+      },
+      {
+        key: 'bar-preloaded',
+        name: 'bar',
+        params: { answer: 99 },
       },
     ],
   });

--- a/packages/routers/src/types.tsx
+++ b/packages/routers/src/types.tsx
@@ -233,17 +233,6 @@ export type Router<
   shouldActionChangeFocus(action: NavigationAction): boolean;
 
   /**
-   * Get the list of routes from the navigation state.
-   *
-   * By default, `state.routes` is used.
-   * But in some cases (like `preloadedRoutes` in stack),
-   * the actual list of routes may be different.
-   *
-   * @param state Navigation state to get the routes from.
-   */
-  getRoutesFromState?(state: State): Route<string>[];
-
-  /**
    * Action creators for the router.
    */
   actionCreators?: ActionCreators<Action>;

--- a/packages/stack/src/views/Stack/CardStack.tsx
+++ b/packages/stack/src/views/Stack/CardStack.tsx
@@ -260,36 +260,24 @@ export function getAnimationEnabled(animation: StackAnimationName | undefined) {
 
 const getAllRoutes = (
   routes: Route<string>[],
-  preloadedRoutes: Route<string>[]
+  state: StackNavigationState<ParamListBase>
 ) => {
   const routeKeys = new Set(routes.map((route) => route.key));
+  const inactiveRoutes = state.routes.slice(state.index + 1);
 
-  // If a route is moved from `state.routes` to `state.preloadedRoutes`,
+  // If a route is moved from active routes to inactive routes,
   // It can still be in the local copy of `routes` until the animation ends
   // So we need to deduplicate the routes to avoid rendering the same route twice
   return [
     ...routes,
-    ...preloadedRoutes.filter((route) => !routeKeys.has(route.key)),
+    ...inactiveRoutes.filter((route) => !routeKeys.has(route.key)),
   ];
 };
 
-const isPreloadedRoute = (
-  route: Route<string>,
-  props: {
-    routes: Route<string>[];
-    state: StackNavigationState<ParamListBase>;
-  }
-) => {
-  // The route can be in both `routes` and `preloadedRoutes` until the animation ends
-  // Treat it as not preloaded, similar to how removed routes are treated until the animation ends
-  if (props.routes.some((currentRoute) => currentRoute.key === route.key)) {
-    return false;
-  }
-
-  return props.state.preloadedRoutes.some(
-    (currentRoute) => currentRoute.key === route.key
-  );
-};
+const isInactiveRoute = (route: Route<string>, routes: Route<string>[]) =>
+  // `routes` contains active routes and routes animating during transitions.
+  // Any route added by `getAllRoutes` that's missing from this list is inactive.
+  !routes.some((currentRoute) => currentRoute.key === route.key);
 
 export class CardStack extends React.Component<Props, State> {
   static getDerivedStateFromProps(
@@ -303,7 +291,7 @@ export class CardStack extends React.Component<Props, State> {
       return null;
     }
 
-    const allRoutes = getAllRoutes(props.routes, props.state.preloadedRoutes);
+    const allRoutes = getAllRoutes(props.routes, props.state);
 
     const gestures = allRoutes.reduce<GestureValues>((acc, curr) => {
       const descriptor = props.descriptors[curr.key];
@@ -314,7 +302,7 @@ export class CardStack extends React.Component<Props, State> {
         new Animated.Value(
           (props.openingRouteKeys.includes(curr.key) &&
             getAnimationEnabled(animation)) ||
-            isPreloadedRoute(curr, props)
+            isInactiveRoute(curr, props.routes)
             ? getDistanceFromOptions(
                 state.layout,
                 descriptor?.options,
@@ -329,10 +317,10 @@ export class CardStack extends React.Component<Props, State> {
     const modalRouteKeys = getModalRouteKeys(allRoutes, props.descriptors);
 
     const scenes = allRoutes.map((route, index, self) => {
-      // For preloaded screens, we don't care about the previous and the next screen
-      const isPreloaded = isPreloadedRoute(route, props);
-      const previousRoute = isPreloaded ? undefined : self[index - 1];
-      const nextRoute = isPreloaded ? undefined : self[index + 1];
+      // For preloaded or retained screens, we don't care about the previous and the next screen
+      const isInactive = isInactiveRoute(route, props.routes);
+      const previousRoute = isInactive ? undefined : self[index - 1];
+      const nextRoute = isInactive ? undefined : self[index + 1];
 
       const oldScene = state.scenes[index];
 
@@ -611,7 +599,7 @@ export class CardStack extends React.Component<Props, State> {
 
     const { scenes, layout, gestures, headerHeights } = this.state;
 
-    const allRoutes = getAllRoutes(routes, state.preloadedRoutes);
+    const allRoutes = getAllRoutes(routes, state);
 
     const focusedRoute = state.routes[state.index];
 
@@ -658,7 +646,7 @@ export class CardStack extends React.Component<Props, State> {
             const focused = focusedRoute.key === route.key;
             const gesture = gestures[route.key];
             const scene = scenes[index];
-            const isPreloaded = isPreloadedRoute(route, this.props);
+            const isInactive = isInactiveRoute(route, this.props.routes);
 
             const {
               inactiveBehavior = 'pause',
@@ -717,16 +705,15 @@ export class CardStack extends React.Component<Props, State> {
               (isAnimationEnabled &&
                 (isFocusing ||
                   isRemoving ||
-                  // Preloaded routes should stay mounted, but remain hidden until focused
-                  (!isPreloaded && index >= routes.length - 2)));
+                  // Preloaded and retained screens should stay mounted, but remain hidden until focused
+                  (!isInactive && index >= routes.length - 2)));
 
             const activityMode = // Render focused and animating screens normally
               focused || isFocusing
                 ? 'normal'
                 : inactiveBehavior === 'none' ||
-                    // Unpause preloaded screens so updates are visible
-                    // This lets preloaded screens initialize
-                    isPreloaded ||
+                    // Unpause preloaded or retained screens so updates are visible
+                    isInactive ||
                     // Keep the screen before transparent screen active
                     // This lets the screen under the transparent screen update and animate
                     isNextScreenTransparent ||
@@ -781,7 +768,7 @@ export class CardStack extends React.Component<Props, State> {
                 onTransitionStart={onTransitionStart}
                 onTransitionEnd={onTransitionEnd}
                 isNextScreenTransparent={isNextScreenTransparent}
-                preloaded={isPreloaded}
+                preloaded={isInactive}
               >
                 <ActivityView
                   mode={activityMode}

--- a/packages/stack/src/views/Stack/StackView.tsx
+++ b/packages/stack/src/views/Stack/StackView.tsx
@@ -62,14 +62,13 @@ export class StackView extends React.Component<Props, State> {
     props: Readonly<Props>,
     state: Readonly<State>
   ) {
-    const allRoutes = [...props.state.routes, ...props.state.preloadedRoutes];
-    const previousRoutes = state.previousState
-      ? [...state.previousState.routes, ...state.previousState.preloadedRoutes]
-      : [];
+    const allRoutes = props.state.routes;
+    const previousRoutes = state.previousState?.routes ?? [];
     const previousFocusedRoute = state.previousState
       ? state.previousState.routes[state.previousState.index]
       : undefined;
     const nextFocusedRouteFromState = props.state.routes[props.state.index];
+    const activeRoutes = props.state.routes.slice(0, props.state.index + 1);
 
     // If there was no change in routes, we don't need to compute anything
     if (
@@ -88,16 +87,16 @@ export class StackView extends React.Component<Props, State> {
       const closingRoutes = state.routes.filter(
         (r) =>
           state.closingRouteKeys.includes(r.key) &&
-          !props.state.routes.some((pr) => pr.key === r.key)
+          !activeRoutes.some((pr) => pr.key === r.key)
       );
 
       const replacingRoutes = state.routes.filter(
         (r) =>
           state.replacingRouteKeys.includes(r.key) &&
-          !props.state.routes.some((pr) => pr.key === r.key)
+          !activeRoutes.some((pr) => pr.key === r.key)
       );
 
-      let routes: Route<string>[] = props.state.routes.slice();
+      let routes: Route<string>[] = activeRoutes.slice();
 
       // Replacing routes go before the focused route (they're being covered)
       if (replacingRoutes.length) {
@@ -122,9 +121,10 @@ export class StackView extends React.Component<Props, State> {
         routes = routes.map((route) => map[route.key] || route);
       }
 
+      const routeKeys = new Set(routes.map((route) => route.key));
       const descriptors = [
         ...routes,
-        ...props.state.preloadedRoutes,
+        ...props.state.routes.filter((route) => !routeKeys.has(route.key)),
       ].reduce<StackDescriptorMap>((acc, route) => {
         acc[route.key] =
           props.descriptors[route.key] || state.descriptors[route.key];
@@ -142,28 +142,20 @@ export class StackView extends React.Component<Props, State> {
     // Here we determine which routes were added or removed to animate them
     // We keep a copy of the route being removed in local state to be able to animate it
 
-    let routes =
-      props.state.index < props.state.routes.length - 1
-        ? // Remove any extra routes from the state
-          // The last visible route should be the focused route, i.e. at current index
-          props.state.routes.slice(0, props.state.index + 1)
-        : props.state.routes;
-
     let { openingRouteKeys, closingRouteKeys, replacingRouteKeys } = state;
 
     // If a route that was closing or being replaced is now back in the routes,
     // it was added back before the animation finished, so stop tracking it
     closingRouteKeys = closingRouteKeys.filter(
-      (key) => !routes.some((r) => r.key === key)
+      (key) => !activeRoutes.some((r) => r.key === key)
     );
 
     replacingRouteKeys = replacingRouteKeys.filter(
-      (key) => !routes.some((r) => r.key === key)
+      (key) => !activeRoutes.some((r) => r.key === key)
     );
 
-    // Get previous focused route from previousState (actual focused route, not last in previousRoutes
-    // which can be a preloaded route that was never focused)
-    const nextFocusedRoute = routes[routes.length - 1];
+    // Get previous focused route from previous active routes
+    const nextFocusedRoute = activeRoutes[activeRoutes.length - 1];
 
     const isAnimationEnabled = (key: string) => {
       const descriptor = props.descriptors[key] || state.descriptors[key];
@@ -176,6 +168,8 @@ export class StackView extends React.Component<Props, State> {
 
       return descriptor.options.animationTypeForReplace ?? 'push';
     };
+
+    let routes = activeRoutes;
 
     if (
       previousFocusedRoute &&
@@ -302,9 +296,10 @@ export class StackView extends React.Component<Props, State> {
       );
     }
 
+    const routeKeys = new Set(routes.map((route) => route.key));
     const descriptors = [
       ...routes,
-      ...props.state.preloadedRoutes,
+      ...props.state.routes.filter((route) => !routeKeys.has(route.key)),
     ].reduce<StackDescriptorMap>((acc, route) => {
       acc[route.key] =
         props.descriptors[route.key] || state.descriptors[route.key];
@@ -353,25 +348,33 @@ export class StackView extends React.Component<Props, State> {
     const { state, navigation } = this.props;
     const { closingRouteKeys, replacingRouteKeys } = this.state;
 
+    const activeRoutes = state.routes.slice(0, state.index + 1);
+
     if (
       closingRouteKeys.some((key) => key === route.key) &&
       replacingRouteKeys.every((key) => key !== route.key) &&
       state.routeNames.includes(route.name) &&
-      !state.routes.some((r) => r.key === route.key)
+      !activeRoutes.some((r) => r.key === route.key)
     ) {
-      // If route isn't present in current state, but was closing, assume that a close animation was cancelled
+      // If route is no longer active, but was closing, assume that a close animation was cancelled
       // So we need to add this route back to the state
       navigation.dispatch((state) => {
-        const routes = [
-          ...state.routes.filter((r) => r.key !== route.key),
-          route,
-        ];
+        const activeRoutes = state.routes
+          .slice(0, state.index + 1)
+          .filter((r) => r.key !== route.key);
+        const inactiveRoutes = state.routes
+          .slice(state.index + 1)
+          .filter((r) => r.key !== route.key);
 
-        return CommonActions.reset({
+        const routes = [...activeRoutes, route];
+
+        const resetState = {
           ...state,
-          routes,
           index: routes.length - 1,
-        });
+          routes: routes.concat(inactiveRoutes),
+        };
+
+        return CommonActions.reset(resetState);
       });
     } else {
       this.setState((state) => {
@@ -409,7 +412,9 @@ export class StackView extends React.Component<Props, State> {
   private handleCloseRoute = ({ route }: { route: Route<string> }) => {
     const { state, navigation } = this.props;
 
-    if (state.routes.some((r) => r.key === route.key)) {
+    const activeRoutes = state.routes.slice(0, state.index + 1);
+
+    if (activeRoutes.some((r) => r.key === route.key)) {
       // If a route exists in state, trigger a pop
       // This will happen in when the route was closed from the card component
       // e.g. When the close animation triggered from a gesture ends

--- a/packages/stack/src/views/Stack/__tests__/StackView.test.tsx
+++ b/packages/stack/src/views/Stack/__tests__/StackView.test.tsx
@@ -21,16 +21,19 @@ const createRoute = (name: string, key?: string): Route<string> => ({
 const createNavigationState = (
   routes: Route<string>[],
   options: { index?: number; preloadedRoutes?: Route<string>[] } = {}
-): StackNavigationState<ParamListBase> => ({
-  stale: false,
-  type: 'stack',
-  key: 'stack-1',
-  index: options.index ?? routes.length - 1,
-  routeNames: routes.map((r) => r.name),
-  routes,
-  preloadedRoutes: options.preloadedRoutes ?? [],
-  retainedRouteKeys: [],
-});
+): StackNavigationState<ParamListBase> => {
+  const preloadedRoutes = options.preloadedRoutes ?? [];
+
+  return {
+    stale: false,
+    type: 'stack',
+    key: 'stack-1',
+    index: options.index ?? routes.length - 1,
+    routeNames: routes.concat(preloadedRoutes).map((r) => r.name),
+    routes: routes.concat(preloadedRoutes),
+    retainedRouteKeys: [],
+  };
+};
 
 const createDescriptors = (
   routes: Route<string>[],
@@ -59,7 +62,10 @@ const createProps = (
   } = {}
 ) => ({
   state: createNavigationState(routes, options),
-  descriptors: createDescriptors(routes, options),
+  descriptors: createDescriptors(
+    routes.concat(options.preloadedRoutes ?? []),
+    options
+  ),
   direction: 'ltr' as const,
   navigation: {} as any,
 });


### PR DESCRIPTION
BREAKING CHANGE: Previously `state.routes` in stack didn't contain routes beyond index.
This changes the behavior to add preloaded and retained routes in those positions,
and removes the `preloadedRoutes` array in favor of routes beyond index.

This makes it possible to treat preloaded routes the same way as regular routes.

This means they can:

- Receive events from parent navigator
- Update their params
- Allow navigation in nested navigators
- Include nested navigator state in getRootState

It also stops treating preloaded routes as removed for `preventRemove`.