### PR TITLE
fix: 🐛 prevent scroll jitter when CardContent switches from page to card styles

### DIFF
--- a/packages/stack/src/views/Stack/CardContent.tsx
+++ b/packages/stack/src/views/Stack/CardContent.tsx
@@ -78,7 +78,7 @@ export function CardContent({ enabled, layout, style, ...rest }: Props) {
 
       if (isTouchDevice) {
         // Keep page mode stable on touch devices while width remains unchanged to
-        // avoid transient re-layout flips to `overflow:hidden card mode.
+        // avoid transient re-layout flips to `overflow:hidden` card mode.
         return isSameWidth;
       }
 

--- a/packages/stack/src/views/Stack/CardContent.tsx
+++ b/packages/stack/src/views/Stack/CardContent.tsx
@@ -30,11 +30,15 @@ export function CardContent({ enabled, layout, style, ...rest }: Props) {
     // the DOM with the current height of the window.
     // See https://css-tricks.com/the-trick-to-viewport-units-on-mobile/
     const isFullHeight = height === layout.height;
+    const isTouchDevice = navigator.maxTouchPoints > 0;
+    const isSameWidth = width === layout.width;
+    const isExactMatch = isSameWidth && isFullHeight;
+    const shouldApplyViewportFix = isTouchDevice && enabled && isSameWidth;
     const id = '__react-navigation-stack-mobile-chrome-viewport-fix';
 
     let unsubscribe: (() => void) | undefined;
 
-    if (isFullHeight && navigator.maxTouchPoints > 0) {
+    if (shouldApplyViewportFix) {
       const style =
         document.getElementById(id) ?? document.createElement('style');
 
@@ -67,10 +71,22 @@ export function CardContent({ enabled, layout, style, ...rest }: Props) {
     }
 
     // eslint-disable-next-line @eslint-react/hooks-extra/no-direct-set-state-in-use-effect
-    setFill(width === layout.width && height === layout.height);
+    setFill(() => {
+      if (!enabled) {
+        return false;
+      }
+
+      if (isTouchDevice) {
+        // Keep page mode stable on touch devices while width remains unchanged to
+        // avoid transient re-layout flips to `overflow:hidden card mode.
+        return isSameWidth;
+      }
+
+      return isExactMatch;
+    });
 
     return unsubscribe;
-  }, [layout.height, layout.width]);
+  }, [enabled, layout.height, layout.width]);
 
   return (
     <View

--- a/packages/stack/src/views/Stack/CardStack.tsx
+++ b/packages/stack/src/views/Stack/CardStack.tsx
@@ -510,20 +510,10 @@ export class CardStack extends React.Component<Props, State> {
   private handleLayout = (e: LayoutChangeEvent) => {
     const { height, width } = e.nativeEvent.layout;
 
+    const layout = { width, height };
+
     this.setState((state, props) => {
-      // iOS Safari can report transient layout height shrink events during scroll,
-      // which can cause visible jitter.
-      const nextHeight =
-        Platform.OS === 'web' && width === state.layout.width
-          ? Math.max(state.layout.height, height)
-          : height;
-
-      const layout = {
-        width,
-        height: nextHeight,
-      };
-
-      if (nextHeight === state.layout.height && width === state.layout.width) {
+      if (height === state.layout.height && width === state.layout.width) {
         return null;
       }
 

--- a/packages/stack/src/views/Stack/CardStack.tsx
+++ b/packages/stack/src/views/Stack/CardStack.tsx
@@ -510,10 +510,20 @@ export class CardStack extends React.Component<Props, State> {
   private handleLayout = (e: LayoutChangeEvent) => {
     const { height, width } = e.nativeEvent.layout;
 
-    const layout = { width, height };
-
     this.setState((state, props) => {
-      if (height === state.layout.height && width === state.layout.width) {
+      // iOS Safari can report transient layout height shrink events during scroll,
+      // which can cause visible jitter.
+      const nextHeight =
+        Platform.OS === 'web' && width === state.layout.width
+          ? Math.max(state.layout.height, height)
+          : height;
+
+      const layout = {
+        width,
+        height: nextHeight,
+      };
+
+      if (nextHeight === state.layout.height && width === state.layout.width) {
         return null;
       }
 


### PR DESCRIPTION
**Motivation**

This PR fixes a mobile web scrolling issue caused by `CardContent` switching from page styles to card styles during transient layout changes.

On mobile web (notably iOS Safari), rapid layout updates during scroll can temporarily report smaller layout heights. In more complex stack screens (for example, long scrollable content with sticky/fixed bottom actions), this can cause:

- visible layout jitter/reflow
- sticky footer shake
- occasional scroll position reset


In `CardContent`, page style keeps the document scrollable (`minHeight: 100%`), while card style applies `overflow: hidden`. Unexpected switches to card style during scroll can cause the jitter/jump behaviour above.

This change stabilizes that behaviour by keeping `CardContent` in page style on touch devices when the width remains unchanged, while preserving strict exact-match behaviour for non-touch environments. 


**Test plan**

1. Run the example app on web (iOS safari) and view `Stack -> Card + Modal` 
2. There should be no regressions

Unfortunately, I wasn’t able to reproduce this in the example app. The issue appears to require a more complex page composition than the example setup. But I've validated the Stack Card example and found no regressions.
I've added screenshots below.

**Screenshots**

**Before**

https://github.com/user-attachments/assets/cf679b39-dc63-4e38-91ae-b2946cdf540c

**After**

https://github.com/user-attachments/assets/670e4848-bf86-4d56-b126-c1459f9753d1

