### PR TITLE
feat(iOS): implement unstable_toolbarItems for stack navigator

### DIFF
--- a/packages/native-stack/src/types.tsx
+++ b/packages/native-stack/src/types.tsx
@@ -373,9 +373,7 @@ export type NativeStackNavigationOptions = {
    *
    * @platform ios
    */
-  unstable_toolbarItems?: (
-    props: NativeStackHeaderItemProps
-  ) => NativeStackToolbarItem[];
+  unstable_toolbarItems?: () => NativeStackToolbarItem[];
   /**
    * String or a function that returns a React Element to be used by the header.
    * Defaults to screen `title` or route name.

--- a/packages/native-stack/src/types.tsx
+++ b/packages/native-stack/src/types.tsx
@@ -364,6 +364,19 @@ export type NativeStackNavigationOptions = {
     | ((props: NativeStackHeaderItemProps) => NativeStackHeaderItem[])
     | undefined;
   /**
+   * Function which returns an array of items to display in the bottom toolbar of the navigation controller.
+   * The toolbar is automatically shown when items are provided and hidden when empty or undefined.
+   *
+   * This is an unstable API and might change in the future.
+   *
+   * Only supported on iOS.
+   *
+   * @platform ios
+   */
+  unstable_toolbarItems?: (
+    props: NativeStackHeaderItemProps
+  ) => NativeStackToolbarItem[];
+  /**
    * String or a function that returns a React Element to be used by the header.
    * Defaults to screen `title` or route name.
    *
@@ -1151,6 +1164,63 @@ export type NativeStackHeaderItem =
   | NativeStackHeaderItemMenu
   | NativeStackHeaderItemSpacing
   | NativeStackHeaderItemCustom;
+
+type SharedToolbarItem = Omit<SharedHeaderItem, 'label'> & {
+  /**
+   * Label of the item. Optional for toolbar items since icon-only buttons are common.
+   */
+  label?: string;
+};
+
+/**
+ * A button item in the toolbar.
+ */
+export type NativeStackToolbarItemButton = SharedToolbarItem & {
+  type: 'button';
+  /**
+   * Function to call when the item is pressed.
+   */
+  onPress: () => void;
+  /**
+   * Whether the item is in a selected state.
+   */
+  selected?: boolean;
+};
+
+/**
+ * An item that shows a menu when pressed, for use in the toolbar.
+ */
+export type NativeStackToolbarItemMenu = SharedToolbarItem & {
+  type: 'menu';
+  /**
+   * Whether the menu is a selection menu.
+   */
+  changesSelectionAsPrimaryAction?: boolean;
+  /**
+   * Menu for the item.
+   */
+  menu: NativeStackHeaderItemMenu['menu'];
+};
+
+/**
+ * A flexible space item that expands to fill available space in the toolbar.
+ */
+export type NativeStackToolbarItemFlexibleSpace = {
+  type: 'flexibleSpace';
+};
+
+/**
+ * An item that can be displayed in the bottom toolbar of the navigation controller.
+ *
+ * Only supported on iOS.
+ *
+ * @platform ios
+ */
+export type NativeStackToolbarItem =
+  | NativeStackToolbarItemButton
+  | NativeStackToolbarItemMenu
+  | NativeStackHeaderItemSpacing
+  | NativeStackToolbarItemFlexibleSpace;
 
 export type NativeStackNavigatorProps = DefaultNavigatorOptions<
   ParamListBase,

--- a/packages/native-stack/src/views/useHeaderConfigProps.tsx
+++ b/packages/native-stack/src/views/useHeaderConfigProps.tsx
@@ -505,10 +505,7 @@ export function useHeaderConfigProps({
     return undefined;
   }, [headerBackIcon, tintColor]);
 
-  const toolbarItems = toolbarItemsProp?.({
-    tintColor,
-    canGoBack,
-  });
+  const toolbarItems = toolbarItemsProp?.();
 
   const children = (
     <>

--- a/packages/native-stack/src/views/useHeaderConfigProps.tsx
+++ b/packages/native-stack/src/views/useHeaderConfigProps.tsx
@@ -10,6 +10,7 @@ import {
 import { useMemo } from 'react';
 import { Platform, StyleSheet, type TextStyle, View } from 'react-native';
 import {
+  type HeaderBarButtonItem,
   type HeaderBarButtonItemMenuAction,
   type HeaderBarButtonItemSubmenu,
   type HeaderBarButtonItemWithAction,
@@ -30,7 +31,12 @@ import type {
   NativeStackHeaderItemMenuAction,
   NativeStackHeaderItemMenuSubmenu,
   NativeStackNavigationOptions,
+  NativeStackToolbarItem,
 } from '../types';
+
+// ToolbarItem is defined in react-native-screens but may not be released yet;
+// define it locally to keep this package self-contained.
+type ToolbarItem = HeaderBarButtonItem | { type: 'flexibleSpace' };
 
 type Props = NativeStackNavigationOptions & {
   headerTopInsetEnabled: boolean;
@@ -158,6 +164,102 @@ const transformIcon = (
   return icon;
 };
 
+const processToolbarItems = (
+  items: NativeStackToolbarItem[] | undefined,
+  colors: Theme['colors'],
+  fonts: Theme['fonts']
+): ToolbarItem[] | undefined => {
+  return items
+    ?.map((item, index) => {
+      if (item.type === 'flexibleSpace') {
+        return item;
+      }
+
+      if (item.type === 'spacing') {
+        if (item.spacing == null) {
+          throw new Error(
+            `Spacing item must have a 'spacing' property defined: ${JSON.stringify(item)}`
+          );
+        }
+        return item;
+      }
+
+      if (item.type === 'button' || item.type === 'menu') {
+        if (item.type === 'menu' && item.menu == null) {
+          throw new Error(
+            `Menu item must have a 'menu' property defined: ${JSON.stringify(item)}`
+          );
+        }
+
+        const { badge, label, labelStyle, icon, ...rest } = item;
+
+        const processedItemCommon = {
+          ...rest,
+          index,
+          title: label,
+          titleStyle:
+            label != null || labelStyle != null
+              ? { ...fonts.regular, ...labelStyle }
+              : undefined,
+          icon: transformIcon(icon),
+        };
+
+        let processedItem:
+          | HeaderBarButtonItemWithAction
+          | HeaderBarButtonItemWithMenu;
+
+        if (processedItemCommon.type === 'menu' && item.type === 'menu') {
+          const { multiselectable, layout } = item.menu;
+          processedItem = {
+            ...processedItemCommon,
+            menu: {
+              ...processedItemCommon.menu,
+              singleSelection: !multiselectable,
+              displayAsPalette: layout === 'palette',
+              items: item.menu.items.map(getMenuItem),
+            },
+          };
+        } else if (
+          processedItemCommon.type === 'button' &&
+          item.type === 'button'
+        ) {
+          processedItem = processedItemCommon;
+        } else {
+          throw new Error(
+            `Invalid toolbar item type: ${JSON.stringify(item)}. Valid types are 'button' and 'menu'.`
+          );
+        }
+
+        if (badge) {
+          const badgeBackgroundColor =
+            badge.style?.backgroundColor ?? colors.notification;
+          const badgeTextColor = Color.foreground(badgeBackgroundColor);
+
+          processedItem = {
+            ...processedItem,
+            badge: {
+              ...badge,
+              value: String(badge.value),
+              style: {
+                backgroundColor: badgeBackgroundColor,
+                color: badgeTextColor,
+                ...fonts.regular,
+                ...badge.style,
+              },
+            },
+          };
+        }
+
+        return processedItem;
+      }
+
+      throw new Error(
+        `Invalid toolbar item type: ${JSON.stringify(item)}. Valid types are 'button', 'menu', 'spacing' and 'flexibleSpace'.`
+      );
+    })
+    .filter((item) => item != null);
+};
+
 const getMenuItem = (
   item: NativeStackHeaderItemMenuAction | NativeStackHeaderItemMenuSubmenu
 ): HeaderBarButtonItemMenuAction | HeaderBarButtonItemSubmenu => {
@@ -218,6 +320,7 @@ export function useHeaderConfigProps({
   title,
   unstable_headerLeftItems: headerLeftItems,
   unstable_headerRightItems: headerRightItems,
+  unstable_toolbarItems: toolbarItemsProp,
 }: Props): ScreenStackHeaderConfigProps {
   const { direction } = useLocale();
   const { colors, fonts, dark } = useTheme();
@@ -402,6 +505,11 @@ export function useHeaderConfigProps({
     return undefined;
   }, [headerBackIcon, tintColor]);
 
+  const toolbarItems = toolbarItemsProp?.({
+    tintColor,
+    canGoBack,
+  });
+
   const children = (
     <>
       {Platform.OS === 'ios' ? (
@@ -554,5 +662,7 @@ export function useHeaderConfigProps({
     headerLeftBarButtonItems: processBarButtonItems(leftItems, colors, fonts),
     headerRightBarButtonItems: processBarButtonItems(rightItems, colors, fonts),
     experimental_userInterfaceStyle: dark ? 'dark' : 'light',
+    // @ts-expect-error toolbarItems is not yet exported from the released react-native-screens
+    toolbarItems: processToolbarItems(toolbarItems, colors, fonts),
   } as const;
 }


### PR DESCRIPTION
**Motivation**

Adds an api to the native stack navigator that adds support for the suggested toolbar items API introduced in https://github.com/software-mansion/react-native-screens/pull/4013

**Test plan**

Run the example app in react-native-screens and open the "Toolbar" example to test it
