### PR TITLE
fix(core): throw on conflicting router path patterns

### DIFF
--- a/packages/core/src/routers/__tests__/PathHandling.test.js
+++ b/packages/core/src/routers/__tests__/PathHandling.test.js
@@ -554,6 +554,48 @@ const performRouterTest = (createTestRouter) => {
     expect(action.type).toEqual(NavigationActions.NAVIGATE);
     expect(action.routeName).toEqual('baz');
   });
+
+  it('throws when route configs resolve to conflicting path patterns', () => {
+    expect(() =>
+      createTestRouter({
+        alpha: {
+          path: 'user/:id',
+          screen: FooNavigator,
+        },
+        beta: {
+          path: 'user/:userId',
+          screen: FooNavigator,
+        },
+      })
+    ).toThrow(
+      'Found conflicting route paths in the same router: "alpha" ("user/:id"), "beta" ("user/:userId").'
+    );
+  });
+
+  it('throws when paths option creates conflicting path patterns', () => {
+    expect(() =>
+      createTestRouter(
+        {
+          alpha: {
+            path: 'a/:id',
+            screen: FooNavigator,
+          },
+          beta: {
+            path: 'b/:id',
+            screen: FooNavigator,
+          },
+        },
+        {
+          paths: {
+            alpha: 'users/:id',
+            beta: 'users/:userId',
+          },
+        }
+      )
+    ).toThrow(
+      'Found conflicting route paths in the same router: "alpha" ("users/:id"), "beta" ("users/:userId").'
+    );
+  });
 };
 
 describe('Path handling for stack router', () => {

--- a/packages/core/src/routers/pathUtils.js
+++ b/packages/core/src/routers/pathUtils.js
@@ -79,6 +79,7 @@ export const createPathParser = (
 ) => {
   const pathsByRouteNames = {};
   let paths = [];
+  const exactMatchers = {};
 
   // Build pathsByRouteNames, which includes a regex to match paths for each route. Keep in mind, the regex will pass for the route and all child routes. The code that uses pathsByRouteNames will need to also verify that the child router produces an action, in the case of isPathMatchable false (a null path).
   Object.keys(childRouters).forEach((routeName) => {
@@ -123,6 +124,32 @@ export const createPathParser = (
       isWildcard,
       toPath: pathPattern === null ? () => '' : compile(pathPattern),
     };
+
+    // Detect conflicting route path patterns where matching would be ambiguous.
+    // We intentionally exclude wildcard/null paths because they are used as pass-through
+    // configurations for nested routers.
+    if (exactRe && !isWildcard) {
+      const matcherKey = exactRe.toString();
+      if (!exactMatchers[matcherKey]) {
+        exactMatchers[matcherKey] = [];
+      }
+      exactMatchers[matcherKey].push({ routeName, pathPattern });
+    }
+  });
+
+  Object.keys(exactMatchers).forEach((matcherKey) => {
+    const conflicts = exactMatchers[matcherKey];
+    if (conflicts.length > 1) {
+      const conflictDescriptions = conflicts
+        .map(
+          ({ routeName, pathPattern }) => `"${routeName}" ("${pathPattern}")`
+        )
+        .join(', ');
+      invariant(
+        false,
+        `Found conflicting route paths in the same router: ${conflictDescriptions}.`
+      );
+    }
   });
 
   paths = Object.entries(pathsByRouteNames);


### PR DESCRIPTION
## Summary
- add a conflict check in `createPathParser` to fail fast when 2 routes resolve to the same exact non-wildcard matcher
- keep existing `null`/empty-string wildcard behavior unchanged
- add regression tests for both route-config and `paths`-override conflict cases

Closes #7653

## Test Plan
- `yarn test packages/core/src/routers/__tests__/PathHandling.test.js`
- pre-commit hook suite (auto-ran on commit): `eslint`, `tsc --noEmit --composite false`, full `jest`

## Notes
- this change only rejects ambiguous exact path patterns (including param-name aliases like `user/:id` vs `user/:userId`) to avoid unpredictable route selection.
