### PR TITLE
fix(tab-view): forward pageMargin to adapters

### DIFF
--- a/packages/react-native-tab-view/src/PagerViewAdapter.native.tsx
+++ b/packages/react-native-tab-view/src/PagerViewAdapter.native.tsx
@@ -21,7 +21,9 @@ export type PagerViewAdapterProps = AdapterProps &
     | 'onPageSelected'
     | 'onPageScrollStateChanged'
     | 'children'
-  >;
+  > & {
+    pageMargin?: PagerViewProps['pageMargin'] | undefined;
+  };
 
 const useNativeDriver = Platform.OS !== 'web';
 
@@ -36,6 +38,7 @@ export function PagerViewAdapter({
   children,
   style,
   animationEnabled,
+  pageMargin,
   ...rest
 }: PagerViewAdapterProps) {
   const { index } = navigationState;
@@ -160,6 +163,7 @@ export function PagerViewAdapter({
         }}
         onPageScrollStateChanged={onPageScrollStateChanged}
         scrollEnabled={swipeEnabled}
+        pageMargin={pageMargin}
       >
         {children}
       </AnimatedViewPager>

--- a/packages/react-native-tab-view/src/PagerViewAdapter.native.tsx
+++ b/packages/react-native-tab-view/src/PagerViewAdapter.native.tsx
@@ -163,7 +163,7 @@ export function PagerViewAdapter({
         }}
         onPageScrollStateChanged={onPageScrollStateChanged}
         scrollEnabled={swipeEnabled}
-        pageMargin={pageMargin}
+        {...(pageMargin != null ? { pageMargin } : null)}
       >
         {children}
       </AnimatedViewPager>

--- a/packages/react-native-tab-view/src/PanResponderAdapter.tsx
+++ b/packages/react-native-tab-view/src/PanResponderAdapter.tsx
@@ -36,6 +36,7 @@ export function PanResponderAdapter({
   onSwipeEnd,
   children,
   style,
+  pageMargin = 0,
   animationEnabled = false,
   layoutDirection = 'ltr',
 }: PanResponderAdapterProps) {
@@ -56,10 +57,11 @@ export function PanResponderAdapter({
 
   const swipeVelocityThreshold = 0.15;
   const swipeDistanceThreshold = layout.width / 1.75;
+  const pageWidth = layout.width + pageMargin;
 
   const jumpToIndex = useLatestCallback(
     (index: number, animate = animationEnabled) => {
-      const offset = -index * layout.width;
+      const offset = -index * pageWidth;
 
       const { timing, ...transitionConfig } = DefaultTransitionSpec;
 
@@ -94,10 +96,10 @@ export function PanResponderAdapter({
   });
 
   React.useLayoutEffect(() => {
-    const offset = -navigationStateRef.current.index * layout.width;
+    const offset = -navigationStateRef.current.index * pageWidth;
 
     panX.setValue(offset);
-  }, [layout.width, panX]);
+  }, [pageWidth, panX]);
 
   React.useEffect(() => {
     if (keyboardDismissMode === 'auto') {
@@ -168,7 +170,7 @@ export function PanResponderAdapter({
 
     if (layout.width) {
       // @ts-expect-error: _offset is private, but docs use it as well
-      const position = (panX._offset + diffX) / -layout.width;
+      const position = (panX._offset + diffX) / -pageWidth;
       const next =
         position > index ? Math.ceil(position) : Math.floor(position);
 
@@ -255,7 +257,7 @@ export function PanResponderAdapter({
     onPanResponderTerminationRequest: () => true,
   });
 
-  const maxTranslate = layout.width * (routes.length - 1);
+  const maxTranslate = pageWidth * (routes.length - 1);
   const translateX = Animated.multiply(
     panX.interpolate({
       inputRange: [-maxTranslate, 0],
@@ -266,8 +268,8 @@ export function PanResponderAdapter({
   );
 
   const position = React.useMemo(
-    () => (layout.width ? Animated.divide(panX, -layout.width) : null),
-    [layout.width, panX]
+    () => (pageWidth ? Animated.divide(panX, -pageWidth) : null),
+    [pageWidth, panX]
   );
 
   return children({
@@ -281,7 +283,7 @@ export function PanResponderAdapter({
             styles.sheet,
             layout.width
               ? {
-                  width: routes.length * layout.width,
+                  width: routes.length * pageWidth,
                   transform: [{ translateX }],
                 }
               : null,
@@ -302,7 +304,14 @@ export function PanResponderAdapter({
                 key={route.key}
                 style={
                   layout.width
-                    ? { width: layout.width }
+                    ? {
+                        width: layout.width,
+                        ...(i < routes.length - 1
+                          ? layoutDirection === 'rtl'
+                            ? { marginLeft: pageMargin }
+                            : { marginRight: pageMargin }
+                          : null),
+                      }
                     : focused
                       ? StyleSheet.absoluteFill
                       : null

--- a/packages/react-native-tab-view/src/PanResponderAdapter.tsx
+++ b/packages/react-native-tab-view/src/PanResponderAdapter.tsx
@@ -36,7 +36,6 @@ export function PanResponderAdapter({
   onSwipeEnd,
   children,
   style,
-  pageMargin = 0,
   animationEnabled = false,
   layoutDirection = 'ltr',
 }: PanResponderAdapterProps) {
@@ -57,11 +56,10 @@ export function PanResponderAdapter({
 
   const swipeVelocityThreshold = 0.15;
   const swipeDistanceThreshold = layout.width / 1.75;
-  const pageWidth = layout.width + pageMargin;
 
   const jumpToIndex = useLatestCallback(
     (index: number, animate = animationEnabled) => {
-      const offset = -index * pageWidth;
+      const offset = -index * layout.width;
 
       const { timing, ...transitionConfig } = DefaultTransitionSpec;
 
@@ -96,10 +94,10 @@ export function PanResponderAdapter({
   });
 
   React.useLayoutEffect(() => {
-    const offset = -navigationStateRef.current.index * pageWidth;
+    const offset = -navigationStateRef.current.index * layout.width;
 
     panX.setValue(offset);
-  }, [pageWidth, panX]);
+  }, [layout.width, panX]);
 
   React.useEffect(() => {
     if (keyboardDismissMode === 'auto') {
@@ -170,7 +168,7 @@ export function PanResponderAdapter({
 
     if (layout.width) {
       // @ts-expect-error: _offset is private, but docs use it as well
-      const position = (panX._offset + diffX) / -pageWidth;
+      const position = (panX._offset + diffX) / -layout.width;
       const next =
         position > index ? Math.ceil(position) : Math.floor(position);
 
@@ -257,7 +255,7 @@ export function PanResponderAdapter({
     onPanResponderTerminationRequest: () => true,
   });
 
-  const maxTranslate = pageWidth * (routes.length - 1);
+  const maxTranslate = layout.width * (routes.length - 1);
   const translateX = Animated.multiply(
     panX.interpolate({
       inputRange: [-maxTranslate, 0],
@@ -268,8 +266,8 @@ export function PanResponderAdapter({
   );
 
   const position = React.useMemo(
-    () => (pageWidth ? Animated.divide(panX, -pageWidth) : null),
-    [pageWidth, panX]
+    () => (layout.width ? Animated.divide(panX, -layout.width) : null),
+    [layout.width, panX]
   );
 
   return children({
@@ -283,7 +281,7 @@ export function PanResponderAdapter({
             styles.sheet,
             layout.width
               ? {
-                  width: routes.length * pageWidth,
+                  width: routes.length * layout.width,
                   transform: [{ translateX }],
                 }
               : null,
@@ -304,14 +302,7 @@ export function PanResponderAdapter({
                 key={route.key}
                 style={
                   layout.width
-                    ? {
-                        width: layout.width,
-                        ...(i < routes.length - 1
-                          ? layoutDirection === 'rtl'
-                            ? { marginLeft: pageMargin }
-                            : { marginRight: pageMargin }
-                          : null),
-                      }
+                    ? { width: layout.width }
                     : focused
                       ? StyleSheet.absoluteFill
                       : null

--- a/packages/react-native-tab-view/src/TabView.tsx
+++ b/packages/react-native-tab-view/src/TabView.tsx
@@ -162,6 +162,7 @@ export function TabView<T extends Route>({
   // eslint-disable-next-line @eslint-react/no-unstable-default-props
   renderAdapter = (props) => <Pager {...props} />,
   pagerStyle,
+  pageMargin,
   style,
   direction = I18nManager.getConstants().isRTL ? 'rtl' : 'ltr',
   swipeEnabled = true,
@@ -208,6 +209,7 @@ export function TabView<T extends Route>({
     animationEnabled,
     layoutDirection: direction,
     style: pagerStyle,
+    pageMargin,
     children: ({ position, render, subscribe, jumpTo }) => {
       // All the props here must not change between re-renders
       // This is crucial to optimizing the routes with PureComponent

--- a/packages/react-native-tab-view/src/__tests__/index.test.tsx
+++ b/packages/react-native-tab-view/src/__tests__/index.test.tsx
@@ -128,7 +128,11 @@ describe.each([{ type: 'ios' as const }, { type: 'web' as const }])(
     });
 
     test('forwards pageMargin to adapter', () => {
-      const renderAdapter = jest.fn((props: any) => <View {...props} />);
+      let capturedProps: { pageMargin?: number } | undefined;
+      const renderAdapter = jest.fn((props: any) => {
+        capturedProps = props;
+        return <View />;
+      });
 
       render(
         <TabView
@@ -144,10 +148,7 @@ describe.each([{ type: 'ios' as const }, { type: 'web' as const }])(
       );
 
       expect(renderAdapter).toHaveBeenCalled();
-      const adapterProps = renderAdapter.mock.calls[0]?.[0] as
-        | { pageMargin?: number }
-        | undefined;
-      expect(adapterProps?.pageMargin).toBe(16);
+      expect(capturedProps?.pageMargin).toBe(16);
     });
   }
 );

--- a/packages/react-native-tab-view/src/__tests__/index.test.tsx
+++ b/packages/react-native-tab-view/src/__tests__/index.test.tsx
@@ -126,5 +126,28 @@ describe.each([{ type: 'ios' as const }, { type: 'web' as const }])(
       expect(onTabSelect).toHaveBeenCalledTimes(1);
       expect(onTabSelect).toHaveBeenCalledWith({ index: 1 });
     });
+
+    test('forwards pageMargin to adapter', () => {
+      const renderAdapter = jest.fn((props: any) => <View {...props} />);
+
+      render(
+        <TabView
+          navigationState={{
+            index: 0,
+            routes: [{ key: 'first', title: 'First' }],
+          }}
+          renderScene={renderScene}
+          onIndexChange={jest.fn()}
+          pageMargin={16}
+          renderAdapter={renderAdapter}
+        />
+      );
+
+      expect(renderAdapter).toHaveBeenCalled();
+      const adapterProps = renderAdapter.mock.calls[0]?.[0] as
+        | { pageMargin?: number }
+        | undefined;
+      expect(adapterProps?.pageMargin).toBe(16);
+    });
   }
 );

--- a/packages/react-native-tab-view/src/types.tsx
+++ b/packages/react-native-tab-view/src/types.tsx
@@ -112,6 +112,10 @@ export type AdapterCommonProps = {
    * Style for the pager adapter.
    */
   style?: StyleProp<ViewStyle> | undefined;
+  /**
+   * Gap between pages.
+   */
+  pageMargin?: number | undefined;
 };
 
 export type AdapterRendererProps = {


### PR DESCRIPTION
## Summary
- thread `pageMargin` through `TabView` into adapter props
- pass `pageMargin` to native pager adapter so `react-native-pager-view` receives it
- add JS fallback support in `PanResponderAdapter` by applying inter-page spacing and matching translate/page width math
- add a regression test to verify `TabView` forwards `pageMargin` to the adapter

Closes #13065

## Testing
- `yarn test packages/react-native-tab-view/src/__tests__/index.test.tsx`
- pre-commit hook (auto-ran): `test`, `types`, `lint`
