### PR TITLE
fix: avoid selected state on drawer links

### DIFF
--- a/packages/drawer/src/__tests__/index.test.tsx
+++ b/packages/drawer/src/__tests__/index.test.tsx
@@ -8,10 +8,14 @@ import {
 } from '@react-navigation/native';
 import { act, fireEvent, render } from '@testing-library/react-native';
 import { useEffect } from 'react';
-import { Button, View } from 'react-native';
+import { Button, Platform, View } from 'react-native';
 import { setUpTests } from 'react-native-reanimated';
 
-import { createDrawerNavigator, type DrawerScreenProps } from '../index';
+import {
+  createDrawerNavigator,
+  DrawerItem,
+  type DrawerScreenProps,
+} from '../index';
 
 setUpTests();
 
@@ -29,6 +33,26 @@ afterEach(() => {
 jest.mock('react-native-worklets', () =>
   require('react-native-worklets/src/mock')
 );
+
+test('does not pass selected accessibility state to drawer links on web', () => {
+  jest.replaceProperty(Platform, 'OS', 'web');
+
+  const { getByTestId } = render(
+    <DrawerItem
+      focused
+      href="/profile"
+      label="Profile"
+      onPress={jest.fn()}
+      testID="drawer-item"
+    />,
+    { wrapper: NavigationContainer }
+  );
+
+  expect(
+    getByTestId('drawer-item').props.accessibilityState.selected
+  ).toBeUndefined();
+  expect(getByTestId('drawer-item').props['aria-selected']).toBeUndefined();
+});
 
 test('renders a drawer navigator with screens', async () => {
   const Test = ({ route, navigation }: DrawerScreenProps<DrawerParamList>) => (

--- a/packages/drawer/src/views/DrawerItem.tsx
+++ b/packages/drawer/src/views/DrawerItem.tsx
@@ -208,7 +208,9 @@ export function DrawerItem(props: Props) {
         onPress={onPress}
         role="button"
         aria-label={accessibilityLabel}
-        aria-selected={focused}
+        accessibilityState={
+          Platform.OS === 'web' ? undefined : { selected: focused }
+        }
         pressColor={pressColor}
         pressOpacity={pressOpacity}
         hoverEffect={typeof color === 'string' ? { color } : undefined}


### PR DESCRIPTION
## Summary

- avoid passing selected accessibility state from `DrawerItem` on web
- keep native selected accessibility state for focused drawer items
- add a regression test for focused web drawer links

Fixes #9418

## Test plan

- `yarn test packages/drawer/src/__tests__/index.test.tsx --runInBand`
- `yarn prettier --check packages/drawer/src/views/DrawerItem.tsx packages/drawer/src/__tests__/index.test.tsx`
- `yarn eslint packages/drawer/src/views/DrawerItem.tsx packages/drawer/src/__tests__/index.test.tsx`
- `yarn typecheck`
- pre-commit hook also ran `types`, `test`, and `lint` successfully
