### PR TITLE
feat: align tab bar with latest material design guidelines

### DIFF
--- a/example/src/Screens/TabView/CustomIndicator.tsx
+++ b/example/src/Screens/TabView/CustomIndicator.tsx
@@ -46,7 +46,7 @@ export const CustomIndicator = () => {
   ]);
 
   const renderIndicator = (props: TabBarIndicatorProps<Route>) => {
-    const { position, getTabWidth, gap, width, style } = props;
+    const { position, widths, offsets, style } = props;
     const inputRange = [
       0, 0.48, 0.49, 0.51, 0.52, 1, 1.48, 1.49, 1.51, 1.52, 2,
     ];
@@ -68,9 +68,7 @@ export const CustomIndicator = () => {
       inputRange: inputRange,
       outputRange: inputRange.map((x) => {
         const i = Math.round(x);
-        return (
-          (i * getTabWidth(i) + i * (gap ?? 0)) * (direction === 'rtl' ? -1 : 1)
-        );
+        return offsets[i] * (direction === 'rtl' ? -1 : 1);
       }),
     });
 
@@ -79,11 +77,11 @@ export const CustomIndicator = () => {
         style={[
           style,
           styles.container,
-          { width, transform: [{ translateX }] },
+          { width: widths[0], transform: [{ translateX }] },
         ]}
       >
         <Animated.View
-          style={[styles.indicator, { opacity, transform: [{ scale }] } as any]}
+          style={[styles.indicator, { opacity, transform: [{ scale }] }]}
         />
       </Animated.View>
     );
@@ -152,6 +150,7 @@ CustomIndicator.options = {
 const styles = StyleSheet.create({
   tabbar: {
     backgroundColor: '#263238',
+    borderBottomWidth: 0,
     overflow: 'hidden',
   },
   tabbarContentContainer: {

--- a/example/src/Screens/TabView/ScrollableTabBar.tsx
+++ b/example/src/Screens/TabView/ScrollableTabBar.tsx
@@ -35,9 +35,11 @@ export const ScrollableTabBar = () => {
   >['renderTabBar'] = (props) => (
     <TabBar
       {...props}
+      variant="secondary"
       scrollEnabled
       contentContainerStyle={styles.tabbarContentContainer}
       tabStyle={styles.tab}
+      indicatorStyle={styles.indicator}
       gap={20}
       direction={direction}
     />
@@ -69,5 +71,8 @@ const styles = StyleSheet.create({
   },
   tab: {
     width: 120,
+  },
+  indicator: {
+    marginHorizontal: 10,
   },
 });

--- a/example/src/Showcase/MaterialTopTabsShowcase.tsx
+++ b/example/src/Showcase/MaterialTopTabsShowcase.tsx
@@ -750,9 +750,6 @@ const MaterialTopTabsShowcaseNavigator = createMaterialTopTabNavigator({
     tabBarScrollEnabled: true,
     tabBarItemStyle: { width: 'auto' },
     tabBarGap: SPACING_XS,
-    tabBarIndicatorStyle: {
-      marginHorizontal: SPACING_XL,
-    },
     tabBarLabelStyle: {
       fontSize: 14,
       letterSpacing: 0.1,

--- a/packages/material-top-tabs/src/types.tsx
+++ b/packages/material-top-tabs/src/types.tsx
@@ -148,6 +148,18 @@ export type MaterialTopTabNavigationOptions = {
     | undefined;
 
   /**
+   * Variant of the tab bar.
+   *
+   * The following variants are available:
+   *
+   * - `primary`: the indicator matches the label & icon width and is centered under the tab.
+   * - `secondary`: the indicator spans the full tab width.
+   *
+   * Defaults to `primary`.
+   */
+  tabBarVariant?: 'primary' | 'secondary' | undefined;
+
+  /**
    * Style object for the tab bar indicator.
    */
   tabBarIndicatorStyle?: StyleProp<ViewStyle> | undefined;
@@ -222,7 +234,7 @@ export type MaterialTopTabNavigationOptions = {
   /**
    * Allows to customize the android ripple effect (Android >= 5.0 only).
    *
-   * Default: `{ borderless: true }`
+   * Default: `{ borderless: false, foreground: true }`
    */
   tabBarAndroidRipple?: PressableAndroidRippleConfig | undefined;
 

--- a/packages/material-top-tabs/src/views/MaterialTopTabBar.tsx
+++ b/packages/material-top-tabs/src/views/MaterialTopTabBar.tsx
@@ -2,21 +2,14 @@ import { Text } from '@react-navigation/elements';
 import { Color } from '@react-navigation/elements/internal';
 import {
   MaterialSymbol,
-  type ParamListBase,
   SFSymbol,
-  type TabNavigationState,
   useLinkBuilder,
   useLocale,
   useTheme,
 } from '@react-navigation/native';
 import React from 'react';
 import { type ColorValue, Image, StyleSheet } from 'react-native';
-import {
-  type Route,
-  TabBar,
-  TabBarIndicator,
-  type TabDescriptor,
-} from 'react-native-tab-view';
+import { type Route, TabBar, type TabDescriptor } from 'react-native-tab-view';
 
 import type { MaterialTopTabBarProps } from '../types';
 
@@ -57,13 +50,23 @@ export function MaterialTopTabBar({
   const { buildHref } = useLinkBuilder();
 
   const focusedOptions = descriptors[state.routes[state.index].key].options;
+  const tabBarVariant = focusedOptions.tabBarVariant ?? 'primary';
 
   const activeColor: ColorValue =
-    focusedOptions.tabBarActiveTintColor ?? colors.text;
+    focusedOptions.tabBarActiveTintColor ??
+    (tabBarVariant === 'primary' ? colors.primary : colors.text);
+
   const inactiveColor: ColorValue =
     focusedOptions.tabBarInactiveTintColor ??
-    Color(activeColor)?.alpha(0.5).string() ??
-    (dark ? 'rgba(255, 255, 255, 0.5)' : 'rgba(0, 0, 0, 0.5)');
+    Color(colors.text)?.alpha(0.68).string() ??
+    (dark ? 'rgba(255, 255, 255, 0.68)' : 'rgba(0, 0, 0, 0.68)');
+
+  const pressColor: ColorValue =
+    focusedOptions.tabBarPressColor ??
+    Color(tabBarVariant === 'primary' ? colors.primary : colors.text)
+      ?.alpha(0.12)
+      .string() ??
+    (dark ? 'rgba(255, 255, 255, 0.12)' : 'rgba(0, 0, 0, 0.12)');
 
   const tabBarOptions = Object.fromEntries(
     state.routes.map((route) => {
@@ -182,6 +185,8 @@ export function MaterialTopTabBar({
     })
   );
 
+  const tabBarIndicator = focusedOptions.tabBarIndicator;
+
   return (
     <TabBar
       {...rest}
@@ -192,7 +197,7 @@ export function MaterialTopTabBar({
       bounces={focusedOptions.tabBarBounces}
       activeColor={activeColor}
       inactiveColor={inactiveColor}
-      pressColor={focusedOptions.tabBarPressColor}
+      pressColor={pressColor}
       pressOpacity={focusedOptions.tabBarPressOpacity}
       tabStyle={focusedOptions.tabBarItemStyle}
       indicatorStyle={[
@@ -200,10 +205,14 @@ export function MaterialTopTabBar({
         focusedOptions.tabBarIndicatorStyle,
       ]}
       gap={focusedOptions.tabBarGap}
+      variant={tabBarVariant}
       android_ripple={focusedOptions.tabBarAndroidRipple}
       indicatorContainerStyle={focusedOptions.tabBarIndicatorContainerStyle}
       contentContainerStyle={focusedOptions.tabBarContentContainerStyle}
-      style={[{ backgroundColor: colors.card }, focusedOptions.tabBarStyle]}
+      style={[
+        { backgroundColor: colors.card, borderBottomColor: colors.border },
+        focusedOptions.tabBarStyle,
+      ]}
       onTabPress={({ route, preventDefault }) => {
         const event = navigation.emit({
           type: 'tabPress',
@@ -221,16 +230,12 @@ export function MaterialTopTabBar({
           target: route.key,
         })
       }
-      renderIndicator={({ navigationState: state, ...rest }) => {
-        return focusedOptions.tabBarIndicator ? (
-          focusedOptions.tabBarIndicator({
-            state: state as TabNavigationState<ParamListBase>,
-            ...rest,
-          })
-        ) : (
-          <TabBarIndicator navigationState={state} {...rest} />
-        );
-      }}
+      renderIndicator={
+        tabBarIndicator
+          ? ({ navigationState: _, ...rest }) =>
+              tabBarIndicator({ ...rest, state })
+          : undefined
+      }
     />
   );
 }
@@ -239,7 +244,6 @@ const styles = StyleSheet.create({
   label: {
     textAlign: 'center',
     fontSize: 14,
-    margin: 4,
     backgroundColor: 'transparent',
   },
 });

--- a/packages/react-native-tab-view/src/PagerViewAdapter.native.tsx
+++ b/packages/react-native-tab-view/src/PagerViewAdapter.native.tsx
@@ -36,9 +36,19 @@ export function PagerViewAdapter({
   children,
   style,
   animationEnabled,
+  layoutDirection = 'ltr',
   ...rest
 }: PagerViewAdapterProps) {
-  const { index } = navigationState;
+  const { index, routes } = navigationState;
+
+  const isRTL = layoutDirection === 'rtl';
+
+  // iOS reports RTL pager offsets from the opposite end
+  // So we need to invert them to get the logical route index
+  const shouldInvertOffset = Platform.OS === 'ios' && isRTL;
+  const initialPosition = shouldInvertOffset
+    ? routes.length - 1 - index
+    : index;
 
   const listeners = React.useRef<Set<Listener>>(new Set()).current;
 
@@ -46,11 +56,25 @@ export function PagerViewAdapter({
   const indexRef = React.useRef<number>(index);
   const navigationStateRef = React.useRef(navigationState);
 
-  const position = useAnimatedValue(index);
+  const position = useAnimatedValue(initialPosition);
   const offset = useAnimatedValue(0);
 
   React.useEffect(() => {
     navigationStateRef.current = navigationState;
+  });
+
+  const setReportedOffset = useLatestCallback((index: number) => {
+    position.setValue(shouldInvertOffset ? routes.length - 1 - index : index);
+    offset.setValue(0);
+  });
+
+  const setPage = useLatestCallback((index: number) => {
+    if (animationEnabled) {
+      pagerRef.current?.setPage(index);
+    } else {
+      pagerRef.current?.setPageWithoutAnimation(index);
+      setReportedOffset(index);
+    }
   });
 
   const jumpTo = useLatestCallback((key: string) => {
@@ -58,13 +82,7 @@ export function PagerViewAdapter({
       (route: { key: string }) => route.key === key
     );
 
-    if (animationEnabled) {
-      pagerRef.current?.setPage(index);
-    } else {
-      pagerRef.current?.setPageWithoutAnimation(index);
-      position.setValue(index);
-    }
-
+    setPage(index);
     onIndexChange(index);
   });
 
@@ -74,14 +92,9 @@ export function PagerViewAdapter({
     }
 
     if (indexRef.current !== index) {
-      if (animationEnabled) {
-        pagerRef.current?.setPage(index);
-      } else {
-        pagerRef.current?.setPageWithoutAnimation(index);
-        position.setValue(index);
-      }
+      setPage(index);
     }
-  }, [keyboardDismissMode, index, animationEnabled, position]);
+  }, [keyboardDismissMode, index, setPage]);
 
   const onPageScrollStateChanged = (
     state: PageScrollStateChangedNativeEvent
@@ -123,10 +136,14 @@ export function PagerViewAdapter({
     };
   });
 
-  const memoizedPosition = React.useMemo(
-    () => Animated.add(position, offset),
-    [offset, position]
-  );
+  const memoizedPosition = React.useMemo(() => {
+    const value = Animated.add(position, offset);
+
+    // Convert the native RTL offset back to the logical route index
+    return shouldInvertOffset
+      ? Animated.subtract(routes.length - 1, value)
+      : value;
+  }, [offset, position, routes.length, shouldInvertOffset]);
 
   return children({
     position: memoizedPosition,
@@ -138,6 +155,7 @@ export function PagerViewAdapter({
         ref={pagerRef}
         style={[styles.container, style]}
         initialPage={index}
+        layoutDirection={layoutDirection}
         keyboardDismissMode={
           keyboardDismissMode === 'auto' ? 'on-drag' : keyboardDismissMode
         }

--- a/packages/react-native-tab-view/src/PlatformPressable.tsx
+++ b/packages/react-native-tab-view/src/PlatformPressable.tsx
@@ -31,7 +31,7 @@ const ANDROID_SUPPORTS_RIPPLE =
 export function PlatformPressable({
   disabled,
   android_ripple,
-  pressColor = 'rgba(0, 0, 0, .32)',
+  pressColor = 'rgba(0, 0, 0, .10)',
   pressOpacity,
   style,
   onPress,

--- a/packages/react-native-tab-view/src/ScrollViewAdapter.tsx
+++ b/packages/react-native-tab-view/src/ScrollViewAdapter.tsx
@@ -152,7 +152,7 @@ export function ScrollViewAdapter({
       },
     ],
     {
-      useNativeDriver: true,
+      useNativeDriver: Platform.OS !== 'web',
       listener: (event: ScrollEvent) => {
         const { x } = event.nativeEvent.contentOffset;
 

--- a/packages/react-native-tab-view/src/ScrollViewAdapter.tsx
+++ b/packages/react-native-tab-view/src/ScrollViewAdapter.tsx
@@ -36,7 +36,7 @@ export function ScrollViewAdapter({
   children,
   style,
   animationEnabled = true,
-  layoutDirection: _, // Not supported in ScrollViewAdapter
+  layoutDirection = 'ltr',
   decelerationRate = 'fast',
   bounces = false,
   overScrollMode = 'never',
@@ -45,6 +45,16 @@ export function ScrollViewAdapter({
 }: ScrollViewAdapterProps) {
   const { index, routes } = navigationState;
 
+  const isRTL = layoutDirection === 'rtl';
+
+  // Android reports RTL scroll offsets from the opposite end (0 at the max scroll offset)
+  // So we need to invert them to get the logical route index
+  const shouldInvertOffset = Platform.OS === 'android' && isRTL;
+
+  // Web uses negative scroll offsets in RTL
+  // So we need to negate them to get the logical route index
+  const shouldNegateOffset = Platform.OS === 'web' && isRTL;
+
   const listeners = React.useRef<Set<Listener>>(new Set()).current;
 
   const scrollViewRef = React.useRef<ScrollView>(null);
@@ -52,13 +62,48 @@ export function ScrollViewAdapter({
 
   const isInitialRef = React.useRef(true);
 
+  const getScrollOffsetForIndex = React.useCallback(
+    (index: number, width: number) =>
+      (shouldNegateOffset ? -index : index) * width,
+    [shouldNegateOffset]
+  );
+
+  const getReportedOffsetForIndex = React.useCallback(
+    (index: number, width: number) =>
+      shouldInvertOffset
+        ? (routes.length - 1 - index) * width
+        : getScrollOffsetForIndex(index, width),
+    [getScrollOffsetForIndex, routes.length, shouldInvertOffset]
+  );
+
+  const getIndexFromOffset = React.useCallback(
+    (x: number, width: number) => {
+      const offset = clamp(
+        x / width,
+        shouldNegateOffset ? -(routes.length - 1) : 0,
+        routes.length - 1
+      );
+
+      if (shouldInvertOffset) {
+        return routes.length - 1 - offset;
+      }
+
+      if (shouldNegateOffset) {
+        return -offset;
+      }
+
+      return offset;
+    },
+    [routes.length, shouldInvertOffset, shouldNegateOffset]
+  );
+
   const [layout, onLayout] = useMeasureLayout(containerRef, ({ width }) => {
     if (isInitialRef.current) {
-      const x = index * width;
+      const x = getScrollOffsetForIndex(index, width);
 
       setContentOffset({ x, y: 0 });
 
-      offsetX.setValue(x);
+      offsetX.setValue(getReportedOffsetForIndex(index, width));
     } else if (indexRef.current !== index) {
       scrollToIndex(index);
     }
@@ -67,14 +112,14 @@ export function ScrollViewAdapter({
   });
 
   const [contentOffset, setContentOffset] = React.useState(() => ({
-    x: index * layout.width,
+    x: getScrollOffsetForIndex(index, layout.width),
     y: 0,
   }));
 
   React.useEffect(() => {
-    // FIXME: contentOffset is not supported on Android
+    // FIXME: contentOffset is not supported on Android and Web
     // So we manually scroll after state update
-    if (Platform.OS === 'android') {
+    if (Platform.OS === 'android' || Platform.OS === 'web') {
       requestAnimationFrame(() => {
         scrollViewRef.current?.scrollTo({
           x: contentOffset.x,
@@ -82,13 +127,13 @@ export function ScrollViewAdapter({
         });
       });
     }
-  }, [animationEnabled, contentOffset.x]);
+  }, [contentOffset.x]);
 
   const [offsetX] = React.useState(() => new Animated.Value(contentOffset.x));
 
   const scrollToIndex = useLatestCallback((index: number) => {
     scrollViewRef.current?.scrollTo({
-      x: index * layout.width,
+      x: getScrollOffsetForIndex(index, layout.width),
       animated: animationEnabled,
     });
   });
@@ -119,10 +164,26 @@ export function ScrollViewAdapter({
     };
   });
 
-  const position = React.useMemo(
-    () => (layout.width ? Animated.divide(offsetX, layout.width) : null),
-    [layout.width, offsetX]
-  );
+  const position = React.useMemo(() => {
+    if (!layout.width) {
+      return null;
+    }
+
+    const value = Animated.divide(offsetX, layout.width);
+
+    // Convert platform scroll offsets back to logical route index
+    return shouldInvertOffset
+      ? Animated.subtract(routes.length - 1, value)
+      : shouldNegateOffset
+        ? Animated.multiply(value, -1)
+        : value;
+  }, [
+    layout.width,
+    offsetX,
+    routes.length,
+    shouldInvertOffset,
+    shouldNegateOffset,
+  ]);
 
   const indexRef = React.useRef(index);
   const timerRef = React.useRef<ReturnType<typeof setTimeout> | undefined>(
@@ -130,16 +191,16 @@ export function ScrollViewAdapter({
   );
 
   const onScrollEnd = (x: number) => {
-    const value = clamp(x / layout.width, 0, routes.length - 1);
+    const nextIndex = getIndexFromOffset(x, layout.width);
 
-    if (value % 1 === 0) {
-      indexRef.current = value;
+    if (nextIndex % 1 === 0) {
+      indexRef.current = nextIndex;
 
-      if (value !== index) {
-        onIndexChange(value);
+      if (nextIndex !== index) {
+        onIndexChange(nextIndex);
       }
 
-      onTabSelect?.({ index: value });
+      onTabSelect?.({ index: nextIndex });
     }
   };
 
@@ -155,8 +216,7 @@ export function ScrollViewAdapter({
       useNativeDriver: Platform.OS !== 'web',
       listener: (event: ScrollEvent) => {
         const { x } = event.nativeEvent.contentOffset;
-
-        const value = clamp(x / layout.width, 0, routes.length - 1);
+        const value = getIndexFromOffset(x, layout.width);
 
         // The offset will overlap the current and the adjacent page
         // So we need to get the index of the adjacent page

--- a/packages/react-native-tab-view/src/TabBar.tsx
+++ b/packages/react-native-tab-view/src/TabBar.tsx
@@ -5,7 +5,6 @@ import {
   type DimensionValue,
   FlatList,
   I18nManager,
-  type LayoutChangeEvent,
   type ListRenderItemInfo,
   Platform,
   type PressableAndroidRippleConfig,
@@ -15,6 +14,12 @@ import {
   type ViewStyle,
 } from 'react-native';
 
+import {
+  PRIMARY_INDICATOR_MIN_WIDTH,
+  TAB_BAR_BACKGROUND_COLOR,
+  TAB_BAR_BORDER_COLOR,
+  TAB_MIN_WIDTH,
+} from './constants';
 import {
   type Props as IndicatorProps,
   TabBarIndicator,
@@ -31,10 +36,12 @@ import type {
   TabDescriptor,
 } from './types';
 import { useAnimatedValue } from './useAnimatedValue';
+import { useLayoutWidths } from './useLayoutWidths';
 import { useMeasureLayout } from './useMeasureLayout';
 
 export type Props<T extends Route> = SceneRendererProps &
   EventEmitterProps & {
+    variant?: 'primary' | 'secondary' | undefined;
     navigationState: NavigationState<T>;
     scrollEnabled?: boolean | undefined;
     bounces?: boolean | undefined;
@@ -71,8 +78,6 @@ type CalculationOptions = {
   flattenedPaddingEnd: DimensionValue | undefined;
   flattenedTabWidth: DimensionValue | undefined;
 };
-
-const useNativeDriver = Platform.OS !== 'web';
 
 const Separator = ({ width }: { width: number }) => {
   return <View style={{ width }} />;
@@ -155,7 +160,7 @@ const getComputedTabWidth = ({
   }
 
   if (scrollEnabled) {
-    return (layoutWidth / 5) * 2;
+    return tabWidths[routes[index].key] || TAB_MIN_WIDTH;
   }
 
   const gapTotalWidth = (gap ?? 0) * (routes.length - 1);
@@ -164,6 +169,25 @@ const getComputedTabWidth = ({
     convertPaddingPercentToSize(flattenedPaddingEnd, layoutWidth);
 
   return (layoutWidth - gapTotalWidth - paddingTotalWidth) / routes.length;
+};
+
+const calculateSize = (
+  value: ViewStyle['width'] | undefined,
+  referenceWidth: number
+): number | undefined => {
+  if (typeof value === 'number') {
+    return value;
+  }
+
+  if (typeof value === 'string' && value.endsWith('%')) {
+    const parsed = parseFloat(value);
+
+    if (Number.isFinite(parsed)) {
+      return referenceWidth * (parsed / 100);
+    }
+  }
+
+  return undefined;
 };
 
 const getMaxScrollDistance = (tabBarWidth: number, layoutWidth: number) =>
@@ -334,9 +358,10 @@ const getTestIdDefault = ({ route }: Scene<Route>) => route.testID;
 
 // How many items measurements should we update per batch.
 // Defaults to 10, since that's whats FlatList is using in initialNumToRender.
-const MEASURE_PER_BATCH = 10;
+const RENDER_PER_BATCH = 10;
 
 export function TabBar<T extends Route>({
+  variant = 'primary',
   renderIndicator = renderIndicatorDefault,
   gap = 0,
   scrollEnabled,
@@ -364,15 +389,41 @@ export function TabBar<T extends Route>({
   const containerRef = React.useRef<View>(null);
   const [layout, onLayout] = useMeasureLayout(containerRef);
 
-  const [tabWidths, setTabWidths] = React.useState<Record<string, number>>({});
+  // Prioritize measuring tabs upto focused item
+  // Since we need those measurements for calculation
+  const priorityKeysForLayout = navigationState.routes
+    .slice(0, navigationState.index + 1)
+    .map((r) => r.key);
+
+  const [tabWidths, onMeasureTabWidth] = useLayoutWidths(priorityKeysForLayout);
+  const [labelWidths, onMeasureLabelWidth] = useLayoutWidths(
+    priorityKeysForLayout
+  );
+
   const flatListRef = React.useRef<FlatList | null>(null);
   const isFirst = React.useRef(true);
+
   const scrollAmount = useAnimatedValue(0);
+
   const { routes } = navigationState;
+
   const flattenedTabWidth = getFlattenedTabWidth(tabStyle);
-  const isWidthDynamic = flattenedTabWidth === 'auto';
+  const isWidthAuto = flattenedTabWidth === 'auto';
+  const isWidthDynamic =
+    isWidthAuto || (scrollEnabled && flattenedTabWidth == null);
+
   const flattenedPaddingEnd = getFlattenedPaddingEnd(contentContainerStyle);
   const flattenedPaddingStart = getFlattenedPaddingStart(contentContainerStyle);
+
+  const paddingEnd = convertPaddingPercentToSize(
+    flattenedPaddingEnd,
+    layout.width
+  );
+
+  const paddingStart = convertPaddingPercentToSize(
+    flattenedPaddingStart,
+    layout.width
+  );
 
   const scrollOffset = getScrollAmount({
     layoutWidth: layout.width,
@@ -399,7 +450,7 @@ export function TabBar<T extends Route>({
       return;
     }
 
-    if (isWidthDynamic && !hasMeasuredTabWidths) {
+    if (isWidthAuto && !hasMeasuredTabWidths) {
       return;
     }
 
@@ -409,7 +460,7 @@ export function TabBar<T extends Route>({
         animated: true,
       });
     }
-  }, [hasMeasuredTabWidths, isWidthDynamic, scrollEnabled, scrollOffset]);
+  }, [hasMeasuredTabWidths, isWidthAuto, scrollEnabled, scrollOffset]);
 
   const tabBarWidth = getTabBarWidth({
     layoutWidth: layout.width,
@@ -422,13 +473,6 @@ export function TabBar<T extends Route>({
     flattenedPaddingEnd,
   });
 
-  const separatorsWidth = Math.max(0, routes.length - 1) * gap;
-  const paddingsWidth = Math.max(
-    0,
-    convertPaddingPercentToSize(flattenedPaddingStart, layout.width) +
-      convertPaddingPercentToSize(flattenedPaddingEnd, layout.width)
-  );
-
   const translateX = React.useMemo(
     () =>
       getTranslateX(
@@ -439,124 +483,72 @@ export function TabBar<T extends Route>({
     [direction, layout.width, scrollAmount, tabBarWidth]
   );
 
-  const measuredTabWidths = React.useRef<Record<string, number>>({});
-  const animationFrameHandle =
-    React.useRef<ReturnType<typeof requestAnimationFrame>>(null);
+  const flattenedTabStyle = StyleSheet.flatten(tabStyle);
+  const isTabWidthSet = flattenedTabStyle?.width !== undefined;
+
+  // Calculate the default width for tab for FlatList to work.
+  const defaultTabWidth = !isWidthDynamic
+    ? getComputedTabWidth({
+        // When `isWidthDynamic` is false, every tab gets the same width and
+        // `getComputedTabWidth` ignores `index`, so we compute it once with index 0.
+        index: 0,
+        layoutWidth: layout.width,
+        routes,
+        scrollEnabled,
+        tabWidths,
+        flattenedTabWidth,
+        flattenedPaddingStart,
+        flattenedPaddingEnd,
+        gap,
+      })
+    : undefined;
 
   const renderItem = React.useCallback(
-    ({ item: route, index }: ListRenderItemInfo<T>) => {
-      const {
-        testID = getTestIdDefault({ route }),
-        labelText = getLabelTextDefault({ route }),
-        accessible = getAccessibleDefault({ route }),
-        accessibilityLabel = getAccessibilityLabelDefault({ route }),
-        ...rest
-      } = options?.[route.key] ?? {};
-
-      const onLayout = isWidthDynamic
-        ? (e: LayoutChangeEvent) => {
-            measuredTabWidths.current[route.key] = e.nativeEvent.layout.width;
-
-            if (animationFrameHandle.current != null) {
-              cancelAnimationFrame(animationFrameHandle.current);
-            }
-
-            animationFrameHandle.current = requestAnimationFrame(() => {
-              setTabWidths({ ...measuredTabWidths.current });
-            });
-          }
-        : undefined;
-
-      const onPress = () => {
-        const event: Scene<T> & Event = {
-          route,
-          defaultPrevented: false,
-          preventDefault: () => {
-            event.defaultPrevented = true;
-          },
-        };
-
-        onTabPress?.(event);
-
-        if (event.defaultPrevented) {
-          return;
-        }
-
-        jumpTo(route.key);
-      };
-
-      const onLongPress = () => onTabLongPress?.({ route });
-
-      // Calculate the default width for tab for FlatList to work
-      const defaultTabWidth = !isWidthDynamic
-        ? getComputedTabWidth({
-            index,
-            layoutWidth: layout.width,
-            routes,
-            scrollEnabled,
-            tabWidths,
-            flattenedTabWidth: getFlattenedTabWidth(tabStyle),
-            flattenedPaddingStart: getFlattenedPaddingStart(
-              contentContainerStyle
-            ),
-            flattenedPaddingEnd: getFlattenedPaddingEnd(contentContainerStyle),
-            gap,
-          })
-        : undefined;
-
-      const props = {
-        ...rest,
-        position,
-        route,
-        navigationState,
-        testID,
-        labelText,
-        accessible,
-        accessibilityLabel,
-        activeColor,
-        inactiveColor,
-        pressColor,
-        pressOpacity,
-        onLayout,
-        onPress,
-        onLongPress,
-        style: tabStyle,
-        defaultTabWidth,
-        android_ripple,
-      } satisfies TabBarItemProps<T>;
-
-      return (
-        <>
-          {gap > 0 && index > 0 ? <Separator width={gap} /> : null}
-          {renderTabBarItem ? (
-            renderTabBarItem({ key: route.key, ...props })
-          ) : (
-            <TabBarItem key={route.key} {...props} />
-          )}
-        </>
-      );
-    },
+    ({ item: route, index }: ListRenderItemInfo<T>) => (
+      <MemoizedTabBarItemWrapper
+        route={route}
+        index={index}
+        option={options?.[route.key]}
+        position={position}
+        navigationState={navigationState}
+        variant={variant}
+        activeColor={activeColor}
+        inactiveColor={inactiveColor}
+        pressColor={pressColor}
+        pressOpacity={pressOpacity}
+        android_ripple={android_ripple}
+        tabStyle={tabStyle}
+        defaultTabWidth={defaultTabWidth}
+        isWidthSet={isTabWidthSet}
+        gap={gap}
+        onMeasureTabWidth={onMeasureTabWidth}
+        onMeasureLabelWidth={onMeasureLabelWidth}
+        onTabPress={onTabPress}
+        onTabLongPress={onTabLongPress}
+        jumpTo={jumpTo}
+        renderTabBarItem={renderTabBarItem}
+      />
+    ),
     [
+      options,
       position,
       navigationState,
-      options,
+      variant,
       activeColor,
       inactiveColor,
       pressColor,
       pressOpacity,
-      isWidthDynamic,
-      tabStyle,
-      layout,
-      routes,
-      scrollEnabled,
-      tabWidths,
-      contentContainerStyle,
-      gap,
       android_ripple,
-      renderTabBarItem,
+      tabStyle,
+      defaultTabWidth,
+      isTabWidthSet,
+      gap,
+      onMeasureTabWidth,
+      onMeasureLabelWidth,
       onTabPress,
-      jumpTo,
       onTabLongPress,
+      jumpTo,
+      renderTabBarItem,
     ]
   );
 
@@ -581,16 +573,112 @@ export function TabBar<T extends Route>({
             },
           },
         ],
-        { useNativeDriver }
+        { useNativeDriver: Platform.OS !== 'web' }
       ),
     [scrollAmount]
   );
+
+  const flattenedIndicatorStyle = StyleSheet.flatten(indicatorStyle);
+  const defaultIndicatorStyle =
+    variant === 'primary' ? styles.primaryIndicator : styles.secondaryIndicator;
+
+  const tabWidthByIndex = routes.map((_, i) =>
+    getComputedTabWidth({
+      index: i,
+      layoutWidth: layout.width,
+      routes,
+      scrollEnabled,
+      tabWidths,
+      flattenedTabWidth,
+      flattenedPaddingEnd,
+      flattenedPaddingStart,
+      gap,
+    })
+  );
+
+  const customIndicatorWidths = routes.map((_, i) =>
+    calculateSize(flattenedIndicatorStyle?.width, tabWidthByIndex[i])
+  );
+
+  const indicatorBaseWidths = routes.map((_, i) => {
+    if (customIndicatorWidths[i] != null) {
+      return customIndicatorWidths[i];
+    }
+
+    if (variant === 'primary') {
+      const labelWidth = labelWidths[routes[i].key];
+
+      return labelWidth ? Math.max(PRIMARY_INDICATOR_MIN_WIDTH, labelWidth) : 0;
+    }
+
+    return tabWidthByIndex[i];
+  });
+
+  const indicatorMargins = indicatorBaseWidths.map((width) => {
+    if (!width) {
+      return { left: 0, right: 0 };
+    }
+
+    const marginHorizontal =
+      flattenedIndicatorStyle?.marginHorizontal ??
+      flattenedIndicatorStyle?.margin;
+
+    const leftMargin =
+      (direction === 'ltr'
+        ? flattenedIndicatorStyle?.marginStart
+        : flattenedIndicatorStyle?.marginEnd) ??
+      flattenedIndicatorStyle?.marginLeft ??
+      marginHorizontal;
+
+    const rightMargin =
+      (direction === 'rtl'
+        ? flattenedIndicatorStyle?.marginStart
+        : flattenedIndicatorStyle?.marginEnd) ??
+      flattenedIndicatorStyle?.marginRight ??
+      marginHorizontal;
+
+    return {
+      left: calculateSize(leftMargin, width) ?? 0,
+      right: calculateSize(rightMargin, width) ?? 0,
+    };
+  });
+
+  const indicatorWidths = indicatorBaseWidths.map((width, i) => {
+    if (!width) {
+      return 0;
+    }
+
+    return Math.max(
+      0,
+      width - indicatorMargins[i].left - indicatorMargins[i].right
+    );
+  });
+
+  const indicatorOffsets = routes.map((_, i) => {
+    const precedingTabsWidth = tabWidthByIndex
+      .slice(0, i)
+      .reduce((sum, width) => sum + width, 0);
+
+    const tabStart = precedingTabsWidth + gap * i;
+
+    const shouldCenterIndicator =
+      variant === 'primary' ||
+      (customIndicatorWidths[i] != null &&
+        (flattenedIndicatorStyle?.margin === 'auto' ||
+          flattenedIndicatorStyle?.marginHorizontal === 'auto'));
+
+    const baseOffset = shouldCenterIndicator
+      ? (tabWidthByIndex[i] - indicatorBaseWidths[i]) / 2
+      : 0;
+
+    return tabStart + baseOffset + indicatorMargins[i].left;
+  });
 
   return (
     <Animated.View
       ref={containerRef}
       onLayout={onLayout}
-      style={[styles.tabBar, style]}
+      style={[styles.tabBar, { direction }, style]}
     >
       <Animated.View
         style={[
@@ -601,33 +689,18 @@ export function TabBar<T extends Route>({
         ]}
       >
         {renderIndicator({
+          variant,
           position,
           navigationState,
           jumpTo,
           direction,
-          width: isWidthDynamic
-            ? 'auto'
-            : Math.max(
-                0,
-                (tabBarWidth - separatorsWidth - paddingsWidth) / routes.length
-              ),
+          widths: indicatorWidths,
+          offsets: indicatorOffsets,
           style: [
+            defaultIndicatorStyle,
             indicatorStyle,
-            { start: flattenedPaddingStart, end: flattenedPaddingEnd },
+            { start: paddingStart, end: paddingEnd },
           ],
-          getTabWidth: (i: number) =>
-            getComputedTabWidth({
-              index: i,
-              layoutWidth: layout.width,
-              routes,
-              scrollEnabled,
-              tabWidths,
-              flattenedTabWidth,
-              flattenedPaddingEnd,
-              flattenedPaddingStart,
-              gap,
-            }),
-          gap,
         })}
       </Animated.View>
       <View style={styles.scroll}>
@@ -639,7 +712,7 @@ export function TabBar<T extends Route>({
           keyboardShouldPersistTaps="handled"
           scrollEnabled={scrollEnabled}
           bounces={bounces}
-          initialNumToRender={MEASURE_PER_BATCH}
+          initialNumToRender={RENDER_PER_BATCH}
           alwaysBounceHorizontal={false}
           scrollsToTop={false}
           showsHorizontalScrollIndicator={false}
@@ -658,28 +731,155 @@ export function TabBar<T extends Route>({
   );
 }
 
+type TabBarItemWrapperProps<T extends Route> = {
+  route: T;
+  index: number;
+  option: TabDescriptor<T> | undefined;
+  position: Animated.AnimatedInterpolation<number>;
+  navigationState: NavigationState<T>;
+  variant: 'primary' | 'secondary';
+  activeColor: ColorValue | undefined;
+  inactiveColor: ColorValue | undefined;
+  pressColor: ColorValue | undefined;
+  pressOpacity: number | undefined;
+  android_ripple: PressableAndroidRippleConfig | undefined;
+  tabStyle: StyleProp<ViewStyle>;
+  defaultTabWidth: number | undefined;
+  isWidthSet: boolean;
+  gap: number;
+  onMeasureTabWidth: (key: string, width: number) => void;
+  onMeasureLabelWidth: (key: string, width: number) => void;
+  onTabPress: ((scene: Scene<T> & Event) => void) | undefined;
+  onTabLongPress: ((scene: Scene<T>) => void) | undefined;
+  jumpTo: (key: string) => void;
+  renderTabBarItem:
+    | ((props: TabBarItemProps<T> & { key: string }) => React.ReactElement)
+    | undefined;
+};
+
+function TabBarItemWrapper<T extends Route>({
+  route,
+  index,
+  option,
+  position,
+  navigationState,
+  variant,
+  activeColor,
+  inactiveColor,
+  pressColor,
+  pressOpacity,
+  android_ripple,
+  tabStyle,
+  defaultTabWidth,
+  isWidthSet,
+  gap,
+  onMeasureTabWidth,
+  onMeasureLabelWidth,
+  onTabPress,
+  onTabLongPress,
+  jumpTo,
+  renderTabBarItem,
+}: TabBarItemWrapperProps<T>) {
+  const {
+    testID = getTestIdDefault({ route }),
+    labelText = getLabelTextDefault({ route }),
+    accessible = getAccessibleDefault({ route }),
+    accessibilityLabel = getAccessibilityLabelDefault({ route }),
+    ...rest
+  } = option ?? {};
+
+  const onMeasureLayout = React.useCallback(
+    ({ width }: { width: number }) => onMeasureTabWidth(route.key, width),
+    [route.key, onMeasureTabWidth]
+  );
+
+  const onMeasureLabelLayout = React.useCallback(
+    ({ width }: { width: number }) => onMeasureLabelWidth(route.key, width),
+    [route.key, onMeasureLabelWidth]
+  );
+
+  const onPress = React.useCallback(() => {
+    const event: Scene<T> & Event = {
+      route,
+      defaultPrevented: false,
+      preventDefault: () => {
+        event.defaultPrevented = true;
+      },
+    };
+
+    onTabPress?.(event);
+
+    if (event.defaultPrevented) {
+      return;
+    }
+
+    jumpTo(route.key);
+  }, [route, onTabPress, jumpTo]);
+
+  const onLongPress = React.useCallback(
+    () => onTabLongPress?.({ route }),
+    [route, onTabLongPress]
+  );
+
+  const style = React.useMemo(
+    () => [
+      tabStyle,
+      isWidthSet
+        ? null
+        : defaultTabWidth !== undefined
+          ? { width: defaultTabWidth }
+          : { minWidth: TAB_MIN_WIDTH },
+    ],
+    [tabStyle, isWidthSet, defaultTabWidth]
+  );
+
+  const props = {
+    ...rest,
+    position,
+    route,
+    navigationState,
+    testID,
+    labelText,
+    accessible,
+    accessibilityLabel,
+    variant,
+    activeColor,
+    inactiveColor,
+    pressColor,
+    pressOpacity,
+    onMeasureLayout,
+    onMeasureLabelLayout,
+    onPress,
+    onLongPress,
+    style,
+    android_ripple,
+  } satisfies TabBarItemProps<T>;
+
+  return (
+    <>
+      {gap > 0 && index > 0 ? <Separator width={gap} /> : null}
+      {renderTabBarItem ? (
+        renderTabBarItem({ key: route.key, ...props })
+      ) : (
+        <TabBarItem key={route.key} {...props} />
+      )}
+    </>
+  );
+}
+
+const MemoizedTabBarItemWrapper = React.memo(
+  TabBarItemWrapper
+) as typeof TabBarItemWrapper;
+
 const styles = StyleSheet.create({
   scroll: {
     overflow: Platform.select({ default: 'scroll', web: undefined }),
   },
   tabBar: {
     zIndex: 1,
-    backgroundColor: '#fff',
-    elevation: 4,
-    ...Platform.select({
-      default: {
-        shadowColor: 'black',
-        shadowOpacity: 0.1,
-        shadowRadius: StyleSheet.hairlineWidth,
-        shadowOffset: {
-          height: StyleSheet.hairlineWidth,
-          width: 0,
-        },
-      },
-      web: {
-        boxShadow: '0 1px 1px rgba(0, 0, 0, 0.1)',
-      },
-    }),
+    backgroundColor: TAB_BAR_BACKGROUND_COLOR,
+    borderBottomColor: TAB_BAR_BORDER_COLOR,
+    borderBottomWidth: 1,
   },
   tabContent: {
     flexGrow: 1,
@@ -693,5 +893,15 @@ const styles = StyleSheet.create({
     end: 0,
     bottom: 0,
     pointerEvents: 'none',
+  },
+  primaryIndicator: {
+    height: 3,
+    borderTopLeftRadius: 3,
+    borderTopRightRadius: 3,
+  },
+  secondaryIndicator: {
+    height: 2,
+    borderTopLeftRadius: 0,
+    borderTopRightRadius: 0,
   },
 });

--- a/packages/react-native-tab-view/src/TabBar.tsx
+++ b/packages/react-native-tab-view/src/TabBar.tsx
@@ -197,13 +197,15 @@ const getTranslateX = (
   scrollAmount: Animated.Value,
   maxScrollDistance: number,
   direction: LocaleDirection
-) =>
-  Animated.multiply(
+) => {
+  const amount =
+    // Android reports scroll from the opposite side in RTL
     Platform.OS === 'android' && direction === 'rtl'
       ? Animated.add(maxScrollDistance, Animated.multiply(scrollAmount, -1))
-      : scrollAmount,
-    direction === 'rtl' ? 1 : -1
-  );
+      : scrollAmount;
+
+  return Animated.multiply(amount, direction === 'rtl' ? 1 : -1);
+};
 
 const getTabBarWidth = <T extends Route>({
   routes,
@@ -252,11 +254,9 @@ const normalizeScrollValue = <T extends Route>({
   flattenedTabWidth,
   flattenedPaddingStart,
   flattenedPaddingEnd,
-  direction,
 }: CalculationOptions & {
   routes: T[];
   value: number;
-  direction: LocaleDirection;
 }) => {
   const tabBarWidth = getTabBarWidth({
     layoutWidth,
@@ -270,12 +270,6 @@ const normalizeScrollValue = <T extends Route>({
   });
   const maxDistance = getMaxScrollDistance(tabBarWidth, layoutWidth);
   const scrollValue = Math.max(Math.min(value, maxDistance), 0);
-
-  if (Platform.OS === 'android' && direction === 'rtl') {
-    // On Android, scroll value is not applied in reverse in RTL
-    // so we need to manually adjust it to apply correct value
-    return maxDistance - scrollValue;
-  }
 
   return scrollValue;
 };
@@ -335,7 +329,6 @@ const getScrollAmount = <T extends Route>({
     flattenedTabWidth,
     flattenedPaddingStart,
     flattenedPaddingEnd,
-    direction,
   });
 };
 const getLabelTextDefault = ({ route }: Scene<Route>) => route.title;
@@ -402,8 +395,6 @@ export function TabBar<T extends Route>({
 
   const flatListRef = React.useRef<FlatList | null>(null);
   const isFirst = React.useRef(true);
-
-  const scrollAmount = useAnimatedValue(0);
 
   const { routes } = navigationState;
 
@@ -473,14 +464,18 @@ export function TabBar<T extends Route>({
     flattenedPaddingEnd,
   });
 
+  const maxScrollDistance = getMaxScrollDistance(tabBarWidth, layout.width);
+  const scrollAmount = useAnimatedValue(0);
+
+  React.useLayoutEffect(() => {
+    scrollAmount.setValue(
+      Platform.OS === 'android' && direction === 'rtl' ? maxScrollDistance : 0
+    );
+  }, [direction, maxScrollDistance, scrollAmount]);
+
   const translateX = React.useMemo(
-    () =>
-      getTranslateX(
-        scrollAmount,
-        getMaxScrollDistance(tabBarWidth, layout.width),
-        direction
-      ),
-    [direction, layout.width, scrollAmount, tabBarWidth]
+    () => getTranslateX(scrollAmount, maxScrollDistance, direction),
+    [direction, maxScrollDistance, scrollAmount]
   );
 
   const flattenedTabStyle = StyleSheet.flatten(tabStyle);

--- a/packages/react-native-tab-view/src/TabBarIndicator.tsx
+++ b/packages/react-native-tab-view/src/TabBarIndicator.tsx
@@ -102,17 +102,17 @@ export function TabBarIndicator<T extends Route>({
   }
 
   const leftRadiusWidth = Math.max(
-    borderTopStartRadius ?? 0,
-    borderBottomStartRadius ?? 0,
-    (isRTL ? borderTopRightRadius : borderTopLeftRadius) ?? 0,
-    (isRTL ? borderBottomRightRadius : borderBottomLeftRadius) ?? 0
+    (isRTL ? borderTopEndRadius : borderTopStartRadius) ?? 0,
+    (isRTL ? borderBottomEndRadius : borderBottomStartRadius) ?? 0,
+    borderTopLeftRadius ?? 0,
+    borderBottomLeftRadius ?? 0
   );
 
   const rightRadiusWidth = Math.max(
-    borderTopEndRadius ?? 0,
-    borderBottomEndRadius ?? 0,
-    (isRTL ? borderTopLeftRadius : borderTopRightRadius) ?? 0,
-    (isRTL ? borderBottomLeftRadius : borderBottomRightRadius) ?? 0
+    (isRTL ? borderTopStartRadius : borderTopEndRadius) ?? 0,
+    (isRTL ? borderBottomStartRadius : borderBottomEndRadius) ?? 0,
+    borderTopRightRadius ?? 0,
+    borderBottomRightRadius ?? 0
   );
 
   const leftPieceWidth = leftRadiusWidth + CAP_FILL_OVERLAP;
@@ -354,37 +354,37 @@ export function TabBarIndicator<T extends Route>({
       <Animated.View
         style={[
           {
-            backgroundColor,
-            borderTopStartRadius,
-            borderBottomStartRadius,
             ...(isRTL
-              ? { borderTopRightRadius, borderBottomRightRadius }
-              : { borderTopLeftRadius, borderBottomLeftRadius }),
+              ? { borderTopEndRadius, borderBottomEndRadius }
+              : { borderTopStartRadius, borderBottomStartRadius }),
+            borderTopLeftRadius,
+            borderBottomLeftRadius,
             height,
             width: leftPieceWidth,
+            backgroundColor,
           },
           styles.cap,
         ]}
       >
-        <Animated.View style={[{ backgroundColor, height }, leftFillStyle]} />
+        <Animated.View style={[{ height, backgroundColor }, leftFillStyle]} />
       </Animated.View>
-      <Animated.View style={[{ backgroundColor, height }, centerFillStyle]} />
+      <Animated.View style={[{ height, backgroundColor }, centerFillStyle]} />
       <Animated.View
         style={[
           {
-            backgroundColor,
-            borderTopEndRadius,
-            borderBottomEndRadius,
             ...(isRTL
-              ? { borderTopLeftRadius, borderBottomLeftRadius }
-              : { borderTopRightRadius, borderBottomRightRadius }),
+              ? { borderTopStartRadius, borderBottomStartRadius }
+              : { borderTopEndRadius, borderBottomEndRadius }),
+            borderTopRightRadius,
+            borderBottomRightRadius,
             height,
             width: rightPieceWidth,
+            backgroundColor,
           },
           rightCapStyle,
         ]}
       >
-        <Animated.View style={[{ backgroundColor, height }, rightFillStyle]} />
+        <Animated.View style={[{ height, backgroundColor }, rightFillStyle]} />
       </Animated.View>
     </Animated.View>
   );

--- a/packages/react-native-tab-view/src/TabBarIndicator.tsx
+++ b/packages/react-native-tab-view/src/TabBarIndicator.tsx
@@ -8,326 +8,401 @@ import {
   type ViewStyle,
 } from 'react-native';
 
+import { TAB_BAR_PRIMARY_ACTIVE_COLOR } from './constants';
 import type {
   LocaleDirection,
   NavigationState,
   Route,
   SceneRendererProps,
 } from './types';
-import { useAnimatedValue } from './useAnimatedValue';
 
-export type GetTabWidth = (index: number) => number;
+const CAP_FILL_OVERLAP = 1;
+const EASING_SAMPLE_COUNT = 16;
+
+const samplePoints = (easing: (t: number) => number) =>
+  Array.from({ length: EASING_SAMPLE_COUNT + 1 }, (_, i) =>
+    easing(i / EASING_SAMPLE_COUNT)
+  );
+
+const TRAILING_EDGE_SAMPLES = samplePoints(Easing.bezier(0.3, 0, 0.8, 0.15));
+const LEADING_EDGE_SAMPLES = samplePoints(Easing.bezier(0.05, 0.7, 0.1, 1));
 
 export type Props<T extends Route> = SceneRendererProps & {
+  variant?: 'primary' | 'secondary' | undefined;
   navigationState: NavigationState<T>;
-  width: 'auto' | `${number}%` | number;
-  getTabWidth: GetTabWidth;
+  widths: number[];
+  offsets: number[];
   direction: LocaleDirection;
   style?: StyleProp<ViewStyle>;
-  gap?: number;
-  children?: React.ReactNode;
-};
-
-const useNativeDriver = Platform.OS !== 'web';
-
-const calculateSize = (
-  value: ViewStyle['width'] | undefined,
-  referenceWidth: number
-): number | undefined => {
-  if (typeof value === 'number') {
-    return value;
-  }
-
-  if (typeof value === 'string' && value.endsWith('%')) {
-    const parsed = parseFloat(value);
-
-    if (Number.isFinite(parsed)) {
-      return referenceWidth * (parsed / 100);
-    }
-  }
-
-  return undefined;
-};
-
-const getIndicatorWidthWithMargins = (
-  width: number,
-  style: ViewStyle | undefined,
-  direction: LocaleDirection
-) => {
-  const marginHorizontal = style?.marginHorizontal ?? style?.margin;
-
-  const leftMargin =
-    (direction === 'ltr' ? style?.marginStart : style?.marginEnd) ??
-    style?.marginLeft ??
-    marginHorizontal;
-
-  const rightMargin =
-    (direction === 'rtl' ? style?.marginStart : style?.marginEnd) ??
-    style?.marginRight ??
-    marginHorizontal;
-
-  return Math.max(
-    0,
-    width -
-      (calculateSize(leftMargin, width) ?? 0) -
-      (calculateSize(rightMargin, width) ?? 0)
-  );
-};
-
-const getIndicatorWidth = (
-  tabWidth: number,
-  width: number | `${number}%`,
-  style: ViewStyle | undefined,
-  direction: LocaleDirection
-): number | `${number}%` => {
-  const customWidth = calculateSize(style?.width, tabWidth);
-
-  if (customWidth !== undefined) {
-    return customWidth;
-  }
-
-  if (typeof width === 'number') {
-    return getIndicatorWidthWithMargins(width, style, direction);
-  }
-
-  return width;
-};
-
-const getTranslateX = (
-  position: Animated.AnimatedInterpolation<number>,
-  routes: Route[],
-  getTabWidth: GetTabWidth,
-  direction: LocaleDirection,
-  gap?: number,
-  getWidth?: (index: number) => number | undefined
-) => {
-  const inputRange = routes.map((_, i) => i);
-  const outputRange = routes.map((_, i) => {
-    let sumTabWidth = 0;
-
-    for (let j = 0; j < i; j++) {
-      sumTabWidth += getTabWidth(j);
-    }
-
-    const indicatorWidth = getWidth?.(i);
-    const tabOffset = sumTabWidth + (gap ? gap * i : 0);
-
-    if (indicatorWidth === undefined) {
-      return tabOffset;
-    }
-
-    return tabOffset + getTabWidth(i) / 2 - indicatorWidth / 2;
-  });
-
-  const translateX = position.interpolate({
-    inputRange,
-    outputRange,
-    extrapolate: 'clamp',
-  });
-
-  return Animated.multiply(translateX, direction === 'rtl' ? -1 : 1);
 };
 
 export function TabBarIndicator<T extends Route>({
-  getTabWidth,
+  variant = 'primary',
+  widths,
+  offsets,
   navigationState,
   position,
-  width,
   direction,
-  gap,
   style,
-  children,
 }: Props<T>) {
-  const isIndicatorShown = React.useRef(false);
-  const isWidthDynamic = width === 'auto';
+  const isRTL = direction === 'rtl';
 
-  const flattenedStyle = StyleSheet.flatten(style);
+  const flattenedStyle: ViewStyle =
+    StyleSheet.flatten([styles.defaults, style]) || {};
 
-  const hasCustomIndicatorWidth =
-    typeof flattenedStyle?.width === 'number' ||
-    (typeof flattenedStyle?.width === 'string' &&
-      flattenedStyle?.width.endsWith('%'));
+  const {
+    backgroundColor,
+    borderRadius,
+    borderBottomEndRadius = borderRadius,
+    borderBottomLeftRadius = borderRadius,
+    borderBottomRightRadius = borderRadius,
+    borderBottomStartRadius = borderRadius,
+    borderTopEndRadius = borderRadius,
+    borderTopLeftRadius = borderRadius,
+    borderTopRightRadius = borderRadius,
+    borderTopStartRadius = borderRadius,
+    height,
+    start: indicatorStart,
+    end: indicatorEnd,
+    left: indicatorLeft,
+    right: indicatorRight,
+    ...restStyle
+  } = flattenedStyle;
 
-  const constantIndicatorWidth =
-    typeof flattenedStyle?.width === 'number'
-      ? flattenedStyle.width
-      : undefined;
+  delete restStyle.width;
+  delete restStyle.margin;
+  delete restStyle.marginHorizontal;
+  delete restStyle.marginStart;
+  delete restStyle.marginEnd;
+  delete restStyle.marginLeft;
+  delete restStyle.marginRight;
 
-  const isCentered =
-    hasCustomIndicatorWidth &&
-    (flattenedStyle?.margin === 'auto' ||
-      flattenedStyle?.marginHorizontal === 'auto');
+  const containerStart =
+    indicatorStart ?? (isRTL ? indicatorRight : indicatorLeft);
+  const containerEnd = indicatorEnd ?? (isRTL ? indicatorLeft : indicatorRight);
 
-  // If indicator has a custom width, we need to adjust calculations to account for it
-  // It should be centered relative to the tab if the margin is set to auto
-  const getCenteredIndicatorWidth = (tabWidth: number) => {
-    if (isCentered) {
-      return calculateSize(flattenedStyle?.width, tabWidth);
-    }
+  if (
+    (borderBottomEndRadius != null &&
+      typeof borderBottomEndRadius !== 'number') ||
+    (borderBottomStartRadius != null &&
+      typeof borderBottomStartRadius !== 'number') ||
+    (borderBottomLeftRadius != null &&
+      typeof borderBottomLeftRadius !== 'number') ||
+    (borderBottomRightRadius != null &&
+      typeof borderBottomRightRadius !== 'number') ||
+    (borderTopEndRadius != null && typeof borderTopEndRadius !== 'number') ||
+    (borderTopStartRadius != null &&
+      typeof borderTopStartRadius !== 'number') ||
+    (borderTopLeftRadius != null && typeof borderTopLeftRadius !== 'number') ||
+    (borderTopRightRadius != null && typeof borderTopRightRadius !== 'number')
+  ) {
+    throw new Error(
+      'Only numeric border radii are supported in TabBarIndicator.'
+    );
+  }
 
-    if (typeof width === 'number') {
-      return width;
-    }
+  const leftRadiusWidth = Math.max(
+    borderTopStartRadius ?? 0,
+    borderBottomStartRadius ?? 0,
+    (isRTL ? borderTopRightRadius : borderTopLeftRadius) ?? 0,
+    (isRTL ? borderBottomRightRadius : borderBottomLeftRadius) ?? 0
+  );
 
-    return undefined;
-  };
+  const rightRadiusWidth = Math.max(
+    borderTopEndRadius ?? 0,
+    borderBottomEndRadius ?? 0,
+    (isRTL ? borderTopLeftRadius : borderTopRightRadius) ?? 0,
+    (isRTL ? borderBottomLeftRadius : borderBottomRightRadius) ?? 0
+  );
 
-  const opacity = useAnimatedValue(isWidthDynamic ? 0 : 1);
-
-  // We should fade-in the indicator when we have widths for all the tab items
-  const indicatorVisible = isWidthDynamic
-    ? navigationState.routes
-        .slice(0, navigationState.index + 1)
-        .every((_, r) => getTabWidth(r))
-    : true;
-
-  React.useEffect(() => {
-    let animation: Animated.CompositeAnimation | undefined;
-
-    const fadeInIndicator = () => {
-      if (!isIndicatorShown.current && isWidthDynamic && indicatorVisible) {
-        animation = Animated.timing(opacity, {
-          toValue: 1,
-          duration: 150,
-          easing: Easing.in(Easing.linear),
-          useNativeDriver,
-        });
-
-        animation.start(({ finished }) => {
-          if (finished) {
-            isIndicatorShown.current = true;
-          }
-        });
-      }
-    };
-
-    fadeInIndicator();
-
-    return () => animation?.stop();
-  }, [indicatorVisible, isWidthDynamic, opacity]);
+  const leftPieceWidth = leftRadiusWidth + CAP_FILL_OVERLAP;
+  const rightPieceWidth = rightRadiusWidth + CAP_FILL_OVERLAP;
 
   const { routes } = navigationState;
 
-  const transform = [];
+  const easedInterpolate = (values: number[], samples: number[] | null) => {
+    if (routes.length <= 1) {
+      return values[0] ?? 0;
+    }
 
-  const translateX =
-    routes.length > 1
-      ? getTranslateX(position, routes, getTabWidth, direction, gap, (index) =>
-          getCenteredIndicatorWidth(getTabWidth(index))
-        )
-      : 0;
+    // On multi-tab jumps, slide directly from source to destination and
+    // Settle one tab before the pager finishes scrolling
+    // This makes the animation feel snappier
+    // Especially on Android where the pager animation is slow
+    if (jumpRange) {
+      const inputRange =
+        jumpRange.from > jumpRange.to
+          ? [jumpRange.to, jumpRange.to + 1, jumpRange.from]
+          : [jumpRange.from, jumpRange.to - 1, jumpRange.to];
 
-  transform.push({ translateX });
-
-  if (width === 'auto' && constantIndicatorWidth == null) {
-    const inputRange = routes.map((_, i) => i);
-    const outputRange = inputRange.map((i) => {
-      const tabW = getTabWidth(i);
-
-      return (
-        calculateSize(flattenedStyle?.width, tabW) ??
-        getIndicatorWidthWithMargins(tabW, flattenedStyle, direction)
+      const outputRange = inputRange.map((i) =>
+        i === jumpRange.from ? values[jumpRange.from] : values[jumpRange.to]
       );
-    });
 
-    transform.push(
-      {
-        scaleX:
-          routes.length > 1
-            ? position.interpolate({
-                inputRange,
-                outputRange,
-                extrapolate: 'clamp',
-              })
-            : outputRange[0],
-      },
-      { translateX: direction === 'rtl' ? -0.5 : 0.5 }
-    );
-  }
+      return position.interpolate({
+        inputRange,
+        outputRange,
+        extrapolate: 'clamp',
+      });
+    }
 
-  const styleList: StyleProp<ViewStyle> = [];
+    if (samples == null) {
+      return position.interpolate({
+        inputRange: values.map((_, i) => i),
+        outputRange: values,
+        extrapolate: 'clamp',
+      });
+    }
 
-  // transform doesn't work properly on chrome and opera for linux and android
-  // so we need to use width and left/right instead of scaleX and translateX
-  // https://github.com/react-navigation/react-navigation/pull/11440
-  if (
-    Platform.OS === 'web' &&
-    width === 'auto' &&
-    constantIndicatorWidth == null
-  ) {
-    const start = flattenedStyle?.start;
-    const translate =
-      direction === 'rtl' ? Animated.multiply(translateX, -1) : translateX;
-    const offset =
-      typeof start === 'number' ? Animated.add(translate, start) : translate;
+    const inputRange: number[] = [];
+    const outputRange: number[] = [];
 
-    styleList.push(
-      { width: transform[1].scaleX },
-      direction === 'rtl' ? { right: offset } : { left: offset }
-    );
-  } else {
-    styleList.push(
-      {
-        width:
-          width === 'auto'
-            ? // if the indicator has a constant width, use it as is
-              // we don't need to scale it to match tab width
-              (constantIndicatorWidth ?? 1)
-            : getIndicatorWidth(
-                getTabWidth(navigationState.index),
-                width,
-                flattenedStyle,
-                direction
-              ),
-      },
-      { start: `${(100 / routes.length) * navigationState.index}%` },
-      { transform }
-    );
-  }
+    for (let i = 0; i < values.length - 1; i++) {
+      const start = values[i];
+      const end = values[i + 1];
 
-  let finalStyle;
-
-  if (hasCustomIndicatorWidth && style != null) {
-    const rest = { ...flattenedStyle };
-
-    delete rest.width;
-
-    if (isCentered) {
-      if (rest.margin === 'auto') {
-        delete rest.margin;
-      }
-
-      if (rest.marginHorizontal === 'auto') {
-        delete rest.marginHorizontal;
+      for (let j = 0; j < samples.length - 1; j++) {
+        inputRange.push(i + j / EASING_SAMPLE_COUNT);
+        outputRange.push(start + (end - start) * samples[j]);
       }
     }
 
-    finalStyle = rest;
-  } else {
-    finalStyle = style;
+    inputRange.push(values.length - 1);
+    outputRange.push(values[values.length - 1]);
+
+    return position.interpolate({
+      inputRange,
+      outputRange,
+      extrapolate: 'clamp',
+    });
+  };
+
+  let containerLayout: ViewStyle;
+  let leftFillStyle: ViewStyle;
+  let centerFillStyle: ViewStyle;
+  let rightCapStyle: ViewStyle;
+  let rightFillStyle: ViewStyle;
+
+  const rightEdges = widths.map((w, i) => offsets[i] + w);
+
+  const [lastIndex, setLastIndex] = React.useState(navigationState.index);
+  const [jumpRange, setJumpRange] = React.useState<{
+    from: number;
+    to: number;
+  } | null>(null);
+
+  if (navigationState.index !== lastIndex) {
+    setLastIndex(navigationState.index);
+
+    if (Math.abs(navigationState.index - lastIndex) > 1) {
+      setJumpRange({ from: lastIndex, to: navigationState.index });
+    }
   }
 
+  React.useEffect(() => {
+    if (jumpRange == null) {
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      setJumpRange(null);
+    }, 500);
+
+    return () => clearTimeout(timer);
+  }, [jumpRange]);
+
+  // Primary tabs use stretch animation
+  // Secondary tabs and multi-tab jumps slide linearly
+  const shouldStretch = variant === 'primary' && jumpRange == null;
+
+  const trailingSamples = shouldStretch ? TRAILING_EDGE_SAMPLES : null;
+  const leadingSamples = shouldStretch ? LEADING_EDGE_SAMPLES : null;
+
+  const offset = easedInterpolate(offsets, trailingSamples);
+  const rightEdge = easedInterpolate(rightEdges, leadingSamples);
+
+  const containerWidth = Animated.subtract(rightEdge, offset);
+  const sideFillWidth = Animated.divide(
+    Animated.subtract(containerWidth, leftPieceWidth + rightPieceWidth),
+    2
+  );
+  const sideFillScale = Animated.add(sideFillWidth, CAP_FILL_OVERLAP);
+
+  if (Platform.OS === 'web') {
+    const centerFillStart = Animated.add(sideFillWidth, leftPieceWidth);
+
+    const positioned =
+      typeof containerStart === 'number'
+        ? Animated.add(offset, containerStart)
+        : offset;
+
+    // Web can't reliably scale via transforms
+    // So the fills use animated `width` instead of `scaleX`
+    // See https://github.com/react-navigation/react-navigation/pull/11440
+    containerLayout = {
+      width: containerWidth,
+      ...(direction === 'rtl' ? { right: positioned } : { left: positioned }),
+    };
+
+    leftFillStyle = {
+      position: 'absolute',
+      start: leftRadiusWidth,
+      width: sideFillScale,
+    };
+
+    centerFillStyle = {
+      position: 'absolute',
+      start: centerFillStart,
+      width: sideFillWidth,
+    };
+
+    rightCapStyle = {
+      position: 'absolute',
+      end: 0,
+    };
+
+    rightFillStyle = {
+      position: 'absolute',
+      end: rightRadiusWidth,
+      width: sideFillScale,
+    };
+  } else {
+    const directionSign = direction === 'rtl' ? -1 : 1;
+    const translateX = Animated.multiply(offset, directionSign);
+
+    const centerFillTranslateX = Animated.multiply(
+      Animated.divide(sideFillWidth, 2),
+      directionSign
+    );
+
+    const rightCapTranslateX = Animated.multiply(
+      Animated.subtract(containerWidth, rightPieceWidth),
+      directionSign
+    );
+
+    containerLayout = {
+      start: containerStart ?? 0,
+      end: containerEnd ?? 0,
+      transform: [{ translateX }],
+    };
+
+    leftFillStyle = {
+      position: 'absolute',
+      start: leftRadiusWidth,
+      width: 1,
+      transformOrigin: isRTL ? 'right center' : 'left center',
+      transform: [{ scaleX: sideFillScale }],
+    };
+
+    centerFillStyle = {
+      position: 'absolute',
+      start: leftPieceWidth,
+      width: 1,
+      transformOrigin: isRTL ? 'right center' : 'left center',
+      transform: [
+        {
+          translateX: centerFillTranslateX,
+        },
+        { scaleX: sideFillWidth },
+      ],
+    };
+
+    rightCapStyle = {
+      position: 'absolute',
+      start: 0,
+      transform: [{ translateX: rightCapTranslateX }],
+    };
+
+    rightFillStyle = {
+      position: 'absolute',
+      end: rightRadiusWidth,
+      width: 1,
+      transformOrigin: isRTL ? 'left center' : 'right center',
+      transform: [{ scaleX: sideFillScale }],
+    };
+  }
+
+  // The tab widths may be measured asynchronously
+  // So we show the indicator when we have widths till focused tab
+  const indicatorVisible = widths
+    .slice(0, navigationState.index + 1)
+    .every((w, i) => w > 0 && offsets[i] >= 0);
+
+  /**
+   * We render the indicator in multiple pieces
+   * So we can preserve border radii when the indicator is scaled with transform
+   * We use 3 pieces for the inner fill as the math isn't correct on Android
+   * So using 1 or 2 pieces result in misalignment or gaps.
+   * Using 3 pieces lets us cover most space from all directions.
+   *
+   * [left fixed cap [left scaled fill >>>]]
+   *                  [center scaled fill]
+   *                [[<<< right scaled fill] right fixed cap]
+   */
   return (
     <Animated.View
       style={[
         styles.indicator,
-        styleList,
-        width === 'auto' ? { opacity: opacity } : null,
-        finalStyle,
+        {
+          height,
+          opacity: indicatorVisible ? 1 : 0,
+        },
+        containerLayout,
+        restStyle,
       ]}
     >
-      {children}
+      <Animated.View
+        style={[
+          {
+            backgroundColor,
+            borderTopStartRadius,
+            borderBottomStartRadius,
+            ...(isRTL
+              ? { borderTopRightRadius, borderBottomRightRadius }
+              : { borderTopLeftRadius, borderBottomLeftRadius }),
+            height,
+            width: leftPieceWidth,
+          },
+          styles.cap,
+        ]}
+      >
+        <Animated.View style={[{ backgroundColor, height }, leftFillStyle]} />
+      </Animated.View>
+      <Animated.View style={[{ backgroundColor, height }, centerFillStyle]} />
+      <Animated.View
+        style={[
+          {
+            backgroundColor,
+            borderTopEndRadius,
+            borderBottomEndRadius,
+            ...(isRTL
+              ? { borderTopLeftRadius, borderBottomLeftRadius }
+              : { borderTopRightRadius, borderBottomRightRadius }),
+            height,
+            width: rightPieceWidth,
+          },
+          rightCapStyle,
+        ]}
+      >
+        <Animated.View style={[{ backgroundColor, height }, rightFillStyle]} />
+      </Animated.View>
     </Animated.View>
   );
 }
 
 const styles = StyleSheet.create({
   indicator: {
-    backgroundColor: 'rgb(0, 122, 255)',
+    flexDirection: 'row',
+    justifyContent: 'center',
+    position: 'absolute',
+    bottom: 0,
+  },
+  defaults: {
+    backgroundColor: TAB_BAR_PRIMARY_ACTIVE_COLOR,
+    height: 2,
+  },
+  cap: {
     position: 'absolute',
     start: 0,
-    bottom: 0,
-    end: 0,
-    height: 2,
   },
 });

--- a/packages/react-native-tab-view/src/TabBarItem.tsx
+++ b/packages/react-native-tab-view/src/TabBarItem.tsx
@@ -12,11 +12,22 @@ import {
 } from 'react-native';
 import useLatestCallback from 'use-latest-callback';
 
+import {
+  TAB_BAR_INACTIVE_COLOR,
+  TAB_BAR_PRIMARY_ACTIVE_COLOR,
+  TAB_BAR_SECONDARY_ACTIVE_COLOR,
+} from './constants';
 import { PlatformPressable } from './PlatformPressable';
 import { TabBarItemLabel } from './TabBarItemLabel';
 import type { NavigationState, Route, TabDescriptor } from './types';
 
+type Layout = {
+  width: number;
+  height: number;
+};
+
 export type Props<T extends Route> = TabDescriptor<T> & {
+  variant?: 'primary' | 'secondary' | undefined;
   position: Animated.AnimatedInterpolation<number>;
   route: T;
   navigationState: NavigationState<T>;
@@ -24,16 +35,14 @@ export type Props<T extends Route> = TabDescriptor<T> & {
   inactiveColor?: ColorValue | undefined;
   pressColor?: ColorValue | undefined;
   pressOpacity?: number | undefined;
-  onLayout?: ((event: LayoutChangeEvent) => void) | undefined;
+  onMeasureLayout: (layout: Layout) => void;
+  onMeasureLabelLayout: (layout: Layout) => void;
   onPress: () => void;
   onLongPress: () => void;
-  defaultTabWidth?: number | undefined;
   style: StyleProp<ViewStyle>;
   android_ripple?: PressableAndroidRippleConfig | undefined;
 };
 
-const DEFAULT_ACTIVE_COLOR = 'rgba(0, 0, 0, 1)';
-const DEFAULT_INACTIVE_COLOR = 'rgba(0, 0, 0, 0.5)';
 const ICON_SIZE = 24;
 
 const getActiveOpacity = (
@@ -78,15 +87,18 @@ type TabBarItemInternalProps<T extends Route> = Omit<
   | 'getTestID'
   | 'getAccessible'
   | 'options'
+  | 'variant'
 > & {
   isFocused: boolean;
   index: number;
   routesLength: number;
+  variant: NonNullable<Props<T>['variant']>;
 } & TabDescriptor<T>;
 
-const ANDROID_RIPPLE_DEFAULT = { borderless: true };
+const ANDROID_RIPPLE_DEFAULT = { borderless: false, foreground: true };
 
 const TabBarItemInternal = <T extends Route>({
+  variant,
   accessibilityLabel,
   accessible,
   label: customlabel,
@@ -99,11 +111,11 @@ const TabBarItemInternal = <T extends Route>({
   inactiveColor: inactiveColorCustom,
   activeColor: activeColorCustom,
   labelStyle,
-  onLayout,
+  onMeasureLayout,
+  onMeasureLabelLayout,
   index: tabIndex,
   pressColor,
   pressOpacity,
-  defaultTabWidth,
   icon: customIcon,
   badge: customBadge,
   href,
@@ -114,19 +126,23 @@ const TabBarItemInternal = <T extends Route>({
   route,
 }: TabBarItemInternalProps<T>) => {
   const labelColorFromStyle = StyleSheet.flatten(labelStyle || {}).color;
+  const defaultActiveColor =
+    variant === 'primary'
+      ? TAB_BAR_PRIMARY_ACTIVE_COLOR
+      : TAB_BAR_SECONDARY_ACTIVE_COLOR;
 
   const activeColor =
     activeColorCustom !== undefined
       ? activeColorCustom
       : typeof labelColorFromStyle === 'string'
         ? labelColorFromStyle
-        : DEFAULT_ACTIVE_COLOR;
+        : defaultActiveColor;
   const inactiveColor =
     inactiveColorCustom !== undefined
       ? inactiveColorCustom
       : typeof labelColorFromStyle === 'string'
         ? labelColorFromStyle
-        : DEFAULT_INACTIVE_COLOR;
+        : TAB_BAR_INACTIVE_COLOR;
 
   const activeOpacity = getActiveOpacity(position, routesLength, tabIndex);
   const inactiveOpacity = getInactiveOpacity(position, routesLength, tabIndex);
@@ -188,6 +204,7 @@ const TabBarItemInternal = <T extends Route>({
           icon={icon}
           label={labelText}
           style={labelStyle}
+          allowFontScaling={labelAllowFontScaling}
         />
       ),
     [
@@ -202,15 +219,36 @@ const TabBarItemInternal = <T extends Route>({
     ]
   );
 
-  const tabStyle = StyleSheet.flatten(style);
-  const isWidthSet = tabStyle?.width !== undefined;
-
-  const tabContainerStyle: ViewStyle | null = isWidthSet
-    ? null
-    : { width: defaultTabWidth };
-
   const ariaLabel =
     typeof accessibilityLabel !== 'undefined' ? accessibilityLabel : labelText;
+
+  const viewRef = React.useRef<View>(null);
+  const labelRef = React.useRef<View>(null);
+
+  React.useLayoutEffect(() => {
+    viewRef.current?.measure((_x, _y, width, height) => {
+      onMeasureLayout({ width, height });
+    });
+
+    labelRef.current?.measure((_x, _y, width, height) => {
+      onMeasureLabelLayout({ width, height });
+    });
+
+    // Only measure on mount. onLayout handles updates.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const onLayout = (event: LayoutChangeEvent) => {
+    const { width, height } = event.nativeEvent.layout;
+
+    onMeasureLayout({ width, height });
+  };
+
+  const onLabelLayout = (event: LayoutChangeEvent) => {
+    const { width, height } = event.nativeEvent.layout;
+
+    onMeasureLabelLayout({ width, height });
+  };
 
   return (
     <PlatformPressable
@@ -223,23 +261,24 @@ const TabBarItemInternal = <T extends Route>({
       pressColor={pressColor}
       pressOpacity={pressOpacity}
       unstable_pressDelay={0}
-      onLayout={onLayout}
       onPress={onPress}
       onLongPress={onLongPress}
       href={href}
-      style={[styles.pressable, tabContainerStyle]}
+      style={styles.pressable}
     >
-      <View style={[styles.item, tabStyle]}>
-        {icon}
-        <View>
-          <Animated.View style={{ opacity: inactiveOpacity }}>
-            {renderLabel(false)}
-          </Animated.View>
-          <Animated.View
-            style={[StyleSheet.absoluteFill, { opacity: activeOpacity }]}
-          >
-            {renderLabel(true)}
-          </Animated.View>
+      <View ref={viewRef} onLayout={onLayout} style={[styles.item, style]}>
+        <View ref={labelRef} onLayout={onLabelLayout}>
+          {icon}
+          <View>
+            <Animated.View style={{ opacity: inactiveOpacity }}>
+              {renderLabel(false)}
+            </Animated.View>
+            <Animated.View
+              style={[StyleSheet.absoluteFill, { opacity: activeOpacity }]}
+            >
+              {renderLabel(true)}
+            </Animated.View>
+          </View>
         </View>
         {customBadge != null ? (
           <View style={styles.badge}>{customBadge({ route })}</View>
@@ -253,21 +292,30 @@ const MemoizedTabBarItemInternal = React.memo(
   TabBarItemInternal
 ) as typeof TabBarItemInternal;
 
-export function TabBarItem<T extends Route>(props: Props<T>) {
-  const { onPress, onLongPress, onLayout, navigationState, route, ...rest } =
-    props;
-
+export function TabBarItem<T extends Route>({
+  variant = 'primary',
+  onPress,
+  onLongPress,
+  onMeasureLayout,
+  onMeasureLabelLayout,
+  navigationState,
+  route,
+  ...rest
+}: Props<T>) {
   const onPressLatest = useLatestCallback(onPress);
   const onLongPressLatest = useLatestCallback(onLongPress);
-  const onLayoutLatest = useLatestCallback(onLayout ? onLayout : () => {});
+  const onMeasureLayoutLatest = useLatestCallback(onMeasureLayout);
+  const onMeasureLabelLayoutLatest = useLatestCallback(onMeasureLabelLayout);
 
   const tabIndex = navigationState.routes.indexOf(route);
 
   return (
     <MemoizedTabBarItemInternal
       {...rest}
+      variant={variant}
       onPress={onPressLatest}
-      onLayout={onLayoutLatest}
+      onMeasureLayout={onMeasureLayoutLatest}
+      onMeasureLabelLayout={onMeasureLabelLayoutLatest}
       onLongPress={onLongPressLatest}
       isFocused={navigationState.index === tabIndex}
       route={route}
@@ -285,7 +333,7 @@ const styles = StyleSheet.create({
     flex: 1,
     alignItems: 'center',
     justifyContent: 'center',
-    padding: 10,
+    paddingHorizontal: 16,
     minHeight: 48,
     pointerEvents: 'none',
   },

--- a/packages/react-native-tab-view/src/TabBarItem.tsx
+++ b/packages/react-native-tab-view/src/TabBarItem.tsx
@@ -167,7 +167,7 @@ const TabBarItemInternal = <T extends Route>({
     });
 
     return (
-      <View style={styles.icon}>
+      <View>
         <Animated.View style={{ opacity: inactiveOpacity }}>
           {inactiveIcon}
         </Animated.View>
@@ -250,6 +250,8 @@ const TabBarItemInternal = <T extends Route>({
     onMeasureLabelLayout({ width, height });
   };
 
+  const hasIconAndLabel = Boolean(customIcon && labelText);
+
   return (
     <PlatformPressable
       android_ripple={android_ripple}
@@ -266,8 +268,16 @@ const TabBarItemInternal = <T extends Route>({
       href={href}
       style={styles.pressable}
     >
-      <View ref={viewRef} onLayout={onLayout} style={[styles.item, style]}>
-        <View ref={labelRef} onLayout={onLabelLayout}>
+      <View
+        ref={viewRef}
+        onLayout={onLayout}
+        style={[
+          styles.item,
+          hasIconAndLabel ? styles.itemWithIcon : null,
+          style,
+        ]}
+      >
+        <View ref={labelRef} onLayout={onLabelLayout} style={styles.content}>
           {icon}
           <View>
             <Animated.View style={{ opacity: inactiveOpacity }}>
@@ -326,16 +336,19 @@ export function TabBarItem<T extends Route>({
 }
 
 const styles = StyleSheet.create({
-  icon: {
-    margin: 2,
-  },
   item: {
-    flex: 1,
     alignItems: 'center',
     justifyContent: 'center',
     paddingHorizontal: 16,
     minHeight: 48,
     pointerEvents: 'none',
+  },
+  itemWithIcon: {
+    minHeight: 62,
+  },
+  content: {
+    alignItems: 'center',
+    justifyContent: 'center',
   },
   badge: {
     position: 'absolute',

--- a/packages/react-native-tab-view/src/TabBarItemLabel.tsx
+++ b/packages/react-native-tab-view/src/TabBarItemLabel.tsx
@@ -4,19 +4,21 @@ import { Animated, StyleSheet } from 'react-native';
 
 interface TabBarItemLabelProps {
   color: ColorValue;
-  label?: string | undefined;
-  style: StyleProp<ViewStyle>;
+  label: string | undefined;
   icon: React.ReactNode;
+  style: StyleProp<ViewStyle>;
+  allowFontScaling?: boolean | undefined;
 }
 
 export const TabBarItemLabel = React.memo(
-  ({ color, label, style, icon }: TabBarItemLabelProps) => {
+  ({ color, label, style, icon, allowFontScaling }: TabBarItemLabelProps) => {
     if (!label) {
       return null;
     }
 
     return (
       <Animated.Text
+        allowFontScaling={allowFontScaling}
         style={[
           styles.label,
           icon ? { marginTop: 0 } : null,
@@ -34,7 +36,6 @@ TabBarItemLabel.displayName = 'TabBarItemLabel';
 
 const styles = StyleSheet.create({
   label: {
-    margin: 4,
     fontSize: 14,
     fontWeight: '500',
     backgroundColor: 'transparent',

--- a/packages/react-native-tab-view/src/__tests__/index.test.tsx
+++ b/packages/react-native-tab-view/src/__tests__/index.test.tsx
@@ -34,13 +34,18 @@ jest.mock('react-native-pager-view', () => {
   };
 });
 
-jest.mock('../DefaultAdapter', () => {
-  const Platform = require('react-native').Platform;
+jest.mock('../DefaultAdapter', () => ({
+  get DefaultAdapter() {
+    // Make sure to use our mocked platform
+    const Platform = require('react-native').Platform;
 
-  return Platform.OS === 'web'
-    ? jest.requireActual('../DefaultAdapter.tsx')
-    : jest.requireActual('../DefaultAdapter.ios.tsx');
-});
+    return jest.requireActual<typeof import('../DefaultAdapter')>(
+      Platform.OS === 'web'
+        ? '../DefaultAdapter.tsx'
+        : '../DefaultAdapter.ios.tsx'
+    ).DefaultAdapter;
+  },
+}));
 
 const FirstRoute = () => (
   <View style={{ flex: 1, backgroundColor: '#ff4081' }} testID={'route1'} />

--- a/packages/react-native-tab-view/src/constants.tsx
+++ b/packages/react-native-tab-view/src/constants.tsx
@@ -1,0 +1,8 @@
+export const TAB_BAR_PRIMARY_ACTIVE_COLOR = '#6750a4';
+export const TAB_BAR_SECONDARY_ACTIVE_COLOR = '#1d1b20';
+export const TAB_BAR_INACTIVE_COLOR = '#49454f';
+export const TAB_BAR_BACKGROUND_COLOR = '#fef7ff';
+export const TAB_BAR_BORDER_COLOR = '#cac4d0';
+
+export const PRIMARY_INDICATOR_MIN_WIDTH = 24;
+export const TAB_MIN_WIDTH = 90;

--- a/packages/react-native-tab-view/src/useLayoutWidths.tsx
+++ b/packages/react-native-tab-view/src/useLayoutWidths.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react';
+
+// Batches onLayout updates from multiple keyed views into a single state update
+// per frame, so layout passes don't trigger N renders.
+export function useLayoutWidths(priorityKeys: string[]) {
+  const [widths, setWidths] = React.useState<Record<string, number>>({});
+
+  const measured = React.useRef<Record<string, number>>({});
+  const handle = React.useRef<ReturnType<typeof requestAnimationFrame>>(null);
+
+  const priorityKeysRef = React.useRef(priorityKeys);
+
+  React.useEffect(() => {
+    priorityKeysRef.current = priorityKeys;
+  });
+
+  const hasFinishedLayoutRef = React.useRef(false);
+
+  React.useLayoutEffect(() => {
+    hasFinishedLayoutRef.current = true;
+  }, []);
+
+  const onMeasureWidth = React.useCallback((key: string, width: number) => {
+    measured.current[key] = width;
+
+    if (handle.current != null) {
+      cancelAnimationFrame(handle.current);
+    }
+
+    if (
+      priorityKeysRef.current.includes(key) &&
+      !hasFinishedLayoutRef.current
+    ) {
+      // Synchronously set widths during the initial layout phase
+      // So we don't have to wait for the next frame to render the indicator
+      setWidths((prev) => ({ ...prev, [key]: width }));
+    } else if (hasFinishedLayoutRef.current) {
+      handle.current = requestAnimationFrame(() => {
+        setWidths({ ...measured.current });
+      });
+    }
+
+    return () => {
+      if (handle.current != null) {
+        cancelAnimationFrame(handle.current);
+      }
+    };
+  }, []);
+
+  return [widths, onMeasureWidth] as const;
+}


### PR DESCRIPTION
This completely reworks the tab bar indicator to support border radii and updates the default styles to align with the latest MD3 guidelines.

The older style is MD3's secondary variant and can be used by specifying `variant="secondary"` on the tab bar.


https://github.com/user-attachments/assets/8c7cec5b-e5c6-4eb8-b6fe-5dd563184350



