### PR TITLE
fix(core): reset lastNotifiedStateRef on cleanup for StrictMode compatibility

### DIFF
--- a/packages/core/src/__tests__/index.test.tsx
+++ b/packages/core/src/__tests__/index.test.tsx
@@ -616,6 +616,51 @@ test('cleans up state when the navigator unmounts', () => {
   expect(onStateChange).toHaveBeenLastCalledWith(undefined);
 });
 
+test('preserves initial state when navigator mount is delayed in StrictMode', async () => {
+  const TestNavigator = (props: any): any => {
+    const { state, descriptors, NavigationContent } = useNavigationBuilder(
+      MockRouter,
+      props
+    );
+
+    return (
+      <NavigationContent>
+        {descriptors[state.routes[state.index].key].render()}
+      </NavigationContent>
+    );
+  };
+
+  const TestScreen = ({ route }: any): any => `[${route.name}]`;
+
+  const navigation = createNavigationContainerRef<ParamListBase>();
+
+  const Test = ({ condition }: { condition: boolean }) => (
+    <React.StrictMode>
+      <BaseNavigationContainer
+        ref={navigation}
+        initialState={{
+          index: 1,
+          routes: [{ name: 'foo' }, { name: 'bar' }],
+        }}
+      >
+        {condition ? (
+          <TestNavigator>
+            <Screen name="foo" component={TestScreen} />
+            <Screen name="bar" component={TestScreen} />
+          </TestNavigator>
+        ) : null}
+      </BaseNavigationContainer>
+    </React.StrictMode>
+  );
+
+  const root = await renderAsync(<Test condition={false} />);
+
+  await root.rerenderAsync(<Test condition />);
+
+  expect(root).toMatchInlineSnapshot(`"[bar]"`);
+  expect(navigation.getCurrentRoute()?.name).toBe('bar');
+});
+
 test('preserves state after rendered in `<Activity mode="hidden">`', async () => {
   const TestNavigator = (props: any): any => {
     const { state, descriptors, NavigationContent } = useNavigationBuilder(

--- a/packages/core/src/useNavigationBuilder.tsx
+++ b/packages/core/src/useNavigationBuilder.tsx
@@ -777,6 +777,11 @@ export function useNavigationBuilder<
         setCurrentState(undefined);
         stateCleanupRef.current = true;
       }
+
+      // Reset so that StrictMode's second mount re-propagates state correctly.
+      // Without this, the guard above sees the same reference and skips setState,
+      // causing deep link state to be lost after cleanup wipes the container state.
+      lastNotifiedStateRef.current = null;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/packages/core/src/useNavigationBuilder.tsx
+++ b/packages/core/src/useNavigationBuilder.tsx
@@ -780,7 +780,7 @@ export function useNavigationBuilder<
 
       // Reset so that StrictMode's second mount re-propagates state correctly.
       // Without this, the guard above sees the same reference and skips setState,
-      // causing deep link state to be lost after cleanup wipes the container state.
+      // causing the initial state to be lost after cleanup wipes the container state.
       lastNotifiedStateRef.current = null;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
## Summary

Fixes deep links being silently dropped when using React's StrictMode with a deferred navigator mount (e.g. behind an auth/loading gate).

## Root cause

The `lastNotifiedStateRef` guard in `useNavigationBuilder.tsx` (introduced in #12985) prevents `setState` from re-propagating state on StrictMode's second effect invocation. The cleanup wipes the container state via `setCurrentState(undefined)`, but `lastNotifiedStateRef` still holds the same reference — so the guard skips `setState` on remount, leaving the container with `undefined` state and losing the deep link.

## Fix

Reset `lastNotifiedStateRef.current = null` in the effect cleanup. This allows StrictMode's second mount to correctly re-propagate state.

This does not affect the `<Activity mode="hidden">` loop prevention since the effect has `[]` deps and only runs once per mount cycle.

## Test plan

- Verified with reproduction repo: https://github.com/NGMarmaduke/deep-link-repro
- Before fix: navigating to `/profile` lands on Home
- After fix: navigating to `/profile` correctly lands on Profile

Fixes #13025