### PR TITLE
feat: add standard navigation compatibility

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -36,7 +36,8 @@
     "react-native-reanimated": "^3.19.4",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "^4.25.0",
-    "react-native-web": "~0.21.0"
+    "react-native-web": "~0.21.0",
+    "standard-navigation": "^0.0.7"
   },
   "devDependencies": {
     "@babel/core": "^7.28.4",

--- a/example/src/Screens/StandardNavigator/MyStackDynamic.tsx
+++ b/example/src/Screens/StandardNavigator/MyStackDynamic.tsx
@@ -1,0 +1,162 @@
+import { Button, Text } from '@react-navigation/elements';
+import {
+  type PathConfigMap,
+  useNavigation,
+  useNavigationState,
+} from '@react-navigation/native';
+import * as React from 'react';
+import { StyleSheet, View } from 'react-native';
+
+import {
+  createMyStackNavigator,
+  type MyStackNavigationProp,
+  type MyStackScreenProps,
+} from './createMyStackNavigator';
+
+type MyStackParamList = {
+  StandardDynamicHome: undefined;
+  StandardDynamicProfile: { user: string };
+  StandardDynamicDetails: { section: string };
+};
+
+const linking: PathConfigMap<MyStackParamList> = {
+  StandardDynamicHome: 'standard-dynamic-home',
+  StandardDynamicProfile: 'standard-dynamic-profile/:user',
+  StandardDynamicDetails: 'standard-dynamic-details/:section',
+};
+
+type MyNavigationObject = MyStackNavigationProp<MyStackParamList>;
+
+const MyStack = createMyStackNavigator<MyStackParamList>();
+
+function HomeScreen() {
+  const navigation = useNavigation<MyNavigationObject>();
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Dynamic home</Text>
+      <Button
+        variant="filled"
+        onPress={() =>
+          navigation.navigate('StandardDynamicProfile', { user: 'jane' })
+        }
+      >
+        Open profile
+      </Button>
+      <Button variant="tinted" onPress={() => navigation.goBack()}>
+        Go back
+      </Button>
+    </View>
+  );
+}
+
+function ProfileScreen({
+  route,
+}: MyStackScreenProps<MyStackParamList, 'StandardDynamicProfile'>) {
+  const navigation = useNavigation<MyNavigationObject>();
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>{route.params.user}</Text>
+      <View style={styles.buttons}>
+        <Button
+          variant="filled"
+          onPress={() =>
+            navigation.navigate('StandardDynamicDetails', {
+              section: 'settings',
+            })
+          }
+        >
+          Open details
+        </Button>
+        <Button
+          variant="tinted"
+          onPress={() =>
+            navigation.preload('StandardDynamicDetails', {
+              section: 'preloaded details',
+            })
+          }
+        >
+          Preload details
+        </Button>
+      </View>
+    </View>
+  );
+}
+
+function DetailsScreen({
+  route,
+}: MyStackScreenProps<MyStackParamList, 'StandardDynamicDetails'>) {
+  const navigation = useNavigation<MyNavigationObject>();
+
+  const isPreloaded = useNavigationState(
+    (state) =>
+      'preloadedRoutes' in state &&
+      Array.isArray(state.preloadedRoutes) &&
+      state.preloadedRoutes.some((r) => 'key' in r && r.key === route.key)
+  );
+
+  const [wasPreloaded, setWasPreloaded] = React.useState(isPreloaded);
+
+  if (isPreloaded && !wasPreloaded) {
+    setWasPreloaded(true);
+  }
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>{route.params.section}</Text>
+      {wasPreloaded ? <Text>(preloaded)</Text> : null}
+      <Button variant="tinted" onPress={() => navigation.popToTop()}>
+        Pop to top
+      </Button>
+    </View>
+  );
+}
+
+export function MyStackDynamic() {
+  return (
+    <MyStack.Navigator
+      screenListeners={{
+        rightButtonPress: (event) => {
+          alert(`Right button pressed (${event.data.count})`);
+        },
+      }}
+    >
+      <MyStack.Screen
+        name="StandardDynamicHome"
+        component={HomeScreen}
+        options={{ title: 'Home', rightButtonTitle: '🌟' }}
+      />
+      <MyStack.Screen
+        name="StandardDynamicProfile"
+        component={ProfileScreen}
+        options={{ title: 'Profile' }}
+      />
+      <MyStack.Screen
+        name="StandardDynamicDetails"
+        component={DetailsScreen}
+        options={{ title: 'Details', rightButtonTitle: '🎨' }}
+      />
+    </MyStack.Navigator>
+  );
+}
+
+MyStackDynamic.title = 'Standard Navigation (Dynamic)';
+MyStackDynamic.linking = linking;
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 12,
+    padding: 16,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: '600',
+  },
+  buttons: {
+    gap: 12,
+  },
+});

--- a/example/src/Screens/StandardNavigator/MyStackNavigator.tsx
+++ b/example/src/Screens/StandardNavigator/MyStackNavigator.tsx
@@ -1,0 +1,123 @@
+import * as React from 'react';
+import {
+  Pressable,
+  type StyleProp,
+  StyleSheet,
+  // eslint-disable-next-line no-restricted-imports
+  Text,
+  View,
+  type ViewStyle,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { createStandardNavigator } from 'standard-navigation';
+
+export type MyStackOptions = {
+  title?: string;
+  rightButtonTitle?: string;
+};
+
+export type MyStackEventMap = {
+  rightButtonPress: {
+    data: { count: number };
+    canPreventDefault: true;
+  };
+};
+
+export type MyStackNavigatorProps = {
+  preloadedCount: number;
+  style?: StyleProp<ViewStyle>;
+};
+
+export const MyStackNavigator = createStandardNavigator<
+  MyStackOptions,
+  MyStackEventMap,
+  MyStackNavigatorProps
+>(({ state, descriptors, actions, emitter, preloadedCount, style }) => {
+  const insets = useSafeAreaInsets();
+  const countRef = React.useRef(0);
+
+  return (
+    <View style={[styles.container, style]}>
+      {state.routes.map((route) => {
+        const isFocused = route.key === state.routes[state.index].key;
+        const descriptor = descriptors[route.key];
+
+        return (
+          <View
+            key={route.key}
+            style={[styles.screen, { display: isFocused ? 'flex' : 'none' }]}
+          >
+            <View style={[{ height: insets.top }, styles.inset]} />
+            <View style={styles.header}>
+              {state.index > 0 ? (
+                <Pressable onPress={() => actions.back()} style={styles.button}>
+                  <Text style={styles.label}>👈</Text>
+                </Pressable>
+              ) : null}
+              <Text style={styles.title}>
+                {descriptor.options.title ?? route.name}
+              </Text>
+              <View style={styles.right}>
+                {preloadedCount > 0 ? <Text>⌛ ({preloadedCount})</Text> : null}
+                {descriptor.options.rightButtonTitle ? (
+                  <Pressable
+                    onPress={() => {
+                      emitter.emit({
+                        type: 'rightButtonPress',
+                        data: { count: ++countRef.current },
+                        canPreventDefault: true,
+                      });
+                    }}
+                    style={styles.button}
+                  >
+                    <Text style={styles.label}>
+                      {descriptor.options.rightButtonTitle}
+                    </Text>
+                  </Pressable>
+                ) : null}
+              </View>
+            </View>
+            {descriptor.render()}
+          </View>
+        );
+      })}
+    </View>
+  );
+});
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  screen: {
+    flex: 1,
+  },
+  button: {
+    padding: 12,
+  },
+  inset: {
+    backgroundColor: 'tomato',
+  },
+  header: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    height: 56,
+    paddingHorizontal: 12,
+    backgroundColor: 'tomato',
+  },
+  title: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: 'white',
+    marginHorizontal: 12,
+  },
+  label: {
+    fontSize: 20,
+    color: 'white',
+  },
+  right: {
+    flex: 1,
+    alignItems: 'flex-end',
+  },
+});

--- a/example/src/Screens/StandardNavigator/MyStackStatic.tsx
+++ b/example/src/Screens/StandardNavigator/MyStackStatic.tsx
@@ -1,0 +1,154 @@
+import { Button, Text } from '@react-navigation/elements';
+import {
+  createPathConfigForStaticNavigation,
+  type StaticParamList,
+  type StaticScreenProps,
+  useNavigation,
+  useNavigationState,
+  useRoute,
+} from '@react-navigation/native';
+import * as React from 'react';
+import { StyleSheet, View } from 'react-native';
+
+import {
+  createMyStackNavigator,
+  createMyStackScreen,
+  type MyStackNavigationProp,
+} from './createMyStackNavigator';
+
+type MyNavigationObject = MyStackNavigationProp<
+  StaticParamList<typeof MyStack>
+>;
+
+function HomeScreen() {
+  const navigation = useNavigation<MyNavigationObject>();
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Static home</Text>
+      <Button
+        variant="filled"
+        onPress={() =>
+          navigation.navigate('StandardStaticProfile', { user: 'jane' })
+        }
+      >
+        Open profile
+      </Button>
+      <Button variant="tinted" onPress={() => navigation.goBack()}>
+        Go back
+      </Button>
+    </View>
+  );
+}
+
+function ProfileScreen({ route }: StaticScreenProps<{ user: string }>) {
+  const navigation = useNavigation<MyNavigationObject>();
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>{route.params.user}</Text>
+      <View style={styles.buttons}>
+        <Button
+          variant="filled"
+          onPress={() =>
+            navigation.navigate('StandardStaticDetails', {
+              section: 'settings',
+            })
+          }
+        >
+          Open details
+        </Button>
+        <Button
+          variant="tinted"
+          onPress={() =>
+            navigation.preload('StandardStaticDetails', {
+              section: 'preloaded details',
+            })
+          }
+        >
+          Preload details
+        </Button>
+      </View>
+    </View>
+  );
+}
+
+function DetailsScreen({ route }: StaticScreenProps<{ section: string }>) {
+  const navigation = useNavigation<MyNavigationObject>();
+  const focusedRoute = useRoute();
+  const isPreloaded = useNavigationState(
+    (state) =>
+      'preloadedRoutes' in state &&
+      Array.isArray(state.preloadedRoutes) &&
+      state.preloadedRoutes.some(
+        (r) => 'key' in r && r.key === focusedRoute.key
+      )
+  );
+
+  const [wasPreloaded, setWasPreloaded] = React.useState(isPreloaded);
+
+  if (isPreloaded && !wasPreloaded) {
+    setWasPreloaded(true);
+  }
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>{route.params.section}</Text>
+      {wasPreloaded ? <Text>(preloaded)</Text> : null}
+      <Button variant="tinted" onPress={() => navigation.popToTop()}>
+        Pop to top
+      </Button>
+    </View>
+  );
+}
+
+export const MyStack = createMyStackNavigator({
+  screenListeners: {
+    rightButtonPress: (event) => {
+      alert(`Right button pressed (${event.data.count})`);
+    },
+  },
+  screens: {
+    StandardStaticHome: createMyStackScreen({
+      screen: HomeScreen,
+      options: { title: 'Home', rightButtonTitle: '🌟' },
+      linking: 'standard-static-home',
+    }),
+    StandardStaticProfile: createMyStackScreen({
+      screen: ProfileScreen,
+      options: { title: 'Profile' },
+      linking: 'standard-static-profile/:user',
+    }),
+    StandardStaticDetails: createMyStackScreen({
+      screen: DetailsScreen,
+      options: { title: 'Details', rightButtonTitle: '🎨' },
+      linking: 'standard-static-details/:section',
+    }),
+  },
+});
+
+const Navigation = MyStack.getComponent();
+
+export function MyStackStatic() {
+  return <Navigation />;
+}
+
+MyStackStatic.title = 'Standard Navigation (Static)';
+MyStackStatic.linking = createPathConfigForStaticNavigation(MyStack, {});
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 12,
+    padding: 16,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: '600',
+  },
+  buttons: {
+    gap: 12,
+  },
+});

--- a/example/src/Screens/StandardNavigator/createMyStackNavigator.tsx
+++ b/example/src/Screens/StandardNavigator/createMyStackNavigator.tsx
@@ -1,0 +1,60 @@
+import {
+  createStandardNavigationFactories,
+  type NavigationProp,
+  type ParamListBase,
+  type RouteProp,
+  type StackActionHelpers,
+  type StackNavigationState,
+  StackRouter,
+  type StackRouterOptions,
+  type StandardNavigationTypeBagBase,
+} from '@react-navigation/native';
+
+import {
+  type MyStackEventMap,
+  MyStackNavigator,
+  type MyStackNavigatorProps,
+  type MyStackOptions,
+} from './MyStackNavigator';
+
+export type MyStackNavigationProp<
+  ParamList extends ParamListBase,
+  RouteName extends keyof ParamList = keyof ParamList,
+  NavigatorID extends string | undefined = undefined,
+> = NavigationProp<
+  ParamList,
+  RouteName,
+  NavigatorID,
+  StackNavigationState<ParamList>,
+  MyStackOptions,
+  MyStackEventMap
+> &
+  StackActionHelpers<ParamList>;
+
+export type MyStackScreenProps<
+  ParamList extends ParamListBase,
+  RouteName extends keyof ParamList = keyof ParamList,
+  NavigatorID extends string | undefined = undefined,
+> = {
+  navigation: MyStackNavigationProp<ParamList, RouteName, NavigatorID>;
+  route: RouteProp<ParamList, RouteName>;
+};
+
+export interface MyStackTypeBag extends StandardNavigationTypeBagBase {
+  State: StackNavigationState<this['ParamList']>;
+  ActionHelpers: StackActionHelpers<this['ParamList']>;
+  ScreenOptions: MyStackOptions;
+  EventMap: MyStackEventMap;
+  RouterOptions: StackRouterOptions;
+}
+
+export const {
+  createNavigator: createMyStackNavigator,
+  createScreen: createMyStackScreen,
+} = createStandardNavigationFactories<MyStackTypeBag, MyStackNavigatorProps>(
+  MyStackNavigator,
+  StackRouter,
+  ({ state }) => ({
+    preloadedCount: state.routes.slice(state.index + 1).length,
+  })
+);

--- a/example/src/Screens/StandardNavigator/typechecks.tsx
+++ b/example/src/Screens/StandardNavigator/typechecks.tsx
@@ -1,0 +1,209 @@
+import {
+  createStandardNavigationFactories,
+  type EventArg,
+  type NavigationProp,
+  type StackActionHelpers,
+  type StackNavigationState,
+  StackRouter,
+  type StaticParamList,
+} from '@react-navigation/native';
+import { expectTypeOf } from 'expect-type';
+import type * as React from 'react';
+
+import {
+  createMyStackNavigator,
+  createMyStackScreen,
+  type MyStackTypeBag,
+} from './createMyStackNavigator';
+import {
+  MyStackNavigator,
+  type MyStackNavigatorProps,
+  type MyStackOptions,
+} from './MyStackNavigator';
+import { MyStack } from './MyStackStatic';
+
+{
+  type MyStackParamList = {
+    StandardStaticHome: undefined;
+    StandardStaticProfile: { user: string };
+    StandardStaticDetails: { section: string };
+  };
+
+  type MyStackNavigation<
+    RouteName extends keyof MyStackParamList = keyof MyStackParamList,
+  > = NavigationProp<
+    MyStackParamList,
+    RouteName,
+    string | undefined,
+    StackNavigationState<MyStackParamList>,
+    MyStackOptions,
+    MyStackTypeBag['EventMap']
+  > &
+    StackActionHelpers<MyStackParamList>;
+
+  type MyStackNavigationList = {
+    [RouteName in keyof MyStackParamList]: MyStackNavigation<RouteName>;
+  };
+
+  type InferredMyStackParamList = StaticParamList<typeof MyStack>;
+
+  expectTypeOf<InferredMyStackParamList>().toEqualTypeOf<MyStackParamList>();
+
+  type MyStackHomeNavigation = MyStackNavigationList['StandardStaticHome'];
+  type MyStackProfileNavigation =
+    MyStackNavigationList['StandardStaticProfile'];
+
+  expectTypeOf<keyof MyStackNavigationList>().toEqualTypeOf<
+    keyof MyStackParamList
+  >();
+
+  expectTypeOf<MyStackHomeNavigation['getState']>().returns.toEqualTypeOf<
+    StackNavigationState<MyStackParamList>
+  >();
+
+  expectTypeOf<MyStackHomeNavigation['setOptions']>()
+    .parameter(0)
+    .toEqualTypeOf<Partial<MyStackOptions>>();
+
+  expectTypeOf<MyStackProfileNavigation['setParams']>()
+    .parameter(0)
+    .toEqualTypeOf<Partial<{ user: string }>>();
+
+  expectTypeOf<MyStackHomeNavigation['replace']>()
+    .parameter(0)
+    .toEqualTypeOf<keyof MyStackParamList>();
+
+  expectTypeOf<MyStackHomeNavigation['replace']>().toMatchTypeOf<
+    StackActionHelpers<MyStackParamList>['replace']
+  >();
+
+  const checkMyStackHomeNavigation = (navigation: MyStackHomeNavigation) => {
+    navigation.replace('StandardStaticProfile', { user: 'Satya' });
+    navigation.setOptions({ title: 'Home', rightButtonTitle: 'Press me' });
+
+    // @ts-expect-error `subtitle` isn't a valid option for MyStack.
+    navigation.setOptions({ subtitle: 'Invalid option' });
+
+    navigation.addListener('rightButtonPress', (event) => {
+      expectTypeOf(event).toEqualTypeOf<
+        EventArg<'rightButtonPress', true, { count: number }>
+      >();
+    });
+  };
+
+  createMyStackScreen({
+    screen: TypeCheckProfileScreen,
+    options: {
+      title: 'Profile',
+      // @ts-expect-error `subtitle` isn't a valid static screen option.
+      subtitle: 'Invalid option',
+    },
+  });
+
+  type DynamicMyStackParamList = {
+    DynamicHome: undefined;
+    DynamicProfile: { user: string };
+    DynamicDetails: { section: string };
+  };
+
+  const DynamicMyStack = createMyStackNavigator<DynamicMyStackParamList>();
+
+  type DynamicMyStackNavigatorProps = React.ComponentProps<
+    typeof DynamicMyStack.Navigator
+  >;
+
+  expectTypeOf<
+    DynamicMyStackNavigatorProps['initialRouteName']
+  >().toEqualTypeOf<keyof DynamicMyStackParamList | undefined>();
+
+  expectTypeOf(DynamicMyStack.Screen).parameter(0).toExtend<{
+    name?: keyof DynamicMyStackParamList;
+  }>();
+
+  const dynamicScreenListeners: DynamicMyStackNavigatorProps['screenListeners'] =
+    {
+      rightButtonPress: (event) => {
+        expectTypeOf(event).toEqualTypeOf<
+          EventArg<'rightButtonPress', true, { count: number }>
+        >();
+
+        // @ts-expect-error rightButtonPress doesn't include routeKey.
+        void event.data.routeKey;
+      },
+    };
+
+  function TypeCheckProfileScreen() {
+    return null;
+  }
+
+  const dynamicScreen = (
+    <DynamicMyStack.Screen
+      name="DynamicProfile"
+      component={TypeCheckProfileScreen}
+      options={({ navigation, route }) => {
+        expectTypeOf(route.params).toEqualTypeOf<Readonly<{ user: string }>>();
+
+        expectTypeOf(navigation.setOptions)
+          .parameter(0)
+          .toEqualTypeOf<Partial<MyStackOptions>>();
+
+        return { title: route.params.user, rightButtonTitle: 'Press me' };
+      }}
+      listeners={{
+        rightButtonPress: (event) => {
+          expectTypeOf(event).toEqualTypeOf<
+            EventArg<'rightButtonPress', true, { count: number }>
+          >();
+        },
+      }}
+    />
+  );
+
+  const invalidDynamicScreenName = (
+    <DynamicMyStack.Screen
+      // @ts-expect-error This route isn't in DynamicMyStackParamList.
+      name="Unknown"
+      component={TypeCheckProfileScreen}
+    />
+  );
+
+  const invalidDynamicScreenOptions = (
+    <DynamicMyStack.Screen
+      name="DynamicProfile"
+      component={TypeCheckProfileScreen}
+      // @ts-expect-error `subtitle` isn't a valid dynamic screen option.
+      options={{ subtitle: 'Invalid option' }}
+    />
+  );
+
+  const dynamicNavigator = (
+    <DynamicMyStack.Navigator
+      initialRouteName="DynamicHome"
+      screenListeners={dynamicScreenListeners}
+    >
+      {dynamicScreen}
+    </DynamicMyStack.Navigator>
+  );
+
+  const invalidDynamicNavigator = (
+    <DynamicMyStack.Navigator
+      // @ts-expect-error `label` isn't a valid navigator prop.
+      label="Dynamic Standard Navigation"
+    >
+      {dynamicScreen}
+    </DynamicMyStack.Navigator>
+  );
+
+  createStandardNavigationFactories<MyStackTypeBag, MyStackNavigatorProps>(
+    MyStackNavigator,
+    StackRouter,
+    // @ts-expect-error Mapped props must be keys from MyStackNavigatorProps.
+    () => ({ label: 'Invalid mapped prop' })
+  );
+
+  void checkMyStackHomeNavigation;
+  void invalidDynamicScreenName;
+  void invalidDynamicScreenOptions;
+  void dynamicNavigator;
+  void invalidDynamicNavigator;
+}

--- a/example/src/screens.tsx
+++ b/example/src/screens.tsx
@@ -27,6 +27,8 @@ import { StackHeaderCustomization } from './Screens/StackHeaderCustomization';
 import { StackPreloadFlow } from './Screens/StackPreloadFlow';
 import { StackPreventRemove } from './Screens/StackPreventRemove';
 import { StackTransparent } from './Screens/StackTransparent';
+import { MyStackDynamic } from './Screens/StandardNavigator/MyStackDynamic';
+import { MyStackStatic } from './Screens/StandardNavigator/MyStackStatic';
 import { StaticScreen } from './Screens/Static';
 import { TabPreloadFlow } from './Screens/TabPreloadFlow';
 import { TabView } from './Screens/TabView';
@@ -59,6 +61,8 @@ export const SCREENS = {
   StackPreloadFlow,
   TabPreloadFlow,
   NativeStackPreloadFlow,
+  StandardStaticNavigation: MyStackStatic,
+  StandardDynamicNavigation: MyStackDynamic,
 } as const satisfies {
   [key: string]: React.ComponentType<{}> & {
     title: string;

--- a/packages/core/src/StaticNavigation.tsx
+++ b/packages/core/src/StaticNavigation.tsx
@@ -36,10 +36,8 @@ type StaticRouteConfig<
 > &
   RouteConfigComponent<ParamList, RouteName>;
 
-declare const StaticScreenConfigSymbol: unique symbol;
-
 type StaticScreenConfigBrand = {
-  readonly [StaticScreenConfigSymbol]: true;
+  readonly __reactNavigationStaticScreenConfig: true;
 };
 
 type UnknownToUndefined<T> = unknown extends T ? undefined : T;

--- a/packages/native/package.json
+++ b/packages/native/package.json
@@ -46,6 +46,7 @@
     "escape-string-regexp": "^4.0.0",
     "fast-deep-equal": "^3.1.3",
     "nanoid": "^3.3.11",
+    "standard-navigation": "^0.0.7",
     "use-latest-callback": "^0.2.4"
   },
   "devDependencies": {

--- a/packages/native/src/createStandardNavigationFactories.tsx
+++ b/packages/native/src/createStandardNavigationFactories.tsx
@@ -1,0 +1,294 @@
+import {
+  CommonActions,
+  createNavigatorFactory,
+  createScreenFactory,
+  type DefaultNavigatorOptions,
+  type DefaultRouterOptions,
+  type EventMapBase,
+  type NavigationAction,
+  type NavigationProp,
+  type NavigatorTypeBagBase,
+  type ParamListBase,
+  type RouterFactory,
+  type StaticConfig,
+  type StaticParamList,
+  type StaticScreenFactory,
+  type TypedNavigator,
+  useNavigationBuilder,
+} from '@react-navigation/core';
+import * as React from 'react';
+import type {
+  createStandardNavigator,
+  NavigatorArgs as StandardNavigationArgs,
+} from 'standard-navigation';
+
+import { useBuildHref } from './useLinkBuilder';
+import { useMemoArray } from './useMemoArray';
+
+type StandardEventMap<EventMap extends EventMapBase> = {
+  [EventName in keyof EventMap]: {
+    data: EventMap[EventName] extends { data?: infer Data }
+      ? Data extends object | undefined
+        ? Data
+        : object | undefined
+      : undefined;
+    canPreventDefault: EventMap[EventName] extends { canPreventDefault: true }
+      ? true
+      : false;
+  };
+};
+
+type ActionHelpersOf<T> =
+  T extends Record<string, (...args: never[]) => unknown> ? T : {};
+
+type StandardNavigationNavigatorProps<
+  TypeBag extends StandardNavigationTypeBagBase,
+> = TypeBag['RouterOptions'] &
+  DefaultNavigatorOptions<
+    ParamListBase,
+    string | undefined,
+    StandardNavigationTypeBagFor<TypeBag, ParamListBase>['State'],
+    TypeBag['ScreenOptions'],
+    TypeBag['EventMap'],
+    StandardNavigation<TypeBag>
+  >;
+
+type StandardNavigationTypeBagFor<
+  TypeBag extends StandardNavigationTypeBagBase,
+  ParamList extends ParamListBase,
+  NavigatorID extends string | undefined = string | undefined,
+> = TypeBag & {
+  ParamList: ParamList;
+  NavigatorID: NavigatorID;
+};
+
+type StandardNavigation<TypeBag extends StandardNavigationTypeBagBase> =
+  StandardNavigationTypeBagFor<
+    TypeBag,
+    ParamListBase
+  >['NavigationList'][keyof StandardNavigationTypeBagFor<
+    TypeBag,
+    ParamListBase
+  >['NavigationList']];
+
+type StandardNavigationPropsMapper<
+  TypeBag extends StandardNavigationTypeBagBase,
+  NavigatorProps extends object,
+> = (props: {
+  state: StandardNavigationTypeBagFor<TypeBag, ParamListBase>['State'];
+  navigation: StandardNavigation<TypeBag>;
+}) => Partial<NavigatorProps>;
+
+type StandardNavigationDefaultBag<
+  TypeBag extends StandardNavigationTypeBagBase,
+> = StandardNavigationTypeBagFor<TypeBag, ParamListBase, string | undefined>;
+
+type StandardNavigationFactories<
+  TypeBag extends StandardNavigationTypeBagBase,
+> = {
+  createNavigator: StandardNavigationCreateNavigator<TypeBag>;
+  createScreen: StaticScreenFactory<StandardNavigationDefaultBag<TypeBag>>;
+};
+
+export type StandardNavigationCreateNavigator<
+  TypeBag extends StandardNavigationTypeBagBase,
+> = {
+  <
+    const ParamList extends ParamListBase,
+    const NavigatorID extends string | undefined = string | undefined,
+  >(): TypedNavigator<
+    StandardNavigationTypeBagFor<TypeBag, ParamList, NavigatorID>,
+    undefined
+  >;
+  <const Config extends StaticConfig<StandardNavigationDefaultBag<TypeBag>>>(
+    config: Config & StaticConfig<StandardNavigationDefaultBag<TypeBag>>
+  ): TypedNavigator<
+    StandardNavigationTypeBagFor<
+      TypeBag,
+      StaticParamList<{ config: Config }> & ParamListBase,
+      string | undefined
+    >,
+    Config
+  >;
+};
+
+export interface StandardNavigationTypeBagBase extends NavigatorTypeBagBase {
+  ActionHelpers: {};
+  ScreenOptions: {};
+  EventMap: EventMapBase;
+  RouterOptions: DefaultRouterOptions;
+  NavigationList: {
+    [RouteName in keyof this['ParamList']]: NavigationProp<
+      this['ParamList'],
+      RouteName,
+      this['NavigatorID'],
+      this['State'],
+      this['ScreenOptions'],
+      this['EventMap']
+    > &
+      ActionHelpersOf<this['ActionHelpers']>;
+  };
+  Navigator: React.ComponentType<{}>;
+}
+
+export function createStandardNavigationFactories<
+  TypeBag extends StandardNavigationTypeBagBase,
+  NavigatorProps extends object = {},
+>(
+  navigator: ReturnType<
+    typeof createStandardNavigator<
+      TypeBag['ScreenOptions'],
+      StandardEventMap<TypeBag['EventMap']>,
+      NavigatorProps
+    >
+  >,
+  router: RouterFactory<
+    StandardNavigationTypeBagFor<TypeBag, ParamListBase>['State'],
+    NavigationAction,
+    TypeBag['RouterOptions']
+  >,
+  mapper?: StandardNavigationPropsMapper<TypeBag, NavigatorProps>
+): StandardNavigationFactories<TypeBag> {
+  const { type, version, NavigatorContent } = navigator;
+
+  if (type !== 'standard') {
+    throw new Error(
+      `createStandardNavigationFactories only works with standard navigator objects, but got navigator of ${typeof type === 'string' ? `type "${type}".` : 'unknown type.'}`
+    );
+  }
+
+  if (version !== 1) {
+    throw new Error(
+      `createStandardNavigationFactories only works with version 1 of standard navigator objects, but got version ${version}.`
+    );
+  }
+
+  type Bag = StandardNavigationTypeBagFor<TypeBag, ParamListBase>;
+  type StandardArgs = StandardNavigationArgs<
+    TypeBag['ScreenOptions'],
+    StandardEventMap<TypeBag['EventMap']>
+  >;
+
+  function StandardNavigationNavigator(
+    props: StandardNavigationNavigatorProps<TypeBag>
+  ) {
+    const builder = useNavigationBuilder<
+      Bag['State'],
+      TypeBag['RouterOptions'],
+      ActionHelpersOf<Bag['ActionHelpers']>,
+      TypeBag['ScreenOptions'],
+      TypeBag['EventMap']
+    >(router, props);
+
+    const buildHref = useBuildHref();
+
+    const routes = useMemoArray(
+      ('preloadedRoutes' in builder.state &&
+      Array.isArray(builder.state.preloadedRoutes)
+        ? builder.state.routes.concat(builder.state.preloadedRoutes)
+        : builder.state.routes
+      ).map((route) => {
+        const href = buildHref(route.name, route.params);
+
+        return [
+          {
+            key: route.key,
+            name: route.name,
+            params: route.params,
+            href,
+          },
+          [route.key, route.name, route.params, href],
+        ];
+      })
+    );
+
+    const state = React.useMemo(
+      (): StandardArgs['state'] => ({
+        index: builder.state.index,
+        routes,
+      }),
+      [builder.state.index, routes]
+    );
+
+    const descriptors: StandardArgs['descriptors'] = {};
+
+    for (const route of state.routes) {
+      const descriptor =
+        builder.descriptors[route.key] ?? builder.describe(route, true);
+
+      descriptors[route.key] = {
+        options: descriptor.options,
+        render: descriptor.render,
+      };
+    }
+
+    const actions = React.useMemo<StandardArgs['actions']>(
+      () => ({
+        navigate(name, params) {
+          builder.navigation.dispatch({
+            ...CommonActions.navigate(name, params),
+            target: builder.state.key,
+          });
+        },
+        back() {
+          builder.navigation.goBack();
+        },
+      }),
+      [builder.navigation, builder.state.key]
+    );
+
+    const emitter = React.useMemo<StandardArgs['emitter']>(
+      () => ({
+        // @ts-expect-error - they are compatible
+        emit: builder.navigation.emit,
+      }),
+      [builder.navigation]
+    );
+
+    const mapped = mapper?.({
+      state: builder.state,
+      navigation: builder.navigation as StandardNavigation<TypeBag>,
+    });
+
+    // Omit props used by useNavigationBuilder and routers internally
+    const {
+      /* eslint-disable @typescript-eslint/no-unused-vars */
+      children,
+      id,
+      initialRouteName,
+      layout,
+      screenLayout,
+      screenListeners,
+      screenOptions,
+      UNSTABLE_routeNamesChangeBehavior,
+      UNSTABLE_router,
+      /* eslint-enable @typescript-eslint/no-unused-vars */
+      ...rest
+    } = props;
+
+    return (
+      <builder.NavigationContent>
+        <NavigatorContent
+          {...(rest as NavigatorProps)}
+          {...mapped}
+          state={state}
+          descriptors={descriptors}
+          actions={actions}
+          emitter={emitter}
+        />
+      </builder.NavigationContent>
+    );
+  }
+
+  const createNavigator = createNavigatorFactory(
+    StandardNavigationNavigator
+  ) as StandardNavigationCreateNavigator<TypeBag>;
+
+  const createScreen =
+    createScreenFactory<StandardNavigationDefaultBag<TypeBag>>();
+
+  return {
+    createNavigator,
+    createScreen,
+  };
+}

--- a/packages/native/src/index.tsx
+++ b/packages/native/src/index.tsx
@@ -1,3 +1,8 @@
+export {
+  createStandardNavigationFactories,
+  type StandardNavigationCreateNavigator,
+  type StandardNavigationTypeBagBase,
+} from './createStandardNavigationFactories';
 export { createStaticNavigation } from './createStaticNavigation';
 export { Link } from './Link';
 export { LinkingContext } from './LinkingContext';

--- a/packages/native/src/useMemoArray.tsx
+++ b/packages/native/src/useMemoArray.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react';
+
+export function useMemoArray<T>(
+  entries: [item: T, deps: readonly unknown[]][]
+): T[] {
+  const previousRef = React.useRef<
+    | {
+        entries: { item: T; deps: readonly unknown[] }[];
+        items: T[];
+      }
+    | undefined
+  >(undefined);
+
+  const previous = previousRef.current;
+  const next = entries.map(([item, deps], index) => {
+    const previousEntry = previous?.entries[index];
+    const depsEqual =
+      previousEntry &&
+      previousEntry.deps.length === deps.length &&
+      previousEntry.deps.every((it, index) => Object.is(it, deps[index]));
+
+    return depsEqual ? previousEntry : { item, deps };
+  });
+
+  if (
+    previous &&
+    previous.entries.length === next.length &&
+    next.every((entry, index) => entry === previous.entries[index])
+  ) {
+    return previous.items;
+  }
+
+  const items = next.map((entry) => entry.item);
+
+  previousRef.current = {
+    entries: next,
+    items,
+  };
+
+  return items;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5276,6 +5276,7 @@ __metadata:
     react-native-web: "npm:~0.21.0"
     react-test-renderer: "npm:19.1.0"
     serve: "npm:^14.2.5"
+    standard-navigation: "npm:^0.0.7"
     typescript: "npm:^5.9.2"
     yaml: "npm:^2.8.0"
   languageName: unknown
@@ -5355,6 +5356,7 @@ __metadata:
     react-native: "npm:0.81.5"
     react-native-builder-bob: "npm:^0.42.0"
     react-test-renderer: "npm:19.1.0"
+    standard-navigation: "npm:^0.0.7"
     typescript: "npm:^5.9.2"
     use-latest-callback: "npm:^0.2.4"
   peerDependencies:
@@ -16071,6 +16073,13 @@ __metadata:
   dependencies:
     type-fest: "npm:^0.7.1"
   checksum: 10c0/4633d9afe8cd2f6c7fb2cebdee3cc8de7fd5f6f9736645fd08c0f66872a303061ce9cc0ccf46f4216dc94a7941b56e331012398dc0024dc25e46b5eb5d4ff018
+  languageName: node
+  linkType: hard
+
+"standard-navigation@npm:^0.0.7":
+  version: 0.0.7
+  resolution: "standard-navigation@npm:0.0.7"
+  checksum: 10c0/70ba842538f5b7b51cf7db2a45e66cc0dbf59bb49cbf6f931ab79b58f47c71abe55521f431c859d96e527cc3e3f1a42cdcfda6e82c432976e1b44d4f070dc201
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
this adds a `createStandardNavigationFactories` helper that works with [`standard-navigation`](https://github.com/react-navigation/standard-navigation).

usage:

```ts
export interface MyStackTypeBag extends StandardNavigationTypeBagBase {
  State: StackNavigationState<this['ParamList']>;
  ActionHelpers: StackActionHelpers<this['ParamList']>;
  ScreenOptions: MyStackOptions;
  EventMap: MyStackEventMap;
  NavigatorProps: MyStackNavigatorProps;
  RouterOptions: StackRouterOptions;
}

export const {
  createNavigator: createMyStackNavigator,
  createScreen: createMyStackScreen,
} = createStandardNavigationFactories<MyStackTypeBag>(
  MyStackNavigator,
  StackRouter
);
```
