### PR TITLE
feat: add standard navigation compatibility

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -51,7 +51,8 @@
     "react-native-showtime": "^0.0.5",
     "react-native-tab-view": "workspace:^",
     "react-native-web": "~0.21.2",
-    "react-native-worklets": "0.7.4"
+    "react-native-worklets": "0.7.4",
+    "standard-navigation": "^0.0.7"
   },
   "devDependencies": {
     "@babel/core": "^7.29.7",

--- a/example/src/Screens/StandardNavigator/MyStackDynamic.tsx
+++ b/example/src/Screens/StandardNavigator/MyStackDynamic.tsx
@@ -1,0 +1,159 @@
+import { Button, Text } from '@react-navigation/elements';
+import {
+  type NavigatorScreenParams,
+  type PathConfig,
+  useNavigation,
+  useNavigationState,
+} from '@react-navigation/native';
+import * as React from 'react';
+import { StyleSheet, View } from 'react-native';
+
+import {
+  createMyStackNavigator,
+  type MyStackScreenProps,
+} from './createMyStackNavigator';
+
+type MyStackParamList = {
+  StandardDynamicHome: undefined;
+  StandardDynamicProfile: { user: string };
+  StandardDynamicDetails: { section: string };
+};
+
+const linking = {
+  screens: {
+    StandardDynamicHome: 'standard-dynamic-home',
+    StandardDynamicProfile: 'standard-dynamic-profile/:user',
+    StandardDynamicDetails: 'standard-dynamic-details/:section',
+  },
+} satisfies PathConfig<NavigatorScreenParams<MyStackParamList>>;
+
+const MyStack = createMyStackNavigator<MyStackParamList>();
+
+function HomeScreen() {
+  const navigation = useNavigation<typeof MyStack>();
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Dynamic home</Text>
+      <Button
+        variant="filled"
+        onPress={() =>
+          navigation.navigate('StandardDynamicProfile', { user: 'jane' })
+        }
+      >
+        Open profile
+      </Button>
+      <Button variant="tinted" onPress={() => navigation.goBack()}>
+        Go back
+      </Button>
+    </View>
+  );
+}
+
+function ProfileScreen({
+  route,
+}: MyStackScreenProps<MyStackParamList, 'StandardDynamicProfile'>) {
+  const navigation = useNavigation<typeof MyStack>();
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>{route.params.user}</Text>
+      <View style={styles.buttons}>
+        <Button
+          variant="filled"
+          onPress={() =>
+            navigation.navigate('StandardDynamicDetails', {
+              section: 'settings',
+            })
+          }
+        >
+          Open details
+        </Button>
+        <Button
+          variant="tinted"
+          onPress={() =>
+            navigation.preload('StandardDynamicDetails', {
+              section: 'preloaded details',
+            })
+          }
+        >
+          Preload details
+        </Button>
+      </View>
+    </View>
+  );
+}
+
+function DetailsScreen({
+  route,
+}: MyStackScreenProps<MyStackParamList, 'StandardDynamicDetails'>) {
+  const navigation = useNavigation<typeof MyStack>();
+
+  const isPreloaded = useNavigationState((state) =>
+    state.routes.slice(state.index + 1).some((r) => r.key === route.key)
+  );
+
+  const [wasPreloaded, setWasPreloaded] = React.useState(isPreloaded);
+
+  if (isPreloaded && !wasPreloaded) {
+    setWasPreloaded(true);
+  }
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>{route.params.section}</Text>
+      {wasPreloaded ? <Text>(preloaded)</Text> : null}
+      <Button variant="tinted" onPress={() => navigation.popToTop()}>
+        Pop to top
+      </Button>
+    </View>
+  );
+}
+
+export function MyStackDynamic() {
+  return (
+    <MyStack.Navigator
+      screenListeners={{
+        rightButtonPress: (event) => {
+          alert(`Right button pressed (${event.data.count})`);
+        },
+      }}
+    >
+      <MyStack.Screen
+        name="StandardDynamicHome"
+        component={HomeScreen}
+        options={{ title: 'Home', rightButtonTitle: '🌟' }}
+      />
+      <MyStack.Screen
+        name="StandardDynamicProfile"
+        component={ProfileScreen}
+        options={{ title: 'Profile' }}
+      />
+      <MyStack.Screen
+        name="StandardDynamicDetails"
+        component={DetailsScreen}
+        options={{ title: 'Details', rightButtonTitle: '🎨' }}
+      />
+    </MyStack.Navigator>
+  );
+}
+
+MyStackDynamic.title = 'Standard Navigation - Dynamic';
+MyStackDynamic.linking = linking;
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 12,
+    padding: 16,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: '600',
+  },
+  buttons: {
+    gap: 12,
+  },
+});

--- a/example/src/Screens/StandardNavigator/MyStackNavigator.tsx
+++ b/example/src/Screens/StandardNavigator/MyStackNavigator.tsx
@@ -1,0 +1,123 @@
+import * as React from 'react';
+import {
+  Pressable,
+  type StyleProp,
+  StyleSheet,
+  // eslint-disable-next-line no-restricted-imports
+  Text,
+  View,
+  type ViewStyle,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { createStandardNavigator } from 'standard-navigation';
+
+export type MyStackOptions = {
+  title?: string;
+  rightButtonTitle?: string;
+};
+
+export type MyStackEventMap = {
+  rightButtonPress: {
+    data: { count: number };
+    canPreventDefault: true;
+  };
+};
+
+export type MyStackNavigatorProps = {
+  preloadedCount: number;
+  style?: StyleProp<ViewStyle>;
+};
+
+export const MyStackNavigator = createStandardNavigator<
+  MyStackOptions,
+  MyStackEventMap,
+  MyStackNavigatorProps
+>(({ state, descriptors, actions, emitter, preloadedCount, style }) => {
+  const insets = useSafeAreaInsets();
+  const countRef = React.useRef(0);
+
+  return (
+    <View style={[styles.container, style]}>
+      {state.routes.map((route) => {
+        const isFocused = route.key === state.routes[state.index]?.key;
+        const descriptor = descriptors[route.key];
+
+        return (
+          <View
+            key={route.key}
+            style={[styles.screen, { display: isFocused ? 'flex' : 'none' }]}
+          >
+            <View style={[{ height: insets.top }, styles.inset]} />
+            <View style={styles.header}>
+              {state.index > 0 ? (
+                <Pressable onPress={() => actions.back()} style={styles.button}>
+                  <Text style={styles.label}>👈</Text>
+                </Pressable>
+              ) : null}
+              <Text style={styles.title}>
+                {descriptor?.options.title ?? route.name}
+              </Text>
+              <View style={styles.right}>
+                {preloadedCount > 0 ? <Text>⌛ ({preloadedCount})</Text> : null}
+                {descriptor?.options.rightButtonTitle ? (
+                  <Pressable
+                    onPress={() => {
+                      emitter.emit({
+                        type: 'rightButtonPress',
+                        data: { count: ++countRef.current },
+                        canPreventDefault: true,
+                      });
+                    }}
+                    style={styles.button}
+                  >
+                    <Text style={styles.label}>
+                      {descriptor.options.rightButtonTitle}
+                    </Text>
+                  </Pressable>
+                ) : null}
+              </View>
+            </View>
+            {descriptor?.render()}
+          </View>
+        );
+      })}
+    </View>
+  );
+});
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  screen: {
+    flex: 1,
+  },
+  button: {
+    padding: 12,
+  },
+  inset: {
+    backgroundColor: 'tomato',
+  },
+  header: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    height: 56,
+    paddingHorizontal: 12,
+    backgroundColor: 'tomato',
+  },
+  title: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: 'white',
+    marginHorizontal: 12,
+  },
+  label: {
+    fontSize: 20,
+    color: 'white',
+  },
+  right: {
+    flex: 1,
+    alignItems: 'flex-end',
+  },
+});

--- a/example/src/Screens/StandardNavigator/MyStackStatic.tsx
+++ b/example/src/Screens/StandardNavigator/MyStackStatic.tsx
@@ -1,0 +1,139 @@
+import { Button, Text } from '@react-navigation/elements';
+import {
+  useNavigation,
+  useNavigationState,
+  useRoute,
+} from '@react-navigation/native';
+import * as React from 'react';
+import { StyleSheet, View } from 'react-native';
+
+import {
+  createMyStackNavigator,
+  createMyStackScreen,
+} from './createMyStackNavigator';
+
+function HomeScreen() {
+  const navigation = useNavigation('StandardStaticHome');
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Static home</Text>
+      <Button
+        variant="filled"
+        onPress={() =>
+          navigation.navigate('StandardStaticProfile', { user: 'jane' })
+        }
+      >
+        Open profile
+      </Button>
+      <Button variant="tinted" onPress={() => navigation.goBack()}>
+        Go back
+      </Button>
+    </View>
+  );
+}
+
+function ProfileScreen() {
+  const navigation = useNavigation('StandardStaticProfile');
+  const route = useRoute('StandardStaticProfile');
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>{route.params.user}</Text>
+      <View style={styles.buttons}>
+        <Button
+          variant="filled"
+          onPress={() =>
+            navigation.navigate('StandardStaticDetails', {
+              section: 'settings',
+            })
+          }
+        >
+          Open details
+        </Button>
+        <Button
+          variant="tinted"
+          onPress={() =>
+            navigation.preload('StandardStaticDetails', {
+              section: 'preloaded details',
+            })
+          }
+        >
+          Preload details
+        </Button>
+      </View>
+    </View>
+  );
+}
+
+function DetailsScreen() {
+  const navigation = useNavigation('StandardStaticDetails');
+  const route = useRoute('StandardStaticDetails');
+
+  const isPreloaded = useNavigationState('StandardStaticDetails', (state) =>
+    state.routes.slice(state.index + 1).some((r) => r.key === route.key)
+  );
+
+  const [wasPreloaded, setWasPreloaded] = React.useState(isPreloaded);
+
+  if (isPreloaded && !wasPreloaded) {
+    setWasPreloaded(true);
+  }
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>{route.params.section}</Text>
+      {wasPreloaded ? <Text>(preloaded)</Text> : null}
+      <Button variant="tinted" onPress={() => navigation.popToTop()}>
+        Pop to top
+      </Button>
+    </View>
+  );
+}
+
+export const MyStack = createMyStackNavigator({
+  screenListeners: {
+    rightButtonPress: (event) => {
+      alert(`Right button pressed (${event.data.count})`);
+    },
+  },
+  screens: {
+    StandardStaticHome: createMyStackScreen({
+      screen: HomeScreen,
+      options: { title: 'Home', rightButtonTitle: '🌟' },
+      linking: 'standard-static-home',
+    }),
+    StandardStaticProfile: createMyStackScreen({
+      screen: ProfileScreen,
+      options: { title: 'Profile' },
+      linking: 'standard-static-profile/:user',
+    }),
+    StandardStaticDetails: createMyStackScreen({
+      screen: DetailsScreen,
+      options: { title: 'Details', rightButtonTitle: '🎨' },
+      linking: 'standard-static-details/:section',
+    }),
+  },
+});
+
+export const MyStackStatic = {
+  screen: MyStack,
+  title: 'Standard Navigation - Static',
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 12,
+    padding: 16,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: '600',
+  },
+  buttons: {
+    gap: 12,
+  },
+});

--- a/example/src/Screens/StandardNavigator/createMyStackNavigator.tsx
+++ b/example/src/Screens/StandardNavigator/createMyStackNavigator.tsx
@@ -1,0 +1,57 @@
+import {
+  createStandardNavigationFactories,
+  type NavigationProp,
+  type ParamListBase,
+  type RouteProp,
+  type StackActionHelpers,
+  type StackNavigationState,
+  StackRouter,
+  type StackRouterOptions,
+  type StandardNavigationTypeBagBase,
+} from '@react-navigation/native';
+
+import {
+  type MyStackEventMap,
+  MyStackNavigator,
+  type MyStackNavigatorProps,
+  type MyStackOptions,
+} from './MyStackNavigator';
+
+export type MyStackNavigationProp<
+  ParamList extends ParamListBase,
+  RouteName extends keyof ParamList = keyof ParamList,
+> = NavigationProp<
+  ParamList,
+  RouteName,
+  StackNavigationState<ParamList>,
+  MyStackOptions,
+  MyStackEventMap,
+  StackActionHelpers<ParamList>
+>;
+
+export type MyStackScreenProps<
+  ParamList extends ParamListBase,
+  RouteName extends keyof ParamList = keyof ParamList,
+> = {
+  navigation: MyStackNavigationProp<ParamList, RouteName>;
+  route: RouteProp<ParamList, RouteName>;
+};
+
+export interface MyStackTypeBag extends StandardNavigationTypeBagBase {
+  State: StackNavigationState<this['ParamList']>;
+  ActionHelpers: StackActionHelpers<this['ParamList']>;
+  ScreenOptions: MyStackOptions;
+  EventMap: MyStackEventMap;
+  RouterOptions: StackRouterOptions;
+}
+
+export const {
+  createNavigator: createMyStackNavigator,
+  createScreen: createMyStackScreen,
+} = createStandardNavigationFactories<MyStackTypeBag, MyStackNavigatorProps>(
+  MyStackNavigator,
+  StackRouter,
+  ({ state }) => ({
+    preloadedCount: state.routes.slice(state.index + 1).length,
+  })
+);

--- a/example/src/Screens/StandardNavigator/typechecks.tsx
+++ b/example/src/Screens/StandardNavigator/typechecks.tsx
@@ -1,0 +1,399 @@
+import {
+  createStandardNavigationFactories,
+  type EventArg,
+  type NavigationProp,
+  type StackActionHelpers,
+  type StackNavigationState,
+  StackRouter,
+  type StaticParamList,
+} from '@react-navigation/native';
+import { expectTypeOf } from 'expect-type';
+import type * as React from 'react';
+
+import {
+  createMyStackNavigator,
+  createMyStackScreen,
+  type MyStackTypeBag,
+} from './createMyStackNavigator';
+import {
+  MyStackNavigator,
+  type MyStackNavigatorProps,
+  type MyStackOptions,
+} from './MyStackNavigator';
+import { MyStack } from './MyStackStatic';
+
+{
+  type MyStackParamList = {
+    StandardStaticHome: undefined;
+    StandardStaticProfile: { user: string };
+    StandardStaticDetails: { section: string };
+  };
+
+  type MyStackNavigation<
+    RouteName extends keyof MyStackParamList = keyof MyStackParamList,
+  > = NavigationProp<
+    MyStackParamList,
+    RouteName,
+    StackNavigationState<MyStackParamList>,
+    MyStackOptions,
+    MyStackTypeBag['EventMap'],
+    StackActionHelpers<MyStackParamList>
+  >;
+
+  function TypeCheckProfileScreen() {
+    return null;
+  }
+
+  /**
+   * Infer param list from the static config
+   */
+  type InferredMyStackParamList = StaticParamList<typeof MyStack>;
+
+  expectTypeOf<InferredMyStackParamList>().toEqualTypeOf<MyStackParamList>();
+
+  /**
+   * Custom screen options are exposed through `setOptions`
+   */
+  expectTypeOf<MyStackNavigation['setOptions']>()
+    .parameter(0)
+    .toEqualTypeOf<Partial<MyStackOptions>>();
+
+  /**
+   * Custom options & events accepted on the navigation prop in real use
+   */
+  const checkMyStackHomeNavigation = (
+    navigation: MyStackNavigation<'StandardStaticHome'>
+  ) => {
+    navigation.replace('StandardStaticProfile', { user: 'Satya' });
+    navigation.setOptions({ title: 'Home', rightButtonTitle: 'Press me' });
+
+    // @ts-expect-error `subtitle` isn't a valid option for MyStack.
+    navigation.setOptions({ subtitle: 'Invalid option' });
+
+    navigation.addListener('rightButtonPress', (event) => {
+      expectTypeOf(event).toEqualTypeOf<
+        EventArg<'rightButtonPress', true, { count: number }>
+      >();
+    });
+  };
+
+  /**
+   * `createMyStackScreen` accepts custom `options` (object form)
+   */
+  createMyStackScreen({
+    screen: TypeCheckProfileScreen,
+    options: { title: 'Profile', rightButtonTitle: 'Press me' },
+  });
+
+  createMyStackScreen({
+    screen: TypeCheckProfileScreen,
+    options: {
+      title: 'Profile',
+      // @ts-expect-error `subtitle` isn't a valid static screen option.
+      subtitle: 'Invalid option',
+    },
+  });
+
+  /**
+   * `createMyStackScreen` accepts custom `options` (function form)
+   */
+  createMyStackScreen({
+    screen: TypeCheckProfileScreen,
+    options: ({ route, navigation }) => {
+      expectTypeOf(route.name).toEqualTypeOf<string>();
+      expectTypeOf(navigation.setOptions)
+        .parameter(0)
+        .toEqualTypeOf<Partial<MyStackOptions>>();
+
+      return { title: 'Profile', rightButtonTitle: 'Press me' };
+    },
+  });
+
+  createMyStackScreen({
+    screen: TypeCheckProfileScreen,
+    // @ts-expect-error `subtitle` isn't a valid static screen option.
+    options: () => ({ subtitle: 'Invalid option' }),
+  });
+
+  /**
+   * `createMyStackScreen` accepts custom event `listeners` (object form)
+   */
+  createMyStackScreen({
+    screen: TypeCheckProfileScreen,
+    listeners: {
+      rightButtonPress: (event) => {
+        expectTypeOf(event).toEqualTypeOf<
+          EventArg<'rightButtonPress', true, { count: number }>
+        >();
+      },
+    },
+  });
+
+  /**
+   * `createMyStackScreen` accepts custom event `listeners` (function form)
+   */
+  createMyStackScreen({
+    screen: TypeCheckProfileScreen,
+    listeners: ({ navigation }) => {
+      expectTypeOf(navigation.setOptions)
+        .parameter(0)
+        .toEqualTypeOf<Partial<MyStackOptions>>();
+
+      return {
+        rightButtonPress: (event) => {
+          expectTypeOf(event).toEqualTypeOf<
+            EventArg<'rightButtonPress', true, { count: number }>
+          >();
+        },
+      };
+    },
+  });
+
+  /**
+   * Static navigator accepts `screenOptions` typed as `MyStackOptions` (object form)
+   */
+  createMyStackNavigator({
+    screens: { StandardStaticHome: TypeCheckProfileScreen },
+    screenOptions: { title: 'Default title' },
+  });
+
+  createMyStackNavigator({
+    screens: { StandardStaticHome: TypeCheckProfileScreen },
+    screenOptions: {
+      // @ts-expect-error `subtitle` isn't a valid option for MyStack.
+      subtitle: 'Invalid option',
+    },
+  });
+
+  /**
+   * Static navigator accepts `screenOptions` (function form)
+   */
+  createMyStackNavigator({
+    screens: { StandardStaticHome: TypeCheckProfileScreen },
+    screenOptions: ({ navigation }) => {
+      expectTypeOf(navigation.setOptions)
+        .parameter(0)
+        .toEqualTypeOf<Partial<MyStackOptions>>();
+
+      return { title: 'Default title' };
+    },
+  });
+
+  /**
+   * Static navigator accepts `screenListeners` for custom events (object form)
+   */
+  createMyStackNavigator({
+    screens: { StandardStaticHome: TypeCheckProfileScreen },
+    screenListeners: {
+      rightButtonPress: (event) => {
+        expectTypeOf(event).toEqualTypeOf<
+          EventArg<'rightButtonPress', true, { count: number }>
+        >();
+      },
+    },
+  });
+
+  /**
+   * Static navigator accepts `screenListeners` for custom events (function form)
+   */
+  createMyStackNavigator({
+    screens: { StandardStaticHome: TypeCheckProfileScreen },
+    screenListeners: ({ navigation }) => {
+      expectTypeOf(navigation.setOptions)
+        .parameter(0)
+        .toEqualTypeOf<Partial<MyStackOptions>>();
+
+      return {
+        rightButtonPress: (event) => {
+          expectTypeOf(event).toEqualTypeOf<
+            EventArg<'rightButtonPress', true, { count: number }>
+          >();
+        },
+      };
+    },
+  });
+
+  /**
+   * Dynamic factory: `createMyStackNavigator<ParamList>()`
+   */
+  type DynamicMyStackParamList = {
+    DynamicHome: undefined;
+    DynamicProfile: { user: string };
+    DynamicDetails: { section: string };
+  };
+
+  const DynamicMyStack = createMyStackNavigator<DynamicMyStackParamList>();
+
+  type DynamicMyStackNavigatorProps = React.ComponentProps<
+    typeof DynamicMyStack.Navigator
+  >;
+
+  expectTypeOf<
+    DynamicMyStackNavigatorProps['initialRouteName']
+  >().toEqualTypeOf<keyof DynamicMyStackParamList | undefined>();
+
+  expectTypeOf(DynamicMyStack.Screen).parameter(0).toExtend<{
+    name?: keyof DynamicMyStackParamList;
+  }>();
+
+  /**
+   * Dynamic `<Navigator>` `screenOptions` accepts `MyStackOptions` (object + function form)
+   */
+  const dynamicScreenOptions: DynamicMyStackNavigatorProps['screenOptions'] = {
+    title: 'Default title',
+    // @ts-expect-error `subtitle` isn't a valid option for MyStack.
+    subtitle: 'Invalid option',
+  };
+
+  const dynamicScreenOptionsFn: DynamicMyStackNavigatorProps['screenOptions'] =
+    ({ navigation }) => {
+      expectTypeOf(navigation.setOptions)
+        .parameter(0)
+        .toEqualTypeOf<Partial<MyStackOptions>>();
+
+      return { title: 'Default title' };
+    };
+
+  /**
+   * Dynamic `<Navigator>` `screenListeners` accepts custom events (object + function form)
+   */
+  const dynamicScreenListeners: DynamicMyStackNavigatorProps['screenListeners'] =
+    {
+      rightButtonPress: (event) => {
+        expectTypeOf(event).toEqualTypeOf<
+          EventArg<'rightButtonPress', true, { count: number }>
+        >();
+
+        // @ts-expect-error rightButtonPress doesn't include routeKey.
+        void event.data.routeKey;
+      },
+    };
+
+  const dynamicScreenListenersFn: DynamicMyStackNavigatorProps['screenListeners'] =
+    ({ navigation }) => {
+      expectTypeOf(navigation.setOptions)
+        .parameter(0)
+        .toEqualTypeOf<Partial<MyStackOptions>>();
+
+      return {
+        rightButtonPress: (event) => {
+          expectTypeOf(event).toEqualTypeOf<
+            EventArg<'rightButtonPress', true, { count: number }>
+          >();
+        },
+      };
+    };
+
+  /**
+   * Dynamic `<Screen>` accepts custom `options` (function form) and `listeners` (object form)
+   */
+  const dynamicScreen = (
+    <DynamicMyStack.Screen
+      name="DynamicProfile"
+      component={TypeCheckProfileScreen}
+      options={({ navigation, route }) => {
+        expectTypeOf(route.params).toEqualTypeOf<Readonly<{ user: string }>>();
+
+        expectTypeOf(navigation.setOptions)
+          .parameter(0)
+          .toEqualTypeOf<Partial<MyStackOptions>>();
+
+        return { title: route.params.user, rightButtonTitle: 'Press me' };
+      }}
+      listeners={{
+        rightButtonPress: (event) => {
+          expectTypeOf(event).toEqualTypeOf<
+            EventArg<'rightButtonPress', true, { count: number }>
+          >();
+        },
+      }}
+    />
+  );
+
+  /**
+   * Dynamic `<Screen>` accepts custom `options` (object form) and `listeners` (function form)
+   */
+  const dynamicScreenObjectForm = (
+    <DynamicMyStack.Screen
+      name="DynamicProfile"
+      component={TypeCheckProfileScreen}
+      options={{ title: 'Profile', rightButtonTitle: 'Press me' }}
+      listeners={({ navigation }) => {
+        expectTypeOf(navigation.setOptions)
+          .parameter(0)
+          .toEqualTypeOf<Partial<MyStackOptions>>();
+
+        return {
+          rightButtonPress: (event) => {
+            expectTypeOf(event).toEqualTypeOf<
+              EventArg<'rightButtonPress', true, { count: number }>
+            >();
+          },
+        };
+      }}
+    />
+  );
+
+  const invalidDynamicScreenName = (
+    <DynamicMyStack.Screen
+      // @ts-expect-error This route isn't in DynamicMyStackParamList.
+      name="Unknown"
+      component={TypeCheckProfileScreen}
+    />
+  );
+
+  const invalidDynamicScreenOptions = (
+    <DynamicMyStack.Screen
+      name="DynamicProfile"
+      component={TypeCheckProfileScreen}
+      // @ts-expect-error `subtitle` isn't a valid dynamic screen option.
+      options={{ subtitle: 'Invalid option' }}
+    />
+  );
+
+  const dynamicNavigator = (
+    <DynamicMyStack.Navigator
+      initialRouteName="DynamicHome"
+      screenOptions={dynamicScreenOptionsFn}
+      screenListeners={dynamicScreenListeners}
+    >
+      {dynamicScreen}
+    </DynamicMyStack.Navigator>
+  );
+
+  const invalidDynamicNavigator = (
+    <DynamicMyStack.Navigator
+      // @ts-expect-error `label` isn't a valid navigator prop.
+      label="Dynamic Standard Navigation"
+    >
+      {dynamicScreen}
+    </DynamicMyStack.Navigator>
+  );
+
+  /**
+   * `createStandardNavigationFactories` validates mapper return against `NavigatorProps`
+   */
+  createStandardNavigationFactories<MyStackTypeBag, MyStackNavigatorProps>(
+    MyStackNavigator,
+    StackRouter,
+    ({ state }) => ({
+      preloadedCount: state.routes.slice(state.index + 1).length,
+    })
+  );
+
+  createStandardNavigationFactories<MyStackTypeBag, MyStackNavigatorProps>(
+    MyStackNavigator,
+    StackRouter,
+    // @ts-expect-error Mapped props must be keys from MyStackNavigatorProps.
+    () => ({ label: 'Invalid mapped prop' })
+  );
+
+  void checkMyStackHomeNavigation;
+  void dynamicScreenOptions;
+  void dynamicScreenListenersFn;
+  void dynamicScreenObjectForm;
+  void invalidDynamicScreenName;
+  void invalidDynamicScreenOptions;
+  void dynamicNavigator;
+  void invalidDynamicNavigator;
+}

--- a/example/src/screens.tsx
+++ b/example/src/screens.tsx
@@ -34,6 +34,8 @@ import { StackPreloadFlow } from './Screens/StackPreloadFlow';
 import { StackPreventRemove } from './Screens/StackPreventRemove';
 import { StackRetain } from './Screens/StackRetain';
 import { StackTransparentModal } from './Screens/StackTransparentModal';
+import { MyStackDynamic } from './Screens/StandardNavigator/MyStackDynamic';
+import { MyStackStatic } from './Screens/StandardNavigator/MyStackStatic';
 import { StaticConfig as StaticConfigScreen } from './Screens/StaticConfig';
 import { BottomTabsShowcase } from './Showcase/BottomTabsShowcase';
 import { DrawerShowcase } from './Showcase/DrawerShowcase';
@@ -82,6 +84,8 @@ export const SCREENS = {
   MaterialTopTabsShowcase,
   NativeStackShowcase,
   StackShowcase,
+  MyStackStatic,
+  MyStackDynamic,
 } as const satisfies {
   [key: string]:
     | (React.ComponentType<{ route: any }> & {

--- a/packages/native/package.json
+++ b/packages/native/package.json
@@ -67,6 +67,7 @@
     "fast-deep-equal": "^3.1.3",
     "nanoid": "^5.1.11",
     "sf-symbols-typescript": "^2.2.0",
+    "standard-navigation": "^0.0.7",
     "use-latest-callback": "^0.3.4"
   },
   "devDependencies": {

--- a/packages/native/src/createStandardNavigationFactories.tsx
+++ b/packages/native/src/createStandardNavigationFactories.tsx
@@ -1,0 +1,218 @@
+import {
+  CommonActions,
+  createNavigatorFactory,
+  createScreenFactory,
+  type DefaultRouterOptions,
+  type EventMapBase,
+  type NavigationAction,
+  type NavigatorTypeBagBase,
+  type ParamListBase,
+  type RouterFactory,
+  useNavigationBuilder,
+} from '@react-navigation/core';
+import * as React from 'react';
+import type {
+  createStandardNavigator,
+  NavigatorArgs as StandardNavigationArgs,
+} from 'standard-navigation';
+
+import { useBuildHref } from './useLinkBuilder';
+import { useMemoArray } from './useMemoArray';
+
+type StandardEventMap<EventMap extends EventMapBase> = {
+  [EventName in keyof EventMap]: {
+    data: EventMap[EventName] extends { data?: infer Data }
+      ? Data extends object | undefined
+        ? Data
+        : object | undefined
+      : undefined;
+    canPreventDefault: EventMap[EventName] extends { canPreventDefault: true }
+      ? true
+      : false;
+  };
+};
+
+export interface StandardNavigationTypeBagBase extends NavigatorTypeBagBase {
+  RouterOptions: DefaultRouterOptions;
+  Navigator: React.ComponentType<{}>;
+}
+
+type StandardNavigationTypeBagFor<
+  TypeBag extends StandardNavigationTypeBagBase,
+  ParamList extends ParamListBase,
+> = TypeBag & { ParamList: ParamList };
+
+type StandardNavigationListFor<
+  TypeBag extends StandardNavigationTypeBagBase,
+  ParamList extends ParamListBase,
+> = StandardNavigationTypeBagFor<TypeBag, ParamList>['NavigationList'];
+
+type StandardNavigationMapperProps<
+  TypeBag extends StandardNavigationTypeBagBase,
+> = {
+  state: StandardNavigationTypeBagFor<TypeBag, ParamListBase>['State'];
+  navigation: StandardNavigationListFor<
+    TypeBag,
+    ParamListBase
+  >[keyof StandardNavigationListFor<TypeBag, ParamListBase>];
+};
+
+export function createStandardNavigationFactories<
+  TypeBag extends StandardNavigationTypeBagBase,
+  NavigatorProps extends object = {},
+>(
+  navigator: ReturnType<
+    typeof createStandardNavigator<
+      TypeBag['ScreenOptions'],
+      StandardEventMap<TypeBag['EventMap']>,
+      NavigatorProps
+    >
+  >,
+  router: RouterFactory<
+    StandardNavigationTypeBagFor<TypeBag, ParamListBase>['State'],
+    NavigationAction,
+    TypeBag['RouterOptions']
+  >,
+  mapper?: (
+    props: StandardNavigationMapperProps<TypeBag>
+  ) => Partial<NavigatorProps>
+) {
+  const { type, version, NavigatorContent } = navigator;
+
+  if (type !== 'standard') {
+    throw new Error(
+      `createStandardNavigationFactories only works with standard navigator objects, but got navigator of ${typeof type === 'string' ? `type "${type}".` : 'unknown type.'}`
+    );
+  }
+
+  if (version !== 1) {
+    throw new Error(
+      `createStandardNavigationFactories only works with version 1 of standard navigator objects, but got version ${version}.`
+    );
+  }
+
+  type StandardArgs = StandardNavigationArgs<
+    TypeBag['ScreenOptions'],
+    StandardEventMap<TypeBag['EventMap']>
+  >;
+
+  function StandardNavigationNavigator(props: any) {
+    const builder = useNavigationBuilder<
+      TypeBag['State'],
+      TypeBag['RouterOptions'],
+      TypeBag['ActionHelpers'],
+      TypeBag['ScreenOptions'],
+      TypeBag['EventMap']
+    >(router, props);
+
+    const buildHref = useBuildHref();
+
+    const routes = useMemoArray(
+      builder.state.routes.map((route) => {
+        const href = buildHref(route.name, route.params);
+
+        return [
+          {
+            key: route.key,
+            name: route.name,
+            params: route.params,
+            href,
+          },
+          [route.key, route.name, route.params, href],
+        ];
+      })
+    );
+
+    const state = React.useMemo(
+      (): StandardArgs['state'] => ({
+        index: builder.state.index,
+        routes,
+      }),
+      [builder.state.index, routes]
+    );
+
+    const descriptors: StandardArgs['descriptors'] = {};
+
+    for (const route of state.routes) {
+      const descriptor = builder.descriptors[route.key];
+
+      if (descriptor == null) {
+        throw new Error(
+          `No descriptor found for route "${route.name}" (${route.key}).`
+        );
+      }
+
+      descriptors[route.key] = {
+        options: descriptor.options,
+        render: descriptor.render,
+      };
+    }
+
+    const actions = React.useMemo<StandardArgs['actions']>(
+      () => ({
+        navigate(name, params) {
+          builder.navigation.dispatch({
+            ...CommonActions.navigate(name, params),
+            target: builder.state.key,
+          });
+        },
+        back() {
+          builder.navigation.goBack();
+        },
+      }),
+      [builder.navigation, builder.state.key]
+    );
+
+    const emitter = React.useMemo<StandardArgs['emitter']>(
+      () => ({
+        // @ts-expect-error - they are compatible
+        emit: builder.navigation.emit,
+      }),
+      [builder.navigation]
+    );
+
+    const mapped = mapper?.({
+      state: builder.state as TypeBag['State'],
+      navigation: builder.navigation as never,
+    });
+
+    // Omit props used by useNavigationBuilder and routers internally
+    const {
+      /* eslint-disable @typescript-eslint/no-unused-vars */
+      children,
+      initialRouteName,
+      layout,
+      routeNamesChangeBehavior,
+      router: routerOverride,
+      screenLayout,
+      screenListeners,
+      screenOptions,
+      /* eslint-enable @typescript-eslint/no-unused-vars */
+      ...rest
+    } = props;
+
+    return (
+      <builder.NavigationContent>
+        <NavigatorContent
+          {...(rest as NavigatorProps)}
+          {...mapped}
+          state={state}
+          descriptors={descriptors}
+          actions={actions}
+          emitter={emitter}
+        />
+      </builder.NavigationContent>
+    );
+  }
+
+  const createNavigator = createNavigatorFactory<TypeBag>(
+    StandardNavigationNavigator
+  );
+
+  const createScreen = createScreenFactory<TypeBag>();
+
+  return {
+    createNavigator,
+    createScreen,
+  };
+}

--- a/packages/native/src/index.tsx
+++ b/packages/native/src/index.tsx
@@ -1,3 +1,7 @@
+export {
+  createStandardNavigationFactories,
+  type StandardNavigationTypeBagBase,
+} from './createStandardNavigationFactories';
 export { createStaticNavigation } from './createStaticNavigation';
 export { Link } from './Link';
 export { LinkingContext } from './LinkingContext';

--- a/packages/native/src/useMemoArray.tsx
+++ b/packages/native/src/useMemoArray.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react';
+
+export function useMemoArray<T>(
+  entries: [item: T, deps: readonly unknown[]][]
+): T[] {
+  const previousRef = React.useRef<
+    | {
+        entries: { item: T; deps: readonly unknown[] }[];
+        items: T[];
+      }
+    | undefined
+  >(undefined);
+
+  const previous = previousRef.current;
+  const next = entries.map(([item, deps], index) => {
+    const previousEntry = previous?.entries[index];
+    const depsEqual =
+      previousEntry &&
+      previousEntry.deps.length === deps.length &&
+      previousEntry.deps.every((it, index) => Object.is(it, deps[index]));
+
+    return depsEqual ? previousEntry : { item, deps };
+  });
+
+  if (
+    previous &&
+    previous.entries.length === next.length &&
+    next.every((entry, index) => entry === previous.entries[index])
+  ) {
+    return previous.items;
+  }
+
+  const items = next.map((entry) => entry.item);
+
+  previousRef.current = {
+    entries: next,
+    items,
+  };
+
+  return items;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4471,6 +4471,7 @@ __metadata:
     react-native-tab-view: "workspace:^"
     react-native-web: "npm:~0.21.2"
     react-native-worklets: "npm:0.7.4"
+    standard-navigation: "npm:^0.0.7"
     typescript: "npm:^6.0.3"
     valibot: "npm:^1.4.1"
     vite: "npm:^7.3.5"
@@ -4550,6 +4551,7 @@ __metadata:
     react-native: "npm:0.83.6"
     react-native-builder-bob: "npm:^0.42.0"
     sf-symbols-typescript: "npm:^2.2.0"
+    standard-navigation: "npm:^0.0.7"
     test-renderer: "npm:1.2.0"
     typescript: "npm:^6.0.3"
     use-latest-callback: "npm:^0.3.4"
@@ -5261,11 +5263,11 @@ __metadata:
   linkType: hard
 
 "@types/react@npm:*":
-  version: 19.2.10
-  resolution: "@types/react@npm:19.2.10"
+  version: 19.2.15
+  resolution: "@types/react@npm:19.2.15"
   dependencies:
     csstype: "npm:^3.2.2"
-  checksum: 10c0/17b96203a79ad3fa3cee8f1f1f324b93f005bc125755e29ac149402807275feaf3f00a4e65b8405f633923ac993da5737fd9800d27ee49911f3ed51dc27478f9
+  checksum: 10c0/b554eab715bb14e581f0ae60e5cefe91e1a5e06c31022b543a9806cf224aa056f21e4fb46208e46eb934d86ca0b247ebc82377192a0dead303cb28b8764c6e67
   languageName: node
   linkType: hard
 
@@ -14050,6 +14052,13 @@ __metadata:
   dependencies:
     type-fest: "npm:^0.7.1"
   checksum: 10c0/4633d9afe8cd2f6c7fb2cebdee3cc8de7fd5f6f9736645fd08c0f66872a303061ce9cc0ccf46f4216dc94a7941b56e331012398dc0024dc25e46b5eb5d4ff018
+  languageName: node
+  linkType: hard
+
+"standard-navigation@npm:^0.0.7":
+  version: 0.0.7
+  resolution: "standard-navigation@npm:0.0.7"
+  checksum: 10c0/70ba842538f5b7b51cf7db2a45e66cc0dbf59bb49cbf6f931ab79b58f47c71abe55521f431c859d96e527cc3e3f1a42cdcfda6e82c432976e1b44d4f070dc201
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
this adds a `createStandardNavigationFactories` helper that works with [`standard-navigation`](https://github.com/react-navigation/standard-navigation).

usage:

```ts
export interface MyStackTypeBag extends StandardNavigationTypeBagBase {
  State: StackNavigationState<this['ParamList']>;
  ActionHelpers: StackActionHelpers<this['ParamList']>;
  ScreenOptions: MyStackOptions;
  EventMap: MyStackEventMap;
  NavigatorProps: MyStackNavigatorProps;
  RouterOptions: StackRouterOptions;
}

export const {
  createNavigator: createMyStackNavigator,
  createScreen: createMyStackScreen,
} = createStandardNavigationFactories<MyStackTypeBag>(
  MyStackNavigator,
  StackRouter
);
```