### PR TITLE
ci: Reuse native E2E build artifacts

### DIFF
--- a/.github/workflows/e2e-android.yml
+++ b/.github/workflows/e2e-android.yml
@@ -9,26 +9,28 @@ on:
   schedule:
     - cron: '0 4 * * *'
 
+env:
+  JAVA_DISTRIBUTION: 'zulu'
+  JAVA_VERSION: '17'
+  ANDROID_HOME: /usr/local/lib/android/sdk
+  ANDROID_USER_HOME: /home/runner/.android
+  API_LEVEL: 34
+  AVD_NAME: e2e_emulator
+  EMULATOR_PROFILE: pixel_5
+  EMULATOR_OPTIONS: '-no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none -partition-size 4096 -cores 2 -memory 4096'
+  ORG_GRADLE_PROJECT_reactNativeArchitectures: x86_64
+
 jobs:
-  maestro-android:
+  build-android:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
-      checks: read
       contents: read
+    outputs:
+      debug-build-artifact: ${{ steps.debug-build-metadata.outputs.artifact-name }}
     concurrency:
-      group: ${{ github.workflow_ref }}-${{ github.ref }}
+      group: ${{ github.workflow_ref }}-${{ github.ref }}-android-build
       cancel-in-progress: true
-    env:
-      JAVA_DISTRIBUTION: 'zulu'
-      JAVA_VERSION: '17'
-      ANDROID_HOME: /usr/local/lib/android/sdk
-      ANDROID_USER_HOME: /home/runner/.android
-      API_LEVEL: 34
-      AVD_NAME: e2e_emulator
-      EMULATOR_PROFILE: pixel_5
-      EMULATOR_OPTIONS: '-no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none -partition-size 4096 -cores 2 -memory 4096'
-      ORG_GRADLE_PROJECT_reactNativeArchitectures: x86_64
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -48,12 +50,18 @@ jobs:
           echo "fingerprint=$FINGERPRINT" >> "$GITHUB_OUTPUT"
         working-directory: example
 
+      - name: Set debug build metadata
+        id: debug-build-metadata
+        run: |
+          echo "cache-key=android-debug-build-v1-${{ runner.os }}-api${{ env.API_LEVEL }}-${{ env.ORG_GRADLE_PROJECT_reactNativeArchitectures }}-${{ steps.calculate-fingerprint.outputs.fingerprint }}" >> "$GITHUB_OUTPUT"
+          echo "artifact-name=android-debug-build-${{ steps.calculate-fingerprint.outputs.fingerprint }}" >> "$GITHUB_OUTPUT"
+
       - name: Restore debug build from cache
         id: restore-debug-build
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           path: android-debug-build/
-          key: android-debug-build-${{ steps.calculate-fingerprint.outputs.fingerprint }}
+          key: ${{ steps.debug-build-metadata.outputs.cache-key }}
 
       - name: Maximize build space
         if: steps.restore-debug-build.outputs.cache-hit != 'true'
@@ -64,12 +72,8 @@ jobs:
           remove-codeql: 'true'
           remove-docker-images: 'true'
 
-      - name: Install AVD dependencies
-        run: |
-          sudo apt update
-          sudo apt-get install -y libpulse0 libgl1 libxkbfile1
-
       - name: Setup JDK
+        if: steps.restore-debug-build.outputs.cache-hit != 'true'
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
         with:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
@@ -106,6 +110,52 @@ jobs:
         with:
           path: android-debug-build/
           key: ${{ steps.restore-debug-build.outputs.cache-primary-key }}
+
+      - name: Upload debug build artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: ${{ steps.debug-build-metadata.outputs.artifact-name }}
+          path: android-debug-build/android-debug.apk
+          if-no-files-found: error
+          retention-days: 1
+
+  e2e-android:
+    needs: build-android
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      checks: read
+      contents: read
+    concurrency:
+      group: ${{ github.workflow_ref }}-${{ github.ref }}-android-test
+      cancel-in-progress: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Setup
+        uses: ./.github/actions/setup
+
+      - name: Install nightly react-native-screens
+        if: github.event_name == 'schedule'
+        run: pnpm --recursive update react-native-screens@nightly --no-save
+
+      - name: Download debug build artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: ${{ needs.build-android.outputs.debug-build-artifact }}
+          path: android-debug-build
+
+      - name: Install AVD dependencies
+        run: |
+          sudo apt update
+          sudo apt-get install -y libpulse0 libgl1 libxkbfile1
+
+      - name: Setup JDK
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
+        with:
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+          java-version: ${{ env.JAVA_VERSION }}
 
       - name: Setup Android SDK
         run: |

--- a/.github/workflows/e2e-android.yml
+++ b/.github/workflows/e2e-android.yml
@@ -15,10 +15,6 @@ env:
   ANDROID_HOME: /usr/local/lib/android/sdk
   ANDROID_USER_HOME: /home/runner/.android
   API_LEVEL: 34
-  AVD_NAME: e2e_emulator
-  EMULATOR_PROFILE: pixel_5
-  EMULATOR_OPTIONS: '-no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none -partition-size 4096 -cores 2 -memory 4096'
-  ORG_GRADLE_PROJECT_reactNativeArchitectures: x86_64
 
 jobs:
   build-android:
@@ -26,11 +22,11 @@ jobs:
     timeout-minutes: 60
     permissions:
       contents: read
-    outputs:
-      debug-build-artifact: ${{ steps.debug-build-metadata.outputs.artifact-name }}
     concurrency:
-      group: ${{ github.workflow_ref }}-${{ github.ref }}-android-build
+      group: ${{ github.workflow_ref }}-${{ github.ref }}
       cancel-in-progress: true
+    env:
+      ORG_GRADLE_PROJECT_reactNativeArchitectures: x86_64
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -50,18 +46,12 @@ jobs:
           echo "fingerprint=$FINGERPRINT" >> "$GITHUB_OUTPUT"
         working-directory: example
 
-      - name: Set debug build metadata
-        id: debug-build-metadata
-        run: |
-          echo "cache-key=android-debug-build-v1-${{ runner.os }}-api${{ env.API_LEVEL }}-${{ env.ORG_GRADLE_PROJECT_reactNativeArchitectures }}-${{ steps.calculate-fingerprint.outputs.fingerprint }}" >> "$GITHUB_OUTPUT"
-          echo "artifact-name=android-debug-build-${{ steps.calculate-fingerprint.outputs.fingerprint }}" >> "$GITHUB_OUTPUT"
-
       - name: Restore debug build from cache
         id: restore-debug-build
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           path: android-debug-build/
-          key: ${{ steps.debug-build-metadata.outputs.cache-key }}
+          key: android-debug-build-${{ runner.os }}-${{ env.API_LEVEL }}-${{ env.ORG_GRADLE_PROJECT_reactNativeArchitectures }}-${{ steps.calculate-fingerprint.outputs.fingerprint }}
 
       - name: Maximize build space
         if: steps.restore-debug-build.outputs.cache-hit != 'true'
@@ -114,7 +104,7 @@ jobs:
       - name: Upload debug build artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
-          name: ${{ steps.debug-build-metadata.outputs.artifact-name }}
+          name: android-debug-build
           path: android-debug-build/android-debug.apk
           if-no-files-found: error
           retention-days: 1
@@ -124,11 +114,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
-      checks: read
       contents: read
     concurrency:
-      group: ${{ github.workflow_ref }}-${{ github.ref }}-android-test
+      group: ${{ github.workflow_ref }}-${{ github.ref }}
       cancel-in-progress: true
+    env:
+      AVD_NAME: e2e_emulator
+      EMULATOR_PROFILE: pixel_5
+      EMULATOR_OPTIONS: '-no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none -partition-size 4096 -cores 2 -memory 4096'
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -143,7 +136,7 @@ jobs:
       - name: Download debug build artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
-          name: ${{ needs.build-android.outputs.debug-build-artifact }}
+          name: android-debug-build
           path: android-debug-build
 
       - name: Install AVD dependencies
@@ -168,7 +161,7 @@ jobs:
       - name: Install Android SDK components
         run: |
           yes | "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" --licenses > /dev/null 2>&1 || true
-          "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" --install emulator "platform-tools" "platforms;android-${{ env.API_LEVEL }}" "system-images;android-${{ env.API_LEVEL }};google_apis;x86_64"
+          "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" --install emulator "platform-tools" "system-images;android-${{ env.API_LEVEL }};google_apis;x86_64"
 
       - name: Enable KVM
         run: |
@@ -204,11 +197,11 @@ jobs:
           cd example
           pnpm e2e:native --platform android
 
-      - name: Store timing output
+      - name: Store E2E output
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
-          name: e2e-timing-android
+          name: e2e-output-android
           path: example/agent-device-artifacts/**/*
           include-hidden-files: true
           overwrite: true
@@ -223,7 +216,6 @@ jobs:
         with:
           name: e2e-artifacts-android
           path: |
-            example/agent-device-artifacts/**/*
             example/agent-device-state/**/*.log
             ~/.agent-device/**/*.log
           include-hidden-files: true

--- a/.github/workflows/e2e-ios.yml
+++ b/.github/workflows/e2e-ios.yml
@@ -9,22 +9,25 @@ on:
   schedule:
     - cron: '0 4 * * *'
 
+env:
+  JAVA_DISTRIBUTION: 'zulu'
+  JAVA_VERSION: '17'
+  SIMULATOR_NAME: iPhone 17 Pro
+  XCODE_VERSION: '26.3'
+  USE_CCACHE: 1
+  CCACHE_COMPILERCHECK: content
+
 jobs:
-  maestro-ios:
+  build-ios:
     runs-on: macos-latest
     timeout-minutes: 60
     permissions:
-      checks: read
       contents: read
+    outputs:
+      debug-build-artifact: ${{ steps.debug-build-metadata.outputs.artifact-name }}
     concurrency:
-      group: ${{ github.workflow_ref }}-${{ github.ref }}
+      group: ${{ github.workflow_ref }}-${{ github.ref }}-ios-build
       cancel-in-progress: true
-    env:
-      JAVA_DISTRIBUTION: 'zulu'
-      JAVA_VERSION: '17'
-      SIMULATOR_NAME: iPhone 17 Pro
-      USE_CCACHE: 1
-      CCACHE_COMPILERCHECK: content
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -44,34 +47,28 @@ jobs:
           echo "fingerprint=$FINGERPRINT" >> "$GITHUB_OUTPUT"
         working-directory: example
 
+      - name: Set debug build metadata
+        id: debug-build-metadata
+        run: |
+          echo "cache-key=ios-debug-build-v1-${{ runner.os }}-xcode${{ env.XCODE_VERSION }}-iphonesimulator-${{ steps.calculate-fingerprint.outputs.fingerprint }}" >> "$GITHUB_OUTPUT"
+          echo "artifact-name=ios-debug-build-${{ steps.calculate-fingerprint.outputs.fingerprint }}" >> "$GITHUB_OUTPUT"
+
       - name: Restore debug build from cache
         id: restore-debug-build
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           path: ios-debug-build/
-          key: ios-debug-build-${{ steps.calculate-fingerprint.outputs.fingerprint }}
+          key: ${{ steps.debug-build-metadata.outputs.cache-key }}
 
       - name: Use appropriate Xcode version
+        if: steps.restore-debug-build.outputs.cache-hit != 'true'
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90
         with:
-          xcode-version: '26.3'
+          xcode-version: ${{ env.XCODE_VERSION }}
 
-      - name: Resolve Xcode cache key
-        id: xcode-cache-key
-        run: |
-          XCODE_VERSION="$(xcodebuild -version | tr '\n' ' ' | sed -E 's/[[:space:]]+/ /g; s/[[:space:]]$//')"
-          XCODE_KEY="$(echo "$XCODE_VERSION" | tr ' ' '-' | tr -cd '[:alnum:]._-')"
-          echo "key=$XCODE_KEY" >> "$GITHUB_OUTPUT"
-
-      - name: Cache agent-device iOS runner
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
-        with:
-          path: ~/.agent-device/ios-runner/derived
-          key: agent-device-ios-runner-${{ runner.os }}-${{ steps.xcode-cache-key.outputs.key }}-${{ hashFiles('node_modules/agent-device/package.json', 'node_modules/agent-device/ios-runner/**') }}
-
-      - name: Install macOS dependencies
-        run: |
-          brew install ccache
+      - name: Install build dependencies
+        if: steps.restore-debug-build.outputs.cache-hit != 'true'
+        run: brew install ccache
 
       - name: Cache CocoaPods
         if: steps.restore-debug-build.outputs.cache-hit != 'true'
@@ -90,8 +87,9 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           path: example/ios/build
-          key: ios-deriveddata-${{ runner.os }}-${{ steps.calculate-fingerprint.outputs.fingerprint }}
+          key: ios-deriveddata-${{ runner.os }}-xcode${{ env.XCODE_VERSION }}-${{ steps.calculate-fingerprint.outputs.fingerprint }}
           restore-keys: |
+            ios-deriveddata-${{ runner.os }}-xcode${{ env.XCODE_VERSION }}-
             ios-deriveddata-${{ runner.os }}-
 
       - name: Cache ccache
@@ -99,8 +97,9 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           path: ~/.ccache
-          key: ios-ccache-${{ runner.os }}-${{ steps.calculate-fingerprint.outputs.fingerprint }}
+          key: ios-ccache-${{ runner.os }}-xcode${{ env.XCODE_VERSION }}-${{ steps.calculate-fingerprint.outputs.fingerprint }}
           restore-keys: |
+            ios-ccache-${{ runner.os }}-xcode${{ env.XCODE_VERSION }}-
             ios-ccache-${{ runner.os }}-
 
       - name: Set ccache directory
@@ -135,6 +134,65 @@ jobs:
         with:
           path: ios-debug-build/
           key: ${{ steps.restore-debug-build.outputs.cache-primary-key }}
+
+      - name: Pack debug build artifact
+        run: tar -czf ios-debug-build/ios-debug.app.tgz -C ios-debug-build ios-debug.app
+
+      - name: Upload debug build artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: ${{ steps.debug-build-metadata.outputs.artifact-name }}
+          path: ios-debug-build/ios-debug.app.tgz
+          if-no-files-found: error
+          retention-days: 1
+
+  e2e-ios:
+    needs: build-ios
+    runs-on: macos-latest
+    timeout-minutes: 60
+    permissions:
+      checks: read
+      contents: read
+    concurrency:
+      group: ${{ github.workflow_ref }}-${{ github.ref }}-ios-test
+      cancel-in-progress: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Setup
+        uses: ./.github/actions/setup
+
+      - name: Install nightly react-native-screens
+        if: github.event_name == 'schedule'
+        run: pnpm --recursive update react-native-screens@nightly --no-save
+
+      - name: Download debug build artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: ${{ needs.build-ios.outputs.debug-build-artifact }}
+          path: ios-debug-build
+
+      - name: Unpack debug build artifact
+        run: tar -xzf ios-debug-build/ios-debug.app.tgz -C ios-debug-build
+
+      - name: Use appropriate Xcode version
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90
+        with:
+          xcode-version: ${{ env.XCODE_VERSION }}
+
+      - name: Resolve Xcode cache key
+        id: xcode-cache-key
+        run: |
+          XCODE_VERSION="$(xcodebuild -version | tr '\n' ' ' | sed -E 's/[[:space:]]+/ /g; s/[[:space:]]$//')"
+          XCODE_KEY="$(echo "$XCODE_VERSION" | tr ' ' '-' | tr -cd '[:alnum:]._-')"
+          echo "key=$XCODE_KEY" >> "$GITHUB_OUTPUT"
+
+      - name: Cache agent-device iOS runner
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
+        with:
+          path: ~/.agent-device/ios-runner/derived
+          key: agent-device-ios-runner-${{ runner.os }}-${{ steps.xcode-cache-key.outputs.key }}-${{ hashFiles('node_modules/agent-device/package.json', 'node_modules/agent-device/ios-runner/**') }}
 
       - name: Setup JDK
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654

--- a/.github/workflows/e2e-ios.yml
+++ b/.github/workflows/e2e-ios.yml
@@ -10,12 +10,7 @@ on:
     - cron: '0 4 * * *'
 
 env:
-  JAVA_DISTRIBUTION: 'zulu'
-  JAVA_VERSION: '17'
-  SIMULATOR_NAME: iPhone 17 Pro
   XCODE_VERSION: '26.3'
-  USE_CCACHE: 1
-  CCACHE_COMPILERCHECK: content
 
 jobs:
   build-ios:
@@ -23,11 +18,12 @@ jobs:
     timeout-minutes: 60
     permissions:
       contents: read
-    outputs:
-      debug-build-artifact: ${{ steps.debug-build-metadata.outputs.artifact-name }}
     concurrency:
-      group: ${{ github.workflow_ref }}-${{ github.ref }}-ios-build
+      group: ${{ github.workflow_ref }}-${{ github.ref }}
       cancel-in-progress: true
+    env:
+      USE_CCACHE: 1
+      CCACHE_COMPILERCHECK: content
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -47,18 +43,12 @@ jobs:
           echo "fingerprint=$FINGERPRINT" >> "$GITHUB_OUTPUT"
         working-directory: example
 
-      - name: Set debug build metadata
-        id: debug-build-metadata
-        run: |
-          echo "cache-key=ios-debug-build-v1-${{ runner.os }}-xcode${{ env.XCODE_VERSION }}-iphonesimulator-${{ steps.calculate-fingerprint.outputs.fingerprint }}" >> "$GITHUB_OUTPUT"
-          echo "artifact-name=ios-debug-build-${{ steps.calculate-fingerprint.outputs.fingerprint }}" >> "$GITHUB_OUTPUT"
-
       - name: Restore debug build from cache
         id: restore-debug-build
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           path: ios-debug-build/
-          key: ${{ steps.debug-build-metadata.outputs.cache-key }}
+          key: ios-debug-build-${{ runner.os }}-${{ env.XCODE_VERSION }}-${{ steps.calculate-fingerprint.outputs.fingerprint }}
 
       - name: Use appropriate Xcode version
         if: steps.restore-debug-build.outputs.cache-hit != 'true'
@@ -87,9 +77,9 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           path: example/ios/build
-          key: ios-deriveddata-${{ runner.os }}-xcode${{ env.XCODE_VERSION }}-${{ steps.calculate-fingerprint.outputs.fingerprint }}
+          key: ios-deriveddata-${{ runner.os }}-${{ env.XCODE_VERSION }}-${{ steps.calculate-fingerprint.outputs.fingerprint }}
           restore-keys: |
-            ios-deriveddata-${{ runner.os }}-xcode${{ env.XCODE_VERSION }}-
+            ios-deriveddata-${{ runner.os }}-${{ env.XCODE_VERSION }}-
             ios-deriveddata-${{ runner.os }}-
 
       - name: Cache ccache
@@ -97,9 +87,9 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           path: ~/.ccache
-          key: ios-ccache-${{ runner.os }}-xcode${{ env.XCODE_VERSION }}-${{ steps.calculate-fingerprint.outputs.fingerprint }}
+          key: ios-ccache-${{ runner.os }}-${{ env.XCODE_VERSION }}-${{ steps.calculate-fingerprint.outputs.fingerprint }}
           restore-keys: |
-            ios-ccache-${{ runner.os }}-xcode${{ env.XCODE_VERSION }}-
+            ios-ccache-${{ runner.os }}-${{ env.XCODE_VERSION }}-
             ios-ccache-${{ runner.os }}-
 
       - name: Set ccache directory
@@ -141,7 +131,7 @@ jobs:
       - name: Upload debug build artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
-          name: ${{ steps.debug-build-metadata.outputs.artifact-name }}
+          name: ios-debug-build
           path: ios-debug-build/ios-debug.app.tgz
           if-no-files-found: error
           retention-days: 1
@@ -151,11 +141,12 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 60
     permissions:
-      checks: read
       contents: read
     concurrency:
-      group: ${{ github.workflow_ref }}-${{ github.ref }}-ios-test
+      group: ${{ github.workflow_ref }}-${{ github.ref }}
       cancel-in-progress: true
+    env:
+      SIMULATOR_NAME: iPhone 17 Pro
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -170,7 +161,7 @@ jobs:
       - name: Download debug build artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
-          name: ${{ needs.build-ios.outputs.debug-build-artifact }}
+          name: ios-debug-build
           path: ios-debug-build
 
       - name: Unpack debug build artifact
@@ -191,14 +182,8 @@ jobs:
       - name: Cache agent-device iOS runner
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
-          path: ~/.agent-device/ios-runner/derived
-          key: agent-device-ios-runner-${{ runner.os }}-${{ steps.xcode-cache-key.outputs.key }}-${{ hashFiles('node_modules/agent-device/package.json', 'node_modules/agent-device/ios-runner/**') }}
-
-      - name: Setup JDK
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
-        with:
-          distribution: ${{ env.JAVA_DISTRIBUTION }}
-          java-version: ${{ env.JAVA_VERSION }}
+          path: ~/.agent-device/apple-runner/derived
+          key: agent-device-ios-runner-${{ runner.os }}-${{ steps.xcode-cache-key.outputs.key }}-${{ hashFiles('node_modules/agent-device/package.json') }}
 
       - name: Start Metro bundler
         run: pnpm --dir example start &
@@ -265,11 +250,11 @@ jobs:
           AGENT_DEVICE_E2E_TIMEOUT_MS=240000 pnpm e2e:native --platform ios
         working-directory: example
 
-      - name: Store E2E timing output
+      - name: Store E2E output
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
-          name: e2e-timing-ios
+          name: e2e-output-ios
           path: example/agent-device-artifacts/**/*
           include-hidden-files: true
           overwrite: true
@@ -283,9 +268,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: e2e-artifacts-ios
-          path: |
-            example/agent-device-artifacts/**/*
-            example/agent-device-state/**/*.log
+          path: example/agent-device-state/**/*.log
           include-hidden-files: true
           overwrite: true
 
@@ -297,6 +280,5 @@ jobs:
           path: |
             ~/.agent-device/**/*.log
             ~/agent-device-simulator.log
-            example/agent-device-state/**/*.log
           include-hidden-files: true
           overwrite: true


### PR DESCRIPTION
## Summary

Split Android and iOS E2E workflows into native build and Maestro test jobs.

Cache native debug builds with stricter fingerprint-based keys that include platform/toolchain inputs, then pass the exact build to the test job via workflow artifacts.

For iOS, package the .app as a tarball before artifact upload so executable permissions survive the job boundary.

## CI Timing Snapshot

Numbers below are from GitHub Actions job timestamps on May 28, 2026.

| Scenario | Platform | Run | Native build | Maestro tests | Total wall time | Notes |
| --- | --- | --- | ---: | ---: | ---: | --- |
| Baseline on merge base `6104e1d` | Android | [run](https://github.com/react-navigation/react-navigation/actions/runs/26573191726) | in one job; build step `7m24s` | step `29m29s` | `41m21s` | Native build and Maestro ran in the same job. |
| Baseline on merge base `6104e1d` | iOS | [run](https://github.com/react-navigation/react-navigation/actions/runs/26573191712) | in one job; build step `16m43s` | step `20m40s` | `46m24s` | Native build and Maestro ran in the same job. |
| PR cold cache, `65c3e14` | Android | [run](https://github.com/react-navigation/react-navigation/actions/runs/26580255306) | job `9m10s`; build step `6m59s` | job `31m12s`; test step `28m09s` | `40m26s` | Cache miss, built APK, saved native cache, uploaded artifact. |
| PR cold cache, `65c3e14` | iOS | [run](https://github.com/react-navigation/react-navigation/actions/runs/26580255130) | job `15m49s`; build step `13m05s` | job `25m23s`; test step `19m33s` | `41m18s` | Cache miss, built .app, saved native cache, tarred and uploaded artifact. |
| PR warm cache, `978a50a` | Android | [run](https://github.com/react-navigation/react-navigation/actions/runs/26583317350) | job `31s` | job `34m33s`; test step `31m32s` | `35m08s` | Cache hit restored `android-debug-build`; native build skipped; artifact upload worked. |
| PR warm cache, `978a50a` | iOS | [run](https://github.com/react-navigation/react-navigation/actions/runs/26583317357) | job `54s` | successful rerun job `25m46s`; test step `21m35s` | `26m40s` job time sum | Cache hit restored `ios-debug-build`; native build skipped; tar artifact upload worked. First Maestro attempt hit an XCTest driver startup timeout after the cached app installed, then the rerun passed. |

Warm cache is the main win: Android native build job dropped from `9m10s` to `31s`, and iOS native build job dropped from `15m49s` to `54s`. The total E2E runtime is still dominated by Maestro execution and simulator/emulator setup.

## Validation

- ruby YAML parse for edited workflows
- actionlint for edited workflows
- git diff --check
