### PR TITLE
feat: add support for shared URLs in linking config

### DIFF
--- a/example/e2e/maestro/showcase-bottom-tabs.yml
+++ b/example/e2e/maestro/showcase-bottom-tabs.yml
@@ -6,15 +6,89 @@ name: Showcase - Bottom Tabs
     env:
       LINK: bottom-tabs-showcase
       TEXT: 'Midnight Waves'
+- runFlow:
+    when:
+      # Android doesn't expose selected state
+      true: ${maestro.platform == 'web' || maestro.platform == 'ios'}
+    commands:
+      - assertVisible:
+          text: 'Albums'
+          selected: true
+- tapOn:
+    id: 'open-album-albums'
+- runFlow:
+    when:
+      true: ${maestro.platform == 'web' || maestro.platform == 'ios'}
+    commands:
+      - assertVisible:
+          text: 'Albums'
+          selected: true
+- assertVisible:
+    text: 'Midnight Waves'
+- assertVisible:
+    text: 'Luna Echo'
 - tapOn:
     text: '.*For You.*'
+- runFlow:
+    when:
+      true: ${maestro.platform == 'web' || maestro.platform == 'ios'}
+    commands:
+      - assertVisible:
+          text: 'For You'
+          selected: true
+- tapOn:
+    id: 'open-album-for-you'
+- runFlow:
+    when:
+      true: ${maestro.platform == 'web' || maestro.platform == 'ios'}
+    commands:
+      - assertVisible:
+          text: 'For You'
+          selected: true
 - assertVisible:
-    text: 'Featured'
+    text: 'Quiet Hours'
+- assertVisible:
+    text: 'Amber Field'
 - tapOn:
     text: 'Radio'
 - assertVisible:
     text: 'Velvet FM'
+- runFlow:
+    when:
+      true: ${maestro.platform == 'web' || maestro.platform == 'ios'}
+    commands:
+      - assertVisible:
+          text: 'Radio'
+          selected: true
 - tapOn:
-    text: 'Search'
+    text: '.*For You.*'
+- runFlow:
+    when:
+      true: ${maestro.platform == 'web' || maestro.platform == 'ios'}
+    commands:
+      - assertVisible:
+          text: 'For You'
+          selected: true
 - assertVisible:
-    text: 'Browse Categories'
+    text: 'Quiet Hours'
+- openLink:
+    link: ${APP_SCHEME}bottom-tabs-showcase/album/12
+- runFlow:
+    when:
+      # On Web, opening a link results in fresh page load
+      platform: web
+    commands:
+      - assertVisible:
+          text: 'Albums'
+          selected: true
+- runFlow:
+    when:
+      platform: ios
+    commands:
+      - assertVisible:
+          text: 'For You'
+          selected: true
+- assertVisible:
+    text: 'Signal Lost'
+- assertVisible:
+    text: 'Pixel Drift'

--- a/example/e2e/tests/maestro.test.ts
+++ b/example/e2e/tests/maestro.test.ts
@@ -1,4 +1,4 @@
-import { expect, type Page, test } from '@playwright/test';
+import { expect, type Locator, type Page, test } from '@playwright/test';
 import fs from 'fs';
 import path from 'path';
 import { parseAllDocuments } from 'yaml';
@@ -387,7 +387,14 @@ function evaluateCondition(condition: boolean | string) {
   }
 }
 
-function query(page: Page, by: string | { text: string } | { id: string }) {
+type QueryBy =
+  | string
+  | { text: string; selected?: boolean }
+  | { id: string; selected?: boolean };
+
+function query(page: Page, by: QueryBy) {
+  let locator: Locator;
+
   if (typeof by === 'string' || 'text' in by) {
     const text = typeof by === 'string' ? by : by.text;
     const isRegex = text.includes('.*');
@@ -397,12 +404,18 @@ function query(page: Page, by: string | { text: string } | { id: string }) {
       isRegex ? undefined : { exact: true },
     ] as const;
 
-    return page.getByLabel(...args).or(page.getByText(...args));
+    locator = page.getByLabel(...args).or(page.getByText(...args));
+  } else if ('id' in by) {
+    locator = page.getByTestId(by.id);
+  } else {
+    throw new Error(`Unknown step format: ${JSON.stringify(by)}`);
   }
 
-  if ('id' in by) {
-    return page.getByTestId(by.id);
+  if (typeof by !== 'string' && typeof by.selected === 'boolean') {
+    return locator.locator(
+      `xpath=ancestor-or-self::*[@aria-selected="${by.selected}"]`
+    );
   }
 
-  throw new Error(`Unknown step format: ${JSON.stringify(by)}`);
+  return locator;
 }

--- a/example/src/Showcase/BottomTabsShowcase.tsx
+++ b/example/src/Showcase/BottomTabsShowcase.tsx
@@ -3,8 +3,8 @@ import {
   createBottomTabNavigator,
   createBottomTabScreen,
 } from '@react-navigation/bottom-tabs';
-import { type Icon, Text } from '@react-navigation/elements';
-import { useNavigation, useTheme } from '@react-navigation/native';
+import { type Icon, PlatformPressable, Text } from '@react-navigation/elements';
+import { useNavigation, useRoute, useTheme } from '@react-navigation/native';
 import {
   createNativeStackNavigator,
   createNativeStackScreen,
@@ -160,6 +160,7 @@ const SEARCH_RESULT_COVER_SIZE = 48;
 
 const AlbumsScreen = () => {
   const { colors, fonts } = useTheme();
+  const navigation = useNavigation('AlbumsHome');
   const dimensions = useWindowDimensions();
   const availableWidth = dimensions.width - SPACING_M * 2;
   const numColumns = Math.max(1, Math.floor(availableWidth / 150));
@@ -171,12 +172,14 @@ const AlbumsScreen = () => {
       contentContainerStyle={styles.albumGridContent}
     >
       {ALBUMS.map((item) => (
-        <View
+        <PlatformPressable
           key={item.id}
+          onPress={() => navigation.navigate('AlbumDetails', { id: item.id })}
           style={[
             styles.albumGridItem,
             Platform.OS !== 'web' && { width: itemSize },
           ]}
+          testID={item.id === '1' ? 'open-album-albums' : undefined}
         >
           <Image
             source={item.cover}
@@ -196,7 +199,7 @@ const AlbumsScreen = () => {
               {item.artist}
             </Text>
           </View>
-        </View>
+        </PlatformPressable>
       ))}
     </ScrollView>
   );
@@ -204,6 +207,8 @@ const AlbumsScreen = () => {
 
 const ForYouScreen = () => {
   const { colors, fonts } = useTheme();
+  const navigation = useNavigation('ForYouHome');
+
   const featured = ALBUMS[2];
 
   return (
@@ -211,7 +216,11 @@ const ForYouScreen = () => {
       contentInsetAdjustmentBehavior="automatic"
       contentContainerStyle={styles.forYouContent}
     >
-      <View style={styles.featuredCard}>
+      <PlatformPressable
+        onPress={() => navigation.navigate('AlbumDetails', { id: featured.id })}
+        style={styles.featuredCard}
+        testID="open-album-for-you"
+      >
         <Image source={featured.cover} style={styles.featuredImage} />
 
         <View style={styles.featuredOverlay}>
@@ -225,7 +234,7 @@ const ForYouScreen = () => {
             {featured.artist}
           </Text>
         </View>
-      </View>
+      </PlatformPressable>
 
       {FOR_YOU_SECTIONS.map((section) => (
         <View key={section.title} style={styles.section}>
@@ -238,7 +247,12 @@ const ForYouScreen = () => {
             showsHorizontalScrollIndicator={false}
             contentContainerStyle={styles.horizontalList}
             renderItem={({ item }) => (
-              <View style={styles.horizontalItem}>
+              <PlatformPressable
+                onPress={() =>
+                  navigation.navigate('AlbumDetails', { id: item.id })
+                }
+                style={styles.horizontalItem}
+              >
                 <Image source={item.cover} style={styles.horizontalCover} />
 
                 <Text
@@ -254,7 +268,7 @@ const ForYouScreen = () => {
                 >
                   {item.artist}
                 </Text>
-              </View>
+              </PlatformPressable>
             )}
           />
         </View>
@@ -265,13 +279,19 @@ const ForYouScreen = () => {
 
 const RadioScreen = () => {
   const { colors, fonts } = useTheme();
+  const insets = useSafeAreaInsets();
 
   return (
     <FlatList
       data={STATIONS}
       keyExtractor={(item) => item.id}
       contentInsetAdjustmentBehavior="automatic"
-      contentContainerStyle={styles.stationList}
+      contentContainerStyle={[
+        styles.stationList,
+        Platform.OS === 'android'
+          ? { paddingTop: insets.top, paddingBottom: insets.bottom }
+          : null,
+      ]}
       ItemSeparatorComponent={() => (
         <View style={[styles.separator, { backgroundColor: colors.border }]} />
       )}
@@ -380,7 +400,12 @@ const SearchScreenContent = () => {
                   />
                 )}
 
-                <View style={styles.searchResultRow}>
+                <PlatformPressable
+                  onPress={() =>
+                    navigation.navigate('AlbumDetails', { id: item.id })
+                  }
+                  style={styles.searchResultRow}
+                >
                   <Image source={item.cover} style={styles.searchResultCover} />
 
                   <View style={styles.searchResultInfo}>
@@ -397,7 +422,7 @@ const SearchScreenContent = () => {
                       {item.artist}
                     </Text>
                   </View>
-                </View>
+                </PlatformPressable>
               </React.Fragment>
             ))}
           </View>
@@ -437,6 +462,64 @@ const SearchScreenContent = () => {
   );
 };
 
+const AlbumDetailsScreen = () => {
+  const { colors, fonts } = useTheme();
+
+  const route = useRoute('AlbumDetails');
+
+  const album = ALBUMS.find((item) => item.id === route.params.id) ?? ALBUMS[0];
+
+  return (
+    <ScrollView
+      contentInsetAdjustmentBehavior="automatic"
+      contentContainerStyle={styles.albumDetailsContent}
+    >
+      <Image source={album.cover} style={styles.albumDetailsCover} />
+
+      <Text style={[styles.albumDetailsTitle, fonts.heavy]}>{album.title}</Text>
+      <Text style={[styles.albumDetailsArtist, { color: colors.text }]}>
+        {album.artist}
+      </Text>
+    </ScrollView>
+  );
+};
+
+const AlbumDetails = createNativeStackScreen({
+  screen: AlbumDetailsScreen,
+  linking: 'album/:id',
+  options: ({ route }) => ({
+    title: ALBUMS.find((a) => a.id === route.params.id)?.title ?? 'Album',
+  }),
+});
+
+const AlbumsStack = createNativeStackNavigator({
+  initialRouteName: 'AlbumsHome',
+  screens: {
+    AlbumsHome: createNativeStackScreen({
+      screen: AlbumsScreen,
+      options: {
+        title: 'Albums',
+        headerLargeTitleEnabled: true,
+      },
+    }),
+    AlbumDetails,
+  },
+});
+
+const ForYouStack = createNativeStackNavigator({
+  initialRouteName: 'ForYouHome',
+  screens: {
+    ForYouHome: createNativeStackScreen({
+      screen: ForYouScreen,
+      options: {
+        title: 'For You',
+        headerLargeTitleEnabled: true,
+      },
+    }),
+    AlbumDetails,
+  },
+});
+
 const SearchStack = createNativeStackNavigator({
   screens: {
     SearchHome: createNativeStackScreen({
@@ -446,6 +529,7 @@ const SearchStack = createNativeStackNavigator({
         headerLargeTitleEnabled: true,
       },
     }),
+    AlbumDetails,
   },
 });
 
@@ -496,37 +580,16 @@ const NowPlayingBar = ({ placement }: { placement: 'inline' | 'regular' }) => {
   );
 };
 
-const SafeAreaLayout = ({ children }: { children: React.ReactNode }) => {
-  const insets = useSafeAreaInsets();
-
-  return (
-    <View
-      style={{
-        flex: 1,
-        paddingTop: insets.top,
-        paddingBottom: insets.bottom,
-      }}
-    >
-      {children}
-    </View>
-  );
-};
-
 const BottomTabsShowcaseNavigator = createBottomTabNavigator({
-  screenLayout: ({ children }) =>
-    Platform.OS === 'android' ? (
-      <SafeAreaLayout>{children}</SafeAreaLayout>
-    ) : (
-      children
-    ),
   screenOptions: {
     bottomAccessory: ({ placement }) => <NowPlayingBar placement={placement} />,
   },
   screens: {
     Albums: createBottomTabScreen({
-      screen: AlbumsScreen,
+      screen: AlbumsStack,
       options: {
         title: 'Albums',
+        tabBarButtonTestID: 'showcase-bottom-tabs-albums',
         tabBarIcon: Platform.select<Icon>({
           ios: { type: 'sfSymbol', name: 'rectangle.stack' },
           android: { type: 'materialSymbol', name: 'library_music' },
@@ -537,9 +600,10 @@ const BottomTabsShowcaseNavigator = createBottomTabNavigator({
     }),
 
     ForYou: createBottomTabScreen({
-      screen: ForYouScreen,
+      screen: ForYouStack,
       options: {
         title: 'For You',
+        tabBarButtonTestID: 'showcase-bottom-tabs-for-you',
         tabBarIcon: Platform.select<Icon>({
           ios: { type: 'sfSymbol', name: 'play.circle' },
           android: { type: 'materialSymbol', name: 'play_circle' },
@@ -553,6 +617,7 @@ const BottomTabsShowcaseNavigator = createBottomTabNavigator({
       screen: RadioScreen,
       options: {
         title: 'Radio',
+        tabBarButtonTestID: 'showcase-bottom-tabs-radio',
         tabBarIcon: Platform.select<Icon>({
           ios: { type: 'sfSymbol', name: 'dot.radiowaves.left.and.right' },
           android: { type: 'materialSymbol', name: 'cell_tower' },
@@ -567,6 +632,7 @@ const BottomTabsShowcaseNavigator = createBottomTabNavigator({
       layout: ({ children }) => children,
       options: {
         tabBarSystemItem: 'search',
+        tabBarButtonTestID: 'showcase-bottom-tabs-search',
         tabBarIcon: Platform.select<Icon>({
           ios: { type: 'sfSymbol', name: 'magnifyingglass' },
           android: { type: 'materialSymbol', name: 'search' },
@@ -812,7 +878,28 @@ const styles = StyleSheet.create({
     fontSize: 16,
     color: '#fff',
   },
-
+  albumDetailsContent: {
+    alignItems: 'center',
+    padding: SPACING_L,
+  },
+  albumDetailsCover: {
+    width: 240,
+    height: 240,
+    borderRadius: BORDER_RADIUS,
+    borderCurve: 'continuous',
+    marginTop: SPACING_XL * 2,
+    marginBottom: SPACING_L,
+  },
+  albumDetailsTitle: {
+    fontSize: 28,
+    textAlign: 'center',
+  },
+  albumDetailsArtist: {
+    fontSize: 16,
+    marginTop: SPACING_XS,
+    marginBottom: SPACING_L,
+    opacity: 0.7,
+  },
   nowPlaying: {
     flexDirection: 'row',
     alignItems: 'center',

--- a/packages/core/src/StaticNavigation.tsx
+++ b/packages/core/src/StaticNavigation.tsx
@@ -6,6 +6,11 @@ import type {
 import * as React from 'react';
 import { isValidElementType } from 'react-is';
 
+import {
+  combinePatternParts,
+  getPatternParts,
+  type PatternPart,
+} from './getPatternParts';
 import type {
   DefaultNavigatorOptions,
   EventMapBase,
@@ -198,6 +203,21 @@ type StaticScreenConfigLinkingAlias = {
    * ```
    */
   stringify?: Record<string, (value: unknown) => string>;
+  /**
+   * Whether this path can resolve to multiple routes.
+   * Both routes should specify `shared: true` for this to work.
+   *
+   * When automatic path generation is enabled,
+   * screens using the same path pattern and the same screen component
+   * or navigator will be automatically marked as shared.
+   * Explicitly specifying the option overrides the automatic detection.
+   *
+   * This is useful when same screen used in multiple navigators,
+   * e.g. tabs with stacks containing profile screen in each stack.
+   *
+   * The path defined first will be the canonical path.
+   */
+  shared?: boolean;
 };
 
 export type StaticScreenConfigLinking =
@@ -747,6 +767,86 @@ type ScreenForPathConfig =
       linking?: LinkingForPathConfig;
     };
 
+type PathConfigMapForStaticNavigation = Record<
+  string,
+  string | PathConfigForStaticNavigation | undefined
+>;
+
+type PathConfigForStaticNavigation = Omit<
+  PathConfig<ParamListBase>,
+  'screens'
+> & {
+  initialRouteName?: string | undefined;
+  screens?: PathConfigMapForStaticNavigation | undefined;
+};
+
+// Mark screens that resolve to the same pattern and same component or navigator
+const markSharedPathConfigs = (
+  screens: PathConfigMapForStaticNavigation,
+  sources: WeakMap<PathConfigForStaticNavigation, ScreenValueForPathConfig>,
+  blocked: WeakSet<PathConfigForStaticNavigation>
+) => {
+  const candidates = new Map<string, PathConfigForStaticNavigation[]>();
+
+  const collect = (
+    screens: PathConfigMapForStaticNavigation,
+    parentParts: PatternPart[],
+    disabled: boolean
+  ) => {
+    for (const config of Object.values(screens)) {
+      if (config == null || typeof config === 'string') {
+        continue;
+      }
+
+      const parts =
+        typeof config.path === 'string'
+          ? combinePatternParts(
+              parentParts,
+              getPatternParts(config.path),
+              config.exact
+            )
+          : parentParts;
+
+      if (sources.has(config) && typeof config.path === 'string') {
+        if (disabled) {
+          blocked.add(config);
+        }
+
+        const pattern = parts.map((part) => part.segment).join('/');
+        const entries = candidates.get(pattern) ?? [];
+
+        entries.push(config);
+        candidates.set(pattern, entries);
+      }
+
+      if (config.screens) {
+        collect(config.screens, parts, disabled || config.shared === false);
+      }
+    }
+  };
+
+  collect(screens, [], false);
+
+  for (const entries of candidates.values()) {
+    for (const entry of entries) {
+      const source = sources.get(entry);
+
+      if (
+        entry.shared === undefined &&
+        !blocked.has(entry) &&
+        entries.some(
+          (candidate) =>
+            candidate !== entry &&
+            !blocked.has(candidate) &&
+            sources.get(candidate) === source
+        )
+      ) {
+        entry.shared = true;
+      }
+    }
+  }
+};
+
 /**
  * Create a path config object from a static navigation config for deep linking.
  *
@@ -776,6 +876,12 @@ export function createPathConfigForStaticNavigation<ParamList extends {}>(
   let initialScreenHasPath: boolean = false;
   let initialScreenConfig: PathConfig<{}> | undefined;
   let hasEmptyPath = false;
+
+  const blocked = new WeakSet<PathConfigForStaticNavigation>();
+  const sources = new WeakMap<
+    PathConfigForStaticNavigation,
+    ScreenValueForPathConfig
+  >();
 
   const createPathConfigForTree = (
     t: TreeForPathConfig,
@@ -821,7 +927,12 @@ export function createPathConfigForStaticNavigation<ParamList extends {}>(
             return 0;
           })
           .map(([key, item]) => {
-            const screenConfig: PathConfig<{}> = {};
+            const screenConfig: PathConfigForStaticNavigation = {};
+
+            sources.set(
+              screenConfig,
+              typeof item === 'object' && 'screen' in item ? item.screen : item
+            );
 
             const normalizePath = (path: string) =>
               path.replace(/^\/+|\/+$/g, '');
@@ -833,7 +944,7 @@ export function createPathConfigForStaticNavigation<ParamList extends {}>(
                 item.linking != null &&
                 typeof item.linking === 'object'
               ) {
-                Object.assign(screenConfig, item.linking);
+                Object.assign(screenConfig, { ...item.linking });
               }
             }
 
@@ -918,7 +1029,6 @@ export function createPathConfigForStaticNavigation<ParamList extends {}>(
             }
 
             if (screens) {
-              // @ts-expect-error - we can't type this properly
               screenConfig.screens = screens;
             }
 
@@ -975,7 +1085,7 @@ export function createPathConfigForStaticNavigation<ParamList extends {}>(
       );
     };
 
-    const screens = {};
+    const screens: PathConfigMapForStaticNavigation = {};
 
     // Loop through the config to find screens and groups
     // So we add the screens and groups in the same order as they are defined
@@ -1016,5 +1126,11 @@ export function createPathConfigForStaticNavigation<ParamList extends {}>(
     initialScreenConfig.path = '';
   }
 
-  return screens;
+  if (!screens) {
+    return undefined;
+  }
+
+  markSharedPathConfigs(screens, sources, blocked);
+
+  return screens as PathConfigMap<ParamList>;
 }

--- a/packages/core/src/__tests__/StaticNavigation.test.tsx
+++ b/packages/core/src/__tests__/StaticNavigation.test.tsx
@@ -992,6 +992,542 @@ test('returns undefined if there is no linking configuration', () => {
   expect(screens).toBeUndefined();
 });
 
+test('marks a reused screen with the same explicit path as shared', () => {
+  const Profile = {
+    screen: TestScreen,
+    linking: 'profile/:id',
+  };
+
+  const HomeStack = createTestNavigator({
+    screens: {
+      Home: {
+        screen: TestScreen,
+      },
+      Profile,
+    },
+  });
+
+  const SearchStack = createTestNavigator({
+    screens: {
+      Search: {
+        screen: TestScreen,
+        linking: 'search',
+      },
+      Profile,
+    },
+  });
+
+  const Tabs = createTestNavigator({
+    screens: {
+      HomeTab: {
+        screen: HomeStack,
+      },
+      SearchTab: {
+        screen: SearchStack,
+      },
+    },
+  });
+
+  expect(createPathConfigForStaticNavigation(Tabs, {}, true)).toEqual({
+    HomeTab: {
+      screens: {
+        Home: {
+          path: '',
+        },
+        Profile: {
+          path: 'profile/:id',
+          shared: true,
+        },
+      },
+    },
+    SearchTab: {
+      screens: {
+        Profile: {
+          path: 'profile/:id',
+          shared: true,
+        },
+        Search: {
+          path: 'search',
+        },
+      },
+    },
+  });
+});
+
+test('marks a reused screen with the same generated path as shared', () => {
+  const Profile = {
+    screen: TestScreen,
+  };
+
+  const HomeStack = createTestNavigator({
+    screens: {
+      Home: {
+        screen: TestScreen,
+      },
+      Profile,
+    },
+  });
+
+  const SearchStack = createTestNavigator({
+    screens: {
+      Search: {
+        screen: TestScreen,
+        linking: 'search',
+      },
+      Profile,
+    },
+  });
+
+  const Tabs = createTestNavigator({
+    screens: {
+      HomeTab: {
+        screen: HomeStack,
+      },
+      SearchTab: {
+        screen: SearchStack,
+      },
+    },
+  });
+
+  expect(createPathConfigForStaticNavigation(Tabs, {}, true)).toEqual({
+    HomeTab: {
+      screens: {
+        Home: {
+          path: '',
+        },
+        Profile: {
+          path: 'profile',
+          shared: true,
+        },
+      },
+    },
+    SearchTab: {
+      screens: {
+        Profile: {
+          path: 'profile',
+          shared: true,
+        },
+        Search: {
+          path: 'search',
+        },
+      },
+    },
+  });
+});
+
+test('marks the same component with the same explicit path as shared', () => {
+  const HomeStack = createTestNavigator({
+    screens: {
+      Home: {
+        screen: TestScreen,
+      },
+      Profile: {
+        screen: TestScreen,
+        linking: 'profile/:id',
+      },
+    },
+  });
+
+  const SearchStack = createTestNavigator({
+    screens: {
+      Search: {
+        screen: TestScreen,
+        linking: 'search',
+      },
+      Profile: {
+        screen: TestScreen,
+        linking: 'profile/:id',
+      },
+    },
+  });
+
+  const Tabs = createTestNavigator({
+    screens: {
+      HomeTab: {
+        screen: HomeStack,
+      },
+      SearchTab: {
+        screen: SearchStack,
+      },
+    },
+  });
+
+  expect(createPathConfigForStaticNavigation(Tabs, {}, true)).toEqual({
+    HomeTab: {
+      screens: {
+        Home: {
+          path: '',
+        },
+        Profile: {
+          path: 'profile/:id',
+          shared: true,
+        },
+      },
+    },
+    SearchTab: {
+      screens: {
+        Profile: {
+          path: 'profile/:id',
+          shared: true,
+        },
+        Search: {
+          path: 'search',
+        },
+      },
+    },
+  });
+});
+
+test('marks the same component with the same generated path as shared', () => {
+  const HomeStack = createTestNavigator({
+    screens: {
+      Home: {
+        screen: TestScreen,
+      },
+      Profile: {
+        screen: TestScreen,
+      },
+    },
+  });
+
+  const SearchStack = createTestNavigator({
+    screens: {
+      Search: {
+        screen: TestScreen,
+        linking: 'search',
+      },
+      Profile: {
+        screen: TestScreen,
+      },
+    },
+  });
+
+  const Tabs = createTestNavigator({
+    screens: {
+      HomeTab: {
+        screen: HomeStack,
+      },
+      SearchTab: {
+        screen: SearchStack,
+      },
+    },
+  });
+
+  expect(createPathConfigForStaticNavigation(Tabs, {}, true)).toEqual({
+    HomeTab: {
+      screens: {
+        Home: {
+          path: '',
+        },
+        Profile: {
+          path: 'profile',
+          shared: true,
+        },
+      },
+    },
+    SearchTab: {
+      screens: {
+        Profile: {
+          path: 'profile',
+          shared: true,
+        },
+        Search: {
+          path: 'search',
+        },
+      },
+    },
+  });
+});
+
+test("doesn't mark a reused screen with different paths as shared", () => {
+  const Profile = {
+    screen: TestScreen,
+    linking: 'profile/:id',
+  };
+
+  const HomeStack = createTestNavigator({
+    screens: {
+      Profile,
+    },
+  });
+
+  const SearchStack = createTestNavigator({
+    screens: {
+      Profile,
+    },
+  });
+
+  const Tabs = createTestNavigator({
+    screens: {
+      HomeTab: {
+        screen: HomeStack,
+      },
+      SearchTab: {
+        screen: SearchStack,
+        linking: 'search',
+      },
+    },
+  });
+
+  expect(createPathConfigForStaticNavigation(Tabs, {})).toEqual({
+    HomeTab: {
+      screens: {
+        Profile: {
+          path: 'profile/:id',
+        },
+      },
+    },
+    SearchTab: {
+      path: 'search',
+      screens: {
+        Profile: {
+          path: 'profile/:id',
+        },
+      },
+    },
+  });
+});
+
+test('preserves explicit shared option in static linking', () => {
+  const Stack = createTestNavigator({
+    screens: {
+      Profile: {
+        screen: TestScreen,
+        linking: {
+          path: 'profile/:id',
+          shared: true,
+        },
+      },
+    },
+  });
+
+  expect(createPathConfigForStaticNavigation(Stack, {})).toEqual({
+    Profile: {
+      path: 'profile/:id',
+      shared: true,
+    },
+  });
+});
+
+test("doesn't override explicit shared: false", () => {
+  const Profile = {
+    screen: TestScreen,
+    linking: {
+      path: 'profile/:id',
+      shared: false,
+    },
+  };
+
+  const HomeStack = createTestNavigator({
+    screens: {
+      Home: {
+        screen: TestScreen,
+      },
+      Profile,
+    },
+  });
+
+  const SearchStack = createTestNavigator({
+    screens: {
+      Search: {
+        screen: TestScreen,
+        linking: 'search',
+      },
+      Profile,
+    },
+  });
+
+  const Tabs = createTestNavigator({
+    screens: {
+      HomeTab: {
+        screen: HomeStack,
+      },
+      SearchTab: {
+        screen: SearchStack,
+      },
+    },
+  });
+
+  expect(createPathConfigForStaticNavigation(Tabs, {}, true)).toEqual({
+    HomeTab: {
+      screens: {
+        Home: {
+          path: '',
+        },
+        Profile: {
+          path: 'profile/:id',
+          shared: false,
+        },
+      },
+    },
+    SearchTab: {
+      screens: {
+        Profile: {
+          path: 'profile/:id',
+          shared: false,
+        },
+        Search: {
+          path: 'search',
+        },
+      },
+    },
+  });
+});
+
+test("doesn't mark screens under a parent with shared: false as shared", () => {
+  const Profile = {
+    screen: TestScreen,
+    linking: 'profile/:id',
+  };
+
+  const HomeStack = createTestNavigator({
+    screens: {
+      Profile,
+    },
+  });
+
+  const SearchStack = createTestNavigator({
+    screens: {
+      Profile,
+    },
+  });
+
+  const Tabs = createTestNavigator({
+    screens: {
+      HomeTab: {
+        screen: HomeStack,
+        linking: {
+          path: '',
+          shared: false,
+        },
+      },
+      SearchTab: {
+        screen: SearchStack,
+      },
+    },
+  });
+
+  expect(createPathConfigForStaticNavigation(Tabs, {}, true)).toEqual({
+    HomeTab: {
+      path: '',
+      shared: false,
+      screens: {
+        Profile: {
+          path: 'profile/:id',
+        },
+      },
+    },
+    SearchTab: {
+      screens: {
+        Profile: {
+          path: 'profile/:id',
+        },
+      },
+    },
+  });
+});
+
+test('preserves explicit shared option under a parent with shared: false', () => {
+  const Profile = {
+    screen: TestScreen,
+    linking: {
+      path: 'profile/:id',
+      shared: true,
+    },
+  };
+
+  const HomeStack = createTestNavigator({
+    screens: {
+      Profile,
+    },
+  });
+
+  const SearchStack = createTestNavigator({
+    screens: {
+      Profile,
+    },
+  });
+
+  const Tabs = createTestNavigator({
+    screens: {
+      HomeTab: {
+        screen: HomeStack,
+        linking: {
+          path: '',
+          shared: false,
+        },
+      },
+      SearchTab: {
+        screen: SearchStack,
+      },
+    },
+  });
+
+  expect(createPathConfigForStaticNavigation(Tabs, {}, true)).toEqual({
+    HomeTab: {
+      path: '',
+      shared: false,
+      screens: {
+        Profile: {
+          path: 'profile/:id',
+          shared: true,
+        },
+      },
+    },
+    SearchTab: {
+      screens: {
+        Profile: {
+          path: 'profile/:id',
+          shared: true,
+        },
+      },
+    },
+  });
+});
+
+test("doesn't mark different components with the same path as shared", () => {
+  const OtherScreen = () => null;
+
+  const HomeStack = createTestNavigator({
+    screens: {
+      Profile: {
+        screen: TestScreen,
+        linking: 'profile/:id',
+      },
+    },
+  });
+
+  const SearchStack = createTestNavigator({
+    screens: {
+      Profile: {
+        screen: OtherScreen,
+        linking: 'profile/:id',
+      },
+    },
+  });
+
+  const Tabs = createTestNavigator({
+    screens: {
+      HomeTab: {
+        screen: HomeStack,
+      },
+      SearchTab: {
+        screen: SearchStack,
+      },
+    },
+  });
+
+  const screens = createPathConfigForStaticNavigation(Tabs, {});
+
+  if (screens == null) {
+    throw new Error('Expected screens to be defined');
+  }
+
+  expect(() => getStateFromPath('/profile/123', { screens })).toThrow(
+    `Found conflicting screens with the same pattern. The pattern 'profile/:id' resolves to both 'SearchTab > Profile' and 'HomeTab > Profile'. Patterns must be unique and cannot resolve to more than one screen unless shared: true is specified.`
+  );
+});
+
 test('automatically generates paths if auto is specified', () => {
   const NestedA = createTestNavigator({
     screens: {

--- a/packages/core/src/__tests__/getActionFromState.test.tsx
+++ b/packages/core/src/__tests__/getActionFromState.test.tsx
@@ -1072,3 +1072,195 @@ test('gets navigate action with pop if config has nested screens at nested level
     type: 'NAVIGATE',
   });
 });
+
+test('gets navigate action for a screen after the initial screen', () => {
+  const state = {
+    routes: [
+      {
+        name: 'HomeBranch',
+        state: {
+          index: 1,
+          routes: [
+            { name: 'Home' },
+            {
+              name: 'Profile',
+              params: { id: '123' },
+              path: '/profile/123',
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  const config = {
+    initialRouteName: 'HomeBranch',
+    screens: {
+      HomeBranch: {
+        initialRouteName: 'Home',
+        screens: {
+          Home: {},
+          Profile: {},
+        },
+      },
+      SearchBranch: {
+        initialRouteName: 'Search',
+        screens: {
+          Search: {},
+          Profile: {},
+        },
+      },
+    },
+  };
+
+  expect(getActionFromState(state, config)).toEqual({
+    payload: {
+      name: 'HomeBranch',
+      params: {
+        initial: false,
+        screen: 'Profile',
+        path: '/profile/123',
+        params: { id: '123' },
+      },
+      pop: true,
+    },
+    type: 'NAVIGATE',
+  });
+});
+
+test('gets navigate action for a screen in the current top-level route', () => {
+  const state = {
+    index: 1,
+    routes: [
+      { name: 'HomeBranch' },
+      {
+        name: 'SearchBranch',
+        state: {
+          index: 1,
+          routes: [
+            { name: 'Search' },
+            {
+              name: 'Profile',
+              params: { id: '123' },
+              path: '/profile/123',
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  const config = {
+    initialRouteName: 'HomeBranch',
+    screens: {
+      HomeBranch: {
+        initialRouteName: 'Home',
+        screens: {
+          Home: {},
+          Profile: {},
+        },
+      },
+      SearchBranch: {
+        initialRouteName: 'Search',
+        screens: {
+          Search: {},
+          Profile: {},
+        },
+      },
+    },
+  };
+
+  expect(getActionFromState(state, config)).toEqual({
+    payload: {
+      name: 'SearchBranch',
+      params: {
+        initial: false,
+        screen: 'Profile',
+        path: '/profile/123',
+        params: { id: '123' },
+      },
+      pop: true,
+    },
+    type: 'NAVIGATE',
+  });
+});
+
+test('gets navigate action for a child screen in the current top-level route', () => {
+  const state = {
+    index: 1,
+    routes: [
+      { name: 'HomeBranch' },
+      {
+        name: 'SearchBranch',
+        state: {
+          index: 1,
+          routes: [
+            { name: 'Search' },
+            {
+              name: 'Post',
+              params: { id: '9' },
+              state: {
+                routes: [
+                  {
+                    name: 'Comments',
+                    params: { commentId: 'latest' },
+                    path: '/post/9/comments/latest',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  const config = {
+    initialRouteName: 'HomeBranch',
+    screens: {
+      HomeBranch: {
+        initialRouteName: 'Home',
+        screens: {
+          Home: {},
+          Post: {
+            screens: {
+              Comments: {},
+            },
+          },
+        },
+      },
+      SearchBranch: {
+        initialRouteName: 'Search',
+        screens: {
+          Search: {},
+          Post: {
+            screens: {
+              Comments: {},
+            },
+          },
+        },
+      },
+    },
+  };
+
+  expect(getActionFromState(state, config)).toEqual({
+    payload: {
+      name: 'SearchBranch',
+      params: {
+        initial: false,
+        screen: 'Post',
+        pop: true,
+        params: {
+          id: '9',
+          initial: true,
+          screen: 'Comments',
+          pop: true,
+          path: '/post/9/comments/latest',
+          params: { commentId: 'latest' },
+        },
+      },
+      pop: true,
+    },
+    type: 'NAVIGATE',
+  });
+});

--- a/packages/core/src/__tests__/getStateFromPath.test.tsx
+++ b/packages/core/src/__tests__/getStateFromPath.test.tsx
@@ -1,5 +1,5 @@
 import { expect, test } from '@jest/globals';
-import type { InitialState } from '@react-navigation/routers';
+import type { InitialState, NavigationState } from '@react-navigation/routers';
 import { produce } from 'immer';
 import * as v from 'valibot';
 import { z } from 'zod';
@@ -2532,7 +2532,7 @@ test('throws if two screens map to the same pattern', () => {
       },
     })
   ).toThrow(
-    "Found conflicting screens with the same pattern. The pattern 'bar/:id/baz' resolves to both 'Foo > Bax' and 'Foo > Bar > Baz'. Patterns must be unique and cannot resolve to more than one screen."
+    "Found conflicting screens with the same pattern. The pattern 'bar/:id/baz' resolves to both 'Foo > Bax' and 'Foo > Bar > Baz'. Patterns must be unique and cannot resolve to more than one screen unless shared: true is specified."
   );
 
   expect(() =>
@@ -2720,6 +2720,7 @@ You can only specify the following properties:
 - exact (boolean)
 - stringify (object)
 - parse (object)
+- shared (boolean)
 
 If you want to specify configuration for screens, you need to specify them under a 'screens' property.
 
@@ -4013,5 +4014,630 @@ test('throws if screen has alias but no path', () => {
     })
   ).toThrow(
     `Screen 'Foo' doesn't specify a 'path'. A 'path' needs to be specified in order to use 'alias'.`
+  );
+});
+
+test('resolves shared paths to the initial tab or current tab', () => {
+  const config = {
+    screens: {
+      Tabs: {
+        initialRouteName: 'HomeTab',
+        screens: {
+          HomeTab: {
+            initialRouteName: 'Home',
+            screens: {
+              Home: '',
+              Profile: {
+                path: 'profile/:id',
+                shared: true,
+              },
+            },
+          },
+          SearchTab: {
+            initialRouteName: 'Search',
+            screens: {
+              Search: 'search',
+              Profile: {
+                path: 'profile/:id',
+                shared: true,
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  expect(getStateFromPath<object>('/profile/123', config)).toEqual({
+    routes: [
+      {
+        name: 'Tabs',
+        state: {
+          routes: [
+            {
+              name: 'HomeTab',
+              state: {
+                index: 1,
+                routes: [
+                  { name: 'Home' },
+                  {
+                    name: 'Profile',
+                    params: { id: '123' },
+                    path: '/profile/123',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  });
+
+  const previous: NavigationState = {
+    index: 0,
+    key: 'root',
+    routeNames: ['Tabs'],
+    stale: false,
+    type: 'test',
+    routes: [
+      {
+        key: 'tabs',
+        name: 'Tabs',
+        state: {
+          index: 1,
+          key: 'tabs-state',
+          routeNames: ['HomeTab', 'SearchTab'],
+          stale: false,
+          type: 'test',
+          routes: [
+            { key: 'home-tab', name: 'HomeTab' },
+            {
+              key: 'search-tab',
+              name: 'SearchTab',
+              state: {
+                index: 0,
+                key: 'search-state',
+                routeNames: ['Search'],
+                stale: false,
+                type: 'test',
+                routes: [{ key: 'search', name: 'Search' }],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  const state = getStateFromPath<object>('/profile/123', config, previous);
+
+  expect(state).toEqual({
+    routes: [
+      {
+        name: 'Tabs',
+        state: {
+          index: 1,
+          routes: [
+            { name: 'HomeTab' },
+            {
+              name: 'SearchTab',
+              state: {
+                index: 1,
+                routes: [
+                  { name: 'Search' },
+                  {
+                    name: 'Profile',
+                    params: { id: '123' },
+                    path: '/profile/123',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  });
+
+  expect(getPathFromState<object>(state!, config)).toBe('/profile/123');
+});
+
+test('uses parse config from the selected shared screen', () => {
+  const config = {
+    screens: {
+      Tabs: {
+        initialRouteName: 'HomeTab',
+        screens: {
+          HomeTab: {
+            initialRouteName: 'Home',
+            screens: {
+              Home: '',
+              Profile: {
+                path: 'profile/:id',
+                shared: true,
+                parse: {
+                  id: (value: string) => `home:${value}`,
+                },
+              },
+            },
+          },
+          SearchTab: {
+            initialRouteName: 'Search',
+            screens: {
+              Search: 'search',
+              Profile: {
+                path: 'profile/:id',
+                shared: true,
+                parse: {
+                  id: (value: string) => `search:${value}`,
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  expect(getStateFromPath<object>('/profile/123', config)).toEqual({
+    routes: [
+      {
+        name: 'Tabs',
+        state: {
+          routes: [
+            {
+              name: 'HomeTab',
+              state: {
+                index: 1,
+                routes: [
+                  { name: 'Home' },
+                  {
+                    name: 'Profile',
+                    params: { id: 'home:123' },
+                    path: '/profile/123',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  });
+
+  const previous: NavigationState = {
+    index: 0,
+    key: 'root',
+    routeNames: ['Tabs'],
+    stale: false,
+    type: 'test',
+    routes: [
+      {
+        key: 'tabs',
+        name: 'Tabs',
+        state: {
+          index: 1,
+          key: 'tabs-state',
+          routeNames: ['HomeTab', 'SearchTab'],
+          stale: false,
+          type: 'test',
+          routes: [
+            { key: 'home-tab', name: 'HomeTab' },
+            {
+              key: 'search-tab',
+              name: 'SearchTab',
+              state: {
+                index: 0,
+                key: 'search-state',
+                routeNames: ['Search'],
+                stale: false,
+                type: 'test',
+                routes: [{ key: 'search', name: 'Search' }],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getStateFromPath<object>('/profile/123', config, previous)).toEqual({
+    routes: [
+      {
+        name: 'Tabs',
+        state: {
+          index: 1,
+          routes: [
+            { name: 'HomeTab' },
+            {
+              name: 'SearchTab',
+              state: {
+                index: 1,
+                routes: [
+                  { name: 'Search' },
+                  {
+                    name: 'Profile',
+                    params: { id: 'search:123' },
+                    path: '/profile/123',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  });
+});
+
+test("uses the initial tab for shared paths when the current tab doesn't contain the screen", () => {
+  const config = {
+    screens: {
+      Tabs: {
+        initialRouteName: 'HomeTab',
+        screens: {
+          HomeTab: {
+            initialRouteName: 'Home',
+            screens: {
+              Home: '',
+              Profile: {
+                path: 'profile/:id',
+                shared: true,
+              },
+            },
+          },
+          OtherTab: {
+            screens: {
+              Other: 'other',
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const previous: NavigationState = {
+    index: 0,
+    key: 'root',
+    routeNames: ['Tabs'],
+    stale: false,
+    type: 'test',
+    routes: [
+      {
+        key: 'tabs',
+        name: 'Tabs',
+        state: {
+          index: 0,
+          key: 'tabs-state',
+          routeNames: ['OtherTab'],
+          stale: false,
+          type: 'test',
+          routes: [
+            {
+              key: 'other-tab',
+              name: 'OtherTab',
+              state: {
+                index: 0,
+                key: 'other-state',
+                routeNames: ['Other'],
+                stale: false,
+                type: 'test',
+                routes: [{ key: 'other', name: 'Other' }],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(getStateFromPath<object>('/profile/123', config, previous)).toEqual({
+    routes: [
+      {
+        name: 'Tabs',
+        state: {
+          routes: [
+            {
+              name: 'HomeTab',
+              state: {
+                index: 1,
+                routes: [
+                  { name: 'Home' },
+                  {
+                    name: 'Profile',
+                    params: { id: '123' },
+                    path: '/profile/123',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  });
+});
+
+test('uses the first shared screen in the config when no tab is preferred', () => {
+  const config = {
+    screens: {
+      Tabs: {
+        screens: {
+          HomeTab: {
+            screens: {
+              Profile: {
+                path: 'profile/:id',
+                shared: true,
+              },
+            },
+          },
+          SearchTab: {
+            screens: {
+              Profile: {
+                path: 'profile/:id',
+                shared: true,
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  expect(getStateFromPath<object>('/profile/123', config)).toEqual({
+    routes: [
+      {
+        name: 'Tabs',
+        state: {
+          routes: [
+            {
+              name: 'HomeTab',
+              state: {
+                routes: [
+                  {
+                    name: 'Profile',
+                    params: { id: '123' },
+                    path: '/profile/123',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  });
+});
+
+test('resolves nested shared paths in the current tab', () => {
+  const config = {
+    screens: {
+      Tabs: {
+        initialRouteName: 'HomeTab',
+        screens: {
+          HomeTab: {
+            initialRouteName: 'Home',
+            screens: {
+              Home: '',
+              Post: {
+                path: 'post/:id',
+                shared: true,
+                screens: {
+                  Comments: {
+                    path: 'comments',
+                    shared: true,
+                  },
+                },
+              },
+            },
+          },
+          SearchTab: {
+            initialRouteName: 'Search',
+            screens: {
+              Search: 'search',
+              Post: {
+                path: 'post/:id',
+                shared: true,
+                screens: {
+                  Comments: {
+                    path: 'comments',
+                    shared: true,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const previous: NavigationState = {
+    index: 0,
+    key: 'root',
+    routeNames: ['Tabs'],
+    stale: false,
+    type: 'test',
+    routes: [
+      {
+        key: 'tabs',
+        name: 'Tabs',
+        state: {
+          index: 1,
+          key: 'tabs-state',
+          routeNames: ['HomeTab', 'SearchTab'],
+          stale: false,
+          type: 'test',
+          routes: [
+            { key: 'home-tab', name: 'HomeTab' },
+            {
+              key: 'search-tab',
+              name: 'SearchTab',
+              state: {
+                index: 0,
+                key: 'search-state',
+                routeNames: ['Post'],
+                stale: false,
+                type: 'test',
+                routes: [
+                  {
+                    key: 'post',
+                    name: 'Post',
+                    params: { id: '9' },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  expect(
+    getStateFromPath<object>('/post/9/comments', config, previous)
+  ).toEqual({
+    routes: [
+      {
+        name: 'Tabs',
+        state: {
+          index: 1,
+          routes: [
+            { name: 'HomeTab' },
+            {
+              name: 'SearchTab',
+              state: {
+                index: 1,
+                routes: [
+                  { name: 'Search' },
+                  {
+                    name: 'Post',
+                    params: { id: '9' },
+                    state: {
+                      routes: [
+                        {
+                          name: 'Comments',
+                          path: '/post/9/comments',
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  });
+});
+
+test('resolves shared alias paths in the current tab', () => {
+  const config = {
+    screens: {
+      Tabs: {
+        initialRouteName: 'HomeTab',
+        screens: {
+          HomeTab: {
+            screens: {
+              Profile: {
+                path: 'home-profile/:id',
+                alias: [{ path: 'u/:id', shared: true }],
+              },
+            },
+          },
+          SearchTab: {
+            screens: {
+              Profile: {
+                path: 'search-profile/:id',
+                alias: [{ path: 'u/:id', shared: true }],
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const previous: NavigationState = {
+    index: 0,
+    key: 'root',
+    routeNames: ['Tabs'],
+    stale: false,
+    type: 'test',
+    routes: [
+      {
+        key: 'tabs',
+        name: 'Tabs',
+        state: {
+          index: 0,
+          key: 'tabs-state',
+          routeNames: ['HomeTab', 'SearchTab'],
+          stale: false,
+          type: 'test',
+          routes: [{ key: 'search-tab', name: 'SearchTab' }],
+        },
+      },
+    ],
+  };
+
+  expect(getStateFromPath<object>('/u/123', config, previous)).toEqual({
+    routes: [
+      {
+        name: 'Tabs',
+        state: {
+          index: 1,
+          routes: [
+            { name: 'HomeTab' },
+            {
+              name: 'SearchTab',
+              state: {
+                routes: [
+                  {
+                    name: 'Profile',
+                    params: { id: '123' },
+                    path: '/u/123',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  });
+});
+
+test("doesn't treat alias paths as shared unless the alias is marked as shared", () => {
+  expect(() =>
+    getStateFromPath<object>('/u/123', {
+      screens: {
+        Tabs: {
+          screens: {
+            HomeTab: {
+              screens: {
+                Profile: {
+                  path: 'home-profile/:id',
+                  shared: true,
+                  alias: [{ path: 'u/:id' }],
+                },
+              },
+            },
+            SearchTab: {
+              screens: {
+                Profile: {
+                  path: 'search-profile/:id',
+                  shared: true,
+                  alias: [{ path: 'u/:id' }],
+                },
+              },
+            },
+          },
+        },
+      },
+    })
+  ).toThrow(
+    `Found conflicting screens with the same pattern. The pattern 'u/:id' resolves to both 'Tabs > HomeTab > Profile' and 'Tabs > SearchTab > Profile'. Patterns must be unique and cannot resolve to more than one screen unless shared: true is specified.`
   );
 });

--- a/packages/core/src/getPatternParts.tsx
+++ b/packages/core/src/getPatternParts.tsx
@@ -124,3 +124,11 @@ export function getPatternParts(path: string): PatternPart[] {
 
   return parts;
 }
+
+export function combinePatternParts<T extends PatternPart>(
+  parentParts: T[],
+  parts: T[],
+  exact = false
+): T[] {
+  return exact ? parts : [...parentParts, ...parts];
+}

--- a/packages/core/src/getStateFromPath.tsx
+++ b/packages/core/src/getStateFromPath.tsx
@@ -8,7 +8,11 @@ import queryString from 'query-string';
 
 import { arrayStartsWith } from './arrayStartsWith';
 import { findFocusedRoute } from './findFocusedRoute';
-import { getPatternParts, type PatternPart } from './getPatternParts';
+import {
+  combinePatternParts,
+  getPatternParts,
+  type PatternPart,
+} from './getPatternParts';
 import { isArrayEqual } from './isArrayEqual';
 import type { PathConfig, PathConfigMap } from './types';
 import type {
@@ -31,6 +35,7 @@ type ParseConfig = Record<string, ParseConfigValue | undefined>;
 
 type RouteConfig = {
   screen: string;
+  order: number;
   regex?: RegExp | undefined;
   segments: string[];
   params: { screen: string; name?: string | undefined; index: number }[];
@@ -38,6 +43,7 @@ type RouteConfig = {
   parse?: ParseConfig | undefined;
   explicitParamNames?: Set<string> | undefined;
   hasNestedScreens: boolean;
+  shared: boolean;
 };
 
 type InitialRouteConfig = {
@@ -55,10 +61,13 @@ type ParsedRoute = {
   params?: Record<string, unknown> | undefined;
 };
 
+type RoutePatternPart = PatternPart & { screen: string };
+
 type ConfigResources = {
   initialRoutes: InitialRouteConfig[];
   configs: RouteConfig[];
   configsByScreen: Record<string, RouteConfig[]>;
+  configsByPattern: Record<string, RouteConfig[]>;
 };
 
 const INVALID_SCHEMA_RESULT_ERROR =
@@ -142,12 +151,27 @@ const getValidationResult = (
  */
 export function getStateFromPath<ParamList extends {}>(
   path: string,
-  options?: Options<ParamList>
+  options?: Options<ParamList>,
+  previous?: NavigationState
 ): ResultState | undefined {
-  const { initialRoutes, configs, configsByScreen } =
+  const { initialRoutes, configs, configsByScreen, configsByPattern } =
     getConfigResources(options);
 
   const screens = options?.screens;
+
+  // When a matched config is shared, the same pattern can resolve to multiple branches
+  // pick the one that best matches the current navigation state
+  const resolveSharedConfig = (config: RouteConfig) => {
+    if (config.shared) {
+      const candidates = configsByPattern[config.segments.join('/')];
+
+      if (candidates) {
+        return selectSharedConfig(config, candidates, previous, initialRoutes);
+      }
+    }
+
+    return config;
+  };
 
   let remaining = path
     .replace(/\/+/g, '/') // Replace multiple slash (//) with single ones
@@ -203,11 +227,13 @@ export function getStateFromPath<ParamList extends {}>(
     const match = configs.find((config) => config.segments.join('/') === '');
 
     if (match) {
+      const config = resolveSharedConfig(match);
+
       return createNestedStateObject(
         path,
-        match.routeNames.map((name) => ({ name })),
+        config.routeNames.map((name) => ({ name })),
         initialRoutes,
-        match
+        config
       );
     }
 
@@ -223,7 +249,29 @@ export function getStateFromPath<ParamList extends {}>(
       continue;
     }
 
-    const state = createNestedStateObject(path, routes, initialRoutes, config);
+    let selectedConfig = resolveSharedConfig(config);
+    let selectedRoutes = routes;
+
+    if (selectedConfig !== config) {
+      const rematchedRoutes = matchAgainstConfig(
+        remaining,
+        selectedConfig,
+        configsByScreen
+      );
+
+      if (rematchedRoutes === undefined) {
+        selectedConfig = config;
+      } else {
+        selectedRoutes = rematchedRoutes;
+      }
+    }
+
+    const state = createNestedStateObject(
+      path,
+      selectedRoutes,
+      initialRoutes,
+      selectedConfig
+    );
 
     if (state !== undefined) {
       return state;
@@ -265,15 +313,18 @@ function prepareConfigResources(options?: Options<{}>) {
   checkForDuplicatedConfigs(configs);
 
   const configsByScreen: Record<string, RouteConfig[]> = {};
+  const configsByPattern: Record<string, RouteConfig[]> = {};
 
   for (const c of configs) {
     (configsByScreen[c.screen] ??= []).push(c);
+    (configsByPattern[c.segments.join('/')] ??= []).push(c);
   }
 
   return {
     initialRoutes,
     configs,
     configsByScreen,
+    configsByPattern,
   };
 }
 
@@ -301,6 +352,7 @@ function getSortedNormalizedConfigs(
         createNormalizedConfigs(key, screens, initialRoutes, [], [], [])
       )
     )
+    .map((config, order) => ({ ...config, order }))
     .sort((a, b) => {
       // Sort config from most specific to least specific:
       // - more segments
@@ -399,13 +451,13 @@ function checkForDuplicatedConfigs(configs: RouteConfig[]) {
           ? b.every((it, i) => a[i] === it)
           : a.every((it, i) => b[i] === it);
 
-      if (!intersects) {
+      if (!intersects && (!acc[pattern].shared || !config.shared)) {
         throw new Error(
           `Found conflicting screens with the same pattern. The pattern '${
             pattern
           }' resolves to both '${a.join(' > ')}' and '${b.join(
             ' > '
-          )}'. Patterns must be unique and cannot resolve to more than one screen.`
+          )}'. Patterns must be unique and cannot resolve to more than one screen unless shared: true is specified.`
         );
       }
     }
@@ -434,10 +486,14 @@ const matchAgainstConfig = (
   let validationFailed = false;
   const matchedRoutes: ParsedRoute[] = [];
 
-  for (const routeName of config.routeNames) {
-    // Check matching name AND pattern in case same screen is used at different levels in config
-    const routeConfig = configsByScreen[routeName]?.find((c) =>
-      arrayStartsWith(config.segments, c.segments)
+  for (const [index, routeName] of config.routeNames.entries()) {
+    // Check matching name, route names and pattern in case same screen is used
+    // at different levels or branches in config
+    const routeConfig = configsByScreen[routeName]?.find(
+      (c) =>
+        index === c.routeNames.length - 1 &&
+        arrayStartsWith(config.routeNames, c.routeNames) &&
+        arrayStartsWith(config.segments, c.segments)
     );
 
     let params: Record<string, unknown> | undefined;
@@ -523,7 +579,7 @@ const createNormalizedConfigs = (
   screen: string,
   routeConfig: Record<string, string | PathConfig<{}>>,
   initials: InitialRouteConfig[],
-  paths: { screen: string; path: string }[],
+  parts: RoutePatternPart[],
   parentScreens: string[],
   routeNames: string[]
 ): RouteConfig[] => {
@@ -536,22 +592,28 @@ const createNormalizedConfigs = (
   const config = routeConfig[screen];
 
   if (typeof config === 'string') {
-    paths.push({ screen, path: config });
-    configs.push(createConfigItem(screen, [...routeNames], [...paths]));
+    const configParts = combinePatternParts(
+      parts,
+      getPatternParts(config).map((part) => ({ ...part, screen }))
+    );
+
+    configs.push(createConfigItem(screen, [...routeNames], configParts));
   } else if (typeof config === 'object') {
     // if an object is specified as the value (e.g. Foo: { ... }),
     // it can have `path` property and
     // it could have `screens` prop which has nested configs
     const nestedScreens = 'screens' in config ? config.screens : undefined;
     const hasNestedScreens = !!nestedScreens;
+    const currentParts =
+      typeof config.path === 'string'
+        ? combinePatternParts(
+            parts,
+            getPatternParts(config.path).map((part) => ({ ...part, screen })),
+            config.exact
+          )
+        : parts;
 
     if (typeof config.path === 'string') {
-      if (config.exact && config.path == null) {
-        throw new Error(
-          `Screen '${screen}' doesn't specify a 'path'. A 'path' needs to be specified when specifying 'exact: true'. If you don't want this screen in the URL, specify it as empty string, e.g. \`path: ''\`.`
-        );
-      }
-
       // We should add alias configs after the main config
       // So unless they are more specific, main config will be matched first
       const aliasConfigs = [];
@@ -563,9 +625,13 @@ const createNormalizedConfigs = (
               createConfigItem(
                 screen,
                 [...routeNames],
-                [...paths, { screen, path: alias }],
+                combinePatternParts(
+                  parts,
+                  getPatternParts(alias).map((part) => ({ ...part, screen }))
+                ),
                 config.parse,
-                hasNestedScreens
+                hasNestedScreens,
+                false
               )
             );
           } else if (typeof alias === 'object') {
@@ -573,31 +639,31 @@ const createNormalizedConfigs = (
               createConfigItem(
                 screen,
                 [...routeNames],
-                alias.exact
-                  ? [{ screen, path: alias.path }]
-                  : [...paths, { screen, path: alias.path }],
+                combinePatternParts(
+                  parts,
+                  getPatternParts(alias.path).map((part) => ({
+                    ...part,
+                    screen,
+                  })),
+                  alias.exact
+                ),
                 alias.parse,
-                hasNestedScreens
+                hasNestedScreens,
+                alias.shared === true
               )
             );
           }
         }
       }
 
-      if (config.exact) {
-        // If it's an exact path, we don't need to keep track of the parent screens
-        // So we can clear it
-        paths.length = 0;
-      }
-
-      paths.push({ screen, path: config.path });
       configs.push(
         createConfigItem(
           screen,
           [...routeNames],
-          [...paths],
+          currentParts,
           config.parse,
-          hasNestedScreens
+          hasNestedScreens,
+          config.shared === true
         )
       );
 
@@ -631,7 +697,7 @@ const createNormalizedConfigs = (
           nestedConfig,
           nestedScreens as Record<string, string | PathConfig<{}>>,
           initials,
-          [...paths],
+          currentParts,
           [...parentScreens],
           routeNames
         );
@@ -649,17 +715,11 @@ const createNormalizedConfigs = (
 const createConfigItem = (
   screen: string,
   routeNames: string[],
-  paths: { screen: string; path: string }[],
+  parts: RoutePatternPart[],
   parse?: ParseConfig,
-  hasNestedScreens = false
+  hasNestedScreens = false,
+  shared = false
 ): RouteConfig => {
-  const parts: (PatternPart & { screen: string })[] = [];
-
-  // Parse the path string into parts for easier matching
-  for (const { screen, path } of paths) {
-    parts.push(...getPatternParts(path).map((part) => ({ ...part, screen })));
-  }
-
   const regex = parts.length
     ? new RegExp(
         `^(${parts
@@ -691,6 +751,7 @@ const createConfigItem = (
 
   return {
     screen,
+    order: 0,
     regex,
     segments,
     params,
@@ -698,7 +759,83 @@ const createConfigItem = (
     parse,
     explicitParamNames: getExplicitParamNames(parse),
     hasNestedScreens,
+    shared,
   };
+};
+
+const selectSharedConfig = (
+  match: RouteConfig,
+  candidates: RouteConfig[],
+  previous: NavigationState | PartialState<NavigationState> | undefined,
+  initialRoutes: InitialRouteConfig[]
+) => {
+  // Walk the previous state down to the focused leaf to get the active route path
+  const focusedRouteNames: string[] = [];
+
+  let current = previous;
+
+  while (current?.routes.length) {
+    const index =
+      typeof current.index === 'number'
+        ? current.index
+        : current.routes.length - 1;
+
+    const route = current.routes[index];
+
+    focusedRouteNames.push(route.name);
+    current = route.state;
+  }
+
+  // Rank a candidate by how far it aligns with the focused path, then by
+  // how many of its levels match a configured initial route
+  const score = (routeNames: string[]) => {
+    let focused = 0;
+
+    while (
+      routeNames[focused] !== undefined &&
+      routeNames[focused] === focusedRouteNames[focused]
+    ) {
+      focused++;
+    }
+
+    let initial = 0;
+
+    for (const config of initialRoutes) {
+      if (
+        arrayStartsWith(routeNames, config.parentScreens) &&
+        routeNames[config.parentScreens.length] === config.initialRouteName
+      ) {
+        initial++;
+      }
+    }
+
+    return { focused, initial };
+  };
+
+  let selected = match;
+  let best = { focused: -1, initial: -1 };
+
+  for (const candidate of candidates) {
+    if (!candidate.shared) {
+      continue;
+    }
+
+    const { focused, initial } = score(candidate.routeNames);
+
+    const better =
+      focused !== best.focused
+        ? focused > best.focused
+        : initial !== best.initial
+          ? initial > best.initial
+          : candidate.order < selected.order;
+
+    if (better) {
+      selected = candidate;
+      best = { focused, initial };
+    }
+  }
+
+  return selected;
 };
 
 // Try to find an initial route connected with the one passed

--- a/packages/core/src/types.tsx
+++ b/packages/core/src/types.tsx
@@ -1357,6 +1357,17 @@ type PathConfigAlias<Params> = {
    * ```
    */
   parse?: ParseConfig<Params> | undefined;
+  /**
+   * Whether this path can resolve to multiple routes.
+   * Both routes should specify `shared: true` for this to work.
+   * By default, a path can only resolve to one route.
+   *
+   * This is useful when same screen used in multiple navigators,
+   * e.g. tabs with stacks containing profile screen in each stack.
+   *
+   * The path defined first will be the canonical path.
+   */
+  shared?: boolean | undefined;
 };
 
 export type PathConfig<Params> = FlatType<

--- a/packages/core/src/validatePathConfig.tsx
+++ b/packages/core/src/validatePathConfig.tsx
@@ -15,6 +15,7 @@ export function validatePathConfig(config: unknown, root = true) {
           exact: 'boolean',
           stringify: 'object',
           parse: 'object',
+          shared: 'boolean',
         }),
   };
 

--- a/packages/native/src/__tests__/useLinkBuilder.test.tsx
+++ b/packages/native/src/__tests__/useLinkBuilder.test.tsx
@@ -1,9 +1,14 @@
 import { expect, test } from '@jest/globals';
-import { NavigationRouteContext } from '@react-navigation/core';
-import { render } from '@testing-library/react-native';
+import {
+  createNavigationContainerRef,
+  NavigationRouteContext,
+  type NavigatorScreenParams,
+} from '@react-navigation/core';
+import { act, render } from '@testing-library/react-native';
 
 import { createStackNavigator } from '../__stubs__/createStackNavigator';
 import { NavigationContainer } from '../NavigationContainer';
+import type { LinkingOptions } from '../types';
 import { useLinkBuilder } from '../useLinkBuilder';
 
 const config = {
@@ -463,6 +468,136 @@ test('throws for invalid hrefs', () => {
       <Root />
     </NavigationContainer>
   );
+});
+
+test('builds action for shared path in the current tab', async () => {
+  type HomeStackParamList = {
+    Home: undefined;
+    Profile: { id: string };
+  };
+
+  type SearchStackParamList = {
+    Search: undefined;
+    Profile: { id: string };
+  };
+
+  type RootStackParamList = {
+    HomeBranch: NavigatorScreenParams<HomeStackParamList>;
+    SearchBranch: NavigatorScreenParams<SearchStackParamList>;
+  };
+
+  const linking: LinkingOptions<RootStackParamList> = {
+    config: {
+      screens: {
+        HomeBranch: {
+          initialRouteName: 'Home',
+          screens: {
+            Home: '',
+            Profile: {
+              path: 'profile/:id',
+              shared: true,
+            },
+          },
+        },
+        SearchBranch: {
+          initialRouteName: 'Search',
+          screens: {
+            Search: 'search',
+            Profile: {
+              path: 'profile/:id',
+              shared: true,
+            },
+          },
+        },
+      },
+    },
+    getInitialURL() {
+      return null;
+    },
+  };
+
+  let buildAction: ReturnType<typeof useLinkBuilder>['buildAction'] | undefined;
+
+  const Test = () => {
+    buildAction = useLinkBuilder().buildAction;
+    return null;
+  };
+
+  const RootStack = createStackNavigator<RootStackParamList>();
+  const HomeStack = createStackNavigator<HomeStackParamList>();
+  const SearchStack = createStackNavigator<SearchStackParamList>();
+
+  const navigation = createNavigationContainerRef<RootStackParamList>();
+
+  render(
+    <NavigationContainer
+      ref={navigation}
+      linking={linking}
+      initialState={{
+        routes: [
+          {
+            name: 'SearchBranch',
+            state: {
+              routes: [{ name: 'Search' }],
+            },
+          },
+        ],
+      }}
+    >
+      <RootStack.Navigator>
+        <RootStack.Screen name="HomeBranch">
+          {() => (
+            <HomeStack.Navigator>
+              <HomeStack.Screen name="Home">{() => null}</HomeStack.Screen>
+              <HomeStack.Screen name="Profile">{() => null}</HomeStack.Screen>
+            </HomeStack.Navigator>
+          )}
+        </RootStack.Screen>
+        <RootStack.Screen name="SearchBranch">
+          {() => (
+            <SearchStack.Navigator>
+              <SearchStack.Screen name="Search" component={Test} />
+              <SearchStack.Screen name="Profile">
+                {() => null}
+              </SearchStack.Screen>
+            </SearchStack.Navigator>
+          )}
+        </RootStack.Screen>
+      </RootStack.Navigator>
+    </NavigationContainer>
+  );
+
+  expect(buildAction?.('/profile/123')).toEqual({
+    type: 'NAVIGATE',
+    payload: {
+      name: 'SearchBranch',
+      params: {
+        initial: false,
+        screen: 'Profile',
+        params: { id: '123' },
+        path: '/profile/123',
+      },
+      pop: true,
+    },
+  });
+
+  act(() => {
+    navigation.navigate('HomeBranch', { screen: 'Home' });
+  });
+
+  expect(buildAction?.('/profile/123')).toEqual({
+    type: 'NAVIGATE',
+    payload: {
+      name: 'HomeBranch',
+      params: {
+        initial: false,
+        screen: 'Profile',
+        params: { id: '123' },
+        path: '/profile/123',
+      },
+      pop: true,
+    },
+  });
 });
 
 test('throws if no prefixes are defined', () => {

--- a/packages/native/src/getStateFromHref.tsx
+++ b/packages/native/src/getStateFromHref.tsx
@@ -1,11 +1,16 @@
-import { getStateFromPath, type ParamListBase } from '@react-navigation/core';
+import {
+  getStateFromPath,
+  type NavigationState,
+  type ParamListBase,
+} from '@react-navigation/core';
 
 import { extractPathFromURL } from './extractPathFromURL';
 import type { LinkingOptions } from './types';
 
 export function getStateFromHref(
   href: string,
-  options: LinkingOptions<ParamListBase> | undefined
+  options: LinkingOptions<ParamListBase> | undefined,
+  previous: NavigationState | undefined
 ): ReturnType<typeof getStateFromPath> {
   const {
     prefixes,
@@ -40,7 +45,7 @@ export function getStateFromHref(
     );
   }
 
-  const state = getStateFromPathHelper(path, config);
+  const state = getStateFromPathHelper(path, config, previous);
 
   return state;
 }

--- a/packages/native/src/useLinkBuilder.tsx
+++ b/packages/native/src/useLinkBuilder.tsx
@@ -3,6 +3,7 @@ import {
   findFocusedRoute,
   getActionFromState,
   getPathFromState,
+  NavigationContainerRefContext,
   NavigationHelpersContext,
   NavigationRouteContext,
   useStateForPath,
@@ -109,6 +110,7 @@ export function useBuildHref() {
  * Helper to build a navigation action from a href based on the linking options.
  */
 export function useBuildAction() {
+  const navigation = React.use(NavigationContainerRefContext);
   const { options } = React.use(LinkingContext);
 
   const getActionFromStateHelper =
@@ -116,7 +118,7 @@ export function useBuildAction() {
 
   const buildAction = React.useCallback(
     (href: string) => {
-      const state = getStateFromHref(href, options);
+      const state = getStateFromHref(href, options, navigation?.getRootState());
 
       if (state) {
         const action = getActionFromStateHelper(state, options?.config);
@@ -128,7 +130,7 @@ export function useBuildAction() {
         );
       }
     },
-    [options, getActionFromStateHelper]
+    [navigation, options, getActionFromStateHelper]
   );
 
   return buildAction;

--- a/packages/native/src/useLinking.native.tsx
+++ b/packages/native/src/useLinking.native.tsx
@@ -2,6 +2,7 @@ import {
   getActionFromState as getActionFromStateDefault,
   getStateFromPath as getStateFromPathDefault,
   type NavigationContainerRef,
+  type NavigationState,
   type ParamListBase,
   useNavigationIndependentTree,
 } from '@react-navigation/core';
@@ -115,18 +116,22 @@ export function useLinking<ParamList extends ParamListBase>(
   });
 
   const getStateFromURL = React.useCallback(
-    (url: string | null | undefined) => {
+    (url: string | null | undefined, previous: NavigationState | undefined) => {
       if (!url) {
         return undefined;
       }
 
       try {
-        return getStateFromHref(url, {
-          prefixes: prefixesRef.current,
-          filter: filterRef.current,
-          config: configRef.current,
-          getStateFromPath: getStateFromPathRef.current,
-        });
+        return getStateFromHref(
+          url,
+          {
+            prefixes: prefixesRef.current,
+            filter: filterRef.current,
+            config: configRef.current,
+            getStateFromPath: getStateFromPathRef.current,
+          },
+          previous
+        );
       } catch (e) {
         return undefined;
       }
@@ -143,14 +148,14 @@ export function useLinking<ParamList extends ParamListBase>(
       if (url != null) {
         if (typeof url !== 'string') {
           return url.then((url) => {
-            const state = getStateFromURL(url);
+            const state = getStateFromURL(url, undefined);
 
             return state;
           });
         }
       }
 
-      state = getStateFromURL(url);
+      state = getStateFromURL(url, undefined);
     }
 
     const thenable: Thenable<ResultState | undefined> = {
@@ -169,7 +174,9 @@ export function useLinking<ParamList extends ParamListBase>(
       }
 
       const navigation = ref.current;
-      const state = navigation ? getStateFromURL(url) : undefined;
+      const state = navigation
+        ? getStateFromURL(url, navigation.getRootState())
+        : undefined;
 
       if (navigation) {
         REACT_NAVIGATION_DEVTOOLS.get(navigation)?.listeners.forEach(

--- a/packages/native/src/useLinking.tsx
+++ b/packages/native/src/useLinking.tsx
@@ -302,7 +302,11 @@ export function useLinking<ParamList extends ParamListBase>(
       let state: ResultState | undefined;
 
       try {
-        state = getStateFromPathRef.current(path, configRef.current);
+        state = getStateFromPathRef.current(
+          path,
+          configRef.current,
+          navigation.getRootState()
+        );
       } catch (e) {
         console.error(e);
 


### PR DESCRIPTION
This adds support for shared URLs with a `shared` property.

For static config, this is automatic - if the same screen (compared by reference) appears in multiple navigators with the same path pattern, it'll be marked as shared automatically.

So the screen keeps one URL, even when it lives in different navigators.

This is useful when the same screen is used in multiple navigators, e.g., tabs with stacks containing a profile screen in each stack.


https://github.com/user-attachments/assets/64c3b280-e6db-4966-ab6f-437441b91d91

