### PR TITLE
fix: flash while switching native bottom tabs

### DIFF
--- a/packages/bottom-tabs/src/views/BottomTabViewNativeImpl.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabViewNativeImpl.tsx
@@ -439,6 +439,7 @@ export function BottomTabViewNative({
         onTabSelectionRejected={onTabSelectionRejected}
         onTabSelectionPrevented={onTabSelectionPrevented}
         tabBarHidden={hasCustomTabBar || shouldHideTabBar}
+        nativeContainerStyle={{ backgroundColor }}
         colorScheme={dark ? 'dark' : 'light'}
         ios={{
           bottomAccessory: bottomAccessory


### PR DESCRIPTION
**Motivation**

Currently nativeContainerStyle is not passed to react-native-screens and therefore a system default background color is set on UITabBarController.
This causes flashes when not using a standard white or dark background.

Fixes #13132

**Test plan**

Set the background color of the navigation theme to blue or red. Switch between native tabs. Notice no flash anymore.
