### PR TITLE
refactor: rework SFSymbol component

### DIFF
--- a/example/src/Screens/ComponentsSFSymbols.tsx
+++ b/example/src/Screens/ComponentsSFSymbols.tsx
@@ -1,4 +1,5 @@
 import { Text } from '@react-navigation/elements';
+import { Color } from '@react-navigation/elements/internal';
 import {
   SFSymbol,
   type SFSymbolProps,
@@ -7,19 +8,64 @@ import {
   useTheme,
 } from '@react-navigation/native';
 import * as React from 'react';
-import { FlatList, Platform, Pressable, StyleSheet, View } from 'react-native';
+import {
+  FlatList,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  View,
+} from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { SF_SYMBOL_NAMES } from '../sf-symbol-names';
-import { SegmentedPicker } from '../Shared/SegmentedPicker';
 
 type SFSymbolWeight = NonNullable<SFSymbolProps['weight']>;
 type SFSymbolScale = NonNullable<SFSymbolProps['scale']>;
-type SFSymbolMode = NonNullable<SFSymbolProps['mode']>;
-type SFSymbolAnimationEffect = Extract<
-  NonNullable<SFSymbolProps['animation']>,
+type SFSymbolRenderingMode = NonNullable<SFSymbolProps['renderingMode']>;
+type SFSymbolEffectName = Extract<NonNullable<SFSymbolProps['effect']>, string>;
+type SFSymbolEffect = SFSymbolProps['effect'];
+type SFSymbolEffectConfig = Exclude<NonNullable<SFSymbolEffect>, string>;
+type SFSymbolEffectRepeat = SFSymbolEffectConfig['repeat'];
+type SFSymbolContentTransition = SFSymbolProps['contentTransition'];
+type SFSymbolVariableValueMode = NonNullable<
+  SFSymbolProps['variableValueMode']
+>;
+type SFSymbolColorRenderingMode = NonNullable<
+  SFSymbolProps['colorRenderingMode']
+>;
+type SFSymbolVariableValue = 0 | 0.25 | 0.5 | 0.75 | 1;
+type SFSymbolEffectRepeatMode =
+  | 'default'
+  | 'continuous'
+  | 'nonRepeating'
+  | 'periodic';
+type SFSymbolEffectScope = 'byLayer' | 'wholeSymbol' | 'individually';
+type SFSymbolEffectDirection =
+  | 'none'
+  | 'up'
+  | 'down'
+  | 'left'
+  | 'right'
+  | 'forward'
+  | 'backward'
+  | 'clockwise'
+  | 'counterClockwise';
+type SFSymbolEffectSpeed = 0.5 | 1 | 2;
+type SFSymbolBreatheVariant = 'plain' | 'pulse';
+type SFSymbolInactiveLayers = 'none' | 'hide' | 'dim';
+type SFSymbolDrawDirection = 'default' | 'reversed' | 'nonReversed';
+type SFSymbolContentTransitionName = Extract<
+  NonNullable<SFSymbolContentTransition>,
   string
 >;
+type SFSymbolContentTransitionVariant = 'downUp' | 'upUp' | 'offUp';
+type SFSymbolContentTransitionScope = 'byLayer' | 'wholeSymbol';
+
+type Choice<T extends string | number | boolean> = {
+  label: string;
+  value: T;
+};
 
 const COLUMN_COUNT = 4;
 const ICON_SIZE = 32;
@@ -30,33 +76,171 @@ const ROW_HEIGHT =
   ICON_SIZE +
   (ICON_PADDING_VERTICAL + ICON_NAME_MARGIN_TOP + ICON_NAME_FONT_SIZE) * 2;
 
-const WEIGHTS: { label: string; value: SFSymbolWeight }[] = [
+const WEIGHTS: Choice<SFSymbolWeight>[] = [
   { label: 'Thin', value: 'thin' },
   { label: 'Light', value: 'light' },
   { label: 'Regular', value: 'regular' },
   { label: 'Bold', value: 'bold' },
 ];
 
-const SCALES: { label: string; value: SFSymbolScale }[] = [
+const SCALES: Choice<SFSymbolScale>[] = [
   { label: 'Small', value: 'small' },
   { label: 'Medium', value: 'medium' },
   { label: 'Large', value: 'large' },
 ];
 
-const MODES: { label: string; value: SFSymbolMode }[] = [
+const MODES: Choice<SFSymbolRenderingMode>[] = [
   { label: 'Mono', value: 'monochrome' },
   { label: 'Hierarchy', value: 'hierarchical' },
   { label: 'Palette', value: 'palette' },
   { label: 'Multi', value: 'multicolor' },
 ];
 
-const ANIMATIONS: { label: string; value: SFSymbolAnimationEffect | 'none' }[] =
+const VARIABLE_VALUES: Choice<SFSymbolVariableValue>[] = [
+  { label: '0', value: 0 },
+  { label: '.25', value: 0.25 },
+  { label: '.5', value: 0.5 },
+  { label: '.75', value: 0.75 },
+  { label: '1', value: 1 },
+];
+
+const VARIABLE_VALUE_MODES: Choice<SFSymbolVariableValueMode>[] = [
+  { label: 'Auto', value: 'automatic' },
+  { label: 'Color', value: 'color' },
+  { label: 'Draw', value: 'draw' },
+];
+
+const COLOR_RENDERING_MODES: Choice<SFSymbolColorRenderingMode>[] = [
+  { label: 'Auto', value: 'automatic' },
+  { label: 'Flat', value: 'flat' },
+  { label: 'Gradient', value: 'gradient' },
+];
+
+const EFFECTS: Choice<SFSymbolEffectName | 'none'>[] = [
+  { label: 'None', value: 'none' },
+  { label: 'Bounce', value: 'bounce' },
+  { label: 'Pulse', value: 'pulse' },
+  { label: 'Appear', value: 'appear' },
+  { label: 'Disappear', value: 'disappear' },
+  { label: 'Variable', value: 'variableColor' },
+  { label: 'Scale', value: 'scale' },
+  { label: 'Breathe', value: 'breathe' },
+  { label: 'Wiggle', value: 'wiggle' },
+  { label: 'Rotate', value: 'rotate' },
+  { label: 'Draw on', value: 'drawOn' },
+  { label: 'Draw off', value: 'drawOff' },
+];
+
+const EFFECT_REPEATS: Choice<SFSymbolEffectRepeatMode>[] = [
+  { label: 'Default', value: 'default' },
+  { label: 'Continuous', value: 'continuous' },
+  { label: 'Once', value: 'nonRepeating' },
+  { label: 'Periodic', value: 'periodic' },
+];
+
+const EFFECT_SCOPES: Choice<SFSymbolEffectScope>[] = [
+  { label: 'Layers', value: 'byLayer' },
+  { label: 'Whole', value: 'wholeSymbol' },
+  { label: 'Each', value: 'individually' },
+];
+
+const EFFECT_DIRECTIONS: Choice<SFSymbolEffectDirection>[] = [
+  { label: 'None', value: 'none' },
+  { label: 'Up', value: 'up' },
+  { label: 'Down', value: 'down' },
+  { label: 'Left', value: 'left' },
+  { label: 'Right', value: 'right' },
+  { label: 'Forward', value: 'forward' },
+  { label: 'Back', value: 'backward' },
+  { label: 'CW', value: 'clockwise' },
+  { label: 'CCW', value: 'counterClockwise' },
+];
+
+const EFFECT_SPEEDS: Choice<SFSymbolEffectSpeed>[] = [
+  { label: '.5x', value: 0.5 },
+  { label: '1x', value: 1 },
+  { label: '2x', value: 2 },
+];
+
+const BREATHE_VARIANTS: Choice<SFSymbolBreatheVariant>[] = [
+  { label: 'Plain', value: 'plain' },
+  { label: 'Pulse', value: 'pulse' },
+];
+
+const INACTIVE_LAYERS: Choice<SFSymbolInactiveLayers>[] = [
+  { label: 'Default', value: 'none' },
+  { label: 'Hide', value: 'hide' },
+  { label: 'Dim', value: 'dim' },
+];
+
+const DRAW_DIRECTIONS: Choice<SFSymbolDrawDirection>[] = [
+  { label: 'Default', value: 'default' },
+  { label: 'Forward', value: 'nonReversed' },
+  { label: 'Reverse', value: 'reversed' },
+];
+
+const CONTENT_TRANSITIONS: Choice<SFSymbolContentTransitionName | 'none'>[] = [
+  { label: 'None', value: 'none' },
+  { label: 'Auto', value: 'automatic' },
+  { label: 'Replace', value: 'replace' },
+];
+
+const CONTENT_TRANSITION_VARIANTS: Choice<SFSymbolContentTransitionVariant>[] =
   [
-    { label: 'None', value: 'none' },
-    { label: 'Bounce', value: 'bounce' },
-    { label: 'Pulse', value: 'pulse' },
-    { label: 'Wiggle', value: 'wiggle' },
+    { label: 'Down/up', value: 'downUp' },
+    { label: 'Up/up', value: 'upUp' },
+    { label: 'Off/up', value: 'offUp' },
   ];
+
+const CONTENT_TRANSITION_SCOPES: Choice<SFSymbolContentTransitionScope>[] = [
+  { label: 'Layers', value: 'byLayer' },
+  { label: 'Whole', value: 'wholeSymbol' },
+];
+
+const MAGIC_MODES: Choice<boolean>[] = [
+  { label: 'Replace', value: false },
+  { label: 'Magic', value: true },
+];
+
+const PREVIEW_SYMBOLS: [SFSymbolProps['name'], ...SFSymbolProps['name'][]] = [
+  'bell',
+  'bell.badge',
+  'wifi',
+  'wifi.slash',
+  'heart',
+  'heart.fill',
+];
+
+function getEffectRepeat(mode: SFSymbolEffectRepeatMode): SFSymbolEffectRepeat {
+  switch (mode) {
+    case 'continuous':
+      return 'continuous';
+    case 'nonRepeating':
+      return 'nonRepeating';
+    case 'periodic':
+      return { count: 3, delay: 0.5 };
+    default:
+      return undefined;
+  }
+}
+
+function getVerticalDirection(direction: SFSymbolEffectDirection) {
+  return direction === 'up' || direction === 'down' ? direction : undefined;
+}
+
+function getRotateDirection(direction: SFSymbolEffectDirection) {
+  return direction === 'clockwise' || direction === 'counterClockwise'
+    ? direction
+    : undefined;
+}
+
+function getWiggleDirection(direction: SFSymbolEffectDirection) {
+  return direction === 'none' ? undefined : direction;
+}
+
+function getPreviewSymbol(index: number) {
+  return PREVIEW_SYMBOLS[index % PREVIEW_SYMBOLS.length] ?? PREVIEW_SYMBOLS[0];
+}
 
 export function ComponentsSFSymbols(_: StaticScreenProps<{}>) {
   const navigation = useNavigation('ComponentsSFSymbols');
@@ -66,10 +250,40 @@ export function ComponentsSFSymbols(_: StaticScreenProps<{}>) {
   const [query, setQuery] = React.useState('');
   const [weight, setWeight] = React.useState<SFSymbolWeight>('regular');
   const [scale, setScale] = React.useState<SFSymbolScale>('medium');
-  const [mode, setMode] = React.useState<SFSymbolMode>('monochrome');
-  const [animation, setAnimation] = React.useState<
-    SFSymbolAnimationEffect | 'none'
+  const [renderingMode, setRenderingMode] =
+    React.useState<SFSymbolRenderingMode>('monochrome');
+  const [variableValue, setVariableValue] =
+    React.useState<SFSymbolVariableValue>(0.5);
+  const [variableValueMode, setVariableValueMode] =
+    React.useState<SFSymbolVariableValueMode>('automatic');
+  const [colorRenderingMode, setColorRenderingMode] =
+    React.useState<SFSymbolColorRenderingMode>('automatic');
+  const [effect, setEffect] = React.useState<SFSymbolEffectName | 'none'>(
+    'none'
+  );
+  const [effectRepeat, setEffectRepeat] =
+    React.useState<SFSymbolEffectRepeatMode>('default');
+  const [effectScope, setEffectScope] =
+    React.useState<SFSymbolEffectScope>('byLayer');
+  const [effectDirection, setEffectDirection] =
+    React.useState<SFSymbolEffectDirection>('none');
+  const [effectSpeed, setEffectSpeed] = React.useState<SFSymbolEffectSpeed>(1);
+  const [breatheVariant, setBreatheVariant] =
+    React.useState<SFSymbolBreatheVariant>('plain');
+  const [inactiveLayers, setInactiveLayers] =
+    React.useState<SFSymbolInactiveLayers>('none');
+  const [drawDirection, setDrawDirection] =
+    React.useState<SFSymbolDrawDirection>('default');
+  const [contentTransition, setContentTransition] = React.useState<
+    SFSymbolContentTransitionName | 'none'
   >('none');
+  const [contentTransitionVariant, setContentTransitionVariant] =
+    React.useState<SFSymbolContentTransitionVariant>('downUp');
+  const [contentTransitionScope, setContentTransitionScope] =
+    React.useState<SFSymbolContentTransitionScope>('byLayer');
+  const [contentTransitionMagic, setContentTransitionMagic] =
+    React.useState(false);
+  const [previewIndex, setPreviewIndex] = React.useState(0);
   const [expanded, setExpanded] = React.useState(false);
 
   React.useEffect(() => {
@@ -86,10 +300,9 @@ export function ComponentsSFSymbols(_: StaticScreenProps<{}>) {
   }, [navigation]);
 
   const rows = React.useMemo(() => {
-    const icons = query.trim()
-      ? SF_SYMBOL_NAMES.filter((name) =>
-          name.toLowerCase().includes(query.toLowerCase())
-        )
+    const search = query.trim().toLowerCase();
+    const icons = search
+      ? SF_SYMBOL_NAMES.filter((name) => name.toLowerCase().includes(search))
       : SF_SYMBOL_NAMES;
 
     // FlatList has performance issues with `numColumns`
@@ -103,14 +316,137 @@ export function ComponentsSFSymbols(_: StaticScreenProps<{}>) {
     return result;
   }, [query]);
 
-  const symbolColors =
-    mode === 'palette'
-      ? {
-          primary: colors.primary,
-          secondary: colors.notification,
-          tertiary: colors.text,
-        }
-      : undefined;
+  const symbolColors = React.useMemo(
+    () =>
+      renderingMode === 'palette' || renderingMode === 'hierarchical'
+        ? {
+            primary: colors.primary,
+            secondary: colors.notification,
+            tertiary: colors.text,
+          }
+        : undefined,
+    [renderingMode, colors.primary, colors.notification, colors.text]
+  );
+
+  const selectedEffect = React.useMemo<SFSymbolEffect>(() => {
+    if (effect === 'none') {
+      return undefined;
+    }
+
+    const repeat = getEffectRepeat(effectRepeat);
+    const scopedScope = effectScope === 'wholeSymbol' ? effectScope : 'byLayer';
+    const base = {
+      speed: effectSpeed,
+      repeat,
+    };
+
+    switch (effect) {
+      case 'bounce':
+      case 'appear':
+      case 'disappear':
+      case 'scale':
+        return {
+          ...base,
+          type: effect,
+          scope: scopedScope,
+          direction: getVerticalDirection(effectDirection),
+        };
+
+      case 'pulse':
+        return {
+          ...base,
+          type: 'pulse',
+          scope: scopedScope,
+        };
+
+      case 'breathe':
+        return {
+          ...base,
+          type: 'breathe',
+          scope: scopedScope,
+          variant: breatheVariant,
+        };
+
+      case 'wiggle':
+        return {
+          ...base,
+          type: 'wiggle',
+          scope: scopedScope,
+          direction: getWiggleDirection(effectDirection),
+        };
+
+      case 'rotate':
+        return {
+          ...base,
+          type: 'rotate',
+          scope: scopedScope,
+          direction: getRotateDirection(effectDirection),
+        };
+
+      case 'drawOn':
+        return {
+          ...base,
+          type: 'drawOn',
+          scope: effectScope,
+        };
+
+      case 'drawOff':
+        return {
+          ...base,
+          type: 'drawOff',
+          scope: effectScope,
+          drawDirection:
+            drawDirection === 'default' ? undefined : drawDirection,
+        };
+
+      case 'variableColor':
+        return {
+          ...base,
+          type: 'variableColor',
+          cumulative: true,
+          inactiveLayers:
+            inactiveLayers === 'none' ? undefined : inactiveLayers,
+        };
+    }
+  }, [
+    breatheVariant,
+    drawDirection,
+    effect,
+    effectDirection,
+    effectRepeat,
+    effectScope,
+    effectSpeed,
+    inactiveLayers,
+  ]);
+
+  const selectedContentTransition =
+    React.useMemo<SFSymbolContentTransition>(() => {
+      switch (contentTransition) {
+        case 'automatic':
+          return {
+            type: 'automatic',
+            speed: effectSpeed,
+          };
+
+        case 'replace':
+          return {
+            type: 'replace',
+            speed: effectSpeed,
+            variant: contentTransitionVariant,
+            scope: contentTransitionScope,
+            magic: contentTransitionMagic,
+          };
+
+        default:
+          return undefined;
+      }
+    }, [
+      contentTransition,
+      contentTransitionMagic,
+      contentTransitionScope,
+      contentTransitionVariant,
+      effectSpeed,
+    ]);
 
   if (Platform.OS !== 'ios') {
     return (
@@ -127,15 +463,7 @@ export function ComponentsSFSymbols(_: StaticScreenProps<{}>) {
       data={rows}
       stickyHeaderIndices={[0]}
       ListHeaderComponent={
-        <View
-          style={[
-            styles.header,
-            {
-              backgroundColor: colors.background,
-              borderBottomColor: colors.border,
-            },
-          ]}
-        >
+        <View style={{ backgroundColor: colors.card }}>
           <Pressable
             onPress={() => setExpanded((v) => !v)}
             style={styles.headerToggle}
@@ -149,28 +477,153 @@ export function ComponentsSFSymbols(_: StaticScreenProps<{}>) {
           </Pressable>
           {expanded && (
             <View style={styles.pickerColumn}>
-              <SegmentedPicker
-                choices={WEIGHTS}
-                value={weight}
-                onValueChange={setWeight}
-              />
-              <SegmentedPicker
-                choices={SCALES}
-                value={scale}
-                onValueChange={setScale}
-              />
-              <SegmentedPicker
-                choices={MODES}
-                value={mode}
-                onValueChange={setMode}
-              />
-              <SegmentedPicker
-                choices={ANIMATIONS}
-                value={animation}
-                onValueChange={setAnimation}
-              />
+              <Section title="Appearance">
+                <ControlGroup
+                  label="Weight"
+                  choices={WEIGHTS}
+                  value={weight}
+                  onValueChange={setWeight}
+                />
+                <ControlGroup
+                  label="Scale"
+                  choices={SCALES}
+                  value={scale}
+                  onValueChange={setScale}
+                />
+                <ControlGroup
+                  label="Rendering"
+                  choices={MODES}
+                  value={renderingMode}
+                  onValueChange={setRenderingMode}
+                />
+                <ControlGroup
+                  label="Color"
+                  choices={COLOR_RENDERING_MODES}
+                  value={colorRenderingMode}
+                  onValueChange={setColorRenderingMode}
+                />
+                <ControlGroup
+                  label="Variable value"
+                  choices={VARIABLE_VALUES}
+                  value={variableValue}
+                  onValueChange={setVariableValue}
+                />
+                <ControlGroup
+                  label="Variable mode"
+                  choices={VARIABLE_VALUE_MODES}
+                  value={variableValueMode}
+                  onValueChange={setVariableValueMode}
+                />
+              </Section>
+              <Section title="Effect">
+                <ControlGroup
+                  label="Type"
+                  choices={EFFECTS}
+                  value={effect}
+                  onValueChange={setEffect}
+                />
+                {effect !== 'none' && (
+                  <>
+                    <ControlGroup
+                      label="Repeat"
+                      choices={EFFECT_REPEATS}
+                      value={effectRepeat}
+                      onValueChange={setEffectRepeat}
+                    />
+                    <ControlGroup
+                      label="Scope"
+                      choices={EFFECT_SCOPES}
+                      value={effectScope}
+                      onValueChange={setEffectScope}
+                    />
+                    <ControlGroup
+                      label="Direction"
+                      choices={EFFECT_DIRECTIONS}
+                      value={effectDirection}
+                      onValueChange={setEffectDirection}
+                    />
+                    <ControlGroup
+                      label="Speed"
+                      choices={EFFECT_SPEEDS}
+                      value={effectSpeed}
+                      onValueChange={setEffectSpeed}
+                    />
+                    {effect === 'breathe' && (
+                      <ControlGroup
+                        label="Variant"
+                        choices={BREATHE_VARIANTS}
+                        value={breatheVariant}
+                        onValueChange={setBreatheVariant}
+                      />
+                    )}
+                    {effect === 'variableColor' && (
+                      <ControlGroup
+                        label="Inactive layers"
+                        choices={INACTIVE_LAYERS}
+                        value={inactiveLayers}
+                        onValueChange={setInactiveLayers}
+                      />
+                    )}
+                    {effect === 'drawOff' && (
+                      <ControlGroup
+                        label="Draw direction"
+                        choices={DRAW_DIRECTIONS}
+                        value={drawDirection}
+                        onValueChange={setDrawDirection}
+                      />
+                    )}
+                  </>
+                )}
+              </Section>
+              <Section title="Transition">
+                <ControlGroup
+                  label="Type"
+                  choices={CONTENT_TRANSITIONS}
+                  value={contentTransition}
+                  onValueChange={setContentTransition}
+                />
+                {contentTransition === 'replace' && (
+                  <>
+                    <ControlGroup
+                      label="Variant"
+                      choices={CONTENT_TRANSITION_VARIANTS}
+                      value={contentTransitionVariant}
+                      onValueChange={setContentTransitionVariant}
+                    />
+                    <ControlGroup
+                      label="Scope"
+                      choices={CONTENT_TRANSITION_SCOPES}
+                      value={contentTransitionScope}
+                      onValueChange={setContentTransitionScope}
+                    />
+                    <ControlGroup
+                      label="Magic"
+                      choices={MAGIC_MODES}
+                      value={contentTransitionMagic}
+                      onValueChange={setContentTransitionMagic}
+                    />
+                  </>
+                )}
+              </Section>
             </View>
           )}
+          <SFSymbolPreview
+            name={getPreviewSymbol(previewIndex)}
+            nextName={getPreviewSymbol(previewIndex + 1)}
+            color={colors.text}
+            weight={weight}
+            scale={scale}
+            renderingMode={renderingMode}
+            colors={symbolColors}
+            variableValue={variableValue}
+            variableValueMode={variableValueMode}
+            colorRenderingMode={colorRenderingMode}
+            effect={selectedEffect}
+            contentTransition={selectedContentTransition}
+            onPress={() =>
+              setPreviewIndex((index) => (index + 1) % PREVIEW_SYMBOLS.length)
+            }
+          />
         </View>
       }
       renderItem={({ item }) => (
@@ -178,9 +631,13 @@ export function ComponentsSFSymbols(_: StaticScreenProps<{}>) {
           items={item}
           weight={weight}
           scale={scale}
-          mode={mode}
+          renderingMode={renderingMode}
           colors={symbolColors}
-          animation={animation === 'none' ? undefined : animation}
+          variableValue={variableValue}
+          variableValueMode={variableValueMode}
+          colorRenderingMode={colorRenderingMode}
+          effect={selectedEffect}
+          contentTransition={selectedContentTransition}
         />
       )}
       keyExtractor={(item) => item[0]}
@@ -206,16 +663,24 @@ const SFSymbolRow = React.memo(function SFSymbolRow({
   items,
   weight,
   scale,
-  mode,
+  renderingMode,
   colors: symbolColors,
-  animation,
+  variableValue,
+  variableValueMode,
+  colorRenderingMode,
+  effect,
+  contentTransition,
 }: {
   items: SFSymbolProps['name'][];
   weight: SFSymbolWeight;
   scale: SFSymbolScale;
-  mode: SFSymbolMode;
+  renderingMode: SFSymbolRenderingMode;
   colors?: SFSymbolProps['colors'];
-  animation?: SFSymbolAnimationEffect;
+  variableValue: SFSymbolVariableValue;
+  variableValueMode: SFSymbolVariableValueMode;
+  colorRenderingMode: SFSymbolColorRenderingMode;
+  effect: SFSymbolEffect;
+  contentTransition: SFSymbolContentTransition;
 }) {
   const { colors } = useTheme();
 
@@ -228,9 +693,13 @@ const SFSymbolRow = React.memo(function SFSymbolRow({
             size={ICON_SIZE}
             weight={weight}
             scale={scale}
-            mode={mode}
+            renderingMode={renderingMode}
             colors={symbolColors}
-            animation={animation}
+            variableValue={variableValue}
+            variableValueMode={variableValueMode}
+            colorRenderingMode={colorRenderingMode}
+            effect={effect}
+            contentTransition={contentTransition}
           />
           <Text style={[styles.name, { color: colors.text }]} numberOfLines={1}>
             {item}
@@ -240,6 +709,149 @@ const SFSymbolRow = React.memo(function SFSymbolRow({
     </View>
   );
 });
+
+function SFSymbolPreview({
+  name,
+  nextName,
+  color,
+  weight,
+  scale,
+  renderingMode,
+  colors,
+  variableValue,
+  variableValueMode,
+  colorRenderingMode,
+  effect,
+  contentTransition,
+  onPress,
+}: {
+  name: SFSymbolProps['name'];
+  nextName: SFSymbolProps['name'];
+  color: NonNullable<SFSymbolProps['color']>;
+  weight: SFSymbolWeight;
+  scale: SFSymbolScale;
+  renderingMode: SFSymbolRenderingMode;
+  colors?: SFSymbolProps['colors'];
+  variableValue: SFSymbolVariableValue;
+  variableValueMode: SFSymbolVariableValueMode;
+  colorRenderingMode: SFSymbolColorRenderingMode;
+  effect: SFSymbolEffect;
+  contentTransition: SFSymbolContentTransition;
+  onPress: () => void;
+}) {
+  const { colors: themeColors } = useTheme();
+
+  return (
+    <Pressable
+      onPress={onPress}
+      style={[styles.preview, { borderTopColor: themeColors.border }]}
+    >
+      <View style={styles.previewIcon}>
+        <SFSymbol
+          name={name}
+          size={48}
+          color={color}
+          weight={weight}
+          scale={scale}
+          renderingMode={renderingMode}
+          colors={colors}
+          variableValue={variableValue}
+          variableValueMode={variableValueMode}
+          colorRenderingMode={colorRenderingMode}
+          effect={effect}
+          contentTransition={contentTransition}
+        />
+      </View>
+      <View style={styles.previewText}>
+        <Text style={{ color: themeColors.text }} numberOfLines={1}>
+          {name}
+        </Text>
+        <Text
+          style={[styles.previewNext, { color: themeColors.text }]}
+          numberOfLines={1}
+        >
+          {nextName}
+        </Text>
+      </View>
+      <SFSymbol name="arrow.triangle.2.circlepath" size={18} color={color} />
+    </Pressable>
+  );
+}
+
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  const { colors } = useTheme();
+
+  return (
+    <View style={styles.section}>
+      <Text style={[styles.sectionTitle, { color: colors.text }]}>{title}</Text>
+      {children}
+    </View>
+  );
+}
+
+function ControlGroup<T extends string | number | boolean>({
+  label,
+  choices,
+  value,
+  onValueChange,
+}: {
+  label: string;
+  choices: Choice<T>[];
+  value: T;
+  onValueChange: (value: T) => void;
+}) {
+  const { colors, fonts } = useTheme();
+
+  return (
+    <View style={styles.controlGroup}>
+      <Text style={[styles.controlLabel, { color: colors.text }]}>{label}</Text>
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        style={styles.chipScroll}
+        contentContainerStyle={styles.chipRow}
+      >
+        {choices.map((option) => {
+          const selected = option.value === value;
+
+          return (
+            <Pressable
+              key={String(option.value)}
+              onPress={() => onValueChange(option.value)}
+              style={[
+                styles.chip,
+                {
+                  borderColor: colors.border,
+                },
+                selected && { backgroundColor: colors.primary },
+              ]}
+            >
+              <Text
+                style={[
+                  fonts.medium,
+                  styles.chipText,
+                  {
+                    color: selected
+                      ? Color.foreground(colors.primary)
+                      : colors.text,
+                  },
+                ]}
+              >
+                {option.label}
+              </Text>
+            </Pressable>
+          );
+        })}
+      </ScrollView>
+    </View>
+  );
+}
 
 ComponentsSFSymbols.title = 'Components - SF Symbols';
 ComponentsSFSymbols.options = { headerShown: true };
@@ -251,19 +863,76 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
   },
-  header: {
-    padding: 8,
-    borderBottomWidth: StyleSheet.hairlineWidth,
-  },
   headerToggle: {
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
-    paddingVertical: 4,
+    paddingVertical: 8,
+    paddingHorizontal: 16,
   },
   pickerColumn: {
-    gap: 8,
-    marginTop: 8,
+    gap: 20,
+    paddingVertical: 8,
+  },
+  section: {
+    gap: 12,
+  },
+  sectionTitle: {
+    fontSize: 11,
+    fontWeight: '600',
+    letterSpacing: 0.5,
+    textTransform: 'uppercase',
+    opacity: 0.5,
+    paddingHorizontal: 16,
+  },
+  controlGroup: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+  },
+  controlLabel: {
+    width: 84,
+    fontSize: 12,
+    opacity: 0.7,
+    marginLeft: 16,
+  },
+  chipScroll: {
+    flex: 1,
+  },
+  chipRow: {
+    flexDirection: 'row',
+    gap: 6,
+  },
+  chip: {
+    borderRadius: 16,
+    borderWidth: StyleSheet.hairlineWidth,
+    paddingVertical: 6,
+    paddingHorizontal: 10,
+  },
+  chipText: {
+    fontSize: 12,
+  },
+  preview: {
+    paddingVertical: 8,
+    paddingHorizontal: 16,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    borderTopWidth: StyleSheet.hairlineWidth,
+  },
+  previewIcon: {
+    width: 56,
+    height: 56,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  previewText: {
+    flex: 1,
+    minWidth: 0,
+  },
+  previewNext: {
+    fontSize: 12,
+    opacity: 0.6,
   },
   row: {
     flexDirection: 'row',

--- a/packages/native/ios/ReactNavigationSFSymbolView.mm
+++ b/packages/native/ios/ReactNavigationSFSymbolView.mm
@@ -47,15 +47,28 @@ static ReactNavigationSFSymbolViewImplProps *convertProps(const Props::Shared &p
     swiftProps.color = RCTUIColorFromSharedColor(viewProps.color);
     swiftProps.weight = viewProps.weight;
     swiftProps.scale = RCTNSStringFromString(viewProps.scale);
-    swiftProps.mode = RCTNSStringFromString(viewProps.mode);
-    swiftProps.animation = RCTNSStringFromString(viewProps.animation);
-    swiftProps.animationRepeating = viewProps.animationRepeating;
-    swiftProps.animationRepeatCount = viewProps.animationRepeatCount;
-    swiftProps.animationSpeed = viewProps.animationSpeed;
-    swiftProps.animationWholeSymbol = viewProps.animationWholeSymbol;
-    swiftProps.animationDirection = RCTNSStringFromString(viewProps.animationDirection);
-    swiftProps.animationReversing = viewProps.animationReversing;
-    swiftProps.animationCumulative = viewProps.animationCumulative;
+    swiftProps.variableValue = viewProps.variableValue;
+    swiftProps.variableValueMode = RCTNSStringFromString(viewProps.variableValueMode);
+    swiftProps.colorRenderingMode = RCTNSStringFromString(viewProps.colorRenderingMode);
+    swiftProps.renderingMode = RCTNSStringFromString(viewProps.renderingMode);
+    swiftProps.effect = RCTNSStringFromString(viewProps.effect);
+    swiftProps.effectRepeat = RCTNSStringFromString(viewProps.effectRepeat);
+    swiftProps.effectRepeatCount = viewProps.effectRepeatCount;
+    swiftProps.effectRepeatDelay = viewProps.effectRepeatDelay;
+    swiftProps.effectSpeed = viewProps.effectSpeed;
+    swiftProps.effectScope = RCTNSStringFromString(viewProps.effectScope);
+    swiftProps.effectDirection = RCTNSStringFromString(viewProps.effectDirection);
+    swiftProps.effectVariant = RCTNSStringFromString(viewProps.effectVariant);
+    swiftProps.effectAngle = viewProps.effectAngle;
+    swiftProps.effectReversing = viewProps.effectReversing;
+    swiftProps.effectCumulative = viewProps.effectCumulative;
+    swiftProps.effectInactiveLayers = RCTNSStringFromString(viewProps.effectInactiveLayers);
+    swiftProps.effectDrawDirection = RCTNSStringFromString(viewProps.effectDrawDirection);
+    swiftProps.contentTransition = RCTNSStringFromString(viewProps.contentTransition);
+    swiftProps.contentTransitionSpeed = viewProps.contentTransitionSpeed;
+    swiftProps.contentTransitionVariant = RCTNSStringFromString(viewProps.contentTransitionVariant);
+    swiftProps.contentTransitionScope = RCTNSStringFromString(viewProps.contentTransitionScope);
+    swiftProps.contentTransitionMagic = viewProps.contentTransitionMagic;
 
     if (viewProps.colorPrimary) {
         swiftProps.colorPrimary = RCTUIColorFromSharedColor(viewProps.colorPrimary);

--- a/packages/native/ios/ReactNavigationSFSymbolView.swift
+++ b/packages/native/ios/ReactNavigationSFSymbolView.swift
@@ -6,23 +6,35 @@ import UIKit
   public var color: UIColor = .black
   public var weight: Int = 0
   public var scale: String = "medium"
-  public var mode: String = "monochrome"
+  public var renderingMode: String = "monochrome"
   public var colorPrimary: UIColor?
   public var colorSecondary: UIColor?
   public var colorTertiary: UIColor?
-  public var animation: String = ""
-  public var animationRepeating: Bool = false
-  public var animationRepeatCount: Int = 0
-  public var animationSpeed: CGFloat = 1
-  public var animationWholeSymbol: Bool = false
-  public var animationDirection: String = ""
-  public var animationReversing: Bool = false
-  public var animationCumulative: Bool = false
+  public var effect: String = ""
+  public var variableValue: CGFloat = -1
+  public var variableValueMode: String = "automatic"
+  public var colorRenderingMode: String = "automatic"
+  public var effectRepeat: String = ""
+  public var effectRepeatCount: Int = 0
+  public var effectRepeatDelay: CGFloat = 0
+  public var effectSpeed: CGFloat = 1
+  public var effectScope: String = ""
+  public var effectDirection: String = ""
+  public var effectVariant: String = ""
+  public var effectAngle: CGFloat = -1
+  public var effectReversing: Bool = false
+  public var effectCumulative: Bool = false
+  public var effectInactiveLayers: String = ""
+  public var effectDrawDirection: String = ""
+  public var contentTransition: String = ""
+  public var contentTransitionSpeed: CGFloat = 1
+  public var contentTransitionVariant: String = ""
+  public var contentTransitionScope: String = ""
+  public var contentTransitionMagic: Bool = false
 }
 
 @objc public class ReactNavigationSFSymbolViewImpl: UIView {
   private var imageView: UIImageView
-  private var currentAnimation: String = ""
 
   override init(frame: CGRect) {
     imageView = UIImageView()
@@ -53,30 +65,55 @@ import UIKit
       props.size != oldProps.size ||
       props.weight != oldProps.weight ||
       props.scale != oldProps.scale ||
-      props.mode != oldProps.mode ||
+      props.variableValue != oldProps.variableValue ||
+      props.variableValueMode != oldProps.variableValueMode ||
+      props.colorRenderingMode != oldProps.colorRenderingMode ||
+      props.renderingMode != oldProps.renderingMode ||
       props.colorPrimary != oldProps.colorPrimary ||
       props.colorSecondary != oldProps.colorSecondary ||
       props.colorTertiary != oldProps.colorTertiary
 
     if needsImageUpdate {
       if let name = props.name {
+        // Content transitions animate between symbol contents, so only run them
+        // when the symbol or its variable value changes and a previous image
+        // exists. Configuration changes and the first appearance set the image
+        // directly to match native behavior.
+        let shouldAnimate =
+          imageView.image != nil &&
+          (props.name != oldProps.name || props.variableValue != oldProps.variableValue)
+
         let symbolWeight = Self.symbolWeight(from: props.weight)
         let symbolScale = Self.symbolScale(from: props.scale)
 
         var configuration = UIImage.SymbolConfiguration(pointSize: props.size, weight: symbolWeight, scale: symbolScale)
 
+        if #available(iOS 26.0, *) {
+          configuration = configuration.applying(
+            UIImage.SymbolConfiguration(
+              variableValueMode: Self.symbolVariableValueMode(from: props.variableValueMode)
+            )
+          )
+
+          configuration = configuration.applying(
+            UIImage.SymbolConfiguration(
+              colorRenderingMode: Self.symbolColorRenderingMode(from: props.colorRenderingMode)
+            )
+          )
+        }
+
         let primaryColor = props.colorPrimary ?? props.color
 
-        switch props.mode {
+        switch props.renderingMode {
         case "hierarchical":
           configuration = configuration.applying(
             UIImage.SymbolConfiguration(hierarchicalColor: primaryColor)
           )
 
-          let image = UIImage(systemName: name, withConfiguration: configuration)
+          let image = Self.symbolImage(name: name, configuration: configuration, props: props)
 
-          imageView.image = image
           imageView.tintColor = nil
+          setImage(image, props: props, animated: shouldAnimate)
 
         case "palette":
           var paletteColors: [UIColor] = []
@@ -95,82 +132,148 @@ import UIKit
             UIImage.SymbolConfiguration(paletteColors: paletteColors)
           )
 
-          let image = UIImage(systemName: name, withConfiguration: configuration)
+          let image = Self.symbolImage(name: name, configuration: configuration, props: props)
 
-          imageView.image = image
           imageView.tintColor = nil
+          setImage(image, props: props, animated: shouldAnimate)
 
         case "multicolor":
           configuration = configuration.applying(
             UIImage.SymbolConfiguration.preferringMulticolor()
           )
 
-          let image = UIImage(systemName: name, withConfiguration: configuration)
+          let image = Self.symbolImage(name: name, configuration: configuration, props: props)
 
-          imageView.image = image
           imageView.tintColor = nil
+          setImage(image, props: props, animated: shouldAnimate)
 
         default:
           // monochrome
-          let image = UIImage(systemName: name, withConfiguration: configuration)
+          let image = Self.symbolImage(name: name, configuration: configuration, props: props)
 
-          imageView.image = image?.withRenderingMode(.alwaysTemplate)
           imageView.tintColor = primaryColor
+          setImage(image?.withRenderingMode(.alwaysTemplate), props: props, animated: shouldAnimate)
         }
       }
     }
 
-    if !needsImageUpdate && props.color != oldProps.color && props.mode == "monochrome" {
+    if !needsImageUpdate && props.color != oldProps.color && props.renderingMode == "monochrome" {
       imageView.tintColor = props.colorPrimary ?? props.color
     }
 
-    let animationChanged =
-      props.animation != oldProps.animation ||
-      props.animationRepeating != oldProps.animationRepeating ||
-      props.animationRepeatCount != oldProps.animationRepeatCount ||
-      props.animationSpeed != oldProps.animationSpeed ||
-      props.animationWholeSymbol != oldProps.animationWholeSymbol ||
-      props.animationDirection != oldProps.animationDirection ||
-      props.animationReversing != oldProps.animationReversing ||
-      props.animationCumulative != oldProps.animationCumulative
+    let effectChanged =
+      props.effect != oldProps.effect ||
+      props.effectRepeat != oldProps.effectRepeat ||
+      props.effectRepeatCount != oldProps.effectRepeatCount ||
+      props.effectRepeatDelay != oldProps.effectRepeatDelay ||
+      props.effectSpeed != oldProps.effectSpeed ||
+      props.effectScope != oldProps.effectScope ||
+      props.effectDirection != oldProps.effectDirection ||
+      props.effectVariant != oldProps.effectVariant ||
+      props.effectAngle != oldProps.effectAngle ||
+      props.effectReversing != oldProps.effectReversing ||
+      props.effectCumulative != oldProps.effectCumulative ||
+      props.effectInactiveLayers != oldProps.effectInactiveLayers ||
+      props.effectDrawDirection != oldProps.effectDrawDirection
 
-    if animationChanged {
-      updateAnimation(props)
+    if effectChanged {
+      updateEffect(props)
     }
   }
 
-  private func updateAnimation(_ props: ReactNavigationSFSymbolViewImplProps) {
+  private func setImage(_ image: UIImage?, props: ReactNavigationSFSymbolViewImplProps, animated: Bool) {
+    guard let image else {
+      imageView.image = nil
+      return
+    }
+
+    guard animated, #available(iOS 17.0, *) else {
+      imageView.image = image
+      return
+    }
+
+    let options = Self.contentTransitionOptions(from: props)
+
+    switch props.contentTransition {
+    case "automatic":
+      imageView.setSymbolImage(
+        image,
+        contentTransition: .automatic,
+        options: options
+      )
+
+    case "replace":
+      var effect = ReplaceSymbolEffect.replace
+
+      switch props.contentTransitionVariant {
+      case "upUp":
+        effect = effect.upUp
+      case "offUp":
+        effect = effect.offUp
+      default:
+        effect = effect.downUp
+      }
+
+      if props.contentTransitionScope == "wholeSymbol" {
+        effect = effect.wholeSymbol
+      } else if props.contentTransitionScope == "byLayer" {
+        effect = effect.byLayer
+      }
+
+      if props.contentTransitionMagic, #available(iOS 18.0, *) {
+        imageView.setSymbolImage(
+          image,
+          contentTransition: effect.magic(fallback: effect),
+          options: options
+        )
+      } else {
+        imageView.setSymbolImage(
+          image,
+          contentTransition: effect,
+          options: options
+        )
+      }
+
+    default:
+      imageView.image = image
+    }
+  }
+
+  @available(iOS 17.0, *)
+  private static func contentTransitionOptions(from props: ReactNavigationSFSymbolViewImplProps) -> SymbolEffectOptions {
+    var options: SymbolEffectOptions = .default
+
+    if props.contentTransitionSpeed != 1 {
+      options = options.speed(props.contentTransitionSpeed)
+    }
+
+    return options
+  }
+
+  private func updateEffect(_ props: ReactNavigationSFSymbolViewImplProps) {
     guard #available(iOS 17.0, *) else { return }
 
     imageView.removeAllSymbolEffects()
 
-    guard !props.animation.isEmpty else { return }
+    guard !props.effect.isEmpty else { return }
 
-    var options: SymbolEffectOptions = .default
+    let options = Self.symbolEffectOptions(from: props)
 
-    if props.animationRepeating {
-      options = options.repeating
-    } else if props.animationRepeatCount > 0 {
-      options = options.repeat(props.animationRepeatCount)
-    }
-
-    if props.animationSpeed != 1 {
-      options = options.speed(props.animationSpeed)
-    }
-
-    switch props.animation {
+    switch props.effect {
     case "bounce":
       var effect = BounceSymbolEffect.bounce
 
-      if props.animationWholeSymbol {
+      if props.effectScope == "wholeSymbol" {
         effect = effect.wholeSymbol
+      } else if props.effectScope == "byLayer" {
+        effect = effect.byLayer
       }
 
-      if props.animationDirection == "up" {
+      if props.effectDirection == "up" {
         effect = effect.up
       }
 
-      if props.animationDirection == "down" {
+      if props.effectDirection == "down" {
         effect = effect.down
       }
 
@@ -179,8 +282,10 @@ import UIKit
     case "pulse":
       var effect = PulseSymbolEffect.pulse
 
-      if props.animationWholeSymbol {
+      if props.effectScope == "wholeSymbol" {
         effect = effect.wholeSymbol
+      } else if props.effectScope == "byLayer" {
+        effect = effect.byLayer
       }
 
       imageView.addSymbolEffect(effect, options: options)
@@ -188,15 +293,17 @@ import UIKit
     case "appear":
       var effect = AppearSymbolEffect.appear
 
-      if props.animationWholeSymbol {
+      if props.effectScope == "wholeSymbol" {
         effect = effect.wholeSymbol
+      } else if props.effectScope == "byLayer" {
+        effect = effect.byLayer
       }
 
-      if props.animationDirection == "up" {
+      if props.effectDirection == "up" {
         effect = effect.up
       }
 
-      if props.animationDirection == "down" {
+      if props.effectDirection == "down" {
         effect = effect.down
       }
 
@@ -205,15 +312,17 @@ import UIKit
     case "disappear":
       var effect = DisappearSymbolEffect.disappear
 
-      if props.animationWholeSymbol {
+      if props.effectScope == "wholeSymbol" {
         effect = effect.wholeSymbol
+      } else if props.effectScope == "byLayer" {
+        effect = effect.byLayer
       }
 
-      if props.animationDirection == "up" {
+      if props.effectDirection == "up" {
         effect = effect.up
       }
 
-      if props.animationDirection == "down" {
+      if props.effectDirection == "down" {
         effect = effect.down
       }
 
@@ -222,10 +331,37 @@ import UIKit
     case "variableColor":
       var effect = VariableColorSymbolEffect.variableColor
 
-      if props.animationReversing {
-        effect = props.animationCumulative ? effect.reversing.cumulative : effect.reversing.iterative
+      if props.effectReversing {
+        effect = props.effectCumulative ? effect.reversing.cumulative : effect.reversing.iterative
       } else {
-        effect = props.animationCumulative ? effect.nonReversing.cumulative : effect.nonReversing.iterative
+        effect = props.effectCumulative ? effect.nonReversing.cumulative : effect.nonReversing.iterative
+      }
+
+      if props.effectInactiveLayers == "hide" {
+        effect = effect.hideInactiveLayers
+      }
+
+      if props.effectInactiveLayers == "dim" {
+        effect = effect.dimInactiveLayers
+      }
+
+      imageView.addSymbolEffect(effect, options: options)
+
+    case "scale":
+      var effect = ScaleSymbolEffect.scale
+
+      if props.effectScope == "wholeSymbol" {
+        effect = effect.wholeSymbol
+      } else if props.effectScope == "byLayer" {
+        effect = effect.byLayer
+      }
+
+      if props.effectDirection == "up" {
+        effect = effect.up
+      }
+
+      if props.effectDirection == "down" {
+        effect = effect.down
       }
 
       imageView.addSymbolEffect(effect, options: options)
@@ -234,8 +370,18 @@ import UIKit
       if #available(iOS 18.0, *) {
         var effect = BreatheSymbolEffect.breathe
 
-        if props.animationWholeSymbol {
+        if props.effectVariant == "plain" {
+          effect = effect.plain
+        }
+
+        if props.effectVariant == "pulse" {
+          effect = effect.pulse
+        }
+
+        if props.effectScope == "wholeSymbol" {
           effect = effect.wholeSymbol
+        } else if props.effectScope == "byLayer" {
+          effect = effect.byLayer
         }
 
         imageView.addSymbolEffect(effect, options: options)
@@ -245,16 +391,30 @@ import UIKit
       if #available(iOS 18.0, *) {
         var effect = WiggleSymbolEffect.wiggle
 
-        if props.animationWholeSymbol {
+        if props.effectScope == "wholeSymbol" {
           effect = effect.wholeSymbol
+        } else if props.effectScope == "byLayer" {
+          effect = effect.byLayer
         }
 
-        if props.animationDirection == "up" {
+        if props.effectAngle >= 0 {
+          effect = effect.custom(angle: Double(props.effectAngle))
+        } else if props.effectDirection == "up" {
           effect = effect.up
-        }
-
-        if props.animationDirection == "down" {
+        } else if props.effectDirection == "down" {
           effect = effect.down
+        } else if props.effectDirection == "left" {
+          effect = effect.left
+        } else if props.effectDirection == "right" {
+          effect = effect.right
+        } else if props.effectDirection == "forward" {
+          effect = effect.forward
+        } else if props.effectDirection == "backward" {
+          effect = effect.backward
+        } else if props.effectDirection == "clockwise" {
+          effect = effect.clockwise
+        } else if props.effectDirection == "counterClockwise" {
+          effect = effect.counterClockwise
         }
 
         imageView.addSymbolEffect(effect, options: options)
@@ -264,14 +424,140 @@ import UIKit
       if #available(iOS 18.0, *) {
         var effect = RotateSymbolEffect.rotate
 
-        if props.animationWholeSymbol {
+        if props.effectScope == "wholeSymbol" {
           effect = effect.wholeSymbol
+        } else if props.effectScope == "byLayer" {
+          effect = effect.byLayer
+        }
+
+        if props.effectDirection == "clockwise" {
+          effect = effect.clockwise
+        }
+
+        if props.effectDirection == "counterClockwise" {
+          effect = effect.counterClockwise
+        }
+
+        imageView.addSymbolEffect(effect, options: options)
+      }
+
+    case "drawOn":
+      if #available(iOS 26.0, *) {
+        var effect = DrawOnSymbolEffect.drawOn
+
+        if props.effectScope == "wholeSymbol" {
+          effect = effect.wholeSymbol
+        } else if props.effectScope == "individually" {
+          effect = effect.individually
+        } else if props.effectScope == "byLayer" {
+          effect = effect.byLayer
+        }
+
+        imageView.addSymbolEffect(effect, options: options)
+      }
+
+    case "drawOff":
+      if #available(iOS 26.0, *) {
+        var effect = DrawOffSymbolEffect.drawOff
+
+        if props.effectDrawDirection == "reversed" {
+          effect = effect.reversed
+        }
+
+        if props.effectDrawDirection == "nonReversed" {
+          effect = effect.nonReversed
+        }
+
+        if props.effectScope == "wholeSymbol" {
+          effect = effect.wholeSymbol
+        } else if props.effectScope == "individually" {
+          effect = effect.individually
+        } else if props.effectScope == "byLayer" {
+          effect = effect.byLayer
         }
 
         imageView.addSymbolEffect(effect, options: options)
       }
 
     default: break
+    }
+  }
+
+  @available(iOS 17.0, *)
+  private static func symbolEffectOptions(from props: ReactNavigationSFSymbolViewImplProps) -> SymbolEffectOptions {
+    var options: SymbolEffectOptions = .default
+
+    switch props.effectRepeat {
+    case "continuous":
+      if #available(iOS 18.0, *) {
+        options = options.repeat(.continuous)
+      } else {
+        options = options.repeating
+      }
+
+    case "nonRepeating":
+      options = options.nonRepeating
+
+    case "periodic":
+      if #available(iOS 18.0, *) {
+        let count: Int? = props.effectRepeatCount > 0 ? props.effectRepeatCount : nil
+        let delay: Double? = props.effectRepeatDelay > 0 ? Double(props.effectRepeatDelay) : nil
+
+        options = options.repeat(
+          .periodic(count, delay: delay)
+        )
+      } else if props.effectRepeatCount > 0 {
+        options = options.repeat(props.effectRepeatCount)
+      } else {
+        options = options.repeating
+      }
+
+    default:
+      break
+    }
+
+    if props.effectSpeed != 1 {
+      options = options.speed(props.effectSpeed)
+    }
+
+    return options
+  }
+
+  private static func symbolImage(
+    name: String,
+    configuration: UIImage.SymbolConfiguration,
+    props: ReactNavigationSFSymbolViewImplProps
+  ) -> UIImage? {
+    if props.variableValue >= 0 {
+      let variableValue = min(max(props.variableValue, 0), 1)
+
+      if #available(iOS 16.0, *) {
+        return UIImage(
+          systemName: name,
+          variableValue: Double(variableValue),
+          configuration: configuration
+        )
+      }
+    }
+
+    return UIImage(systemName: name, withConfiguration: configuration)
+  }
+
+  @available(iOS 26.0, *)
+  private static func symbolVariableValueMode(from value: String) -> UIImage.SymbolVariableValueMode {
+    switch value {
+    case "color": return .color
+    case "draw": return .draw
+    default: return .automatic
+    }
+  }
+
+  @available(iOS 26.0, *)
+  private static func symbolColorRenderingMode(from value: String) -> UIImage.SymbolColorRenderingMode {
+    switch value {
+    case "flat": return .flat
+    case "gradient": return .gradient
+    default: return .automatic
     }
   }
 

--- a/packages/native/src/native/SFSymbol.ios.tsx
+++ b/packages/native/src/native/SFSymbol.ios.tsx
@@ -2,9 +2,43 @@ import type { ViewProps } from 'react-native';
 
 import { FONT_WEIGHTS } from './constants';
 import SFSymbolViewNativeComponent from './SFSymbolViewNativeComponent';
-import type { SFSymbolOptions } from './types';
+import type {
+  SFSymbolBreatheVariant,
+  SFSymbolContentTransitionEffect,
+  SFSymbolContentTransitionScope,
+  SFSymbolDrawDirection,
+  SFSymbolEffectDirection,
+  SFSymbolEffectName,
+  SFSymbolEffectRepeat,
+  SFSymbolEffectScope,
+  SFSymbolInactiveLayers,
+  SFSymbolOptions,
+  SFSymbolReplaceTransitionVariant,
+} from './types';
 
 export type SFSymbolProps = SFSymbolOptions & ViewProps;
+
+type NativeEffectConfig = {
+  type: SFSymbolEffectName;
+  speed?: number | undefined;
+  repeat?: SFSymbolEffectRepeat | undefined;
+  scope?: SFSymbolEffectScope | undefined;
+  direction?: SFSymbolEffectDirection | undefined;
+  variant?: SFSymbolBreatheVariant | undefined;
+  angle?: number | undefined;
+  reversing?: boolean | undefined;
+  cumulative?: boolean | undefined;
+  inactiveLayers?: SFSymbolInactiveLayers | undefined;
+  drawDirection?: SFSymbolDrawDirection | undefined;
+};
+
+type NativeContentTransitionConfig = {
+  type: SFSymbolContentTransitionEffect;
+  speed?: number | undefined;
+  variant?: SFSymbolReplaceTransitionVariant | undefined;
+  scope?: SFSymbolContentTransitionScope | undefined;
+  magic?: boolean | undefined;
+};
 
 export function SFSymbol({
   name,
@@ -12,14 +46,24 @@ export function SFSymbol({
   color,
   weight,
   scale = 'medium',
-  mode = 'monochrome',
+  variableValue,
+  variableValueMode = 'automatic',
+  colorRenderingMode = 'automatic',
+  renderingMode = 'monochrome',
   colors,
-  animation,
+  effect,
+  contentTransition,
   style,
   ...rest
 }: SFSymbolProps): React.ReactElement {
-  const animConfig =
-    typeof animation === 'string' ? { effect: animation } : animation;
+  const effectConfig: NativeEffectConfig | undefined =
+    typeof effect === 'string' ? { type: effect } : effect;
+  const contentTransitionConfig: NativeContentTransitionConfig | undefined =
+    typeof contentTransition === 'string'
+      ? { type: contentTransition }
+      : contentTransition;
+
+  const repeat = effectConfig?.repeat;
 
   return (
     <SFSymbolViewNativeComponent
@@ -28,18 +72,33 @@ export function SFSymbol({
       color={color}
       weight={typeof weight === 'string' ? FONT_WEIGHTS[weight] : (weight ?? 0)}
       scale={scale}
-      mode={mode}
+      variableValue={variableValue ?? -1}
+      variableValueMode={variableValueMode}
+      colorRenderingMode={colorRenderingMode}
+      renderingMode={renderingMode}
       colorPrimary={colors?.primary ?? color}
       colorSecondary={colors?.secondary}
       colorTertiary={colors?.tertiary}
-      animation={animConfig?.effect ?? ''}
-      animationRepeating={animConfig?.repeating ?? false}
-      animationRepeatCount={animConfig?.repeatCount ?? 0}
-      animationSpeed={animConfig?.speed ?? 1}
-      animationWholeSymbol={animConfig?.wholeSymbol ?? false}
-      animationDirection={animConfig?.direction ?? ''}
-      animationReversing={animConfig?.reversing ?? false}
-      animationCumulative={animConfig?.cumulative ?? false}
+      effect={effectConfig?.type ?? ''}
+      effectRepeat={
+        typeof repeat === 'string' ? repeat : repeat ? 'periodic' : ''
+      }
+      effectRepeatCount={typeof repeat === 'object' ? (repeat.count ?? 0) : 0}
+      effectRepeatDelay={typeof repeat === 'object' ? (repeat.delay ?? 0) : 0}
+      effectSpeed={effectConfig?.speed ?? 1}
+      effectScope={effectConfig?.scope ?? ''}
+      effectDirection={effectConfig?.direction ?? ''}
+      effectVariant={effectConfig?.variant ?? ''}
+      effectAngle={effectConfig?.angle ?? -1}
+      effectReversing={effectConfig?.reversing ?? false}
+      effectCumulative={effectConfig?.cumulative ?? false}
+      effectInactiveLayers={effectConfig?.inactiveLayers ?? ''}
+      effectDrawDirection={effectConfig?.drawDirection ?? ''}
+      contentTransition={contentTransitionConfig?.type ?? ''}
+      contentTransitionSpeed={contentTransitionConfig?.speed ?? 1}
+      contentTransitionVariant={contentTransitionConfig?.variant ?? ''}
+      contentTransitionScope={contentTransitionConfig?.scope ?? ''}
+      contentTransitionMagic={contentTransitionConfig?.magic ?? false}
       style={[
         {
           width: size,

--- a/packages/native/src/native/SFSymbolViewNativeComponent.ts
+++ b/packages/native/src/native/SFSymbolViewNativeComponent.ts
@@ -13,18 +13,31 @@ export interface NativeProps extends ViewProps {
   color?: ColorValue;
   weight: CodegenTypes.Int32;
   scale: string;
-  mode: string;
+  variableValue: CodegenTypes.Float;
+  variableValueMode: string;
+  colorRenderingMode: string;
+  renderingMode: string;
   colorPrimary?: ColorValue;
   colorSecondary?: ColorValue;
   colorTertiary?: ColorValue;
-  animation: string;
-  animationRepeating: boolean;
-  animationRepeatCount: CodegenTypes.Int32;
-  animationSpeed: CodegenTypes.Float;
-  animationWholeSymbol: boolean;
-  animationDirection: string;
-  animationReversing: boolean;
-  animationCumulative: boolean;
+  effect: string;
+  effectRepeat: string;
+  effectRepeatCount: CodegenTypes.Int32;
+  effectRepeatDelay: CodegenTypes.Float;
+  effectSpeed: CodegenTypes.Float;
+  effectScope: string;
+  effectDirection: string;
+  effectVariant: string;
+  effectAngle: CodegenTypes.Float;
+  effectReversing: boolean;
+  effectCumulative: boolean;
+  effectInactiveLayers: string;
+  effectDrawDirection: string;
+  contentTransition: string;
+  contentTransitionSpeed: CodegenTypes.Float;
+  contentTransitionVariant: string;
+  contentTransitionScope: string;
+  contentTransitionMagic: boolean;
 }
 
 export default codegenNativeComponent<NativeProps>(

--- a/packages/native/src/native/types.tsx
+++ b/packages/native/src/native/types.tsx
@@ -85,76 +85,280 @@ export type MaterialSymbolOptions = {
   color?: ColorValue | undefined;
 };
 
-export type SFSymbolScale = 'small' | 'medium' | 'large';
+type SFSymbolScale = 'small' | 'medium' | 'large';
 
-export type SFSymbolMode =
+type SFSymbolRenderingMode =
   | 'monochrome'
   | 'hierarchical'
   | 'palette'
   | 'multicolor';
 
-export type SFSymbolAnimationEffect =
+export type SFSymbolEffectName =
   | 'bounce'
   | 'pulse'
   | 'appear'
   | 'disappear'
   | 'variableColor'
+  | 'scale'
   | 'breathe'
   | 'wiggle'
-  | 'rotate';
+  | 'rotate'
+  | 'drawOn'
+  | 'drawOff';
 
-export type SFSymbolAnimationConfig = {
+export type SFSymbolContentTransitionEffect = 'automatic' | 'replace';
+
+export type SFSymbolEffectRepeat =
+  | 'continuous'
+  | 'nonRepeating'
+  | {
+      /**
+       * Number of times to repeat the effect.
+       */
+      count?: number | undefined;
+      /**
+       * Delay in seconds between repeated effect cycles.
+       */
+      delay?: number | undefined;
+    };
+
+export type SFSymbolEffectScope = 'byLayer' | 'wholeSymbol' | 'individually';
+
+export type SFSymbolEffectDirection =
+  | 'up'
+  | 'down'
+  | 'left'
+  | 'right'
+  | 'forward'
+  | 'backward'
+  | 'clockwise'
+  | 'counterClockwise';
+
+export type SFSymbolBreatheVariant = 'plain' | 'pulse';
+
+export type SFSymbolDrawDirection = 'reversed' | 'nonReversed';
+
+export type SFSymbolInactiveLayers = 'hide' | 'dim';
+
+type SFSymbolEffectBaseConfig = {
   /**
-   * The animation effect to apply.
-   */
-  effect: SFSymbolAnimationEffect;
-  /**
-   * Whether the animation repeats continuously.
-   *
-   * @default false
-   */
-  repeating?: boolean | undefined;
-  /**
-   * Number of times to repeat the animation.
-   * Ignored if `repeating` is `true`.
-   */
-  repeatCount?: number | undefined;
-  /**
-   * Speed multiplier for the animation.
+   * Speed multiplier for the effect.
    *
    * @default 1
    */
   speed?: number | undefined;
   /**
-   * Whether to animate the whole symbol at once or layer by layer.
-   *
-   * @default false
+   * Repeat behavior for the effect. Use an object for periodic repeats.
    */
-  wholeSymbol?: boolean | undefined;
+  repeat?: SFSymbolEffectRepeat | undefined;
+};
+
+type SFSymbolScopedEffectConfig = SFSymbolEffectBaseConfig & {
   /**
-   * Direction of the animation.
-   * Applicable to `bounce` and `wiggle`.
+   * Whether to animate the whole symbol at once or by layer.
+   *
+   * @default 'byLayer'
+   */
+  scope?: Extract<SFSymbolEffectScope, 'byLayer' | 'wholeSymbol'> | undefined;
+};
+
+type SFSymbolDirectionalEffectName = 'bounce' | 'appear' | 'disappear';
+
+type SFSymbolDirectionalEffectConfig = SFSymbolScopedEffectConfig & {
+  /**
+   * The symbol effect to apply.
+   */
+  type: SFSymbolDirectionalEffectName;
+  /**
+   * The direction the symbol moves during the effect.
    */
   direction?: 'up' | 'down' | undefined;
+};
+
+type SFSymbolScaleEffectConfig = SFSymbolScopedEffectConfig & {
+  /**
+   * The symbol effect to apply.
+   */
+  type: 'scale';
+  /**
+   * Whether the symbol scales up or down.
+   */
+  direction?: 'up' | 'down' | undefined;
+};
+
+type SFSymbolBasicScopedEffectConfig = SFSymbolScopedEffectConfig & {
+  /**
+   * The symbol effect to apply.
+   */
+  type: 'pulse';
+};
+
+type SFSymbolBreatheEffectConfig = SFSymbolScopedEffectConfig & {
+  /**
+   * The symbol effect to apply.
+   */
+  type: 'breathe';
+  /**
+   * The breathe effect variant.
+   */
+  variant?: SFSymbolBreatheVariant | undefined;
+};
+
+type SFSymbolWiggleEffectConfig = SFSymbolScopedEffectConfig & {
+  /**
+   * The symbol effect to apply.
+   */
+  type: 'wiggle';
+  /**
+   * The direction the symbol wiggles toward.
+   */
+  direction?: SFSymbolEffectDirection | undefined;
+  /**
+   * A custom wiggle angle in degrees. Overrides `direction` when set.
+   */
+  angle?: number | undefined;
+};
+
+type SFSymbolRotateEffectConfig = SFSymbolScopedEffectConfig & {
+  /**
+   * The symbol effect to apply.
+   */
+  type: 'rotate';
+  /**
+   * Which way the symbol rotates.
+   */
+  direction?: 'clockwise' | 'counterClockwise' | undefined;
+};
+
+type SFSymbolDrawEffectConfig = SFSymbolEffectBaseConfig & {
+  /**
+   * The symbol effect to apply.
+   */
+  type: 'drawOn';
+  /**
+   * Whether to animate the whole symbol at once, by layer, or individually.
+   *
+   * @default 'byLayer'
+   */
+  scope?: SFSymbolEffectScope | undefined;
+};
+
+type SFSymbolDrawOffEffectConfig = SFSymbolEffectBaseConfig & {
+  /**
+   * The symbol effect to apply.
+   */
+  type: 'drawOff';
+  /**
+   * Whether to animate the whole symbol at once, by layer, or individually.
+   *
+   * @default 'byLayer'
+   */
+  scope?: SFSymbolEffectScope | undefined;
+  /**
+   * Whether the draw-off animation follows the symbol's authored draw
+   * order or plays it in reverse.
+   * - `nonReversed`: follows the symbol's draw order.
+   * - `reversed`: plays it in reverse.
+   */
+  drawDirection?: SFSymbolDrawDirection | undefined;
+};
+
+type SFSymbolVariableColorEffectConfig = SFSymbolEffectBaseConfig & {
+  /**
+   * The symbol effect to apply.
+   */
+  type: 'variableColor';
   /**
    * Whether the variable color effect reverses with each cycle.
-   * Only applicable to `variableColor`.
    *
    * @default false
    */
   reversing?: boolean | undefined;
   /**
-   * Whether each layer remains changed until the end of the cycle.
-   * Only applicable to `variableColor`.
+   * Whether layers light up cumulatively and stay active through the
+   * cycle, rather than one at a time.
    *
    * @default false
    */
   cumulative?: boolean | undefined;
+  /**
+   * How layers that aren't currently active are displayed.
+   * - `hide`: inactive layers are invisible.
+   * - `dim`: inactive layers stay visible but faded.
+   *
+   * Defaults to the symbol's standard appearance when unset.
+   */
+  inactiveLayers?: SFSymbolInactiveLayers | undefined;
 };
 
-export type SFSymbolAnimation =
-  | SFSymbolAnimationEffect
-  | SFSymbolAnimationConfig;
+type SFSymbolEffectConfig =
+  | SFSymbolDirectionalEffectConfig
+  | SFSymbolScaleEffectConfig
+  | SFSymbolBasicScopedEffectConfig
+  | SFSymbolBreatheEffectConfig
+  | SFSymbolWiggleEffectConfig
+  | SFSymbolRotateEffectConfig
+  | SFSymbolDrawEffectConfig
+  | SFSymbolDrawOffEffectConfig
+  | SFSymbolVariableColorEffectConfig;
+
+export type SFSymbolContentTransitionScope = 'byLayer' | 'wholeSymbol';
+
+export type SFSymbolReplaceTransitionVariant = 'downUp' | 'upUp' | 'offUp';
+
+type SFSymbolContentTransitionBaseConfig = {
+  /**
+   * Speed multiplier for the transition.
+   *
+   * @default 1
+   */
+  speed?: number | undefined;
+};
+
+type SFSymbolContentTransitionConfig =
+  | (SFSymbolContentTransitionBaseConfig & {
+      /**
+       * The transition effect to apply when the symbol `name` or `variableValue` changes.
+       */
+      type: 'automatic';
+    })
+  | (SFSymbolContentTransitionBaseConfig & {
+      /**
+       * The transition effect to apply when the symbol `name` or `variableValue` changes.
+       */
+      type: 'replace';
+      /**
+       * The direction the outgoing and incoming symbols move.
+       * - `downUp`: the old symbol slides down, the new one comes up.
+       * - `upUp`: both the old and new symbols move up.
+       * - `offUp`: the old symbol fades in place, the new one comes up.
+       */
+      variant?: SFSymbolReplaceTransitionVariant | undefined;
+      /**
+       * Whether to transition the whole symbol at once or by layer.
+       *
+       * @default 'byLayer'
+       */
+      scope?: SFSymbolContentTransitionScope | undefined;
+      /**
+       * Whether to prefer Magic Replace when possible.
+       *
+       * Falls back to regular Replace on iOS 17.
+       *
+       * @default false
+       */
+      magic?: boolean | undefined;
+    });
+
+type SFSymbolEffect = SFSymbolEffectName | SFSymbolEffectConfig;
+
+type SFSymbolContentTransition =
+  | SFSymbolContentTransitionEffect
+  | SFSymbolContentTransitionConfig;
+
+type SFSymbolVariableValueMode = 'automatic' | 'color' | 'draw';
+
+type SFSymbolColorRenderingMode = 'automatic' | 'flat' | 'gradient';
 
 export type SFSymbolOptions = {
   /**
@@ -163,6 +367,7 @@ export type SFSymbolOptions = {
   name: import('sf-symbols-typescript').SFSymbol;
   /**
    * The size of the symbol.
+   *
    * @default 24
    */
   size?: number | undefined;
@@ -184,11 +389,33 @@ export type SFSymbolOptions = {
     | (typeof FONT_WEIGHTS)[keyof typeof FONT_WEIGHTS]
     | undefined;
   /**
-   * The scale of the symbol relative to the font size.
+   * The symbol's scale variant (`small`, `medium`, or `large`).
    *
    * @default 'medium'
    */
   scale?: SFSymbolScale | undefined;
+  /**
+   * The value used to customize variable symbols.
+   * Must be between `0` and `1`.
+   *
+   * Variable symbols (e.g. `wifi`, `speaker.wave.3`) have layers that
+   * activate progressively to represent a magnitude. This controls how
+   * many are shown: `0` renders the fewest, `1` the full symbol.
+   *
+   * Has no effect on symbols that aren't variable.
+   */
+  variableValue?: number | undefined;
+  /**
+   * How the partial state from `variableValue` is rendered.
+   * - `automatic`: the system chooses based on the symbol.
+   * - `color`: fades inactive layers using opacity.
+   * - `draw`: partially draws layers instead of fading them.
+   *
+   * Requires iOS 26+. Ignored on earlier versions.
+   *
+   * @default 'automatic'
+   */
+  variableValueMode?: SFSymbolVariableValueMode | undefined;
   /**
    * The rendering mode of the symbol.
    * - `monochrome`: Single color tint (default).
@@ -198,7 +425,7 @@ export type SFSymbolOptions = {
    *
    * @default 'monochrome'
    */
-  mode?: SFSymbolMode | undefined;
+  renderingMode?: SFSymbolRenderingMode | undefined;
   /**
    * The colors for non-monochrome rendering modes.
    * - `hierarchical`: uses `primary` as the base color.
@@ -215,8 +442,27 @@ export type SFSymbolOptions = {
       }
     | undefined;
   /**
-   * The animation effect to apply to the symbol.
+   * How color is applied across the symbol's layers.
+   * - `automatic`: the system chooses based on the symbol.
+   * - `flat`: a solid color per layer.
+   * - `gradient`: a gradient derived from each layer's color.
+   *
+   * Requires iOS 26+. Ignored on earlier versions.
+   *
+   * @default 'automatic'
+   */
+  colorRenderingMode?: SFSymbolColorRenderingMode | undefined;
+  /**
+   * The effect to apply to the symbol.
+   *
+   * Requires iOS 17+. Effects introduced in later iOS versions are ignored
+   * on earlier versions.
+   */
+  effect?: SFSymbolEffect | undefined;
+  /**
+   * The content transition to apply when the symbol `name` or `variableValue` changes.
+   *
    * Requires iOS 17+. Ignored on earlier versions.
    */
-  animation?: SFSymbolAnimation | undefined;
+  contentTransition?: SFSymbolContentTransition | undefined;
 };


### PR DESCRIPTION
This reworks the `SFSymbol` component to align props with native terminology and expose for native functionality, such as magic replace transition when the name changes.

https://github.com/user-attachments/assets/41664aed-dfbf-40ea-89e1-87654ffd041b

