### PR TITLE
fix(drawer): aria-selected should not be set on role link (#9418)

### DIFF
--- a/packages/drawer/src/views/DrawerItem.tsx
+++ b/packages/drawer/src/views/DrawerItem.tsx
@@ -128,6 +128,7 @@ export function DrawerItem(props: Props) {
     pressOpacity = 1,
     testID,
     accessibilityLabel,
+    accessibilityState,
     ...rest
   } = props;
 
@@ -208,7 +209,8 @@ export function DrawerItem(props: Props) {
         onPress={onPress}
         role="button"
         aria-label={accessibilityLabel}
-        aria-selected={focused}
+        aria-selected={href ? undefined : focused}
+        accessibilityState={accessibilityState}
         pressColor={pressColor}
         pressOpacity={pressOpacity}
         hoverEffect={typeof color === 'string' ? { color } : undefined}


### PR DESCRIPTION
## Summary

Fixes #9418 — aria-selected should not be set on elements with role='link'.

## Problem

The DrawerItem component sets aria-selected on PlatformPressable even when an href is provided, causing the element to render with role='link'. Per the ARIA specification, aria-selected is not a valid attribute for link elements.

Additionally, accessibilityState was not destructured from props, causing it to be spread onto the outer View via ...rest instead of being passed to PlatformPressable where it belongs.

## Changes

1. **Conditionally set aria-selected**: Only applies when href is not present (i.e., when PlatformPressable renders as a button, not a link)
2. **Destructure accessibilityState**: Extracts it from props to prevent leaking into ...rest, passes directly to PlatformPressable

### Before
```tsx
aria-selected={focused}
```

### After
```tsx
aria-selected={href ? undefined : focused}
accessibilityState={accessibilityState}
```