### PR TITLE
feat: add getter support to screens for lazy requires

### DIFF
--- a/packages/core/src/DataLoading.tsx
+++ b/packages/core/src/DataLoading.tsx
@@ -134,7 +134,10 @@ export function getLoaderForStateChange(
   const nested =
     'config' in item
       ? item
-      : 'screen' in item && 'config' in item.screen
+      : 'screen' in item &&
+          // Nested navigators cannot be defined as a getter
+          Object.getOwnPropertyDescriptor(item, 'screen')?.get == null &&
+          'config' in item.screen
         ? item.screen
         : undefined;
 

--- a/packages/core/src/StaticNavigation.tsx
+++ b/packages/core/src/StaticNavigation.tsx
@@ -678,6 +678,9 @@ const MemoizedScreen = React.memo(
 
 MemoizedScreen.displayName = 'Memo(Screen)';
 
+const hasPropertyGetter = (object: object, property: PropertyKey) =>
+  Object.getOwnPropertyDescriptor(object, property)?.get != null;
+
 const getItemsFromScreens = (
   Screen: React.ComponentType<any>,
   screens: StaticConfigScreens<any, any, any, any, any>
@@ -688,18 +691,57 @@ const getItemsFromScreens = (
     let useIf: (() => boolean) | undefined;
 
     let isNavigator = false;
+    let getComponent: (() => React.ComponentType<any>) | undefined;
 
     if ('screen' in item) {
-      const { screen, if: _if, ...rest } = item;
+      if (hasPropertyGetter(item, 'screen')) {
+        const rest: Record<string, unknown> = {};
 
-      useIf = _if;
-      props = rest;
+        // Iterate over the keys to avoid triggering the getter for 'screen'
+        for (const key of Object.keys(item)) {
+          if (key === 'screen' || key === 'if') {
+            continue;
+          }
 
-      if (isValidElementType(screen)) {
-        component = screen;
-      } else if ('config' in screen) {
-        isNavigator = true;
-        component = screen.getComponent();
+          rest[key] = Reflect.get(item, key);
+        }
+
+        useIf = item.if;
+        props = rest;
+
+        getComponent = () => {
+          const screen = item.screen;
+
+          if (isValidElementType(screen)) {
+            return screen;
+          }
+
+          if (
+            screen != null &&
+            typeof screen === 'object' &&
+            'config' in screen
+          ) {
+            throw new Error(
+              `Got a navigator object for the screen '${name}' instead of a component. A navigator cannot be specified when using a getter.`
+            );
+          }
+
+          throw new Error(
+            `Got an invalid screen component for the screen '${name}'. This can happen if you passed 'undefined'. You likely forgot to export your component from the file it's defined in, or mixed up default import and named import when importing.`
+          );
+        };
+      } else {
+        const { screen, if: _if, ...rest } = item;
+
+        useIf = _if;
+        props = rest;
+
+        if (isValidElementType(screen)) {
+          component = screen;
+        } else if ('config' in screen) {
+          isNavigator = true;
+          component = screen.getComponent();
+        }
       }
     } else if (isValidElementType(item)) {
       component = item;
@@ -708,17 +750,28 @@ const getItemsFromScreens = (
       component = item.getComponent();
     }
 
-    if (component == null) {
+    let children: (() => React.JSX.Element) | undefined;
+
+    if (getComponent != null) {
+      let element: React.JSX.Element | undefined;
+
+      children = () =>
+        (element ??= <MemoizedScreen component={getComponent()} />);
+    } else if (component != null) {
+      const element = isNavigator ? (
+        React.createElement(component, {})
+      ) : (
+        <MemoizedScreen component={component} />
+      );
+
+      children = () => element;
+    }
+
+    if (children == null) {
       throw new Error(
         `Couldn't find a 'screen' property for the screen '${name}'. This can happen if you passed 'undefined'. You likely forgot to export your component from the file it's defined in, or mixed up default import and named import when importing.`
       );
     }
-
-    const element = isNavigator ? (
-      React.createElement(component, {})
-    ) : (
-      <MemoizedScreen component={component} />
-    );
 
     return () => {
       const shouldRender = useIf == null || useIf();
@@ -729,7 +782,7 @@ const getItemsFromScreens = (
 
       return (
         <Screen key={name} name={name} {...props}>
-          {() => element}
+          {children}
         </Screen>
       );
     };
@@ -895,7 +948,7 @@ type PathConfigForStaticNavigation = Omit<
 // Mark screens that resolve to the same pattern and same component or navigator
 const markSharedPathConfigs = (
   screens: PathConfigMapForStaticNavigation,
-  sources: WeakMap<PathConfigForStaticNavigation, ScreenValueForPathConfig>,
+  sources: WeakMap<PathConfigForStaticNavigation, ScreenForPathConfig>,
   blocked: WeakSet<PathConfigForStaticNavigation>
 ) => {
   const candidates = new Map<string, PathConfigForStaticNavigation[]>();
@@ -992,7 +1045,7 @@ export function createPathConfigForStaticNavigation<ParamList extends {}>(
   const blocked = new WeakSet<PathConfigForStaticNavigation>();
   const sources = new WeakMap<
     PathConfigForStaticNavigation,
-    ScreenValueForPathConfig
+    ScreenForPathConfig
   >();
 
   const createPathConfigForTree = (
@@ -1043,7 +1096,11 @@ export function createPathConfigForStaticNavigation<ParamList extends {}>(
 
             sources.set(
               screenConfig,
-              typeof item === 'object' && 'screen' in item ? item.screen : item
+              typeof item === 'object' &&
+                'screen' in item &&
+                !hasPropertyGetter(item, 'screen')
+                ? item.screen
+                : item
             );
 
             const normalizePath = (path: string) =>
@@ -1129,6 +1186,7 @@ export function createPathConfigForStaticNavigation<ParamList extends {}>(
               !hasExplicitScreens &&
               !hasDisabledLinking &&
               'screen' in item &&
+              !hasPropertyGetter(item, 'screen') &&
               'config' in item.screen &&
               (item.screen.config.screens || item.screen.config.groups)
             ) {

--- a/packages/core/src/__tests__/StaticNavigation.test.tsx
+++ b/packages/core/src/__tests__/StaticNavigation.test.tsx
@@ -12,7 +12,10 @@ import { BaseNavigationContainer } from '../BaseNavigationContainer';
 import { createNavigationContainerRef } from '../createNavigationContainerRef';
 import { createNavigatorFactory } from '../createNavigatorFactory';
 import { getStateFromPath } from '../getStateFromPath';
-import { createPathConfigForStaticNavigation } from '../StaticNavigation';
+import {
+  createPathConfigForStaticNavigation,
+  createScreenFactory,
+} from '../StaticNavigation';
 import type {
   DefaultNavigatorOptions,
   EventMapBase,
@@ -84,6 +87,255 @@ const TestScreen = ({ route }: any) => {
     </Text>
   );
 };
+
+test('does not read getter screens until rendering them', async () => {
+  const reads = {
+    Account: 0,
+    Details: 0,
+    Settings: 0,
+    NestedFeed: 0,
+    NestedProfile: 0,
+  };
+
+  const FocusedTestNavigator = (props: TestNavigatorProps) => {
+    const { state, descriptors, NavigationContent } = useNavigationBuilder<
+      NavigationState,
+      DefaultRouterOptions,
+      {},
+      TestNavigatorScreenOptions,
+      EventMapBase
+    >(MockRouter, props);
+
+    const route = state.routes[state.index];
+
+    if (route == null) {
+      return null;
+    }
+
+    return (
+      <NavigationContent>
+        <main>{descriptors[route.key]?.render()}</main>
+      </NavigationContent>
+    );
+  };
+
+  interface FocusedTestNavigatorTypeBag extends NavigatorTypeBagBase {
+    ScreenOptions: TestNavigatorScreenOptions;
+    Navigator: typeof FocusedTestNavigator;
+  }
+
+  const createFocusedTestNavigator =
+    createNavigatorFactory<FocusedTestNavigatorTypeBag>(FocusedTestNavigator);
+  const createFocusedTestScreen =
+    createScreenFactory<FocusedTestNavigatorTypeBag>();
+
+  const Nested = createFocusedTestNavigator({
+    screens: {
+      Feed: {
+        get screen() {
+          reads.NestedFeed++;
+
+          return TestScreen;
+        },
+      },
+      Profile: {
+        get screen() {
+          reads.NestedProfile++;
+
+          return TestScreen;
+        },
+        linking: 'u/:id',
+      },
+    },
+  });
+
+  const Root = createFocusedTestNavigator({
+    initialRouteName: 'Home',
+    screens: {
+      Home: TestScreen,
+      Account: createFocusedTestScreen({
+        get screen() {
+          reads.Account++;
+
+          return TestScreen;
+        },
+      }),
+      Details: {
+        get screen() {
+          reads.Details++;
+
+          return TestScreen;
+        },
+        linking: 'details/:id',
+      },
+      Settings: {
+        get screen() {
+          reads.Settings++;
+
+          return TestScreen;
+        },
+      },
+      Nested,
+    },
+  });
+
+  const navigation = React.createRef<any>();
+
+  expect(createPathConfigForStaticNavigation(Root, {}, true)).toEqual({
+    Details: {
+      path: 'details/:id',
+    },
+    Settings: {
+      path: 'settings',
+    },
+    Account: {
+      path: 'account',
+    },
+    Home: {
+      path: '',
+    },
+    Nested: {
+      screens: {
+        Feed: {
+          path: 'feed',
+        },
+        Profile: {
+          path: 'u/:id',
+        },
+      },
+    },
+  });
+
+  expect(reads).toEqual({
+    Account: 0,
+    Details: 0,
+    Settings: 0,
+    NestedFeed: 0,
+    NestedProfile: 0,
+  });
+
+  const RootComponent = Root.getComponent();
+
+  expect(reads).toEqual({
+    Account: 0,
+    Details: 0,
+    Settings: 0,
+    NestedFeed: 0,
+    NestedProfile: 0,
+  });
+
+  const element = await render(
+    <BaseNavigationContainer ref={navigation}>
+      <RootComponent />
+    </BaseNavigationContainer>
+  );
+
+  expect(element).toMatchInlineSnapshot(`
+<main>
+  <Text>
+    Screen:
+    Home
+    (focused)
+  </Text>
+</main>
+`);
+
+  expect(reads).toEqual({
+    Account: 0,
+    Details: 0,
+    Settings: 0,
+    NestedFeed: 0,
+    NestedProfile: 0,
+  });
+
+  await act(() => navigation.current.navigate('Account'));
+
+  expect(element).toMatchInlineSnapshot(`
+<main>
+  <Text>
+    Screen:
+    Account
+    (focused)
+  </Text>
+</main>
+`);
+
+  expect(reads).toEqual({
+    Account: 1,
+    Details: 0,
+    Settings: 0,
+    NestedFeed: 0,
+    NestedProfile: 0,
+  });
+
+  await act(() => navigation.current.navigate('Home'));
+  await act(() => navigation.current.navigate('Account'));
+
+  expect(reads).toEqual({
+    Account: 1,
+    Details: 0,
+    Settings: 0,
+    NestedFeed: 0,
+    NestedProfile: 0,
+  });
+});
+
+test('throws if getter screen returns an invalid component', async () => {
+  const Root = createTestNavigator({
+    initialRouteName: 'Home',
+    screens: {
+      Home: {
+        // @ts-expect-error: intentionally invalid for test
+        get screen() {
+          return undefined;
+        },
+      },
+    },
+  });
+
+  const RootComponent = Root.getComponent();
+
+  await expect(
+    render(
+      <BaseNavigationContainer>
+        <RootComponent />
+      </BaseNavigationContainer>
+    )
+  ).rejects.toThrow(
+    "Got an invalid screen component for the screen 'Home'. This can happen if you passed 'undefined'."
+  );
+});
+
+test('throws if getter screen returns a nested navigator', async () => {
+  const Nested = createTestNavigator({
+    screens: {
+      Profile: TestScreen,
+    },
+  });
+
+  const Root = createTestNavigator({
+    initialRouteName: 'Nested',
+    screens: {
+      Nested: {
+        get screen() {
+          return Nested;
+        },
+      },
+    },
+  });
+
+  const RootComponent = Root.getComponent();
+
+  await expect(
+    render(
+      <BaseNavigationContainer>
+        <RootComponent />
+      </BaseNavigationContainer>
+    )
+  ).rejects.toThrow(
+    "Got a navigator object for the screen 'Nested' instead of a component. A navigator cannot be specified when using a getter."
+  );
+});
 
 test('renders the specified nested navigator configuration', async () => {
   const Nested = createTestNavigator({


### PR DESCRIPTION
Currently, the static config API has no way to lazily evaluate screen components, like `getComponent` in the dynamic API.

This adds support for getters to `screen`:

```js
const MyStack = createNativeStackNavigator({
  screens: {
    Home: HomeScreen,
    Profile: createNativeStackScreen({
      get screen() {
        return require('./ProfileScreen').default;
      }
    })
  }
});
```

Some caveats:

- Unlike dynamic config, getters can't include nested navigators, only screens. We need to read nested navigators to generate linking config.
- When a getter is encountered, we don't read the value, so shared paths won't compare component instances. It'll still work if the same return value of `createXScreen` is used in multiple navigators.