### PR TITLE
fix(native): provide LinkingContext during NavigationContainer fallback

### DIFF
--- a/packages/native/src/NavigationContainer.tsx
+++ b/packages/native/src/NavigationContainer.tsx
@@ -249,7 +249,9 @@ export function NavigationContainer<ParamList extends {} = RootParamList>({
   if (!isStateReady) {
     return (
       <LocaleDirContext.Provider value={direction}>
-        <ThemeProvider value={theme}>{fallback}</ThemeProvider>
+        <LinkingContext.Provider value={linkingConfig}>
+          <ThemeProvider value={theme}>{fallback}</ThemeProvider>
+        </LinkingContext.Provider>
       </LocaleDirContext.Provider>
     );
   }


### PR DESCRIPTION
## Summary

- Fixes crash when UI rendered in `NavigationContainer` `fallback` reads linking APIs while deep-link initial state is still resolving.
- Root cause: the `!isLinkingReady` branch rendered only `LocaleDirContext` + `ThemeProvider`, without `LinkingContext.Provider`.
- Ready branch already provided `LinkingContext`; fallback branch now uses the same provider/value.

Fixes #13051.

## Repro

1. Configure `NavigationContainer` with `linking` and async `getInitialURL` (delay ~5s).
2. Provide a `fallback` component that calls `useLinkBuilder()` (or reads `LinkingContext`).
3. Launch app.

Before: crash with `Couldn't find a LinkingContext context.`  
After: fallback renders, then navigator mounts normally.

## Test plan

- [x] Reproduced locally with delayed `getInitialURL` + `useLinkBuilder` in fallback
- [x] Verified no crash after wrapping fallback with `LinkingContext.Provider`
- [x] Verified navigator still mounts and initial route renders after linking resolves