### PR TITLE
fix(core): prevent useNavigation(name) from degrading on large trees

### DIFF
--- a/packages/core/src/useNavigation.tsx
+++ b/packages/core/src/useNavigation.tsx
@@ -29,7 +29,6 @@ export function useNavigation<
 >(): NavigationListForNavigator<Navigator>[keyof NavigationListForNavigator<Navigator>];
 export function useNavigation<
   const Navigator = RootNavigator,
-  const List = NavigationListForNested<Navigator>,
   const RouteName extends keyof NavigationListForNested<Navigator> = keyof NavigationListForNested<Navigator>,
 >(name: RouteName): NavigationListForNested<Navigator>[RouteName];
 export function useNavigation(name?: string): unknown {

--- a/packages/core/src/useNavigation.tsx
+++ b/packages/core/src/useNavigation.tsx
@@ -30,7 +30,7 @@ export function useNavigation<
 export function useNavigation<
   const Navigator = RootNavigator,
   const List = NavigationListForNested<Navigator>,
-  const RouteName extends keyof List = keyof List,
+  const RouteName extends keyof NavigationListForNested<Navigator> = keyof NavigationListForNested<Navigator>,
 >(name: RouteName): List[RouteName];
 export function useNavigation(name?: string): unknown {
   const root = React.use(NavigationContainerRefContext);

--- a/packages/core/src/useNavigation.tsx
+++ b/packages/core/src/useNavigation.tsx
@@ -29,7 +29,8 @@ export function useNavigation<
 >(): NavigationListForNavigator<Navigator>[keyof NavigationListForNavigator<Navigator>];
 export function useNavigation<
   const Navigator = RootNavigator,
-  const RouteName extends keyof NavigationListForNested<Navigator> = keyof NavigationListForNested<Navigator>,
+  const RouteName extends keyof NavigationListForNested<Navigator> =
+    keyof NavigationListForNested<Navigator>,
 >(name: RouteName): NavigationListForNested<Navigator>[RouteName];
 export function useNavigation(name?: string): unknown {
   const root = React.use(NavigationContainerRefContext);

--- a/packages/core/src/useNavigation.tsx
+++ b/packages/core/src/useNavigation.tsx
@@ -29,11 +29,9 @@ export function useNavigation<
 >(): NavigationListForNavigator<Navigator>[keyof NavigationListForNavigator<Navigator>];
 export function useNavigation<
   const Navigator = RootNavigator,
-  const RouteName extends string = string,
->(
-  name: RouteName & keyof NavigationListForNested<Navigator>
-): NavigationListForNested<Navigator>[RouteName &
-  keyof NavigationListForNested<Navigator>];
+  const List = NavigationListForNested<Navigator>,
+  const RouteName extends keyof List = keyof List,
+>(name: RouteName): List[RouteName];
 export function useNavigation(name?: string): unknown {
   const root = React.use(NavigationContainerRefContext);
   const navigation = React.use(NavigationContext);

--- a/packages/core/src/useNavigation.tsx
+++ b/packages/core/src/useNavigation.tsx
@@ -31,7 +31,7 @@ export function useNavigation<
   const Navigator = RootNavigator,
   const List = NavigationListForNested<Navigator>,
   const RouteName extends keyof NavigationListForNested<Navigator> = keyof NavigationListForNested<Navigator>,
->(name: RouteName): List[RouteName];
+>(name: RouteName): NavigationListForNested<Navigator>[RouteName];
 export function useNavigation(name?: string): unknown {
   const root = React.use(NavigationContainerRefContext);
   const navigation = React.use(NavigationContext);


### PR DESCRIPTION
**Motivation**

`useNavigation('SomeScreen')` stops resolving to the navigator that actually contains
`SomeScreen` once the navigation tree is moderately large — it falls back to the **root**
navigator (so navigating to a sibling screen fails to type-check), or collapses to `any`. The
resolution is also unstable: the validity of an identical `navigation.navigate(...)` call can
flip depending on how many *unrelated* modules a file imports, which is the fingerprint of the
type exceeding TypeScript's instantiation-depth budget.

This was correct in `@react-navigation/core@8.0.0-alpha.19` and regressed in `alpha.20`, when the
`useNavigation(name)` overload was rewritten to:

```ts
export function useNavigation<
  const Navigator = RootNavigator,
  const RouteName extends string = string,
>(
  name: RouteName & keyof NavigationListForNested<Navigator>
): NavigationListForNested<Navigator>[RouteName & keyof NavigationListForNested<Navigator>];
```

Two problems: `NavigationListForNested<Navigator>` — already a deep, recursive type — is
instantiated **three times** (constraint, parameter, return), and `RouteName` is unconstrained,
so the name is re-derived via the `RouteName & keyof …` intersection in both the parameter and
the index. On a real-world tree that tips over the depth budget and the type silently degrades.

**The change**

Compute `NavigationListForNested<Navigator>` **once** (bind it to a `List` type parameter) and
constrain `RouteName` to `keyof List`:

```ts
export function useNavigation<
  const Navigator = RootNavigator,
  const List = NavigationListForNested<Navigator>,
  const RouteName extends keyof List = keyof List,
>(name: RouteName): List[RouteName];
```

This is the `alpha.19` behaviour with the heavy type evaluated a single time. No change to the
type machinery (`NavigationListForNested` etc.) is needed.

Note: constraining `RouteName extends keyof List` means a value typed as a plain `string` is no
longer accepted as `name` (you must pass a known route-name literal) — same as `alpha.19`. Keeping
the loose `RouteName extends string` form, even with `List` computed once, does **not** fix the
regression (it still degrades to `any`), so the constraint is load-bearing.

Fixes the issue tracked here: https://github.com/react-navigation/react-navigation/issues/13144

**Test plan**

- `yarn typecheck` — passes (existing `useNavigation` `@ts-expect-error` type tests stay green).
- `yarn jest packages/core/src/__tests__/useNavigation.test.tsx` — 6/6 pass (runtime is unchanged;
  this is a types-only change).
- Standalone reproduction (on the same `alpha.20` dependency set), before vs. after the fix:
  https://github.com/Bram-dc/rn-usenavigation-instability-repro
  - Before: `useNavigation('FeatureList').push('FeatureDetails', { type })` errors because the prop
    is resolved as the root navigator's.
  - After: it resolves to the correct `FeatureStack` composite prop (not the root navigator and not
    `any`); valid sibling navigations type-check and unknown screens / wrong params are still
    rejected.
