### PR TITLE
refactor: improve TypeScript memory usage and performance

### DIFF
--- a/packages/core/src/StaticNavigation.tsx
+++ b/packages/core/src/StaticNavigation.tsx
@@ -140,25 +140,29 @@ type ParamListForGroups<
   ? ParamListForScreens<UnionToIntersection<Screens>>
   : {};
 
+// Hoisted to a top-level alias so it's not re-instantiated for every screen
+type RouteTypeBase = {
+  key: string;
+  name: string;
+  path?: string | undefined;
+  history?: { type: 'params'; params: object }[] | undefined;
+};
+
 type RouteType<Params, P = AnyToUnknown<Params>> = Readonly<
-  {
-    key: string;
-    name: string;
-    path?: string | undefined;
-    history?: { type: 'params'; params: object }[] | undefined;
-  } & (undefined extends Params
-    ? {
-        /**
-         * Params for this route
-         */
-        params?: P;
-      }
-    : {
-        /**
-         * Params for this route
-         */
-        params: P;
-      })
+  RouteTypeBase &
+    (undefined extends Params
+      ? {
+          /**
+           * Params for this route
+           */
+          params?: P;
+        }
+      : {
+          /**
+           * Params for this route
+           */
+          params: P;
+        })
 >;
 
 type StaticScreenConfigLinkingAlias = {

--- a/packages/core/src/StaticNavigation.tsx
+++ b/packages/core/src/StaticNavigation.tsx
@@ -140,7 +140,6 @@ type ParamListForGroups<
   ? ParamListForScreens<UnionToIntersection<Screens>>
   : {};
 
-// Hoisted to a top-level alias so it's not re-instantiated for every screen
 type RouteTypeBase = {
   key: string;
   name: string;

--- a/packages/core/src/types.tsx
+++ b/packages/core/src/types.tsx
@@ -1039,7 +1039,7 @@ type RouteForNameNested<
 /**
  * Union of param lists of the nested navigators in a param list.
  */
-type NestedParamLists<ParamList extends {}> = {
+export type NestedParamLists<ParamList extends {}> = {
   [RouteName in keyof ParamList]: NavigatorScreenParams<{}> extends ParamList[RouteName]
     ? NotUndefined<ParamList[RouteName]> extends NavigatorScreenParams<infer T>
       ? T

--- a/packages/core/src/types.tsx
+++ b/packages/core/src/types.tsx
@@ -287,6 +287,13 @@ export class PrivateValueStore<T extends [any, any, any, any]> {
   protected ''?: T;
 }
 
+// Hoisted to a top-level alias so it's not re-instantiated
+// for every param list and route name `navigate` is called with
+type NavigateOptions = {
+  merge?: boolean | undefined;
+  pop?: boolean | undefined;
+};
+
 type NavigationHelpersCommon<
   ParamList extends ParamListBase,
   State extends NavigationState = NavigationState,
@@ -321,18 +328,12 @@ type NavigationHelpersCommon<
         ? [
             screen: RouteName,
             params?: ParamList[RouteName],
-            options?: {
-              merge?: boolean | undefined;
-              pop?: boolean | undefined;
-            },
+            options?: NavigateOptions,
           ]
         : [
             screen: RouteName,
             params: ParamList[RouteName],
-            options?: {
-              merge?: boolean | undefined;
-              pop?: boolean | undefined;
-            },
+            options?: NavigateOptions,
           ]
       : never
   ): void;
@@ -1013,12 +1014,38 @@ export type GenericNavigation<ParamList extends {}> = Omit<
 export type RouteForName<
   ParamList extends {},
   RouteName extends string,
-> = RouteForNameInternal<RouteName, ParamListRoute<ParamList>>;
+> = string extends RouteName
+  ? ParamListRoute<ParamList>
+  : RouteForNameInternal<ParamList, RouteName>;
 
-type RouteForNameInternal<
+// Look up the route for a name by checking the keys at each level of the tree
+// and recursing into the param lists of nested navigators.
+// This avoids building a union of all routes in the tree and scanning it for
+// every name, which doesn't scale on large trees with many lookups.
+type RouteForNameInternal<ParamList extends {}, RouteName extends string> =
+  | (RouteName extends infer Name extends KeyOf<ParamList>
+      ? RouteProp<ParamList, Name>
+      : never)
+  | RouteForNameNested<NestedParamLists<ParamList>, RouteName>;
+
+// Distributes over the union of nested param lists
+type RouteForNameNested<
+  ParamLists,
   RouteName extends string,
-  Routes,
-> = string extends RouteName ? Routes : Extract<Routes, { name: RouteName }>;
+> = ParamLists extends infer ParamList extends {}
+  ? RouteForNameInternal<ParamList, RouteName>
+  : never;
+
+/**
+ * Union of param lists of the nested navigators in a param list.
+ */
+type NestedParamLists<ParamList extends {}> = {
+  [RouteName in keyof ParamList]: NavigatorScreenParams<{}> extends ParamList[RouteName]
+    ? NotUndefined<ParamList[RouteName]> extends NavigatorScreenParams<infer T>
+      ? T
+      : never
+    : never;
+}[keyof ParamList];
 
 type ParamListRoute<ParamList extends {}> = {
   [RouteName in keyof ParamList]: NavigatorScreenParams<{}> extends ParamList[RouteName]

--- a/packages/core/src/types.tsx
+++ b/packages/core/src/types.tsx
@@ -287,8 +287,6 @@ export class PrivateValueStore<T extends [any, any, any, any]> {
   protected ''?: T;
 }
 
-// Hoisted to a top-level alias so it's not re-instantiated
-// for every param list and route name `navigate` is called with
 type NavigateOptions = {
   merge?: boolean | undefined;
   pop?: boolean | undefined;
@@ -1015,26 +1013,29 @@ export type RouteForName<
   ParamList extends {},
   RouteName extends string,
 > = string extends RouteName
-  ? ParamListRoute<ParamList>
+  ? // RouteName is a not a literal but `string`
+    // Return union of all possible routes in the tree
+    ParamListRoute<ParamList>
   : RouteForNameInternal<ParamList, RouteName>;
 
-// Look up the route for a name by checking the keys at each level of the tree
-// and recursing into the param lists of nested navigators.
-// This avoids building a union of all routes in the tree and scanning it for
-// every name, which doesn't scale on large trees with many lookups.
+// Look up route object by checking each level and recursing into the nested param lists
+// This avoids building a union of all routes, which doesn't scale on large trees
 type RouteForNameInternal<ParamList extends {}, RouteName extends string> =
   | (RouteName extends infer Name extends KeyOf<ParamList>
       ? RouteProp<ParamList, Name>
       : never)
   | RouteForNameNested<NestedParamLists<ParamList>, RouteName>;
 
-// Distributes over the union of nested param lists
-type RouteForNameNested<
-  ParamLists,
-  RouteName extends string,
-> = ParamLists extends infer ParamList extends {}
-  ? RouteForNameInternal<ParamList, RouteName>
-  : never;
+type RouteForNameNested<ParamLists, RouteName extends string> =
+  // Distributes over the union of nested param lists
+  // e.g. if ParamLists is A | B
+  // TypeScript evaluates the branch once per member (A, then B)
+  // and unions the outcomes
+  // The infer ParamList extends {} just captures the current member
+  // and re-asserts the {} constraint that RouteForNameInternal requires
+  ParamLists extends infer ParamList extends {}
+    ? RouteForNameInternal<ParamList, RouteName>
+    : never;
 
 /**
  * Union of param lists of the nested navigators in a param list.

--- a/packages/core/src/useRoute.tsx
+++ b/packages/core/src/useRoute.tsx
@@ -35,12 +35,12 @@ type AllNestedRouteNames<ParamLists> =
  */
 export function useRoute<
   const ParamList extends {} = RootParamList,
-  const RouteName extends string = string,
->(
-  // `NoInfer` so `RouteName` is inferred from the name as a literal,
-  // instead of TS matching it against the union and inferring nothing
-  name: RouteName & NoInfer<AllRouteNames<ParamList>>
-): RouteForName<ParamList, RouteName>;
+  // The `& string` reduces the constraint to a plain union of names,
+  // so errors for invalid names list the valid names
+  // instead of showing the unresolved `AllRouteNames` type
+  const RouteName extends AllRouteNames<ParamList> & string =
+    AllRouteNames<ParamList> & string,
+>(name: RouteName): RouteForName<ParamList, RouteName>;
 export function useRoute<
   const ParamList extends {} = RootParamList,
 >(): {} extends ParamList

--- a/packages/core/src/useRoute.tsx
+++ b/packages/core/src/useRoute.tsx
@@ -5,15 +5,28 @@ import {
   NamedRouteContextListContext,
   NavigationRouteContext,
 } from './NavigationProvider';
-import type { RootParamList, RouteForName, RouteProp } from './types';
+import type {
+  NestedParamLists,
+  RootParamList,
+  RouteForName,
+  RouteProp,
+} from './types';
+import type { KeyOf } from './utilities';
 
 /**
  * Get all possible route names from a param list and its nested navigators.
+ * Recurses into the param lists directly instead of using `RouteForName`,
+ * So the route objects don't need to be built just to get the names.
  */
-type AllRouteNames<ParamList extends {}> = RouteForName<
-  ParamList,
-  string
->['name'];
+type AllRouteNames<ParamList extends {}> =
+  | KeyOf<ParamList>
+  | AllNestedRouteNames<NestedParamLists<ParamList>>;
+
+// Distributes over the union of nested param lists
+type AllNestedRouteNames<ParamLists> =
+  ParamLists extends infer ParamList extends {}
+    ? AllRouteNames<ParamList>
+    : never;
 
 /**
  * Hook to access the route prop of the parent screen anywhere.
@@ -24,7 +37,9 @@ export function useRoute<
   const ParamList extends {} = RootParamList,
   const RouteName extends string = string,
 >(
-  name: RouteName & AllRouteNames<ParamList>
+  // `NoInfer` so `RouteName` is inferred from the name as a literal,
+  // instead of TS matching it against the union and inferring nothing
+  name: RouteName & NoInfer<AllRouteNames<ParamList>>
 ): RouteForName<ParamList, RouteName>;
 export function useRoute<
   const ParamList extends {} = RootParamList,

--- a/packages/core/src/useRoute.tsx
+++ b/packages/core/src/useRoute.tsx
@@ -22,8 +22,8 @@ type AllRouteNames<ParamList extends {}> =
   | KeyOf<ParamList>
   | AllNestedRouteNames<NestedParamLists<ParamList>>;
 
-// Distributes over the union of nested param lists
 type AllNestedRouteNames<ParamLists> =
+  // Distributes over the union of nested param lists
   ParamLists extends infer ParamList extends {}
     ? AllRouteNames<ParamList>
     : never;
@@ -37,7 +37,6 @@ export function useRoute<
   const ParamList extends {} = RootParamList,
   // The `& string` reduces the constraint to a plain union of names,
   // so errors for invalid names list the valid names
-  // instead of showing the unresolved `AllRouteNames` type
   const RouteName extends AllRouteNames<ParamList> & string =
     AllRouteNames<ParamList> & string,
 >(name: RouteName): RouteForName<ParamList, RouteName>;


### PR DESCRIPTION
- **Keyed route lookup replacing union-scan**: `RouteForName` now matches the name against each level's param-list keys and recurses into nested navigators, instead of building a union of all routes and `Extract`-ing, making lookups proportional to tree depth
- **Distributive conditional for nested lookup**: splitting the union of nested param lists so each child navigator is looked up independently and the results unioned.
- **Cheap discriminant guarding the expensive branch**: `string extends RouteName` only builds the full route union when the name is unknown, keeping named lookups off that path.
- **Hoisting parameter-independent object types**: `NavigateOptions` and `RouteType`'s base pulled to top-level aliases so they're instantiated once rather than per screen and route name.
- **Lazy name gathering for useRoute validation**: collecting just the route names by recursing into param lists, so full route object types are only built for screens actually looked up.
- **Generic constraint for route names**: constraining the route-name generic like `useNavigation`, with & string at the use site for clean error messages.