### PR TITLE
feat: add support for extending SFSymbol name types

### DIFF
--- a/packages/elements/src/types.tsx
+++ b/packages/elements/src/types.tsx
@@ -1,4 +1,7 @@
-import type { MaterialSymbolProps } from '@react-navigation/native';
+import type {
+  MaterialSymbolProps,
+  SFSymbolNames,
+} from '@react-navigation/native';
 import * as React from 'react';
 import type {
   Animated,
@@ -46,7 +49,7 @@ type IconSfSymbol = {
   /**
    * Name of the SF Symbol to use as the icon.
    */
-  name: SFSymbol;
+  name: SFSymbol | keyof SFSymbolNames;
 };
 
 type IconMaterialSymbol = {

--- a/packages/native/src/native/types.tsx
+++ b/packages/native/src/native/types.tsx
@@ -1,5 +1,6 @@
 import type { ColorValue } from 'react-native';
 
+import type { SFSymbolNames } from '../types';
 import type { FONT_WEIGHTS } from './constants';
 import type { MaterialSymbolName } from './MaterialSymbolData';
 
@@ -364,7 +365,7 @@ export type SFSymbolOptions = {
   /**
    * The name of the SF Symbol to display.
    */
-  name: import('sf-symbols-typescript').SFSymbol;
+  name: import('sf-symbols-typescript').SFSymbol | keyof SFSymbolNames;
   /**
    * The size of the symbol.
    *

--- a/packages/native/src/types.tsx
+++ b/packages/native/src/types.tsx
@@ -58,6 +58,9 @@ declare module '@react-navigation/core' {
   interface Theme extends NativeTheme {}
 }
 
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface SFSymbolNames {}
+
 export type LocaleDirection = 'ltr' | 'rtl';
 
 export type LinkingPrefix = '*' | (string & {});


### PR DESCRIPTION
this makes it possible to specify additional SFSymbol names via module augmentation:

```ts
declare module '@react-navigation/native' {
  interface SFSymbolNames {
    'my-custom-symbol': true
  }
}
```