### PR TITLE
feat: support custom asset-catalog symbols in SFSymbol

### DIFF
--- a/packages/native/ios/ReactNavigationSFSymbolView.swift
+++ b/packages/native/ios/ReactNavigationSFSymbolView.swift
@@ -532,15 +532,19 @@ import UIKit
       let variableValue = min(max(props.variableValue, 0), 1)
 
       if #available(iOS 16.0, *) {
-        return UIImage(
+        if let systemImage = UIImage(
           systemName: name,
           variableValue: Double(variableValue),
           configuration: configuration
-        )
+        ) {
+          return systemImage
+        }
       }
     }
 
+    // Fall back to a custom symbol from the app's asset catalog.
     return UIImage(systemName: name, withConfiguration: configuration)
+      ?? UIImage(named: name)?.applyingSymbolConfiguration(configuration)
   }
 
   @available(iOS 26.0, *)


### PR DESCRIPTION
**What**

Custom, app-provided SF Symbols now render through the existing `sfSymbol` `Icon` type — no new type. The native `<SFSymbol>` view falls back `UIImage(systemName:) ?? UIImage(named:)` and applies the same `SymbolConfiguration`, so rendering modes (monochrome / hierarchical / palette / multicolor) and symbol-effect animations work on a custom asset-catalog symbol just like a built-in one.

Since `PlatformIcon` landed on `main`, every `Icon` consumer (`Button`, `HeaderIcon`, `DrawerItem`, `DrawerToggleButton`, `MaterialTopTabBar`, native bottom tabs) already routes through `<SFSymbol>`, so this is a native-only change.

**Scope change (per review)**

Split out of the earlier `image`/`sfSymbol` bundle:

- Non-square image sizing moved to a separate PR as `aspectRatio` (replacing the earlier `width` / `height` proposal).
- This PR is now just the SFSymbol custom-symbol support, which is mergeable independently of react-native-screens.

**Depends on**

- #13166 — custom SF Symbol *names* (`SFSymbolNames` augmentation makes `{ type: 'sfSymbol', name }` accept them).

**Test plan**

Built and ran on iOS. A custom asset-catalog symbol renders via `{ type: 'sfSymbol', name }` in `Button`, the header back button, drawer items, and material top tabs, and on the native bottom tab bar — including palette / hierarchical modes and animations on the custom symbol. Built-in SF Symbols unaffected.
