### PR TITLE
feat(bottom-tabs): per-tab icon size & active-indicator sizing on the native tab bar

### DIFF
--- a/packages/bottom-tabs/src/types.tsx
+++ b/packages/bottom-tabs/src/types.tsx
@@ -174,7 +174,7 @@ type BottomTabCustomOptions = {
    *
    * Only supported with `custom` implementation.
    */
-  tabBarIconStyle?: StyleProp<TextStyle>;
+  tabBarIconStyle?: StyleProp<ViewStyle>;
 
   /**
    * Whether the tab bar gets hidden when the keyboard is shown.
@@ -401,6 +401,40 @@ export type BottomTabNavigationOptions = {
    * Only supported on Android with `native` implementation.
    */
   tabBarLabelVisibilityMode?: TabBarItemLabelVisibilityMode;
+
+  /**
+   * Size (in dp) of this tab's icon. Can be set globally via `screenOptions`
+   * and/or overridden per screen. Unset tabs use the default size.
+   *
+   * On the `custom` implementation it sizes the icon on all platforms. On the
+   * `native` implementation the largest value across tabs sets the bar's icon
+   * box and smaller icons are inset to their own size (Android only).
+   */
+  tabBarIconSize?: number;
+
+  /**
+   * Width (in dp) of the active indicator. Bar-wide, taken from the focused
+   * tab (like `tabBarActiveIndicatorColor`); set it in `screenOptions` for a
+   * consistent value. If unset, it auto-scales to wrap the icon box when icons
+   * are enlarged via `tabBarIconSize`.
+   *
+   * Only supported with `native` implementation.
+   *
+   * @platform android
+   */
+  tabBarActiveIndicatorWidth?: number;
+
+  /**
+   * Height (in dp) of the active indicator. Bar-wide, taken from the focused
+   * tab (like `tabBarActiveIndicatorColor`); set it in `screenOptions` for a
+   * consistent value. If unset, it auto-scales to wrap the icon box when icons
+   * are enlarged via `tabBarIconSize`.
+   *
+   * Only supported with `native` implementation.
+   *
+   * @platform android
+   */
+  tabBarActiveIndicatorHeight?: number;
 
   /**
    * Style object for the tab label.

--- a/packages/bottom-tabs/src/views/BottomTabBar.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabBar.tsx
@@ -514,6 +514,7 @@ export function BottomTabBar({ state, navigation, descriptors, style }: Props) {
                 label={label}
                 labelVisibilityMode={tabBarLabelVisibilityMode}
                 labelStyle={options.tabBarLabelStyle}
+                iconSize={options.tabBarIconSize}
                 iconStyle={options.tabBarIconStyle}
                 style={[
                   sidebar

--- a/packages/bottom-tabs/src/views/BottomTabItem.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabItem.tsx
@@ -136,6 +136,10 @@ type Props = {
    */
   labelStyle?: StyleProp<TextStyle> | undefined;
   /**
+   * Size (in dp) of the icon, overriding the default for the variant.
+   */
+  iconSize?: number | undefined;
+  /**
    * Style object for the icon element.
    */
   iconStyle?: StyleProp<ViewStyle> | undefined;
@@ -181,6 +185,7 @@ export function BottomTabItem({
   // https://developer.apple.com/documentation/uikit/uiview/3183939-largecontenttitle
   allowFontScaling = SUPPORTS_LARGE_CONTENT_VIEWER ? false : undefined,
   labelStyle,
+  iconSize,
   iconStyle,
   style,
 }: Props) {
@@ -290,6 +295,7 @@ export function BottomTabItem({
         route={route}
         variant={variant}
         size={compact ? 'compact' : 'regular'}
+        iconSize={iconSize}
         badge={badge}
         badgeStyle={badgeStyle}
         activeOpacity={activeOpacity}

--- a/packages/bottom-tabs/src/views/BottomTabViewNativeImpl.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabViewNativeImpl.tsx
@@ -480,6 +480,7 @@ export function BottomTabViewNative({
             tabBarSelectionEnabled,
             tabBarBadgeStyle,
             tabBarIcon,
+            tabBarIconSize,
             tabBarBadge,
             tabBarSystemItem,
             tabBarBlurEffect = dark ? 'systemMaterialDark' : 'systemMaterial',
@@ -594,6 +595,7 @@ export function BottomTabViewNative({
               android={{
                 icon: icon?.android ?? icon?.shared,
                 selectedIcon: selectedIcon?.android ?? selectedIcon?.shared,
+                drawableIconSize: tabBarIconSize,
                 standardAppearance: {
                   tabBarBackgroundColor:
                     tabBarBackgroundColor ?? backgroundColor,
@@ -605,6 +607,10 @@ export function BottomTabViewNative({
                   tabBarItemActiveIndicatorColor: activeIndicatorColor,
                   tabBarItemActiveIndicatorEnabled:
                     currentOptions?.tabBarActiveIndicatorEnabled,
+                  tabBarItemActiveIndicatorWidth:
+                    currentOptions?.tabBarActiveIndicatorWidth,
+                  tabBarItemActiveIndicatorHeight:
+                    currentOptions?.tabBarActiveIndicatorHeight,
                   tabBarItemTitleFontFamily: fontFamily,
                   tabBarItemTitleFontWeight: fontWeight,
                   tabBarItemTitleSmallLabelFontSize: fontSize,
@@ -747,7 +753,16 @@ function getPlatformIcon(icon: Icon): PlatformIcon {
         },
         shared: undefined,
       };
-    case 'image':
+    case 'image': {
+      // A `{ uri: 'name' }` source maps to an Android drawable by name.
+      const drawableName =
+        typeof icon.source === 'object' &&
+        icon.source != null &&
+        !Array.isArray(icon.source) &&
+        typeof icon.source.uri === 'string'
+          ? icon.source.uri
+          : undefined;
+
       return {
         ios:
           icon.tinted === false
@@ -759,12 +774,20 @@ function getPlatformIcon(icon: Icon): PlatformIcon {
                 type: 'templateSource',
                 templateSource: icon.source,
               },
-        android: undefined,
+        android:
+          drawableName != null
+            ? {
+                type: 'drawableResource',
+                name: drawableName,
+                tinted: icon.tinted,
+              }
+            : undefined,
         shared: {
           type: 'imageSource',
           imageSource: icon.source,
         },
       };
+    }
     default: {
       const _exhaustiveCheck: never = icon;
 

--- a/packages/bottom-tabs/src/views/TabBarIcon.tsx
+++ b/packages/bottom-tabs/src/views/TabBarIcon.tsx
@@ -15,6 +15,10 @@ export type TabBarIconProps = {
   route: Route<string>;
   variant: 'uikit' | 'material';
   size: 'compact' | 'regular';
+  /**
+   * Explicit icon size (in dp) overriding the default for the variant/size.
+   */
+  iconSize?: number | undefined;
   badge?: string | number | undefined;
   badgeStyle?: StyleProp<TextStyle> | undefined;
   activeOpacity: number;
@@ -48,6 +52,7 @@ export function TabBarIcon({
   route: _,
   variant,
   size,
+  iconSize: iconSizeOverride,
   badge,
   badgeStyle,
   activeOpacity,
@@ -59,11 +64,25 @@ export function TabBarIcon({
   style,
 }: TabBarIconProps) {
   const iconSize =
-    variant === 'material'
+    iconSizeOverride ??
+    (variant === 'material'
       ? ICON_SIZE_MATERIAL
       : size === 'compact'
         ? ICON_SIZE_SQUARE_COMPACT
-        : ICON_SIZE_SQUARE;
+        : ICON_SIZE_SQUARE);
+
+  // Grow only the container's width to fit a wider image (e.g. a logo); height
+  // stays the default so icons stay vertically aligned across tabs.
+  const imageAspectRatio =
+    typeof icon === 'object' && icon != null && 'type' in icon
+      ? icon.type === 'image'
+        ? icon.aspectRatio
+        : undefined
+      : undefined;
+  const boxWidth =
+    imageAspectRatio != null
+      ? iconSize * imageAspectRatio
+      : iconSizeOverride;
 
   // We render the icon twice at the same position on top of each other:
   // active and inactive one, so we can fade between them.
@@ -75,6 +94,7 @@ export function TabBarIcon({
           : size === 'compact'
             ? styles.wrapperUikitCompact
             : styles.wrapperUikit,
+        boxWidth != null && { width: boxWidth },
         style,
       ]}
     >


### PR DESCRIPTION
**What**

Bottom-tab icon sizing options, on the `native` bar:

- `tabBarIconSize` (dp) — per-tab icon size. On the `custom` (JS) bar it sizes the icon on **all platforms**; on the `native` bar it maps to react-native-screens' `drawableIconSize` — the bar boxes to the largest size across tabs and insets smaller ones (Android only). Unset uses the default.
- `tabBarActiveIndicatorWidth` / `tabBarActiveIndicatorHeight` (dp) — bar-wide active-indicator size, taken from the focused tab. Native bar only; unset auto-scales to wrap the icon box.

Android drawable tinting on the native bar is driven by `image`'s `tinted` (no `tintingMode` in the public API) — `tinted: false` keeps the drawable's own colors.

Also fixes `tabBarIconStyle`'s type (`TextStyle` → `ViewStyle`) — it styles the icon container View.

**Changes since review**

- Rebased onto `PlatformIcon`.
- `tabBarIconSize` is no longer restricted to Android on the `custom` implementation — it is plain RN layout and works on iOS too. It stays Android-only on the `native` implementation, where it maps to `drawableIconSize`.
- Non-square image sizing moved out to `aspectRatio` (#13194); this PR is stacked on it.

**Depends on**

- #13194 (icon `aspectRatio`) and software-mansion/react-native-screens#4209 (native Android support). Stays a draft until #4209 publishes — the cross-repo `tinted` on `PlatformIconAndroid` isn't in the released screens types yet.

**Test plan**

Native bottom tab navigator on Android, with `react-native-screens` from #4209:

- `tabBarIconSize` on one screen scales that tab's icon; others stay default.
- `tabBarActiveIndicatorWidth` / `tabBarActiveIndicatorHeight` in `screenOptions` reshape the indicator.
- `tinted: false` on a multicolor drawable keeps its colors as a tab icon.
- On the custom (JS) bar, `tabBarIconSize` scales the icon on iOS and Android.
