### PR TITLE
feat: wrap navigations in startTransition by default

### DIFF
--- a/example/e2e/tests/maestro.test.ts
+++ b/example/e2e/tests/maestro.test.ts
@@ -143,7 +143,12 @@ async function runStep(page: Page, step: any) {
 
       const locator = query(page, step.tapOn);
 
-      await locator.filter({ visible: true }).last().dispatchEvent('click');
+      const target = locator.filter({ visible: true }).last();
+
+      const handle = await target.elementHandle();
+      await handle?.waitForElementState('stable');
+
+      await target.dispatchEvent('click');
 
       break;
     }

--- a/example/src/Showcase/NativeStackShowcase.tsx
+++ b/example/src/Showcase/NativeStackShowcase.tsx
@@ -302,7 +302,9 @@ const PlaceItem = React.memo(({ item }: { item: Place }) => {
     <Pressable
       testID={getPlaceItemTestID(item.id)}
       style={styles.placeItem}
-      onPress={() => navigation.goBack()}
+      onPress={() =>
+        navigation.navigate('LocationDetails', { placeId: item.id })
+      }
     >
       <Image source={item.image} style={styles.placeImage} />
 

--- a/packages/bottom-tabs/src/views/BottomTabBar.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabBar.tsx
@@ -12,7 +12,7 @@ import {
   useLocale,
   useTheme,
 } from '@react-navigation/native';
-import React from 'react';
+import * as React from 'react';
 import {
   Animated,
   type LayoutChangeEvent,
@@ -449,9 +449,11 @@ export function BottomTabBar({ state, navigation, descriptors, style }: Props) {
               !event.defaultPrevented &&
               options.tabBarSelectionEnabled !== false
             ) {
-              navigation.dispatch({
-                ...CommonActions.navigate(route.name, route.params),
-                target: state.key,
+              React.startTransition(() => {
+                navigation.dispatch({
+                  ...CommonActions.navigate(route.name, route.params),
+                  target: state.key,
+                });
               });
             }
           };

--- a/packages/bottom-tabs/src/views/BottomTabItem.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabItem.tsx
@@ -1,7 +1,7 @@
 import { getLabel, Label, PlatformPressable } from '@react-navigation/elements';
 import { Color } from '@react-navigation/elements/internal';
 import { type Route, useTheme } from '@react-navigation/native';
-import React from 'react';
+import * as React from 'react';
 import {
   type ColorValue,
   type GestureResponderEvent,

--- a/packages/bottom-tabs/src/views/TabBarIcon.tsx
+++ b/packages/bottom-tabs/src/views/TabBarIcon.tsx
@@ -1,7 +1,7 @@
 import { Badge, type Icon } from '@react-navigation/elements';
 import { MissingIcon } from '@react-navigation/elements/internal';
 import { MaterialSymbol, type Route, SFSymbol } from '@react-navigation/native';
-import React from 'react';
+import * as React from 'react';
 import {
   type ColorValue,
   Image,

--- a/packages/core/src/BaseNavigationContainer.tsx
+++ b/packages/core/src/BaseNavigationContainer.tsx
@@ -125,10 +125,16 @@ export function BaseNavigationContainer<ParamList extends {} = RootParamList>({
     (
       action: NavigationAction | ((state: NavigationState) => NavigationAction)
     ) => {
-      if (listeners.focus[0] == null) {
+      const listener = listeners.focus[0];
+
+      if (listener == null) {
         console.error(NOT_INITIALIZED_ERROR);
       } else {
-        listeners.focus[0]((navigation) => navigation.dispatch(action));
+        listener((navigation) =>
+          React.startTransition(() => {
+            navigation.dispatch(action);
+          })
+        );
       }
     }
   );
@@ -195,6 +201,7 @@ export function BaseNavigationContainer<ParamList extends {} = RootParamList>({
         acc[name] = (...args: any[]) =>
           // @ts-expect-error: this is ok
           dispatch(CommonActions[name](...args));
+
         return acc;
       }, {}),
       ...emitter.create('root'),

--- a/packages/core/src/__tests__/concurrent.test.tsx
+++ b/packages/core/src/__tests__/concurrent.test.tsx
@@ -1,4 +1,4 @@
-import { beforeEach, expect, test } from '@jest/globals';
+import { beforeEach, expect, jest, test } from '@jest/globals';
 import type { NavigationState, ParamListBase } from '@react-navigation/routers';
 import { CommonActions } from '@react-navigation/routers';
 import { act, render } from '@testing-library/react-native';
@@ -34,7 +34,7 @@ const TestNavigator = (props: any): any => {
   );
 };
 
-test('shows the fallback when navigating to a suspending screen without a transition', async () => {
+test('shows the fallback when navigating with resetRoot without a transition', async () => {
   const { promise, resolve } = Promise.withResolvers<void>();
 
   const ScreenA = () => <Text>[screen-a]</Text>;
@@ -64,8 +64,8 @@ test('shows the fallback when navigating to a suspending screen without a transi
     </Text>
   `);
 
-  await act(async () => {
-    navigation.navigate('B');
+  await act(() => {
+    navigation.resetRoot({ index: 0, routes: [{ name: 'B' }] });
   });
 
   expect(root).toMatchInlineSnapshot(`
@@ -85,7 +85,7 @@ test('shows the fallback when navigating to a suspending screen without a transi
     </>
   `);
 
-  await act(async () => resolve());
+  await act(() => resolve());
 
   expect(root).toMatchInlineSnapshot(`
     <Text>
@@ -94,87 +94,7 @@ test('shows the fallback when navigating to a suspending screen without a transi
   `);
 });
 
-test('shows the fallback when navigating to a lazy screen without a transition', async () => {
-  const { promise, resolve } = Promise.withResolvers<{
-    default: React.ComponentType;
-  }>();
-
-  const ScreenA = () => <Text>[screen-a]</Text>;
-  const ScreenB = () => <Text>[screen-b]</Text>;
-
-  const LazyScreenB = React.lazy(() => promise);
-
-  const LazyNavigator = (props: any): any => {
-    const { state, descriptors, NavigationContent } = useNavigationBuilder(
-      MockRouter,
-      props
-    );
-
-    const route = state.routes[state.index];
-
-    if (route == null) {
-      return null;
-    }
-
-    return (
-      <NavigationContent>{descriptors[route.key]?.render()}</NavigationContent>
-    );
-  };
-
-  const navigation = createNavigationContainerRef<ParamListBase>();
-
-  const root = await render(
-    <BaseNavigationContainer ref={navigation}>
-      <React.Suspense fallback={<Text>[fallback]</Text>}>
-        <LazyNavigator>
-          <Screen name="A" component={ScreenA} />
-          <Screen name="B" component={LazyScreenB} />
-        </LazyNavigator>
-      </React.Suspense>
-    </BaseNavigationContainer>
-  );
-
-  expect(root).toMatchInlineSnapshot(`
-    <Text>
-      [screen-a]
-    </Text>
-  `);
-
-  await act(async () => {
-    navigation.navigate('B');
-  });
-
-  expect(root).toMatchInlineSnapshot(`
-    <>
-      <Text
-        style={
-          {
-            "display": "none",
-          }
-        }
-      >
-        [screen-a]
-      </Text>
-      <Text>
-        [fallback]
-      </Text>
-    </>
-  `);
-
-  await act(async () => {
-    resolve({
-      default: ScreenB,
-    });
-  });
-
-  expect(root).toMatchInlineSnapshot(`
-    <Text>
-      [screen-b]
-    </Text>
-  `);
-});
-
-test('keeps the previous screen visible when navigating with a transition', async () => {
+test('keeps the previous screen visible when navigating to a suspending screen', async () => {
   const { promise, resolve } = Promise.withResolvers<void>();
 
   const ScreenA = () => <Text>[screen-a]</Text>;
@@ -204,10 +124,8 @@ test('keeps the previous screen visible when navigating with a transition', asyn
     </Text>
   `);
 
-  await act(async () => {
-    React.startTransition(() => {
-      navigation.navigate('B');
-    });
+  await act(() => {
+    navigation.navigate('B');
   });
 
   expect(root).toMatchInlineSnapshot(`
@@ -216,7 +134,7 @@ test('keeps the previous screen visible when navigating with a transition', asyn
     </Text>
   `);
 
-  await act(async () => resolve());
+  await act(() => resolve());
 
   expect(root).toMatchInlineSnapshot(`
     <Text>
@@ -225,78 +143,7 @@ test('keeps the previous screen visible when navigating with a transition', asyn
   `);
 });
 
-test('keeps the previous screen visible when navigating to a lazy screen with a transition', async () => {
-  const { promise, resolve } = Promise.withResolvers<{
-    default: React.ComponentType;
-  }>();
-
-  const ScreenA = () => <Text>[screen-a]</Text>;
-  const ScreenB = () => <Text>[screen-b]</Text>;
-
-  const LazyScreenB = React.lazy(() => promise);
-
-  const LazyNavigator = (props: any): any => {
-    const { state, descriptors, NavigationContent } = useNavigationBuilder(
-      MockRouter,
-      props
-    );
-
-    const route = state.routes[state.index];
-
-    if (route == null) {
-      return null;
-    }
-
-    return (
-      <NavigationContent>{descriptors[route.key]?.render()}</NavigationContent>
-    );
-  };
-
-  const navigation = createNavigationContainerRef<ParamListBase>();
-
-  const root = await render(
-    <BaseNavigationContainer ref={navigation}>
-      <React.Suspense fallback={<Text>[fallback]</Text>}>
-        <LazyNavigator>
-          <Screen name="A" component={ScreenA} />
-          <Screen name="B" component={LazyScreenB} />
-        </LazyNavigator>
-      </React.Suspense>
-    </BaseNavigationContainer>
-  );
-
-  expect(root).toMatchInlineSnapshot(`
-    <Text>
-      [screen-a]
-    </Text>
-  `);
-
-  await act(async () => {
-    React.startTransition(() => {
-      navigation.navigate('B');
-    });
-  });
-
-  expect(root).toMatchInlineSnapshot(`
-    <Text>
-      [screen-a]
-    </Text>
-  `);
-
-  await act(async () => {
-    resolve({
-      default: ScreenB,
-    });
-  });
-
-  expect(root).toMatchInlineSnapshot(`
-    <Text>
-      [screen-b]
-    </Text>
-  `);
-});
-
-test('keeps the current screen when going back to a suspending screen with a transition', async () => {
+test('keeps the current screen when going back to a suspending screen', async () => {
   const { promise, resolve } = Promise.withResolvers<void>();
 
   const ScreenA = () => <Text>[screen-a]</Text>;
@@ -326,10 +173,8 @@ test('keeps the current screen when going back to a suspending screen with a tra
     </Text>
   `);
 
-  await act(async () => {
-    React.startTransition(() => {
-      navigation.goBack();
-    });
+  await act(() => {
+    navigation.goBack();
   });
 
   expect(root).toMatchInlineSnapshot(`
@@ -338,7 +183,7 @@ test('keeps the current screen when going back to a suspending screen with a tra
     </Text>
   `);
 
-  await act(async () => resolve());
+  await act(() => resolve());
 
   expect(root).toMatchInlineSnapshot(`
     <Text>
@@ -347,7 +192,7 @@ test('keeps the current screen when going back to a suspending screen with a tra
   `);
 });
 
-test('keeps the previous screen when resetting to a suspending screen with a transition', async () => {
+test('keeps the previous screen when resetting to a suspending screen', async () => {
   const { promise, resolve } = Promise.withResolvers<void>();
 
   const ScreenA = () => <Text>[screen-a]</Text>;
@@ -377,10 +222,8 @@ test('keeps the previous screen when resetting to a suspending screen with a tra
     </Text>
   `);
 
-  await act(async () => {
-    React.startTransition(() => {
-      navigation.reset({ index: 0, routes: [{ name: 'B' }] });
-    });
+  await act(() => {
+    navigation.reset({ index: 0, routes: [{ name: 'B' }] });
   });
 
   expect(root).toMatchInlineSnapshot(`
@@ -389,7 +232,7 @@ test('keeps the previous screen when resetting to a suspending screen with a tra
     </Text>
   `);
 
-  await act(async () => resolve());
+  await act(() => resolve());
 
   expect(root).toMatchInlineSnapshot(`
     <Text>
@@ -398,7 +241,7 @@ test('keeps the previous screen when resetting to a suspending screen with a tra
   `);
 });
 
-test('keeps the previous screen when navigating in a nested navigator with a transition', async () => {
+test('keeps the previous screen when navigating in a nested navigator', async () => {
   const { promise, resolve } = Promise.withResolvers<void>();
 
   const ScreenA = () => <Text>[screen-a]</Text>;
@@ -434,10 +277,8 @@ test('keeps the previous screen when navigating in a nested navigator with a tra
     </Text>
   `);
 
-  await act(async () => {
-    React.startTransition(() => {
-      navigation.navigate('inner-b');
-    });
+  await act(() => {
+    navigation.navigate('inner-b');
   });
 
   expect(root).toMatchInlineSnapshot(`
@@ -446,7 +287,7 @@ test('keeps the previous screen when navigating in a nested navigator with a tra
     </Text>
   `);
 
-  await act(async () => resolve());
+  await act(() => resolve());
 
   expect(root).toMatchInlineSnapshot(`
     <Text>
@@ -455,7 +296,7 @@ test('keeps the previous screen when navigating in a nested navigator with a tra
   `);
 });
 
-test('shows stale content instead of fallback with startTransition for setParams', async () => {
+test('holds stale content instead of fallback when setParams suspends', async () => {
   const SetParamsNavigator = (props: any) => {
     const { state, descriptors, NavigationContent } = useNavigationBuilder(
       MockRouter,
@@ -475,7 +316,7 @@ test('shows stale content instead of fallback with startTransition for setParams
 
   const navigation = createNavigationContainerRef<ParamListBase>();
 
-  let { promise, resolve } = Promise.withResolvers<void>();
+  const { promise, resolve } = Promise.withResolvers<void>();
 
   const Content = ({ contentId }: { contentId: number }) => {
     if (contentId !== 0) {
@@ -511,96 +352,24 @@ test('shows stale content instead of fallback with startTransition for setParams
     </Text>
   `);
 
-  await act(async () => {
+  await act(() => {
     navigation.dispatch(CommonActions.setParams({ contentId: 1 }));
   });
 
   expect(root).toMatchInlineSnapshot(`
-    <>
-      <Text
-        style={
-          {
-            "display": "none",
-          }
-        }
-      >
-        [content-
-        0
-        ]
-      </Text>
-      <Text>
-        [fallback]
-      </Text>
-    </>
+    <Text>
+      [content-
+      0
+      ]
+    </Text>
   `);
 
-  await act(async () => resolve());
+  await act(() => resolve());
 
   expect(root).toMatchInlineSnapshot(`
     <Text>
       [content-
       1
-      ]
-    </Text>
-  `);
-
-  ({ promise, resolve } = Promise.withResolvers<void>());
-
-  await act(async () => {
-    navigation.dispatch(CommonActions.setParams({ contentId: 2 }));
-  });
-
-  expect(root).toMatchInlineSnapshot(`
-    <>
-      <Text
-        style={
-          {
-            "display": "none",
-          }
-        }
-      >
-        [content-
-        1
-        ]
-      </Text>
-      <Text>
-        [fallback]
-      </Text>
-    </>
-  `);
-
-  await act(async () => resolve());
-
-  expect(root).toMatchInlineSnapshot(`
-    <Text>
-      [content-
-      2
-      ]
-    </Text>
-  `);
-
-  ({ promise, resolve } = Promise.withResolvers<void>());
-
-  await act(async () => {
-    React.startTransition(() => {
-      navigation.dispatch(CommonActions.setParams({ contentId: 3 }));
-    });
-  });
-
-  expect(root).toMatchInlineSnapshot(`
-    <Text>
-      [content-
-      2
-      ]
-    </Text>
-  `);
-
-  await act(async () => resolve());
-
-  expect(root).toMatchInlineSnapshot(`
-    <Text>
-      [content-
-      3
       ]
     </Text>
   `);
@@ -651,7 +420,7 @@ test('reflects the pending state with useTransition during navigation', async ()
     </Text>
   `);
 
-  await act(async () => {
+  await act(() => {
     startNavigation?.();
   });
 
@@ -663,7 +432,7 @@ test('reflects the pending state with useTransition during navigation', async ()
     </Text>
   `);
 
-  await act(async () => resolve());
+  await act(() => resolve());
 
   expect(root).toMatchInlineSnapshot(`
     <Text>
@@ -672,7 +441,7 @@ test('reflects the pending state with useTransition during navigation', async ()
   `);
 });
 
-test('keeps useNavigationState consistent with the held screen during a transition', async () => {
+test('keeps useNavigationState consistent with the held screen during navigation', async () => {
   const { promise, resolve } = Promise.withResolvers<void>();
 
   const ScreenA = () => <Text>[screen-a]</Text>;
@@ -734,10 +503,8 @@ test('keeps useNavigationState consistent with the held screen during a transiti
     </>
   `);
 
-  await act(async () => {
-    React.startTransition(() => {
-      navigation.navigate('B');
-    });
+  await act(() => {
+    navigation.navigate('B');
   });
 
   expect(root).toMatchInlineSnapshot(`
@@ -753,7 +520,7 @@ test('keeps useNavigationState consistent with the held screen during a transiti
     </>
   `);
 
-  await act(async () => resolve());
+  await act(() => resolve());
 
   expect(root).toMatchInlineSnapshot(`
     <>
@@ -764,6 +531,352 @@ test('keeps useNavigationState consistent with the held screen during a transiti
       </Text>
       <Text>
         [screen-b]
+      </Text>
+    </>
+  `);
+});
+
+test('interrupts an in-flight transition when navigating again', async () => {
+  const promiseB = Promise.withResolvers<void>();
+  const promiseC = Promise.withResolvers<void>();
+
+  const ScreenA = () => <Text>[screen-a]</Text>;
+
+  const ScreenB = () => {
+    React.use(promiseB.promise);
+
+    return <Text>[screen-b]</Text>;
+  };
+
+  const ScreenC = () => {
+    React.use(promiseC.promise);
+
+    return <Text>[screen-c]</Text>;
+  };
+
+  const navigation = createNavigationContainerRef<ParamListBase>();
+
+  const root = await render(
+    <BaseNavigationContainer ref={navigation}>
+      <React.Suspense fallback={<Text>[fallback]</Text>}>
+        <TestNavigator>
+          <Screen name="A" component={ScreenA} />
+          <Screen name="B" component={ScreenB} />
+          <Screen name="C" component={ScreenC} />
+        </TestNavigator>
+      </React.Suspense>
+    </BaseNavigationContainer>
+  );
+
+  await act(() => {
+    navigation.navigate('B');
+  });
+
+  expect(root).toMatchInlineSnapshot(`
+    <Text>
+      [screen-a]
+    </Text>
+  `);
+
+  await act(() => {
+    navigation.navigate('C');
+  });
+
+  expect(root).toMatchInlineSnapshot(`
+    <Text>
+      [screen-a]
+    </Text>
+  `);
+
+  await act(() => promiseB.resolve());
+
+  expect(root).toMatchInlineSnapshot(`
+    <Text>
+      [screen-a]
+    </Text>
+  `);
+
+  await act(() => promiseC.resolve());
+
+  expect(root).toMatchInlineSnapshot(`
+    <Text>
+      [screen-c]
+    </Text>
+  `);
+});
+
+test('shows the error boundary when a navigation transition fails', async () => {
+  const { promise, reject } = Promise.withResolvers<void>();
+
+  class ErrorBoundary extends React.Component<
+    { children: React.ReactNode },
+    { hasError: boolean }
+  > {
+    override state = { hasError: false };
+
+    static getDerivedStateFromError() {
+      return { hasError: true };
+    }
+
+    override render() {
+      if (this.state.hasError) {
+        return <Text>[error]</Text>;
+      }
+
+      return this.props.children;
+    }
+  }
+
+  const ScreenA = () => <Text>[screen-a]</Text>;
+
+  const ScreenB = () => {
+    React.use(promise);
+
+    return <Text>[screen-b]</Text>;
+  };
+
+  const navigation = createNavigationContainerRef<ParamListBase>();
+
+  const root = await render(
+    <BaseNavigationContainer ref={navigation}>
+      <ErrorBoundary>
+        <React.Suspense fallback={<Text>[fallback]</Text>}>
+          <TestNavigator>
+            <Screen name="A" component={ScreenA} />
+            <Screen name="B" component={ScreenB} />
+          </TestNavigator>
+        </React.Suspense>
+      </ErrorBoundary>
+    </BaseNavigationContainer>
+  );
+
+  await act(() => {
+    navigation.navigate('B');
+  });
+
+  expect(root).toMatchInlineSnapshot(`
+    <Text>
+      [screen-a]
+    </Text>
+  `);
+
+  const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+  await act(() => {
+    reject(new Error('Failed to load'));
+  });
+
+  expect(root).toMatchInlineSnapshot(`
+    <Text>
+      [error]
+    </Text>
+  `);
+
+  expect(errorSpy).toHaveBeenCalled();
+
+  errorSpy.mockRestore();
+});
+
+test('shows the fallback of a freshly mounted boundary during navigation', async () => {
+  const { promise, resolve } = Promise.withResolvers<void>();
+
+  const ScreenA = () => <Text>[screen-a]</Text>;
+
+  const ScreenB = () => {
+    React.use(promise);
+
+    return <Text>[screen-b]</Text>;
+  };
+
+  const navigation = createNavigationContainerRef<ParamListBase>();
+
+  const root = await render(
+    <BaseNavigationContainer ref={navigation}>
+      <TestNavigator>
+        <Screen name="A" component={ScreenA} />
+        <Screen name="B">
+          {() => (
+            <React.Suspense fallback={<Text>[fallback-b]</Text>}>
+              <ScreenB />
+            </React.Suspense>
+          )}
+        </Screen>
+      </TestNavigator>
+    </BaseNavigationContainer>
+  );
+
+  expect(root).toMatchInlineSnapshot(`
+    <Text>
+      [screen-a]
+    </Text>
+  `);
+
+  await act(() => {
+    navigation.navigate('B');
+  });
+
+  expect(root).toMatchInlineSnapshot(`
+    <Text>
+      [fallback-b]
+    </Text>
+  `);
+
+  await act(() => resolve());
+
+  expect(root).toMatchInlineSnapshot(`
+    <Text>
+      [screen-b]
+    </Text>
+  `);
+});
+
+test('allows navigating away while a transition is pending', async () => {
+  const { promise, resolve } = Promise.withResolvers<void>();
+
+  const ScreenA = () => <Text>[screen-a]</Text>;
+
+  const ScreenB = () => {
+    React.use(promise);
+
+    return <Text>[screen-b]</Text>;
+  };
+
+  const ScreenC = () => <Text>[screen-c]</Text>;
+
+  const navigation = createNavigationContainerRef<ParamListBase>();
+
+  const root = await render(
+    <BaseNavigationContainer ref={navigation}>
+      <React.Suspense fallback={<Text>[fallback]</Text>}>
+        <TestNavigator>
+          <Screen name="A" component={ScreenA} />
+          <Screen name="B" component={ScreenB} />
+          <Screen name="C" component={ScreenC} />
+        </TestNavigator>
+      </React.Suspense>
+    </BaseNavigationContainer>
+  );
+
+  await act(() => {
+    navigation.navigate('B');
+  });
+
+  expect(root).toMatchInlineSnapshot(`
+    <Text>
+      [screen-a]
+    </Text>
+  `);
+
+  await act(() => {
+    navigation.navigate('C');
+  });
+
+  expect(root).toMatchInlineSnapshot(`
+    <Text>
+      [screen-c]
+    </Text>
+  `);
+
+  await act(() => resolve());
+
+  expect(root).toMatchInlineSnapshot(`
+    <Text>
+      [screen-c]
+    </Text>
+  `);
+});
+
+test('resets the pending state after a setParams transition completes', async () => {
+  const { promise, resolve } = Promise.withResolvers<void>();
+
+  let triggerUpdate: (() => void) | undefined;
+
+  const Content = ({ contentId }: { contentId: number }) => {
+    if (contentId !== 0) {
+      React.use(promise);
+    }
+
+    return <Text>[content-{contentId}]</Text>;
+  };
+
+  const PendingScreen = (props: any) => {
+    const navigation: any = useNavigation();
+    const [isPending, startTransition] = React.useTransition();
+    const contentId = props.route.params?.contentId ?? 0;
+
+    triggerUpdate = () => {
+      startTransition(() => {
+        navigation.setParams({ contentId: 1 });
+      });
+    };
+
+    return (
+      <>
+        <Text>[{isPending ? 'pending' : 'idle'}]</Text>
+        <React.Suspense fallback={<Text>[fallback]</Text>}>
+          <Content contentId={contentId} />
+        </React.Suspense>
+      </>
+    );
+  };
+
+  const navigation = createNavigationContainerRef<ParamListBase>();
+
+  const root = await render(
+    <BaseNavigationContainer ref={navigation}>
+      <TestNavigator>
+        <Screen name="A" component={PendingScreen} />
+      </TestNavigator>
+    </BaseNavigationContainer>
+  );
+
+  expect(root).toMatchInlineSnapshot(`
+    <>
+      <Text>
+        [
+        idle
+        ]
+      </Text>
+      <Text>
+        [content-
+        0
+        ]
+      </Text>
+    </>
+  `);
+
+  await act(() => {
+    triggerUpdate?.();
+  });
+
+  expect(root).toMatchInlineSnapshot(`
+    <>
+      <Text>
+        [
+        pending
+        ]
+      </Text>
+      <Text>
+        [content-
+        0
+        ]
+      </Text>
+    </>
+  `);
+
+  await act(() => resolve());
+
+  expect(root).toMatchInlineSnapshot(`
+    <>
+      <Text>
+        [
+        idle
+        ]
+      </Text>
+      <Text>
+        [content-
+        1
+        ]
       </Text>
     </>
   `);

--- a/packages/core/src/useNavigationCache.tsx
+++ b/packages/core/src/useNavigationCache.tsx
@@ -96,22 +96,10 @@ export function useNavigationCache<
   >((acc, route) => {
     const previous = cache.current[route.key];
 
-    type Thunk =
-      | NavigationAction
-      | ((state: State) => NavigationAction | null | undefined);
-
     if (previous) {
       // If a cached navigation object already exists, reuse it
       acc[route.key] = previous;
     } else {
-      const dispatch = (thunk: Thunk) => {
-        const action = typeof thunk === 'function' ? thunk(getState()) : thunk;
-
-        if (action != null) {
-          navigation.dispatch({ source: route.key, ...action });
-        }
-      };
-
       const withStack = (callback: () => void) => {
         let isStackSet = false;
 
@@ -134,6 +122,23 @@ export function useNavigationCache<
         }
       };
 
+      const dispatch = (
+        thunk:
+          | NavigationAction
+          | ((state: State) => NavigationAction | null | undefined)
+      ) => {
+        withStack(() =>
+          React.startTransition(() => {
+            const action =
+              typeof thunk === 'function' ? thunk(getState()) : thunk;
+
+            if (action != null) {
+              navigation.dispatch({ source: route.key, ...action });
+            }
+          })
+        );
+      };
+
       const actions = {
         ...router.actionCreators,
         ...CommonActions,
@@ -142,10 +147,8 @@ export function useNavigationCache<
       const helpers = Object.keys(actions).reduce<Record<string, () => void>>(
         (acc, name) => {
           acc[name] = (...args: any) =>
-            withStack(() =>
-              // @ts-expect-error: name is a valid key, but TypeScript is dumb
-              dispatch(actions[name](...args))
-            );
+            // @ts-expect-error: name is a valid key, but TypeScript is dumb
+            dispatch(actions[name](...args));
 
           return acc;
         },
@@ -160,7 +163,7 @@ export function useNavigationCache<
         ...helpers,
         // FIXME: too much work to fix the types for now
         ...(emitter.create(route.key) as any),
-        dispatch: (thunk: Thunk) => withStack(() => dispatch(thunk)),
+        dispatch,
         getParent: (routeName) => {
           if (routeName === route.name) {
             // If the passed route name is the same as the current route's name,

--- a/packages/drawer/src/views/DrawerItem.tsx
+++ b/packages/drawer/src/views/DrawerItem.tsx
@@ -6,7 +6,7 @@ import {
   SFSymbol,
   useTheme,
 } from '@react-navigation/native';
-import React from 'react';
+import * as React from 'react';
 import {
   type ColorValue,
   Image,

--- a/packages/drawer/src/views/DrawerItemList.tsx
+++ b/packages/drawer/src/views/DrawerItemList.tsx
@@ -54,11 +54,13 @@ export function DrawerItemList({ state, navigation, descriptors }: Props) {
       });
 
       if (!event.defaultPrevented) {
-        navigation.dispatch({
-          ...(focused
-            ? DrawerActions.closeDrawer()
-            : CommonActions.navigate(route.name, route.params)),
-          target: state.key,
+        React.startTransition(() => {
+          navigation.dispatch({
+            ...(focused
+              ? DrawerActions.closeDrawer()
+              : CommonActions.navigate(route.name, route.params)),
+            target: state.key,
+          });
         });
       }
     };

--- a/packages/material-top-tabs/src/views/MaterialTopTabBar.tsx
+++ b/packages/material-top-tabs/src/views/MaterialTopTabBar.tsx
@@ -7,7 +7,7 @@ import {
   useLocale,
   useTheme,
 } from '@react-navigation/native';
-import React from 'react';
+import * as React from 'react';
 import { type ColorValue, Image, StyleSheet } from 'react-native';
 import { type Route, TabBar, type TabDescriptor } from 'react-native-tab-view';
 

--- a/packages/native-stack/src/views/FooterComponent.tsx
+++ b/packages/native-stack/src/views/FooterComponent.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { ScreenFooter } from 'react-native-screens';
 
 type FooterProps = {

--- a/packages/native/src/useLinking.tsx
+++ b/packages/native/src/useLinking.tsx
@@ -131,10 +131,12 @@ const isPoppingLastEntry = (
  */
 export const series = (cb: () => Promise<void>) => {
   let queue = Promise.resolve();
+
   const callback = () => {
     // eslint-disable-next-line promise/no-callback-in-promise
     queue = queue.then(cb);
   };
+
   return callback;
 };
 
@@ -509,7 +511,7 @@ export function useLinking<ParamList extends ParamListBase>(
       }
     }
 
-    const onStateChange = async () => {
+    const onUpdate = async () => {
       const navigation = ref.current;
 
       if (!navigation || !enabled) {
@@ -521,6 +523,13 @@ export function useLinking<ParamList extends ParamListBase>(
 
       // root state may not available, for example when root navigators switch inside the container
       if (!state) {
+        return;
+      }
+
+      // Skip if the state hasn't changed since we last synced it
+      // This avoids redundant work when the committed `state` event fires
+      // after we already synced from `__unsafe_action__`
+      if (previousState === state) {
         return;
       }
 
@@ -595,10 +604,30 @@ export function useLinking<ParamList extends ParamListBase>(
       previousIndexRef.current = history.index;
     };
 
-    // We debounce onStateChange coz we don't want multiple state changes to be handled at one time
+    // We debounce onUpdate coz we don't want multiple state changes to be handled at one time
     // This could happen since `history.go(n)` is asynchronous
     // If `pushState` or `replaceState` were called before `history.go(n)` completes, it'll mess stuff up
-    return ref.current?.addListener('state', series(onStateChange));
+    const handleUpdate = series(onUpdate);
+
+    // We sync history on `__unsafe_action__` which fires synchronously on dispatch
+    // The committed `state` event can be deferred or skipped with transitions when a
+    // navigation interrupts an in-flight one, which would drop history entries
+    const unsubscribeAction = ref.current?.addListener(
+      '__unsafe_action__',
+      (e) => {
+        if (!e.data.noop) {
+          handleUpdate();
+        }
+      }
+    );
+
+    // We still listen to `state` for changes that don't go through dispatch, e.g. conditional rendering
+    const unsubscribeState = ref.current?.addListener('state', handleUpdate);
+
+    return () => {
+      unsubscribeAction?.();
+      unsubscribeState?.();
+    };
   }, [enabled, history, ref]);
 
   return {

--- a/packages/react-native-tab-view/src/TabBarItemLabel.tsx
+++ b/packages/react-native-tab-view/src/TabBarItemLabel.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import type { ColorValue, StyleProp, ViewStyle } from 'react-native';
 import { Animated, StyleSheet } from 'react-native';
 


### PR DESCRIPTION
this wraps actions dispatched via methods on `navigation` object such as `navigate`, `setParams`, `dispatch` etc. in `React.startTransition` to make them work well with suspense.

the `navigation` object received by navigators as well `resetRoot` on the container ref don't use transitions as an escape hatch.
