### PR TITLE
feat(native-stack): Support XCAsset header icons

### DIFF
--- a/example/__typechecks__/static.check.tsx
+++ b/example/__typechecks__/static.check.tsx
@@ -30,6 +30,7 @@ import {
 import {
   createNativeStackNavigator,
   createNativeStackScreen,
+  type NativeStackNavigationOptions,
 } from '@react-navigation/native-stack';
 import {
   createStackNavigator,
@@ -60,6 +61,19 @@ const NativeStack = createNativeStackNavigator({
     },
   },
 });
+
+const nativeStackOptions = {
+  unstable_headerRightItems: () => [
+    {
+      type: 'button',
+      label: 'Archive',
+      icon: { type: 'xcasset', name: 'archive' },
+      onPress: () => {},
+    },
+  ],
+} satisfies NativeStackNavigationOptions;
+
+expectTypeOf(nativeStackOptions).toExtend<NativeStackNavigationOptions>();
 
 createStaticNavigation(NativeStack);
 

--- a/packages/native-stack/src/types.tsx
+++ b/packages/native-stack/src/types.tsx
@@ -824,7 +824,18 @@ export type NativeStackNavigationOptions = {
   inactiveBehavior?: 'pause' | 'unmount' | 'none' | undefined;
 };
 
-type IconIOS = Extract<Icon, { type: 'image' | 'sfSymbol' }>;
+type IconIOS =
+  | Extract<Icon, { type: 'image' | 'sfSymbol' }>
+  | {
+      /**
+       * - `xcasset` - Use an image from the iOS asset catalog.
+       */
+      type: 'xcasset';
+      /**
+       * Name of the image in the iOS asset catalog.
+       */
+      name: string;
+    };
 
 type SharedHeaderItem = {
   /**


### PR DESCRIPTION
## Summary

- add the XCAsset icon variant to native-stack's iOS header-item icon type
- add static type coverage for an XCAsset-backed header button

## Context

`react-native-screens` already supports iOS platform icons in the form `{ type: 'xcasset', name: string }`, and native-stack already passes non-image platform icon objects through at runtime. This change exposes that supported shape in native-stack's public TypeScript API.