### PR TITLE
fix: preserve static param list inference with TypeScript 7

### DIFF
--- a/example/__typechecks__/static.check.tsx
+++ b/example/__typechecks__/static.check.tsx
@@ -53,6 +53,32 @@ expectTypeOf<StaticParamList<typeof NativeStack>>().toMatchTypeOf<{
   Foo: undefined;
 }>();
 
+const NestedStaticStack = createNativeStackNavigator({
+  screens: {
+    Profile: (_: StaticScreenProps<{ id: string }>) => null,
+  },
+});
+
+const StaticRootStack = createNativeStackNavigator({
+  screens: {
+    Home: () => null,
+    Nested: NestedStaticStack,
+  },
+});
+
+createStaticNavigation(StaticRootStack);
+
+type StaticRootParamList = StaticParamList<typeof StaticRootStack>;
+
+expectTypeOf<StaticRootParamList>().toEqualTypeOf<{
+  Home: undefined;
+  Nested:
+    | NavigatorScreenParams<{
+        Profile: { id: string };
+      }>
+    | undefined;
+}>();
+
 const HomeTabs = createBottomTabNavigator({
   screens: {
     Groups: () => null,

--- a/packages/core/src/__tests__/StaticNavigation.test.tsx
+++ b/packages/core/src/__tests__/StaticNavigation.test.tsx
@@ -82,6 +82,12 @@ type TestNavigatorTypeBag<ParamList extends {}> = {
   Navigator: typeof TestNavigator;
 };
 
+type Assert<T extends true> = T;
+type IsEqual<T, U> =
+  (<V>() => V extends T ? 1 : 2) extends <V>() => V extends U ? 1 : 2
+    ? true
+    : false;
+
 function createTestNavigator<
   const ParamList extends ParamListBase,
 >(): TypedNavigator<TestNavigatorTypeBag<ParamList>, undefined>;
@@ -107,6 +113,45 @@ const TestScreen = ({ route }: any) => {
     </>
   );
 };
+
+test('infers static param list from nested navigator configuration', () => {
+  type StaticParamListTypeTest = StaticParamList<{
+    config: {
+      screens: {
+        Home: typeof TestScreen;
+        Nested: {
+          screen: {
+            config: {
+              screens: {
+                Profile: typeof TestScreen;
+              };
+            };
+          };
+        };
+      };
+    };
+  }>;
+
+  type StaticParamListRootKeysTypeCheck = Assert<
+    IsEqual<keyof StaticParamListTypeTest, 'Home' | 'Nested'>
+  >;
+
+  type NestedStaticParamListRouteName = Extract<
+    NonNullable<StaticParamListTypeTest['Nested']>,
+    { screen: unknown }
+  >['screen'];
+
+  type StaticParamListNestedRouteNameTypeCheck = Assert<
+    IsEqual<NestedStaticParamListRouteName, 'Profile'>
+  >;
+
+  const staticParamListTypeChecks: [
+    StaticParamListRootKeysTypeCheck,
+    StaticParamListNestedRouteNameTypeCheck,
+  ] = [true, true];
+
+  expect(staticParamListTypeChecks).toEqual([true, true]);
+});
 
 test('renders the specified nested navigator configuration', () => {
   const Nested = createTestNavigator({

--- a/packages/core/src/__tests__/StaticNavigation.test.tsx
+++ b/packages/core/src/__tests__/StaticNavigation.test.tsx
@@ -82,12 +82,6 @@ type TestNavigatorTypeBag<ParamList extends {}> = {
   Navigator: typeof TestNavigator;
 };
 
-type Assert<T extends true> = T;
-type IsEqual<T, U> =
-  (<V>() => V extends T ? 1 : 2) extends <V>() => V extends U ? 1 : 2
-    ? true
-    : false;
-
 function createTestNavigator<
   const ParamList extends ParamListBase,
 >(): TypedNavigator<TestNavigatorTypeBag<ParamList>, undefined>;
@@ -113,45 +107,6 @@ const TestScreen = ({ route }: any) => {
     </>
   );
 };
-
-test('infers static param list from nested navigator configuration', () => {
-  type StaticParamListTypeTest = StaticParamList<{
-    config: {
-      screens: {
-        Home: typeof TestScreen;
-        Nested: {
-          screen: {
-            config: {
-              screens: {
-                Profile: typeof TestScreen;
-              };
-            };
-          };
-        };
-      };
-    };
-  }>;
-
-  type StaticParamListRootKeysTypeCheck = Assert<
-    IsEqual<keyof StaticParamListTypeTest, 'Home' | 'Nested'>
-  >;
-
-  type NestedStaticParamListRouteName = Extract<
-    NonNullable<StaticParamListTypeTest['Nested']>,
-    { screen: unknown }
-  >['screen'];
-
-  type StaticParamListNestedRouteNameTypeCheck = Assert<
-    IsEqual<NestedStaticParamListRouteName, 'Profile'>
-  >;
-
-  const staticParamListTypeChecks: [
-    StaticParamListRootKeysTypeCheck,
-    StaticParamListNestedRouteNameTypeCheck,
-  ] = [true, true];
-
-  expect(staticParamListTypeChecks).toEqual([true, true]);
-});
 
 test('renders the specified nested navigator configuration', () => {
   const Nested = createTestNavigator({

--- a/packages/core/src/types.tsx
+++ b/packages/core/src/types.tsx
@@ -44,10 +44,10 @@ type ParamsForScreenComponent<T> = T extends {
 
 type StaticNavigationConfig = {
   readonly config: {
-    readonly screens?: Record<string, any>;
+    readonly screens?: Record<string, unknown>;
     readonly groups?: {
       [key: string]: {
-        screens: Record<string, any>;
+        screens: Record<string, unknown>;
       };
     };
   };


### PR DESCRIPTION
**Motivation**

TypeScript v7 (and typescript 6 with --stableTypeOrdering) broke static navigation type inference for me: 
`TS2315: Type 'StaticParamList' is not generic.`
`StaticParamList` started being treated as non-generic, which caused inferred route names/params to collapse.

This small type-only change fixes the issue by tightening the internal static screen map constraint from `Record<string, any>` to `Record<string, unknown>`. I’m not fully sure why this specific shape trips TS7’s circular type alias handling, but this keeps the existing inference working.

**Test plan**

Added a type-level regression test for nested static navigation inference.


**Related**

- [https://github.com/react-navigation/react-navigation/discussions/12891](https://github.com/react-navigation/react-navigation/discussions/12891)
- https://github.com/microsoft/typescript-go/issues/2698