### PR TITLE
feat(elements): add aspectRatio to image icons

### DIFF
--- a/packages/elements/src/PlatformIcon.tsx
+++ b/packages/elements/src/PlatformIcon.tsx
@@ -54,7 +54,7 @@ export function PlatformIcon({
           tintColor={icon.tinted === false ? undefined : color}
           style={[
             {
-              width: size,
+              width: size * (icon.aspectRatio ?? 1),
               height: size,
             },
             style,

--- a/packages/elements/src/types.tsx
+++ b/packages/elements/src/types.tsx
@@ -36,6 +36,13 @@ type IconImage = {
    * Defaults to `true`.
    */
   tinted?: boolean;
+  /**
+   * Width to height ratio for non-square images.
+   * The image renders at `size * aspectRatio` × `size` of the consumer's icon size.
+   *
+   * Defaults to `1`.
+   */
+  aspectRatio?: number;
 };
 
 type IconSfSymbol = {

--- a/packages/native/ios/ReactNavigationSFSymbolView.swift
+++ b/packages/native/ios/ReactNavigationSFSymbolView.swift
@@ -532,15 +532,19 @@ import UIKit
       let variableValue = min(max(props.variableValue, 0), 1)
 
       if #available(iOS 16.0, *) {
-        return UIImage(
+        if let systemImage = UIImage(
           systemName: name,
           variableValue: Double(variableValue),
           configuration: configuration
-        )
+        ) {
+          return systemImage
+        }
       }
     }
 
+    // Fall back to a custom symbol from the app's asset catalog.
     return UIImage(systemName: name, withConfiguration: configuration)
+      ?? UIImage(named: name)?.applyingSymbolConfiguration(configuration)
   }
 
   @available(iOS 26.0, *)


### PR DESCRIPTION
**What**

Adds `aspectRatio` to the `image` `Icon` type, for non-square art (a wide logo, a pill badge). The image renders at `size * aspectRatio` × `size` of the consumer's icon size, so height stays on the shared baseline and only width grows.

```ts
{ type: 'image', source: { uri: 'logo' }, aspectRatio: 2 } // 2:1, twice as wide as tall
```

Replaces the earlier `width` / `height` proposal from #13167. One shape knob composes cleanly with the icon-size layer (`tabBarIconSize`) instead of a second absolute-size control that overlaps it. Only `image` needs it — SF Symbols and Material Symbols self-size from their own geometry.

Handled in `PlatformIcon` (so every `Icon` consumer inherits it) and in the custom bottom-tab bar, where a wider image also grows its slot width to stay aligned with the other tabs.

**Test plan**

Built and ran. A 2:1 image icon renders full-width uncropped in `Button`, the header, drawer items, material top tabs, and the custom bottom-tab bar; square icons unchanged.
