### PR TITLE
feat: make native package work without react-native-web

### DIFF
--- a/example/metro.config.js
+++ b/example/metro.config.js
@@ -17,6 +17,19 @@ module.exports = {
     ...defaultConfig.resolver,
 
     resolveRequest: (context, realModuleName, platform) => {
+      // We want these packages to work without `react-native-web`
+      if (
+        platform === 'web' &&
+        context.originModulePath.startsWith(
+          `${path.resolve(__dirname, '../packages/native')}${path.sep}`
+        ) &&
+        /^react-native-web(?:\/|$)/.test(realModuleName)
+      ) {
+        throw new Error(
+          `The module '${realModuleName}' should not be imported at runtime from '${context.originModulePath}' on Web.`
+        );
+      }
+
       // We mock out these native deps on web
       // This is an additional measure to ensure they don't get added accidentally
       const excludedModules = [

--- a/example/vite.config.mjs
+++ b/example/vite.config.mjs
@@ -70,6 +70,23 @@ export default defineConfig((env) => {
     },
     plugins: [
       {
+        name: 'react-native-web-import',
+        enforce: 'pre',
+        resolveId(source, importer) {
+          // We want these packages to work without `react-native-web`
+          if (
+            importer?.startsWith(
+              `${path.join(root, 'packages/native')}${path.sep}`
+            ) &&
+            /^react-native-web(?:\/|$)/.test(source)
+          ) {
+            throw new Error(
+              `The module '${source}' should not be imported at runtime from '${importer}' on Web.`
+            );
+          }
+        },
+      },
+      {
         name: 'server-rendering',
         configureServer(server) {
           return () => {

--- a/packages/native/src/Link.native.tsx
+++ b/packages/native/src/Link.native.tsx
@@ -1,0 +1,69 @@
+import { type RootParamList, useTheme } from '@react-navigation/core';
+import { type GestureResponderEvent, Text } from 'react-native';
+
+// eslint-disable-next-line import-x/extensions
+import type { Props } from './Link.tsx';
+import { useLinkProps } from './useLinkProps';
+
+export function Link<
+  ParamList extends {} = RootParamList,
+  RouteName extends Extract<keyof ParamList, string> = Extract<
+    keyof ParamList,
+    string
+  >,
+>({
+  in: parent,
+  screen,
+  params,
+  action,
+  href,
+  style,
+  disabled,
+  children,
+  onPress,
+  id,
+  numberOfLines,
+  testID,
+  'aria-label': ariaLabel,
+  'aria-busy': ariaBusy,
+  'aria-expanded': ariaExpanded,
+  'aria-hidden': ariaHidden,
+  'aria-labelledby': ariaLabelledBy,
+  'aria-live': ariaLive,
+}: Props<ParamList, RouteName>) {
+  // @ts-expect-error: destructuring loses the relationship between target props
+  const props = useLinkProps({ in: parent, screen, params, action, href });
+
+  // Keep usage of `useTheme` after `useLinkProps`
+  // This ensures proper error when used outside of navigation container
+  const { colors, fonts } = useTheme();
+
+  const onLinkPress = (e: GestureResponderEvent) => {
+    onPress?.(e);
+
+    // Let user prevent default behavior
+    if (!e.defaultPrevented) {
+      props.onPress(e);
+    }
+  };
+
+  return (
+    <Text
+      {...props}
+      aria-busy={ariaBusy}
+      aria-expanded={ariaExpanded}
+      aria-hidden={ariaHidden}
+      aria-label={ariaLabel}
+      accessibilityLabelledBy={ariaLabelledBy}
+      accessibilityLiveRegion={ariaLive === 'off' ? 'none' : ariaLive}
+      disabled={disabled}
+      id={id}
+      testID={testID}
+      numberOfLines={numberOfLines}
+      onPress={onLinkPress}
+      style={[{ color: colors.primary }, fonts.regular, style]}
+    >
+      {children}
+    </Text>
+  );
+}

--- a/packages/native/src/Link.tsx
+++ b/packages/native/src/Link.tsx
@@ -1,11 +1,6 @@
 import { type RootParamList, useTheme } from '@react-navigation/core';
 import * as React from 'react';
-import {
-  type GestureResponderEvent,
-  Platform,
-  Text,
-  type TextProps,
-} from 'react-native';
+import type { GestureResponderEvent, TextProps, TextStyle } from 'react-native';
 
 import { type LinkProps, useLinkProps } from './useLinkProps';
 
@@ -13,12 +8,33 @@ type PressEvent =
   | React.MouseEvent<HTMLAnchorElement, MouseEvent>
   | GestureResponderEvent;
 
-type LinkBaseProps = Omit<TextProps, 'disabled'> & {
-  target?: string;
-  onPress?: (e: PressEvent) => void;
+type LinkBaseProps = {
+  target?: React.AnchorHTMLAttributes<HTMLAnchorElement>['target'];
   disabled?: boolean | undefined;
+  id?: string | undefined;
+  testID?: string | undefined;
+  onPress?: (e: PressEvent) => void;
+  numberOfLines?: number | undefined;
+  className?: React.AnchorHTMLAttributes<HTMLAnchorElement>['className'];
+  style?: (React.CSSProperties & TextStyle) | undefined;
   children: React.ReactNode;
-};
+} & Pick<
+  TextProps,
+  | 'aria-busy'
+  | 'aria-expanded'
+  | 'aria-hidden'
+  | 'aria-label'
+  | 'aria-labelledby'
+  | 'aria-live'
+>;
+
+export type Props<
+  ParamList extends {} = RootParamList,
+  RouteName extends Extract<keyof ParamList, string> = Extract<
+    keyof ParamList,
+    string
+  >,
+> = LinkProps<NoInfer<ParamList>, RouteName> & LinkBaseProps;
 
 /**
  * Component to render link to another screen using a path.
@@ -43,10 +59,21 @@ export function Link<
   params,
   action,
   href,
-  style,
   target,
-  ...rest
-}: LinkProps<NoInfer<ParamList>, RouteName> & LinkBaseProps) {
+  disabled,
+  id,
+  testID,
+  onPress,
+  className,
+  style,
+  children,
+  'aria-label': ariaLabel,
+  'aria-busy': ariaBusy,
+  'aria-expanded': ariaExpanded,
+  'aria-hidden': ariaHidden,
+  'aria-labelledby': ariaLabelledBy,
+  'aria-live': ariaLive,
+}: Props<ParamList, RouteName>) {
   // @ts-expect-error: destructuring loses the relationship between target props
   const props = useLinkProps({ in: parent, screen, params, action, href });
 
@@ -54,16 +81,18 @@ export function Link<
   // This ensures proper error when used outside of navigation container
   const { colors, fonts } = useTheme();
 
-  const onPress = (e: PressEvent) => {
-    if (rest.disabled) {
+  if (typeof colors.primary !== 'string') {
+    throw new Error('Invalid color format.');
+  }
+
+  const onClick = (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
+    if (disabled) {
       e.preventDefault();
       e.stopPropagation();
       return;
     }
 
-    if ('onPress' in rest) {
-      rest.onPress?.(e);
-    }
+    onPress?.(e);
 
     // Let user prevent default behavior
     if (!e.defaultPrevented) {
@@ -71,23 +100,62 @@ export function Link<
     }
   };
 
-  return React.createElement(Text, {
-    ...props,
-    ...rest,
-    ...Platform.select({
-      web: {
-        'aria-disabled': rest.disabled,
-        onAuxClick: rest.disabled
-          ? (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
+  return (
+    <a
+      aria-busy={ariaBusy}
+      aria-disabled={disabled}
+      aria-expanded={ariaExpanded}
+      aria-hidden={ariaHidden}
+      aria-label={ariaLabel}
+      aria-labelledby={ariaLabelledBy}
+      aria-live={ariaLive}
+      id={id}
+      data-testid={testID}
+      tabIndex={props.href == null ? 0 : undefined}
+      target={target}
+      role={props.role}
+      href={props.href}
+      onAuxClick={
+        disabled
+          ? (e) => {
               e.preventDefault();
               e.stopPropagation();
             }
-          : undefined,
-        onClick: onPress,
-        hrefAttrs: { target },
-      },
-      default: { onPress },
-    }),
-    style: [{ color: colors.primary }, fonts.regular, style],
-  });
+          : undefined
+      }
+      onClick={onClick}
+      onKeyDown={
+        props.href == null
+          ? (e) => {
+              // On browser, pressing Enter on a link triggers a click event
+              // So we simulate browser behavior when href is not provided
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                e.currentTarget.click();
+              }
+            }
+          : undefined
+      }
+      className={className}
+      style={{
+        backgroundColor: 'transparent',
+        boxSizing: 'border-box',
+        color: colors.primary,
+        cursor: disabled ? 'default' : 'pointer',
+        display: 'inline',
+        fontSize: 14,
+        margin: 0,
+        overflowWrap: 'break-word',
+        padding: 0,
+        position: 'relative',
+        textAlign: 'start',
+        textDecoration: 'none',
+        whiteSpace: 'pre-wrap',
+        ...fonts.regular,
+        ...style,
+      }}
+    >
+      {children}
+    </a>
+  );
 }

--- a/packages/native/src/NavigationContainer.tsx
+++ b/packages/native/src/NavigationContainer.tsx
@@ -13,8 +13,8 @@ import {
   validatePathConfig,
 } from '@react-navigation/core';
 import * as React from 'react';
-import { I18nManager, Platform } from 'react-native';
 
+import { DEFAULT_DIRECTION, IS_NATIVE } from './constants';
 import { LinkingContext } from './LinkingContext';
 import { LocaleDirContext } from './LocaleDirContext';
 import { LightTheme } from './theming/LightTheme';
@@ -120,7 +120,7 @@ const RESTORE_STATE_ERROR =
  * This should be rendered at the root wrapping the whole app.
  */
 export function NavigationContainer<ParamList extends {} = RootParamList>({
-  direction = I18nManager.getConstants().isRTL ? 'rtl' : 'ltr',
+  direction = DEFAULT_DIRECTION,
   theme = LightTheme,
   linking,
   persistor,
@@ -188,8 +188,7 @@ export function NavigationContainer<ParamList extends {} = RootParamList>({
     return getInitialState();
   });
 
-  const isPersistenceSupported =
-    Platform.OS === 'web' ? !linkingConfig.options.enabled : true;
+  const isPersistenceSupported = IS_NATIVE || !linkingConfig.options.enabled;
 
   const [isPersistedStateResolved, initialStateFromPersisted] = useThenable(
     () => {

--- a/packages/native/src/constants.native.tsx
+++ b/packages/native/src/constants.native.tsx
@@ -1,0 +1,10 @@
+import { I18nManager } from 'react-native';
+
+import type { LocaleDirection } from './types';
+
+export const DEFAULT_DIRECTION: LocaleDirection = I18nManager.getConstants()
+  .isRTL
+  ? 'rtl'
+  : 'ltr';
+
+export const IS_NATIVE = true;

--- a/packages/native/src/constants.tsx
+++ b/packages/native/src/constants.tsx
@@ -1,0 +1,5 @@
+import type { LocaleDirection } from './types';
+
+export const DEFAULT_DIRECTION: LocaleDirection = 'ltr';
+
+export const IS_NATIVE = false;

--- a/packages/native/src/native/CornerInset.tsx
+++ b/packages/native/src/native/CornerInset.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { View } from 'react-native';
+import type { ViewProps } from 'react-native';
 
 export type CornerInsetProps = {
   /**
@@ -17,7 +17,7 @@ export type CornerInsetProps = {
    * @default true
    */
   adaptive?: boolean;
-} & React.ComponentProps<typeof View>;
+} & Omit<ViewProps, 'children'>;
 
 export type CornerInsetRef = {
   relayout(): void;
@@ -27,7 +27,7 @@ type Props = CornerInsetProps & {
   ref?: React.Ref<CornerInsetRef>;
 };
 
-export function CornerInset({ ref, ...rest }: Props) {
+export function CornerInset({ ref }: Props) {
   React.useImperativeHandle(
     ref,
     () => ({
@@ -36,5 +36,5 @@ export function CornerInset({ ref, ...rest }: Props) {
     []
   );
 
-  return <View {...rest} />;
+  return null;
 }

--- a/packages/native/src/native/MaterialSymbol.tsx
+++ b/packages/native/src/native/MaterialSymbol.tsx
@@ -1,4 +1,4 @@
-import { type ImageSourcePropType, type ViewProps } from 'react-native';
+import type { ImageSourcePropType, ViewProps } from 'react-native';
 
 import type { MaterialSymbolOptions } from './types';
 

--- a/packages/native/src/theming/fonts.native.tsx
+++ b/packages/native/src/theming/fonts.native.tsx
@@ -1,0 +1,41 @@
+import type { Theme } from '@react-navigation/core';
+import { Platform } from 'react-native';
+
+export const fonts = Platform.select({
+  ios: {
+    regular: {
+      fontFamily: 'System',
+      fontWeight: '400',
+    },
+    medium: {
+      fontFamily: 'System',
+      fontWeight: '500',
+    },
+    bold: {
+      fontFamily: 'System',
+      fontWeight: '600',
+    },
+    heavy: {
+      fontFamily: 'System',
+      fontWeight: '700',
+    },
+  },
+  default: {
+    regular: {
+      fontFamily: 'sans-serif',
+      fontWeight: 'normal',
+    },
+    medium: {
+      fontFamily: 'sans-serif-medium',
+      fontWeight: 'normal',
+    },
+    bold: {
+      fontFamily: 'sans-serif',
+      fontWeight: '600',
+    },
+    heavy: {
+      fontFamily: 'sans-serif',
+      fontWeight: '700',
+    },
+  },
+} as const satisfies Record<string, Theme['fonts']>);

--- a/packages/native/src/theming/fonts.tsx
+++ b/packages/native/src/theming/fonts.tsx
@@ -1,62 +1,23 @@
 import type { Theme } from '@react-navigation/core';
-import { Platform } from 'react-native';
 
 const WEB_FONT_STACK =
   'system-ui, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"';
 
-export const fonts = Platform.select({
-  web: {
-    regular: {
-      fontFamily: WEB_FONT_STACK,
-      fontWeight: '400',
-    },
-    medium: {
-      fontFamily: WEB_FONT_STACK,
-      fontWeight: '500',
-    },
-    bold: {
-      fontFamily: WEB_FONT_STACK,
-      fontWeight: '600',
-    },
-    heavy: {
-      fontFamily: WEB_FONT_STACK,
-      fontWeight: '700',
-    },
+export const fonts = {
+  regular: {
+    fontFamily: WEB_FONT_STACK,
+    fontWeight: '400',
   },
-  ios: {
-    regular: {
-      fontFamily: 'System',
-      fontWeight: '400',
-    },
-    medium: {
-      fontFamily: 'System',
-      fontWeight: '500',
-    },
-    bold: {
-      fontFamily: 'System',
-      fontWeight: '600',
-    },
-    heavy: {
-      fontFamily: 'System',
-      fontWeight: '700',
-    },
+  medium: {
+    fontFamily: WEB_FONT_STACK,
+    fontWeight: '500',
   },
-  default: {
-    regular: {
-      fontFamily: 'sans-serif',
-      fontWeight: 'normal',
-    },
-    medium: {
-      fontFamily: 'sans-serif-medium',
-      fontWeight: 'normal',
-    },
-    bold: {
-      fontFamily: 'sans-serif',
-      fontWeight: '600',
-    },
-    heavy: {
-      fontFamily: 'sans-serif',
-      fontWeight: '700',
-    },
+  bold: {
+    fontFamily: WEB_FONT_STACK,
+    fontWeight: '600',
   },
-} as const satisfies Record<string, Theme['fonts']>);
+  heavy: {
+    fontFamily: WEB_FONT_STACK,
+    fontWeight: '700',
+  },
+} as const satisfies Theme['fonts'];

--- a/packages/native/src/useLinkProps.tsx
+++ b/packages/native/src/useLinkProps.tsx
@@ -16,9 +16,10 @@ import {
   type RootParamList,
 } from '@react-navigation/core';
 import * as React from 'react';
-import { type GestureResponderEvent, Platform } from 'react-native';
+import type { GestureResponderEvent } from 'react-native';
 import useLatestCallback from 'use-latest-callback';
 
+import { IS_NATIVE } from './constants';
 import { LinkingContext } from './LinkingContext';
 import { useDeepStableValue } from './useDeepStableValue';
 
@@ -321,7 +322,7 @@ export function useLinkProps<
         | React.MouseEvent<HTMLAnchorElement, MouseEvent>
         | GestureResponderEvent
     ) => {
-      if (Platform.OS === 'web' && e) {
+      if (!IS_NATIVE && e) {
         // ignore clicks with modifier keys
         const hasModifierKey =
           ('metaKey' in e && e.metaKey) ||
@@ -379,7 +380,7 @@ export function useLinkProps<
   );
 
   const target = useDeepStableValue(
-    Platform.OS === 'web'
+    !IS_NATIVE
       ? typeof screen === 'string'
         ? {
             screen,
@@ -391,12 +392,12 @@ export function useLinkProps<
   );
 
   const state =
-    Platform.OS === 'web' && rest.href == null && target != null
+    !IS_NATIVE && rest.href == null && target != null
       ? React.use(NavigationFocusedRouteStateContext)
       : undefined;
 
   const href = React.useMemo(() => {
-    if (Platform.OS !== 'web' || rest.href != null || target == null) {
+    if (IS_NATIVE || rest.href != null || target == null) {
       return rest.href;
     }
 


### PR DESCRIPTION
this makes `@react-navigation/native` work on normal React web apps without needing to have `react-native-web` installed or aliased.

as part of this change, the API for `Link` component has changed. we now have a hardcoded list of props that we support for `Link` which is in the prop types of the component. there are also some breaking changes to existing props:

- `numberOfLines` is only supported on native. for web, prefer specifying appropriate styles instead.
- `target` no longer normalizes passed value (e.g. add `_` to text such as `_blank`). pass the value with `_` directly.
- `className` is now a valid prop on web, so you can customize the styling using a class.
- `style` now accepts a plain object, nested arrays etc. aren't supported and need to be used with `StyleSheet.compose`.
- `accessibilityX` and other deprecated props are removed in favor of `aria-x` props