### PR TITLE
fix(tab-view): keep the pager in sync with a controlled index

### DIFF
--- a/packages/react-native-tab-view/src/PagerViewAdapter.native.tsx
+++ b/packages/react-native-tab-view/src/PagerViewAdapter.native.tsx
@@ -53,7 +53,10 @@ export function PagerViewAdapter({
   const listeners = React.useRef<Set<Listener>>(new Set()).current;
 
   const pagerRef = React.useRef<ViewPager>(null);
-  const indexRef = React.useRef<number>(index);
+  // The page the underlying (uncontrolled) pager last reported it settled on.
+  // Kept in state so that a swipe or tab press triggers a re-render, letting us
+  // reconcile the pager back to the controlled `index` when they diverge.
+  const [pagerIndex, setPagerIndex] = React.useState(index);
   const navigationStateRef = React.useRef(navigationState);
 
   const position = useAnimatedValue(initialPosition);
@@ -90,11 +93,17 @@ export function PagerViewAdapter({
     if (keyboardDismissMode === 'auto') {
       Keyboard.dismiss();
     }
+  }, [keyboardDismissMode, index]);
 
-    if (indexRef.current !== index) {
+  // `react-native-pager-view` is uncontrolled: it moves on swipe or tab press and
+  // only reports the change afterwards. To keep `TabView` a truly controlled
+  // component, re-assert the controlled `index` on the pager whenever its settled
+  // page drifts away from it (e.g. the parent ignores or overrides `onIndexChange`).
+  React.useEffect(() => {
+    if (pagerIndex !== index) {
       setPage(index);
     }
-  }, [keyboardDismissMode, index, setPage]);
+  }, [index, pagerIndex, setPage]);
 
   const onPageScrollStateChanged = (
     state: PageScrollStateChangedNativeEvent
@@ -171,10 +180,10 @@ export function PagerViewAdapter({
           { useNativeDriver }
         )}
         onPageSelected={(e) => {
-          const index = e.nativeEvent.position;
-          indexRef.current = index;
-          onIndexChange(index);
-          onTabSelect?.({ index });
+          const newIndex = e.nativeEvent.position;
+          setPagerIndex(newIndex);
+          onIndexChange(newIndex);
+          onTabSelect?.({ index: newIndex });
         }}
         onPageScrollStateChanged={onPageScrollStateChanged}
         scrollEnabled={swipeEnabled}

--- a/packages/react-native-tab-view/src/__tests__/index.test.tsx
+++ b/packages/react-native-tab-view/src/__tests__/index.test.tsx
@@ -111,4 +111,41 @@ describe('iOS implementation', () => {
     expect(onTabSelect).toHaveBeenCalledTimes(1);
     expect(onTabSelect).toHaveBeenCalledWith({ index: 1 });
   });
+
+  test('keeps the pager on the controlled index when the parent rejects a change', async () => {
+    const user = userEvent.setup();
+    const onTabSelect = jest.fn();
+
+    const Pinned = () => {
+      const [routes] = React.useState([
+        { key: 'first', title: 'First' },
+        { key: 'second', title: 'Second' },
+      ]);
+
+      // Fully controlled parent: the index is pinned to 0 and requested
+      // changes via `onIndexChange` are intentionally not applied.
+      return (
+        <TabView
+          navigationState={{ index: 0, routes }}
+          renderScene={renderScene}
+          onIndexChange={() => {}}
+          onTabSelect={onTabSelect}
+        />
+      );
+    };
+
+    await render(<Pinned />);
+
+    await act(() => jest.runAllTimers());
+
+    await user.press(screen.getByLabelText('Second'));
+
+    await act(() => jest.runAllTimers());
+
+    // Since the parent keeps the index pinned to 0, a controlled TabView must
+    // drive the pager back to index 0 instead of leaving it on the pressed tab.
+    // `onTabSelect` fires for every settled page, so its last call reflects the
+    // page the pager actually ended up on.
+    expect(onTabSelect).toHaveBeenLastCalledWith({ index: 0 });
+  });
 });


### PR DESCRIPTION
**Motivation**

Closes #11412

`TabView` documents itself as a controlled component, but its native adapter isn't fully controlled. `react-native-pager-view` is uncontrolled — it moves on a swipe or tab press and only reports the change afterwards. The adapter tracked the pager's settled page in a `ref` and only re-asserted the controlled `index` inside an effect keyed on the `index` **prop** changing.

So when the pager physically moves but the parent keeps `navigationState.index` unchanged — e.g. it ignores `onIndexChange`, or resets it to the same value in response — nothing drives the pager back. The pager ends up on a different tab than the one the parent controls (`onIndexChange` reports `2`, the parent stays on `0`, the pager sits on `2` while the state says `0`). This matches the diagnosis in the issue (the underlying pager-view not being controlled, fixable in tab-view).

**Fix**

Track the pager's settled page in state instead of a ref, so a swipe/tab press triggers a re-render, and add an effect that reconciles the pager back to the controlled `index` whenever the settled page diverges from it. The controlled `index` is now always the source of truth after the pager settles, so a parent that pins or overrides the index keeps the pager in sync.

**Test plan**

- Added a unit test (`packages/react-native-tab-view/src/__tests__/index.test.tsx`) with a fully controlled parent that pins `index` to `0` and does not apply `onIndexChange`. Pressing the second tab must leave the pager back on tab `0`; the test asserts this via `onTabSelect` (which fires for every settled page). It fails on `main` and passes with this change.
- `yarn test`, `yarn lint`, and `yarn typecheck` all pass locally (the pre-commit hook runs the full suite: 1189 tests / 165 snapshots).
