### PR TITLE
fix(native): provide linking context to the fallback element

### DIFF
--- a/packages/native/src/NavigationContainer.tsx
+++ b/packages/native/src/NavigationContainer.tsx
@@ -246,9 +246,14 @@ export function NavigationContainer<ParamList extends {} = RootParamList>({
     (isLinkStateResolved && isPersistedStateResolved);
 
   if (!isStateReady) {
+    // Keep the same linking context available as in the ready branch, so that
+    // anything rendered in `fallback` (e.g. a `Link`) doesn't hit the default
+    // `LinkingContext` value, which throws.
     return (
       <LocaleDirContext.Provider value={direction}>
-        <ThemeProvider value={theme}>{fallback}</ThemeProvider>
+        <LinkingContext.Provider value={linkingConfig}>
+          <ThemeProvider value={theme}>{fallback}</ThemeProvider>
+        </LinkingContext.Provider>
       </LocaleDirContext.Provider>
     );
   }

--- a/packages/native/src/__tests__/NavigationContainer.web.test.tsx
+++ b/packages/native/src/__tests__/NavigationContainer.web.test.tsx
@@ -12,8 +12,10 @@ import {
   useNavigationBuilder,
 } from '@react-navigation/core';
 import { act, render, screen, waitFor } from '@testing-library/react';
+import * as React from 'react';
 import { Text } from 'react-native';
 
+import { LinkingContext } from '../LinkingContext';
 import { NavigationContainer } from '../NavigationContainer';
 
 beforeEach(() => {
@@ -327,6 +329,54 @@ test('renders normally when state restoration throws', async () => {
     'Failed to restore navigation state. The state will be initialized based on the navigation tree.',
     expect.any(Error)
   );
+});
+
+test('provides the linking context to the fallback while state is not ready', async () => {
+  const createStackNavigator = createNavigatorFactory((props: any) => {
+    const { state, descriptors, NavigationContent } = useNavigationBuilder(
+      StackRouter,
+      props
+    );
+
+    const route = state.routes[state.index];
+
+    return (
+      <NavigationContent>
+        {route ? descriptors[route.key]?.render() : null}
+      </NavigationContent>
+    );
+  });
+
+  const Stack = createStackNavigator();
+
+  const TestScreen = ({ route }: any): any => <Text>{route.name}</Text>;
+
+  // Reads the linking context the same way `Link`/`useLinkBuilder` do internally.
+  // Accessing `options` throws "Couldn't find a LinkingContext context." if the
+  // fallback isn't wrapped in `LinkingContext.Provider`.
+  const LinkingConsumer = () => {
+    const { options } = React.use(LinkingContext);
+    return <Text>fallback:{String(options?.enabled ?? false)}</Text>;
+  };
+
+  // Never resolves, so the container stays on the `fallback` branch.
+  const { promise } = Promise.withResolvers<PartialState<NavigationState>>();
+
+  render(
+    <NavigationContainer
+      fallback={<LinkingConsumer />}
+      persistor={{
+        persist() {},
+        restore: () => promise,
+      }}
+    >
+      <Stack.Navigator>
+        <Stack.Screen name="Home" component={TestScreen} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+
+  expect(screen.getByText('fallback:false')).toBeInTheDocument();
 });
 
 test('renders normally when state restoration rejects', async () => {


### PR DESCRIPTION
**Motivation**

Closes #13051

While `NavigationContainer` is restoring state asynchronously (deep link or persisted state), it renders the `fallback` element through an early return. That early-return branch wraps `fallback` in `LocaleDirContext` and `ThemeProvider`, but — unlike the ready branch — it does **not** mount `LinkingContext.Provider`.

`LinkingContext`'s default value throws (`Couldn't find a LinkingContext context.`) as soon as its `options` are read. So anything rendered in `fallback` that touches linking — a `Link`, `useLinkBuilder`, `useLinkProps`, `useRoutePath`, or portaled UI — crashes during the restore window instead of rendering.

**Fix**

Wrap the `fallback` branch in `LinkingContext.Provider` with the same `linkingConfig` value used by the ready branch, so the linking context is consistently available whenever `NavigationContainer` is mounted.

**Test plan**

- Added a test in `NavigationContainer.web.test.tsx`: with a never-resolving `persistor` (container stays on `fallback`), a `fallback` that reads `LinkingContext` now renders instead of throwing `Couldn't find a LinkingContext context.`. It fails on `main` and passes with this change.
- `yarn test`, `yarn lint`, `yarn typecheck` pass locally (pre-commit hook runs the full suite).
