### PR TITLE
fix: avoid import * in InteractionManager shims

### DIFF
--- a/packages/react-native-drawer-layout/src/views/InteractionManager.native.tsx
+++ b/packages/react-native-drawer-layout/src/views/InteractionManager.native.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable no-restricted-imports */
-import * as ReactNative from 'react-native';
+import { Platform } from 'react-native';
 
 type InteractionManagerType = {
   createInteractionHandle(): number;
@@ -8,13 +7,13 @@ type InteractionManagerType = {
 
 let InteractionManager: InteractionManagerType | undefined;
 
-const version = ReactNative.Platform.constants?.reactNativeVersion;
+const version = Platform.constants?.reactNativeVersion;
 
 try {
   InteractionManager =
     version?.major === 0 && version.minor >= 82
       ? undefined
-      : ReactNative.InteractionManager;
+      : require('react-native').InteractionManager;
 } catch (e) {
   // On newer React Native versions, accessing InteractionManager throws an error
   // https://github.com/react/react-native/pull/57026

--- a/packages/react-native-drawer-layout/src/views/InteractionManager.tsx
+++ b/packages/react-native-drawer-layout/src/views/InteractionManager.tsx
@@ -8,13 +8,8 @@ type InteractionManagerType = {
 
 let InteractionManager: InteractionManagerType | undefined;
 
-const version = ReactNative.Platform.constants?.reactNativeVersion;
-
 try {
-  InteractionManager =
-    version?.major === 0 && version.minor >= 82
-      ? undefined
-      : ReactNative.InteractionManager;
+  InteractionManager = ReactNative.InteractionManager;
 } catch (e) {
   // On newer React Native versions, accessing InteractionManager throws an error
   // https://github.com/react/react-native/pull/57026

--- a/packages/react-native-drawer-layout/src/views/InteractionManager.tsx
+++ b/packages/react-native-drawer-layout/src/views/InteractionManager.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable no-restricted-imports */
-import * as ReactNative from 'react-native';
+import { Platform } from 'react-native';
 
 type InteractionManagerType = {
   createInteractionHandle(): number;
@@ -8,13 +7,13 @@ type InteractionManagerType = {
 
 let InteractionManager: InteractionManagerType | undefined;
 
-const version = ReactNative.Platform.constants?.reactNativeVersion;
+const version = Platform.constants?.reactNativeVersion;
 
 try {
   InteractionManager =
     version?.major === 0 && version.minor >= 82
       ? undefined
-      : ReactNative.InteractionManager;
+      : require('react-native').InteractionManager;
 } catch (e) {
   // On newer React Native versions, accessing InteractionManager throws an error
   // https://github.com/react/react-native/pull/57026

--- a/packages/stack/src/views/InteractionManager.native.tsx
+++ b/packages/stack/src/views/InteractionManager.native.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable no-restricted-imports */
-import * as ReactNative from 'react-native';
+import { Platform } from 'react-native';
 
 type InteractionManagerType = {
   createInteractionHandle(): number;
@@ -8,13 +7,13 @@ type InteractionManagerType = {
 
 let InteractionManager: InteractionManagerType | undefined;
 
-const version = ReactNative.Platform.constants?.reactNativeVersion;
+const version = Platform.constants?.reactNativeVersion;
 
 try {
   InteractionManager =
     version?.major === 0 && version.minor >= 82
       ? undefined
-      : ReactNative.InteractionManager;
+      : require('react-native').InteractionManager;
 } catch (e) {
   // On newer React Native versions, accessing InteractionManager throws an error
   // https://github.com/react/react-native/pull/57026

--- a/packages/stack/src/views/InteractionManager.tsx
+++ b/packages/stack/src/views/InteractionManager.tsx
@@ -8,13 +8,8 @@ type InteractionManagerType = {
 
 let InteractionManager: InteractionManagerType | undefined;
 
-const version = ReactNative.Platform.constants?.reactNativeVersion;
-
 try {
-  InteractionManager =
-    version?.major === 0 && version.minor >= 82
-      ? undefined
-      : ReactNative.InteractionManager;
+  InteractionManager = ReactNative.InteractionManager;
 } catch (e) {
   // On newer React Native versions, accessing InteractionManager throws an error
   // https://github.com/react/react-native/pull/57026

--- a/packages/stack/src/views/InteractionManager.tsx
+++ b/packages/stack/src/views/InteractionManager.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable no-restricted-imports */
-import * as ReactNative from 'react-native';
+import { Platform } from 'react-native';
 
 type InteractionManagerType = {
   createInteractionHandle(): number;
@@ -8,13 +7,13 @@ type InteractionManagerType = {
 
 let InteractionManager: InteractionManagerType | undefined;
 
-const version = ReactNative.Platform.constants?.reactNativeVersion;
+const version = Platform.constants?.reactNativeVersion;
 
 try {
   InteractionManager =
     version?.major === 0 && version.minor >= 82
       ? undefined
-      : ReactNative.InteractionManager;
+      : require('react-native').InteractionManager;
 } catch (e) {
   // On newer React Native versions, accessing InteractionManager throws an error
   // https://github.com/react/react-native/pull/57026

--- a/packages/stack/src/views/InteractionManager.tsx
+++ b/packages/stack/src/views/InteractionManager.tsx
@@ -1,4 +1,5 @@
-import { Platform } from 'react-native';
+/* eslint-disable no-restricted-imports */
+import * as ReactNative from 'react-native';
 
 type InteractionManagerType = {
   createInteractionHandle(): number;
@@ -7,13 +8,13 @@ type InteractionManagerType = {
 
 let InteractionManager: InteractionManagerType | undefined;
 
-const version = Platform.constants?.reactNativeVersion;
+const version = ReactNative.Platform.constants?.reactNativeVersion;
 
 try {
   InteractionManager =
     version?.major === 0 && version.minor >= 82
       ? undefined
-      : require('react-native').InteractionManager;
+      : ReactNative.InteractionManager;
 } catch (e) {
   // On newer React Native versions, accessing InteractionManager throws an error
   // https://github.com/react/react-native/pull/57026


### PR DESCRIPTION
## Motivation

`import * as ReactNative from 'react-native'` in the InteractionManager shims
becomes `metroImportAll` under Metro `experimentalImportSupport`, which
enumerates all RN lazy getters → deprecated-export warnings and possible
iOS `NativeEventEmitter` crash.

**Repro**: https://github.com/delekta/NativeEventEmitterCrash  

## Minimal conditions to reproduce
1. `@react-navigation/stack` ≥ 7.10.10
2. Metro `experimentalImportSupport: true` + Babel `disableImportExportTransform: true`
(stock RN 0.81 does not reproduce — uses `_interopRequireWildcard`)
3. A stack screen mounts (Card loads the shim)

Still present in `@react-navigation/stack@7.10.17`.  
`native-stack` unaffected. Same shim in `react-native-drawer-layout`.

## Changes
- Read `InteractionManager` via `require('react-native').InteractionManager` inside `try`
- Keep RN ≥ 0.82 skip via named `Platform` import
- Apply to stack + react-native-drawer-layout

Base: `7.x` (keeps 7.x `runAfterInteractions` behavior; full removal belongs in 8).

## Testing from repro above

new EventEmitter crash - results in screen uninteractive 

| Before | After |
--------|-------
| <video src="https://github.com/user-attachments/assets/789703f1-820b-4d88-bf14-44c053b6bcc4" /> | <video src="https://github.com/user-attachments/assets/851245dc-a899-4d60-99f4-344040061dfb" />


## Test plan
- [ ] `pnpm typecheck` / `pnpm lint` / `pnpm test` (or `yarn` on `7.x` if that’s what the branch uses)
- [ ] Stack screen with experimental import support: no deprecated warn spam / no NativeEventEmitter red box from the shim
- [ ] Transitions still work; `runAfterInteractions` still defers when API exists
- [ ] Drawer-layout open/close on native still works
- [ ] Stock Metro path still works
