### PR TITLE
feat: add `inactiveBehavior: 'pauseWhenCovered'` 

### DIFF
--- a/packages/native-stack/src/__tests__/index.test.tsx
+++ b/packages/native-stack/src/__tests__/index.test.tsx
@@ -7,13 +7,18 @@ import {
   test,
 } from '@jest/globals';
 import { useHeaderHeight } from '@react-navigation/elements';
-import { NavigationContainer } from '@react-navigation/native';
 import {
+  createNavigationContainerRef,
+  NavigationContainer,
+} from '@react-navigation/native';
+import {
+  act,
   isHiddenFromAccessibility,
   render,
   screen,
   userEvent,
 } from '@testing-library/react-native';
+import * as React from 'react';
 import { Button, Platform, Text, View } from 'react-native';
 
 import {
@@ -75,6 +80,150 @@ test('renders a native-stack navigator with screens', async () => {
     )
   ).toBe(true);
   expect(isHiddenFromAccessibility(screen.getByText('Screen B'))).toBe(false);
+});
+
+const useTrackedEffect = (onChange: (active: boolean) => void) => {
+  React.useEffect(() => {
+    onChange(true);
+
+    return () => {
+      onChange(false);
+    };
+  }, [onChange]);
+};
+
+// Presentations that don't hide the screen below them
+const PARTIAL_PRESENTATIONS = ['formSheet', 'modal'] as const;
+
+test.each(PARTIAL_PRESENTATIONS)(
+  'default inactiveBehavior="pause" keeps the screen behind a %s active',
+  async (presentation) => {
+    let effectActive = false;
+
+    const ScreenA = () => {
+      useTrackedEffect((active) => {
+        effectActive = active;
+      });
+
+      return null;
+    };
+
+    const Stack = createNativeStackNavigator<StackParamList>();
+    const navigation = createNavigationContainerRef<StackParamList>();
+
+    await render(
+      <NavigationContainer ref={navigation}>
+        <Stack.Navigator>
+          <Stack.Screen name="A" component={ScreenA} />
+          <Stack.Screen name="B" options={{ presentation }}>
+            {() => null}
+          </Stack.Screen>
+        </Stack.Navigator>
+      </NavigationContainer>
+    );
+
+    expect(effectActive).toBe(true);
+
+    await act(() => navigation.navigate('B'));
+    await act(() => jest.runAllTimers());
+
+    // The screen stays visible under the cover, so it's kept active
+    expect(effectActive).toBe(true);
+  }
+);
+
+test.each(PARTIAL_PRESENTATIONS)(
+  'inactiveBehavior="pauseWhenCovered" pauses the screen behind a %s',
+  async (presentation) => {
+    let effectActive = false;
+
+    const ScreenA = () => {
+      useTrackedEffect((active) => {
+        effectActive = active;
+      });
+
+      return null;
+    };
+
+    const Stack = createNativeStackNavigator<StackParamList>();
+    const navigation = createNavigationContainerRef<StackParamList>();
+
+    await render(
+      <NavigationContainer ref={navigation}>
+        <Stack.Navigator>
+          <Stack.Screen
+            name="A"
+            component={ScreenA}
+            options={{ inactiveBehavior: 'pauseWhenCovered' }}
+          />
+          <Stack.Screen name="B" options={{ presentation }}>
+            {() => null}
+          </Stack.Screen>
+        </Stack.Navigator>
+      </NavigationContainer>
+    );
+
+    expect(effectActive).toBe(true);
+
+    await act(() => navigation.navigate('B'));
+    await act(() => jest.runAllTimers());
+
+    // Unlike `pause`, the screen is paused even though the cover doesn't hide it
+    expect(effectActive).toBe(false);
+
+    await act(() => navigation.goBack());
+    await act(() => jest.runAllTimers());
+
+    expect(effectActive).toBe(true);
+  }
+);
+
+test('inactiveBehavior="pauseWhenCovered" pauses the screen when a parent navigator is covered', async () => {
+  let effectActive = false;
+
+  const ScreenC = () => {
+    useTrackedEffect((active) => {
+      effectActive = active;
+    });
+
+    return null;
+  };
+
+  const Stack = createNativeStackNavigator<StackParamList>();
+  const NestedStack = createNativeStackNavigator<NestedStackParamList>();
+  const navigation = createNavigationContainerRef<StackParamList>();
+
+  await render(
+    <NavigationContainer ref={navigation}>
+      <Stack.Navigator>
+        <Stack.Screen name="A">
+          {() => (
+            <NestedStack.Navigator>
+              <NestedStack.Screen
+                name="C"
+                component={ScreenC}
+                options={{ inactiveBehavior: 'pauseWhenCovered' }}
+              />
+            </NestedStack.Navigator>
+          )}
+        </Stack.Screen>
+        <Stack.Screen name="B">{() => null}</Stack.Screen>
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+
+  expect(effectActive).toBe(true);
+
+  await act(() => navigation.navigate('B'));
+  await act(() => jest.runAllTimers());
+
+  // The nested screen is still focused in its own stack
+  expect(effectActive).toBe(false);
+
+  await act(() => navigation.goBack());
+  await act(() => jest.runAllTimers());
+
+  expect(effectActive).toBe(true);
 });
 
 describe('useHeaderHeight in native-stack', () => {

--- a/packages/native-stack/src/__tests__/index.web.test.tsx
+++ b/packages/native-stack/src/__tests__/index.web.test.tsx
@@ -7,9 +7,13 @@ import {
   test,
 } from '@jest/globals';
 import { useHeaderHeight } from '@react-navigation/elements';
-import { NavigationContainer } from '@react-navigation/native';
-import { render, screen } from '@testing-library/react';
+import {
+  createNavigationContainerRef,
+  NavigationContainer,
+} from '@react-navigation/native';
+import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import * as React from 'react';
 import { Button } from 'react-native';
 
 import {
@@ -33,6 +37,127 @@ beforeEach(() => {
 afterEach(() => {
   jest.runOnlyPendingTimers();
   jest.useRealTimers();
+});
+
+test('inactiveBehavior="pauseWhenCovered" pauses the screen when it is covered', async () => {
+  let effectActive = false;
+
+  const ScreenA = () => {
+    React.useEffect(() => {
+      effectActive = true;
+
+      return () => {
+        effectActive = false;
+      };
+    }, []);
+
+    return null;
+  };
+
+  const Stack = createNativeStackNavigator<StackParamList>();
+  const navigation = createNavigationContainerRef<StackParamList>();
+
+  render(
+    <NavigationContainer ref={navigation}>
+      <Stack.Navigator>
+        <Stack.Screen
+          name="A"
+          component={ScreenA}
+          options={{ inactiveBehavior: 'pauseWhenCovered' }}
+        />
+        <Stack.Screen name="B" options={{ presentation: 'transparentModal' }}>
+          {() => null}
+        </Stack.Screen>
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+
+  expect(effectActive).toBe(true);
+
+  await act(async () => {
+    navigation.navigate('B');
+  });
+
+  await act(async () => {
+    jest.runAllTimers();
+  });
+
+  // Unlike `pause`, the screen is paused even though it's visible under the modal
+  expect(effectActive).toBe(false);
+
+  await act(async () => {
+    navigation.goBack();
+  });
+
+  await act(async () => {
+    jest.runAllTimers();
+  });
+
+  expect(effectActive).toBe(true);
+});
+
+test('inactiveBehavior="pauseWhenCovered" pauses the screen when a parent navigator is covered', async () => {
+  let effectActive = false;
+
+  const ScreenC = () => {
+    React.useEffect(() => {
+      effectActive = true;
+
+      return () => {
+        effectActive = false;
+      };
+    }, []);
+
+    return null;
+  };
+
+  const Stack = createNativeStackNavigator<StackParamList>();
+  const NestedStack = createNativeStackNavigator<NestedStackParamList>();
+  const navigation = createNavigationContainerRef<StackParamList>();
+
+  render(
+    <NavigationContainer ref={navigation}>
+      <Stack.Navigator>
+        <Stack.Screen name="A">
+          {() => (
+            <NestedStack.Navigator>
+              <NestedStack.Screen
+                name="C"
+                component={ScreenC}
+                options={{ inactiveBehavior: 'pauseWhenCovered' }}
+              />
+            </NestedStack.Navigator>
+          )}
+        </Stack.Screen>
+        <Stack.Screen name="B" options={{ presentation: 'transparentModal' }}>
+          {() => null}
+        </Stack.Screen>
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+
+  expect(effectActive).toBe(true);
+
+  await act(async () => {
+    navigation.navigate('B');
+  });
+
+  await act(async () => {
+    jest.runAllTimers();
+  });
+
+  // The nested screen is still focused in its own stack
+  expect(effectActive).toBe(false);
+
+  await act(async () => {
+    navigation.goBack();
+  });
+
+  await act(async () => {
+    jest.runAllTimers();
+  });
+
+  expect(effectActive).toBe(true);
 });
 
 describe('useHeaderHeight in native-stack', () => {

--- a/packages/native-stack/src/types.tsx
+++ b/packages/native-stack/src/types.tsx
@@ -830,6 +830,8 @@ export type NativeStackNavigationOptions = {
   /**
    * What should happen when screens become inactive.
    * - `pause`: Effects are cleaned up.
+   * - `pauseWhenCovered`: Effects are cleaned up, also when the screen is covered
+   *   by the screen above it.
    * - `unmount`: Screen is unmounted
    * - `none`: Screen renders normally
    *
@@ -839,8 +841,19 @@ export type NativeStackNavigationOptions = {
    * This makes sure that effects are run to initialize the screen.
    *
    * Screens with nested navigators and last 2 screens won't be unmounted.
+   *
+   * `pauseWhenCovered` is useful for expensive screens, that are partially visible or behind current screen.
+   * May produce stale content while the user interacts with the screen covering them.
+   * It doesn't change whether the screen is visible - a paused screen is shown or hidden
+   * by the same rules as any other covered screen.
+   * A screen covered by a sheet or a modal is paused as well, even if it stays visible.
    */
-  inactiveBehavior?: 'pause' | 'unmount' | 'none' | undefined;
+  inactiveBehavior?:
+    | 'pause'
+    | 'pauseWhenCovered'
+    | 'unmount'
+    | 'none'
+    | undefined;
 };
 
 type IconIOS = Extract<Icon, { type: 'image' | 'sfSymbol' }>;

--- a/packages/native-stack/src/views/NativeStackView.native.tsx
+++ b/packages/native-stack/src/views/NativeStackView.native.tsx
@@ -11,6 +11,7 @@ import {
   SafeAreaProviderCompat,
 } from '@react-navigation/elements/internal';
 import {
+  IsFocusedContext,
   NavigationProvider,
   type ParamListBase,
   StackActions,
@@ -59,6 +60,7 @@ type SceneViewProps = {
   isNextScreenModal: boolean;
   isInactive: boolean;
   isBeforeLast: boolean;
+  isCoveredExternally: boolean;
   onWillDisappear: () => void;
   onWillAppear: () => void;
   onAppear: () => void;
@@ -90,6 +92,7 @@ const SceneView = ({
   isNextScreenModal,
   isInactive,
   isBeforeLast,
+  isCoveredExternally,
   onWillDisappear,
   onWillAppear,
   onAppear,
@@ -306,27 +309,38 @@ const SceneView = ({
         }
       );
 
+  const pauseWhenCovered = inactiveBehavior === 'pauseWhenCovered';
+
+  // Whether the screen is covered: by the screen above it in this stack,
+  // or by a screen covering the navigator it's in
+  const isCovered = focused
+    ? isCoveredExternally
+    : !isInactive && (isNextScreenTransparent || isBeforeLast);
+
   const activityMode =
-    // Render focused screens normally
-    // Unpause preloaded and retained screens so updates are visible
-    // Unpause previous screen so update isn't delayed for swipe back
-    // This lets effects on those screens run
-    // We don't need to handle inert as it'll be handled natively
-    inactiveBehavior === 'none' ||
-    focused ||
-    isInactive ||
-    isNextScreenTransparent ||
-    // Unpause the screen behind a sheet so it stays up to date
-    // Sheets don't cover the whole screen, so the screen behind is visible
-    isNextScreenSheet ||
-    // On iPadOS, the base screen is visible while modal is in a smaller area
-    // So also keep the screens unpaused
-    (isNextScreenModal && !isModal) ||
-    isBeforeLast
-      ? 'normal'
-      : inactiveBehavior === 'unmount' && !('state' in route && route.state)
-        ? 'unmounted'
-        : 'paused';
+    // Pause covered screens, including covers that leave them visible, e.g. sheets
+    pauseWhenCovered && isCovered
+      ? 'paused'
+      : // Render focused screens normally
+        // Unpause preloaded and retained screens so updates are visible
+        // Unpause previous screen so update isn't delayed for swipe back
+        // This lets effects on those screens run
+        // We don't need to handle inert as it'll be handled natively
+        inactiveBehavior === 'none' ||
+          focused ||
+          isInactive ||
+          isNextScreenTransparent ||
+          // Unpause the screen behind a sheet so it stays up to date
+          // Sheets don't cover the whole screen, so the screen behind is visible
+          isNextScreenSheet ||
+          // On iPadOS, the base screen is visible while modal is in a smaller area
+          // So also keep the screens unpaused
+          (isNextScreenModal && !isModal) ||
+          isBeforeLast
+        ? 'normal'
+        : inactiveBehavior === 'unmount' && !('state' in route && route.state)
+          ? 'unmounted'
+          : 'paused';
 
   const content = (
     <AnimatedHeaderHeightContext.Provider value={animatedHeaderHeight}>
@@ -485,6 +499,11 @@ type Props = {
 };
 
 export function NativeStackView({ state, navigation, descriptors }: Props) {
+  // Whether a navigator above this one is covered, e.g. by a modal in a parent stack
+  // The context composes the parent chain, so it's `false` if any ancestor is blurred
+  // It's `undefined` in the root navigator, which is always considered focused
+  const isCoveredExternally = React.use(IsFocusedContext) === false;
+
   const { setNextDismissedKey } = useDismissedRouteError(state);
 
   useInvalidPreventRemoveError(descriptors);
@@ -540,6 +559,7 @@ export function NativeStackView({ state, navigation, descriptors }: Props) {
               isNextScreenModal={isNextScreenModal}
               isInactive={index > state.index}
               isBeforeLast={index === activeRoutes.length - 2}
+              isCoveredExternally={isCoveredExternally}
               onWillDisappear={() => {
                 navigation.emit({
                   type: 'transitionStart',

--- a/packages/native-stack/src/views/NativeStackView.tsx
+++ b/packages/native-stack/src/views/NativeStackView.tsx
@@ -11,6 +11,7 @@ import {
   Screen,
 } from '@react-navigation/elements/internal';
 import {
+  IsFocusedContext,
   type ParamListBase,
   type StackNavigationState,
   useLinkBuilder,
@@ -39,6 +40,11 @@ const TRANSPARENT_PRESENTATIONS = [
 export function NativeStackView({ state, descriptors }: Props) {
   const parentHeaderBack = React.use(HeaderBackContext);
   const { buildHref } = useLinkBuilder();
+
+  // Whether a navigator above this one is covered, e.g. by a modal in a parent stack
+  // The context composes the parent chain, so it's `false` if any ancestor is blurred
+  // It's `undefined` in the root navigator, which is always considered focused
+  const isCoveredExternally = React.use(IsFocusedContext) === false;
 
   const activeRoutes = state.routes.slice(0, state.index + 1);
   const modalRouteKeys = getModalRouteKeys(activeRoutes, descriptors);
@@ -105,22 +111,33 @@ export function NativeStackView({ state, descriptors }: Props) {
           ? modalRouteKeys.includes(nextKey)
           : false;
 
+        const pauseWhenCovered = inactiveBehavior === 'pauseWhenCovered';
+
+        // Whether the screen is covered: by the screen above it in this stack,
+        // or by a screen covering the navigator it's in
+        const isCovered = isFocused
+          ? isCoveredExternally
+          : !isInactive && (isNextScreenTransparent || isBeforeLast);
+
         const activityMode =
-          // Render focused screens normally
-          isFocused
-            ? 'normal'
-            : // Unpause preloaded and retained screens so updates are visible
-              // This lets effects on those screens run
-              inactiveBehavior === 'none' ||
-                isInactive ||
-                isNextScreenTransparent
-              ? 'inert'
-              : inactiveBehavior === 'unmount' &&
-                  !isNextScreenModal &&
-                  !isBeforeLast &&
-                  !route.state
-                ? 'unmounted'
-                : 'paused';
+          // Pause covered screens, including covers that leave them visible
+          pauseWhenCovered && isCovered
+            ? 'paused'
+            : // Render focused screens normally
+              isFocused
+              ? 'normal'
+              : // Unpause preloaded and retained screens so updates are visible
+                // This lets effects on those screens run
+                inactiveBehavior === 'none' ||
+                  isInactive ||
+                  isNextScreenTransparent
+                ? 'inert'
+                : inactiveBehavior === 'unmount' &&
+                    !isNextScreenModal &&
+                    !isBeforeLast &&
+                    !route.state
+                  ? 'unmounted'
+                  : 'paused';
 
         if (activityMode === 'unmounted') {
           return null;

--- a/packages/stack/src/__tests__/index.test.tsx
+++ b/packages/stack/src/__tests__/index.test.tsx
@@ -428,6 +428,101 @@ test('default inactiveBehavior="pause" unmounts effects except last 2 screens', 
   expect(effectActiveB).toBe(true);
 });
 
+test('inactiveBehavior="pauseWhenCovered" pauses the screen when it is covered', async () => {
+  let effectActive = false;
+
+  const ScreenA = () => {
+    React.useEffect(() => {
+      effectActive = true;
+      return () => {
+        effectActive = false;
+      };
+    }, []);
+    return null;
+  };
+
+  const Stack = createStackNavigator<StackParamList>();
+  const navigation = createNavigationContainerRef<StackParamList>();
+
+  await render(
+    <NavigationContainer ref={navigation}>
+      <Stack.Navigator>
+        <Stack.Screen
+          name="A"
+          component={ScreenA}
+          options={{ inactiveBehavior: 'pauseWhenCovered' }}
+        />
+        <Stack.Screen name="B">{() => null}</Stack.Screen>
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+
+  expect(effectActive).toBe(true);
+
+  await act(() => navigation.navigate('B'));
+  await act(() => jest.runAllTimers());
+
+  // The screen before the last one stays active by default
+  // Here it's paused since the screen opted in with `pauseWhenCovered`
+  expect(effectActive).toBe(false);
+
+  await act(() => navigation.goBack());
+  await act(() => jest.runAllTimers());
+
+  expect(effectActive).toBe(true);
+});
+
+test('inactiveBehavior="pauseWhenCovered" pauses the screen when a parent navigator is covered', async () => {
+  let effectActive = false;
+
+  const ScreenD = () => {
+    React.useEffect(() => {
+      effectActive = true;
+      return () => {
+        effectActive = false;
+      };
+    }, []);
+    return null;
+  };
+
+  const Stack = createStackNavigator<StackParamList>();
+  const NestedStack = createStackNavigator<NestedStackParamList>();
+  const navigation = createNavigationContainerRef<StackParamList>();
+
+  await render(
+    <NavigationContainer ref={navigation}>
+      <Stack.Navigator>
+        <Stack.Screen name="A">
+          {() => (
+            <NestedStack.Navigator>
+              <NestedStack.Screen
+                name="D"
+                component={ScreenD}
+                options={{ inactiveBehavior: 'pauseWhenCovered' }}
+              />
+            </NestedStack.Navigator>
+          )}
+        </Stack.Screen>
+        <Stack.Screen name="B">{() => null}</Stack.Screen>
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+
+  expect(effectActive).toBe(true);
+
+  await act(() => navigation.navigate('B'));
+  await act(() => jest.runAllTimers());
+
+  // The nested screen is still focused in its own stack,
+  // but the screen containing the nested navigator is covered
+  expect(effectActive).toBe(false);
+
+  await act(() => navigation.goBack());
+  await act(() => jest.runAllTimers());
+
+  expect(effectActive).toBe(true);
+});
+
 test('preloading a screen runs effects', async () => {
   let effectActive = false;
 

--- a/packages/stack/src/types.tsx
+++ b/packages/stack/src/types.tsx
@@ -409,6 +409,8 @@ export type StackNavigationOptions = StackHeaderOptions &
     /**
      * What should happen when screens become inactive.
      * - `pause`: Effects are cleaned up
+     * - `pauseWhenCovered`: Effects are cleaned up, also when the screen is covered
+     *   by the screen above it
      * - `unmount`: Screen is unmounted
      * - `none`: Screen renders normally
      *
@@ -418,8 +420,18 @@ export type StackNavigationOptions = StackHeaderOptions &
      * This makes sure that effects are run to initialize the screen.
      *
      * Screens with nested navigators and last 2 screens won't be unmounted.
+     *
+     * `pauseWhenCovered` is useful for expensive screens, that are partially visible or behind current screen.
+     * May produce stale content while the user interacts with the screen covering them.
+     * It doesn't change whether the screen is visible - a paused screen is shown or hidden
+     * by the same rules as any other covered screen.
      */
-    inactiveBehavior?: 'pause' | 'unmount' | 'none' | undefined;
+    inactiveBehavior?:
+      | 'pause'
+      | 'pauseWhenCovered'
+      | 'unmount'
+      | 'none'
+      | undefined;
   };
 
 export type StackNavigationConfig = {};

--- a/packages/stack/src/views/Stack/CardStack.tsx
+++ b/packages/stack/src/views/Stack/CardStack.tsx
@@ -3,11 +3,12 @@ import {
   ActivityView,
   SafeAreaProviderCompat,
 } from '@react-navigation/elements/internal';
-import type {
-  LocaleDirection,
-  ParamListBase,
-  Route,
-  StackNavigationState,
+import {
+  IsFocusedContext,
+  type LocaleDirection,
+  type ParamListBase,
+  type Route,
+  type StackNavigationState,
 } from '@react-navigation/native';
 import * as React from 'react';
 import {
@@ -311,6 +312,9 @@ const isInactiveRoute = (route: Route<string>, routes: Route<string>[]) =>
   !routes.some((currentRoute) => currentRoute.key === route.key);
 
 export class CardStack extends React.Component<Props, State> {
+  // Used to read whether a navigator above this one is covered
+  static override contextType = IsFocusedContext;
+
   static getDerivedStateFromProps(
     props: Props,
     state: State
@@ -655,6 +659,13 @@ export class CardStack extends React.Component<Props, State> {
       throw new Error(`Couldn't find a route at index ${state.index}.`);
     }
 
+    // Whether a navigator above this one is covered, e.g. by a modal in a parent stack
+    // The context composes the parent chain, so it's `false` if any ancestor is blurred
+    // It's `undefined` in the root navigator, which is always considered focused
+    // The type of `this.context` isn't inferred from `contextType`, so we cast it
+    const isCoveredExternally =
+      (this.context as React.ContextType<typeof IsFocusedContext>) === false;
+
     // Render only two top-most active headers as a workaround for
     // https://github.com/react-navigation/react-navigation/issues/12456.
     // If the header is persisted, it might be placed incorrectly when navigating back
@@ -730,6 +741,8 @@ export class CardStack extends React.Component<Props, State> {
               headerTransparent,
             } = scene.descriptor.options;
 
+            const pauseWhenCovered = inactiveBehavior === 'pauseWhenCovered';
+
             const safeAreaInsetTop = insets.top;
             const safeAreaInsetRight = insets.right;
             const safeAreaInsetBottom = insets.bottom;
@@ -790,6 +803,17 @@ export class CardStack extends React.Component<Props, State> {
             const isTopmost = index === routes.length - 1;
             const isBeforeLast = index === routes.length - 2;
 
+            // Whether the screen is covered: by the screen above it in this stack,
+            // or by a screen covering the navigator it's in
+            // Screens animating in or out aren't covered yet
+            const isCovered =
+              !isFocusing &&
+              (focused
+                ? isCoveredExternally
+                : !isInactive &&
+                  !isRetained &&
+                  (isNextScreenTransparent || isBeforeLast));
+
             // Keep animating and the last two rendered routes visible for smoother transitions
             const isVisible =
               focused ||
@@ -810,29 +834,33 @@ export class CardStack extends React.Component<Props, State> {
                   // Preloaded screens should stay mounted, but remain hidden until focused
                   (!isPreloaded && index >= routes.length - 2)));
 
-            const activityMode = // Render focused and animating screens normally
-              focused || isFocusing
-                ? 'normal'
-                : inactiveBehavior === 'none' ||
-                    // Unpause preloaded or retained screens so updates are visible
-                    // Handle retained explicitly as isInactive won't be updated until animation end
-                    isInactive ||
-                    isRetained ||
-                    // Keep the screen before transparent screen active
-                    // This lets the screen under the transparent screen update and animate
-                    isNextScreenTransparent ||
-                    // Keep the screen before last screen active
-                    // Otherwise it breaks animation when going back
-                    isBeforeLast
-                  ? 'inert'
-                  : inactiveBehavior === 'unmount' &&
-                      // Don't unmount screens that needs to stay visible
-                      !isVisible &&
-                      // Don't unmount screens with nested navigators
-                      // So we don't lose their state
-                      !('state' in route && route.state)
-                    ? 'unmounted'
-                    : 'paused';
+            const activityMode =
+              // Pause covered screens, including covers that leave them visible
+              pauseWhenCovered && isCovered
+                ? 'paused'
+                : // Render focused and animating screens normally
+                  focused || isFocusing
+                  ? 'normal'
+                  : inactiveBehavior === 'none' ||
+                      // Unpause preloaded or retained screens so updates are visible
+                      // Handle retained explicitly as isInactive won't be updated until animation end
+                      isInactive ||
+                      isRetained ||
+                      // Keep the screen before transparent screen active
+                      // This lets the screen under the transparent screen update and animate
+                      isNextScreenTransparent ||
+                      // Keep the screen before last screen active
+                      // Otherwise it breaks animation when going back
+                      isBeforeLast
+                    ? 'inert'
+                    : inactiveBehavior === 'unmount' &&
+                        // Don't unmount screens that needs to stay visible
+                        !isVisible &&
+                        // Don't unmount screens with nested navigators
+                        // So we don't lose their state
+                        !('state' in route && route.state)
+                      ? 'unmounted'
+                      : 'paused';
 
             if (activityMode === 'unmounted') {
               return null;


### PR DESCRIPTION
**Motivation**

By default a covered screen stays active whenever its content might still be visible: under a transparent screen or a sheet, or when it's the screen before the last one. Its effects keep running and it re-renders synchronously on every store update. On a heavy screen, say a long list, all of that work ends up inside whatever interaction is happening on the screen above it.

There's no option today that reaches those positions. `inactiveBehavior: 'pause'` only pauses screens buried two or more levels deep under opaque covers, and both `CardStack` and `NativeStackView` hard-code the transparent-cover and before-last cases to stay active. Neither one can see a cover coming from a parent navigator either, because a stack only compares route indexes inside itself. That means a modal presented by the root stack can't pause anything inside a nested navigator.

I measured this on React Navigation 8 alpha in the Expensify app: https://github.com/Expensify/App/pull/97477

**What this adds**

`inactiveBehavior: 'pauseWhenCovered'`, a fourth value that screens opt into individually. It pauses a screen when the screen above it in its own stack covers it, and also when a navigator above it gets covered. The second case comes from `IsFocusedContext`, which already composes the parent chain: it's `false` as soon as any ancestor is blurred, and `undefined` in the root navigator, which counts as focused.

All three views end up with the same rule. A screen pauses when it isn't focused, isn't preloaded or being dismissed, and is either under a transparent screen or sitting before last.

* `stack/CardStack.tsx` gets `static contextType = IsFocusedContext`, an `isCovered` flag, one leading `'paused'` branch and an `isVisible` clause, so a paused card stays painted instead of turning into `display: none`.
* `native-stack/NativeStackView.native.tsx` reads the same context and passes it down as an `isCoveredExternally` scene prop, then uses the same flag and branch.
* `native-stack/NativeStackView.tsx` gets the same treatment, otherwise the option would silently do nothing on web.

Paused screens keep rendering at Offscreen priority, so their content may stay up to date while staying off the critical path of the interaction above them (if something cause rerender, effects are unmounted when paused)

One deliberate decision: `'pauseWhenCovered'` makes no exception for covers that leave the screen visible, such as sheets or a modal shown in a smaller area. Pausing screens that remain visible is the whole point of the option, and the reason `pause` skips those cases ("so it stays up to date") is exactly the tradeoff being opted out of.

**Test plan**

`yarn test`, `yarn lint` and `yarn typecheck` all pass. There are 7 new tests, and I checked each of them fails when the pause condition is stubbed out.

| Suite | Cases |
| --- | --- |
| `stack` | in-stack cover; cover from a parent navigator |
| `native-stack` (native) | behind `formSheet`; behind `modal`; parent navigator covered; plus one test pinning that default `pause` keeps the first two active |
| `native-stack` (web) | `transparentModal` cover; parent navigator covered |

I also verified it by hand in the Expensify app on web, iOS and Android. The flagged list screens pause under a covering screen but stay painted, content under the cover still updates (could be rerender from context that listen from specific store changes), and state and scroll position survive resume.

**Open questions**

