### PR TITLE
feat: add new animations and update existing animations in stack

### DIFF
--- a/example/src/Screens/StackAnimations.tsx
+++ b/example/src/Screens/StackAnimations.tsx
@@ -1,0 +1,273 @@
+import { MaterialDesignIcons } from '@react-native-vector-icons/material-design-icons';
+import { Button, Text, useHeaderHeight } from '@react-navigation/elements';
+import {
+  type StaticScreenProps,
+  useNavigation,
+  useTheme,
+} from '@react-navigation/native';
+import {
+  CardStyleInterpolators,
+  createStackNavigator,
+  createStackScreen,
+  HeaderStyleInterpolators,
+  TransitionPresets,
+} from '@react-navigation/stack';
+import * as React from 'react';
+import { ScrollView, StyleSheet, View } from 'react-native';
+
+import { Divider } from '../Shared/Divider';
+import { ListGroupItem } from '../Shared/ListGroupItem';
+import { ListItem } from '../Shared/LIstItem';
+
+const CARD_ANIMATION_NAMES = [
+  'forHorizontalIOS',
+  'forVerticalIOS',
+  'forModalPresentationIOS',
+  'forFadeFromBottomAndroid',
+  'forRevealFromBottomAndroid',
+  'forScaleFromCenterAndroid',
+  'forFadeFromRightAndroid',
+  'forBottomSheetAndroid',
+  'forDialogAndroid',
+  'forFadeFromCenter',
+  'forCrossDissolveIOS',
+  'forFlipIOS',
+  'forNoAnimation',
+] satisfies readonly (keyof typeof CardStyleInterpolators)[];
+
+const HEADER_ANIMATION_NAMES = [
+  'forUIKit',
+  'forFade',
+  'forSlideLeft',
+  'forSlideRight',
+  'forSlideUp',
+  'forNoAnimation',
+] satisfies readonly (keyof typeof HeaderStyleInterpolators)[];
+
+const TRANSITION_PRESET_NAMES = [
+  'SlideFromRightIOS',
+  'ModalSlideFromBottomIOS',
+  'ModalPresentationIOS',
+  'FadeFromBottomAndroid',
+  'DialogAndroid',
+  'RevealFromBottomAndroid',
+  'ScaleFromCenterAndroid',
+  'FadeFromRightAndroid',
+  'BottomSheetAndroid',
+  'ModalFadeTransition',
+  'ModalFlipIOS',
+  'CrossDissolveIOS',
+  'DefaultTransition',
+  'ModalTransition',
+  'SlideFromLeftIOS',
+] satisfies readonly (keyof typeof TransitionPresets)[];
+
+type CardAnimationName = (typeof CARD_ANIMATION_NAMES)[number];
+type HeaderAnimationName = (typeof HEADER_ANIMATION_NAMES)[number];
+type TransitionPresetName = (typeof TRANSITION_PRESET_NAMES)[number];
+
+type AnimationParams =
+  | { transitionPreset: TransitionPresetName }
+  | {
+      cardAnimation: CardAnimationName;
+      headerAnimation: HeaderAnimationName;
+    };
+
+function AnimationsScreen() {
+  const navigation = useNavigation('StackAnimationList');
+
+  const { colors } = useTheme();
+
+  const [cardAnimation, setCardAnimation] =
+    React.useState<CardAnimationName>('forHorizontalIOS');
+  const [headerAnimation, setHeaderAnimation] =
+    React.useState<HeaderAnimationName>('forUIKit');
+  const [transitionPreset, setTransitionPreset] =
+    React.useState<TransitionPresetName>();
+
+  return (
+    <ScrollView>
+      <Button
+        variant="filled"
+        onPress={() => {
+          if (transitionPreset !== undefined) {
+            navigation.navigate('StackAnimationPreview', {
+              transitionPreset,
+            });
+          } else {
+            navigation.navigate('StackAnimationPreview', {
+              cardAnimation,
+              headerAnimation,
+            });
+          }
+        }}
+        style={styles.button}
+      >
+        Preview animation
+      </Button>
+      <ListGroupItem title="Transition presets">
+        {TRANSITION_PRESET_NAMES.map((name) => (
+          <React.Fragment key={name}>
+            <ListItem title={name} onPress={() => setTransitionPreset(name)}>
+              {transitionPreset === name ? (
+                <MaterialDesignIcons
+                  name="check"
+                  color={colors.primary}
+                  size={24}
+                />
+              ) : null}
+            </ListItem>
+            <Divider />
+          </React.Fragment>
+        ))}
+      </ListGroupItem>
+      <ListGroupItem title="Card style interpolators">
+        {CARD_ANIMATION_NAMES.map((name) => (
+          <React.Fragment key={name}>
+            <ListItem
+              title={name}
+              onPress={() => {
+                setTransitionPreset(undefined);
+                setCardAnimation(name);
+              }}
+            >
+              {transitionPreset === undefined && cardAnimation === name ? (
+                <MaterialDesignIcons
+                  name="check"
+                  color={colors.primary}
+                  size={24}
+                />
+              ) : null}
+            </ListItem>
+            <Divider />
+          </React.Fragment>
+        ))}
+      </ListGroupItem>
+      <ListGroupItem title="Header style interpolators">
+        {HEADER_ANIMATION_NAMES.map((name) => (
+          <React.Fragment key={name}>
+            <ListItem
+              title={name}
+              onPress={() => {
+                setTransitionPreset(undefined);
+                setHeaderAnimation(name);
+              }}
+            >
+              {transitionPreset === undefined && headerAnimation === name ? (
+                <MaterialDesignIcons
+                  name="check"
+                  color={colors.primary}
+                  size={24}
+                />
+              ) : null}
+            </ListItem>
+            <Divider />
+          </React.Fragment>
+        ))}
+      </ListGroupItem>
+    </ScrollView>
+  );
+}
+
+function AnimationScreen({ route }: StaticScreenProps<AnimationParams>) {
+  const navigation = useNavigation('StackAnimationPreview');
+
+  const headerHeight = useHeaderHeight();
+
+  return (
+    <View style={styles.content}>
+      {'transitionPreset' in route.params ? (
+        <>
+          <Text style={styles.description}>Preset</Text>
+          <Text style={styles.name}>{route.params.transitionPreset}</Text>
+        </>
+      ) : (
+        <>
+          <Text style={styles.description}>Card</Text>
+          <Text style={styles.name}>{route.params.cardAnimation}</Text>
+          <Text style={[styles.description, styles.headerDescription]}>
+            Header
+          </Text>
+          <Text style={styles.name}>{route.params.headerAnimation}</Text>
+        </>
+      )}
+      <View style={styles.buttons}>
+        <Button
+          variant="filled"
+          onPress={() => navigation.push('StackAnimationPreview', route.params)}
+        >
+          Push again
+        </Button>
+        <Button variant="tinted" onPress={() => navigation.goBack()}>
+          Go back
+        </Button>
+      </View>
+      <View style={{ height: headerHeight }} />
+    </View>
+  );
+}
+
+const StackAnimationsNavigator = createStackNavigator({
+  screenOptions: {
+    animation: 'default',
+    gestureEnabled: true,
+  },
+  screens: {
+    StackAnimationList: createStackScreen({
+      screen: AnimationsScreen,
+      options: { title: 'Animations' },
+    }),
+    StackAnimationPreview: createStackScreen({
+      screen: AnimationScreen,
+      options: ({ route }) =>
+        'transitionPreset' in route.params
+          ? {
+              ...TransitionPresets[route.params.transitionPreset],
+              title: 'Animation',
+            }
+          : {
+              title: 'Animation',
+              cardStyleInterpolator:
+                CardStyleInterpolators[route.params.cardAnimation],
+              headerStyleInterpolator:
+                HeaderStyleInterpolators[route.params.headerAnimation],
+            },
+    }),
+  },
+});
+
+export const StackAnimations = {
+  screen: StackAnimationsNavigator,
+  title: 'Stack - Animations',
+};
+
+const styles = StyleSheet.create({
+  content: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+    padding: 16,
+  },
+  description: {
+    fontSize: 16,
+  },
+  name: {
+    fontSize: 20,
+    fontWeight: '600',
+  },
+  headerDescription: {
+    marginTop: 12,
+  },
+  buttons: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'center',
+    gap: 12,
+    marginTop: 8,
+  },
+  button: {
+    marginHorizontal: 16,
+    marginTop: 16,
+  },
+});

--- a/example/src/screens.tsx
+++ b/example/src/screens.tsx
@@ -26,6 +26,7 @@ import { NativeStackPreloadFlow } from './Screens/NativeStackPreloadFlow';
 import { NativeStackPreventRemove } from './Screens/NativeStackPreventRemove';
 import { NavigatorLayout } from './Screens/NavigatorLayout';
 import { ScreenLayout } from './Screens/ScreenLayout';
+import { StackAnimations } from './Screens/StackAnimations';
 import { StackBasic } from './Screens/StackBasic';
 import { StackCardModal } from './Screens/StackCardModal';
 import { StackFloatScreenHeader } from './Screens/StackFloatScreenHeader';
@@ -51,6 +52,7 @@ export const SCREENS = {
   NativeStackHeaderCustomization,
   NativeStackPreloadFlow,
   NativeStackPreventRemove,
+  StackAnimations,
   StackBasic,
   StackCardModal,
   StackFloatScreenHeader,

--- a/packages/stack/src/TransitionConfigs/CardStyleInterpolators.tsx
+++ b/packages/stack/src/TransitionConfigs/CardStyleInterpolators.tsx
@@ -5,6 +5,16 @@ import type {
   StackCardInterpolationProps,
 } from '../types';
 import { conditional } from '../utils/conditional';
+import {
+  accelerate,
+  ACTIVITY_CLOSE_DIM,
+  clamp,
+  decelerate,
+  FAST_OUT_EXTRA_SLOW_IN,
+  FAST_OUT_SLOW_IN,
+  LINEAR_OUT_SLOW_IN,
+  timeline,
+} from './TransitionEasings';
 
 const { add, multiply } = Animated;
 
@@ -39,13 +49,7 @@ export function forHorizontalIOS({
 
   const overlayOpacity = current.progress.interpolate({
     inputRange: [0, 1],
-    outputRange: [0, 0.07],
-    extrapolate: 'clamp',
-  });
-
-  const shadowOpacity = current.progress.interpolate({
-    inputRange: [0, 1],
-    outputRange: [0, 0.3],
+    outputRange: [0, 0.1],
     extrapolate: 'clamp',
   });
 
@@ -59,21 +63,8 @@ export function forHorizontalIOS({
       ],
     },
     overlayStyle: { opacity: overlayOpacity },
-    shadowStyle: { shadowOpacity },
+    shadowStyle: { shadowOpacity: 0.04 },
   };
-}
-
-/**
- * iOS-style slide in from the left.
- */
-export function forHorizontalIOSInverted({
-  inverted,
-  ...rest
-}: StackCardInterpolationProps): StackCardInterpolatedStyle {
-  return forHorizontalIOS({
-    ...rest,
-    inverted: Animated.multiply(inverted, -1),
-  });
 }
 
 /**
@@ -242,9 +233,9 @@ export function forModalPresentationIOS({
  */
 export function forFadeFromBottomAndroid({
   current,
+  next,
   inverted,
   layouts: { screen },
-  closing,
 }: StackCardInterpolationProps): StackCardInterpolatedStyle {
   const translateY = multiply(
     current.progress.interpolate({
@@ -256,13 +247,24 @@ export function forFadeFromBottomAndroid({
   );
 
   const opacity = conditional(
-    closing,
-    current.progress,
-    current.progress.interpolate({
-      inputRange: [0, 0.5, 0.9, 1],
-      outputRange: [0, 0.25, 0.7, 1],
-      extrapolate: 'clamp',
-    })
+    current.closing,
+    current.progress.interpolate(
+      timeline({
+        duration: 250,
+        easing: (value) => accelerate(4, value),
+        closing: true,
+        stops: [100],
+        output: (time) => 1 - clamp((time - 100) / 150),
+      })
+    ),
+    current.progress.interpolate(
+      timeline({
+        duration: 350,
+        easing: (value) => decelerate(5, value),
+        stops: [200],
+        output: (time) => decelerate(4, clamp(time / 200)),
+      })
+    )
   );
 
   return {
@@ -270,6 +272,29 @@ export function forFadeFromBottomAndroid({
       opacity,
       transform: [{ translateY }],
     },
+    dimStyle: next
+      ? {
+          opacity: conditional(
+            next.closing,
+            next.progress.interpolate(
+              timeline({
+                duration: 250,
+                easing: (value) => accelerate(4, value),
+                closing: true,
+                output: (time) => 0.3 * (1 - LINEAR_OUT_SLOW_IN(time / 250)),
+              })
+            ),
+            next.progress.interpolate(
+              timeline({
+                duration: 350,
+                easing: (value) => decelerate(5, value),
+                stops: [217],
+                output: (time) => 0.3 * FAST_OUT_SLOW_IN(clamp(time / 217)),
+              })
+            )
+          ),
+        }
+      : undefined,
   };
 }
 
@@ -282,40 +307,80 @@ export function forRevealFromBottomAndroid({
   inverted,
   layouts: { screen },
 }: StackCardInterpolationProps): StackCardInterpolatedStyle {
+  const translationOpenRanges = timeline({
+    duration: 425,
+    easing: FAST_OUT_EXTRA_SLOW_IN,
+    output: (time) => FAST_OUT_SLOW_IN(time / 425),
+  });
+
+  const translationCloseRanges = timeline({
+    duration: 425,
+    easing: FAST_OUT_EXTRA_SLOW_IN,
+    closing: true,
+    output: (time) => 1 - FAST_OUT_SLOW_IN(time / 425),
+  });
+
+  const clipProgress = current.progress.interpolate({
+    inputRange: [0, 1],
+    outputRange: [0, 1],
+    extrapolate: 'clamp',
+  });
+
+  const translationProgress = conditional(
+    current.closing,
+    current.progress.interpolate(translationCloseRanges),
+    current.progress.interpolate(translationOpenRanges)
+  );
+
   const containerTranslateY = multiply(
-    current.progress.interpolate({
-      inputRange: [0, 1],
-      outputRange: [screen.height, 0],
-      extrapolate: 'clamp',
-    }),
+    multiply(
+      add(
+        add(1, multiply(clipProgress, -0.959)),
+        multiply(translationProgress, -0.041)
+      ),
+      screen.height
+    ),
     inverted
   );
 
   const cardTranslateYFocused = multiply(
-    current.progress.interpolate({
-      inputRange: [0, 1],
-      outputRange: [screen.height * (95.9 / 100) * -1, 0],
-      extrapolate: 'clamp',
-    }),
+    multiply(add(clipProgress, -1), screen.height * 0.959),
     inverted
   );
 
   const cardTranslateYUnfocused = next
     ? multiply(
-        next.progress.interpolate({
-          inputRange: [0, 1],
-          outputRange: [0, screen.height * (2 / 100) * -1],
-          extrapolate: 'clamp',
-        }),
+        multiply(
+          conditional(
+            next.closing,
+            next.progress.interpolate(translationCloseRanges),
+            next.progress.interpolate(translationOpenRanges)
+          ),
+          screen.height * -0.02
+        ),
         inverted
       )
     : 0;
 
-  const overlayOpacity = current.progress.interpolate({
-    inputRange: [0, 0.36, 1],
-    outputRange: [0, 0.1, 0.1],
-    extrapolate: 'clamp',
-  });
+  const overlayOpacity = conditional(
+    current.closing,
+    current.progress.interpolate(
+      timeline({
+        duration: 425,
+        easing: FAST_OUT_EXTRA_SLOW_IN,
+        closing: true,
+        output: (time) => 0.1 * (1 - ACTIVITY_CLOSE_DIM(time / 425)),
+      })
+    ),
+    current.progress.interpolate(
+      timeline({
+        duration: 425,
+        easing: FAST_OUT_EXTRA_SLOW_IN,
+        stops: [117],
+        output: (time) => 0.1 * clamp(time / 117),
+      })
+    )
+  );
 
   return {
     containerStyle: {
@@ -333,62 +398,94 @@ export function forRevealFromBottomAndroid({
 }
 
 /**
- * Standard Android-style zoom for Android 10.
+ * Standard Android-style scale from center for Android 10.
  */
 export function forScaleFromCenterAndroid({
   current,
   next,
-  closing,
 }: StackCardInterpolationProps): StackCardInterpolatedStyle {
-  const progress = add(
-    current.progress.interpolate({
-      inputRange: [0, 1],
-      outputRange: [0, 1],
-      extrapolate: 'clamp',
-    }),
-    next
-      ? next.progress.interpolate({
+  const opacity = conditional(
+    current.closing,
+    current.progress.interpolate(
+      timeline({
+        duration: 400,
+        easing: FAST_OUT_EXTRA_SLOW_IN,
+        closing: true,
+        stops: [33, 83],
+        output: (time) => 1 - clamp((time - 33) / 50),
+      })
+    ),
+    current.progress.interpolate(
+      timeline({
+        duration: 400,
+        easing: FAST_OUT_EXTRA_SLOW_IN,
+        stops: [50, 100],
+        output: (time) => clamp((time - 50) / 50),
+      })
+    )
+  );
+
+  const scale = next
+    ? conditional(
+        next.closing,
+        next.progress.interpolate({
           inputRange: [0, 1],
-          outputRange: [0, 1],
+          outputRange: [1, 1.1],
+          extrapolate: 'clamp',
+        }),
+        next.progress.interpolate({
+          inputRange: [0, 1],
+          outputRange: [1, 1.05],
           extrapolate: 'clamp',
         })
-      : 0
-  );
-
-  const opacity = progress.interpolate({
-    inputRange: [0, 0.75, 0.875, 1, 1.0825, 1.2075, 2],
-    outputRange: [0, 0, 1, 1, 1, 1, 0],
-  });
-
-  const scale = conditional(
-    closing,
-    current.progress.interpolate({
-      inputRange: [0, 1],
-      outputRange: [0.925, 1],
-      extrapolate: 'clamp',
-    }),
-    progress.interpolate({
-      inputRange: [0, 1, 2],
-      outputRange: [0.85, 1, 1.075],
-    })
-  );
+      )
+    : conditional(
+        current.closing,
+        current.progress.interpolate({
+          inputRange: [0, 1],
+          outputRange: [0.9, 1],
+          extrapolate: 'clamp',
+        }),
+        current.progress.interpolate({
+          inputRange: [0, 1],
+          outputRange: [0.85, 1],
+          extrapolate: 'clamp',
+        })
+      );
 
   return {
     cardStyle: {
       opacity,
       transform: [{ scale }],
     },
+    dimStyle: next
+      ? {
+          opacity: multiply(
+            next.closing.interpolate({
+              inputRange: [0, 1],
+              outputRange: [1, 0],
+            }),
+            next.progress.interpolate(
+              timeline({
+                duration: 400,
+                easing: FAST_OUT_EXTRA_SLOW_IN,
+                stops: [83, 250],
+                output: (time) => 0.6 * clamp((time - 83) / 167),
+              })
+            )
+          ),
+        }
+      : undefined,
   };
 }
 
 /**
- * Standard Android-style fade from right for Android 14.
+ * Standard Android-style fade from right for Android 14 and later.
  */
 export function forFadeFromRightAndroid({
   current,
   next,
   inverted,
-  closing,
 }: StackCardInterpolationProps): StackCardInterpolatedStyle {
   const translateFocused = multiply(
     current.progress.interpolate({
@@ -411,13 +508,24 @@ export function forFadeFromRightAndroid({
     : 0;
 
   const opacity = conditional(
-    closing,
-    current.progress.interpolate({
-      inputRange: [0, 1],
-      outputRange: [0, 1],
-      extrapolate: 'clamp',
-    }),
-    current.progress
+    current.closing,
+    current.progress.interpolate(
+      timeline({
+        duration: 450,
+        easing: FAST_OUT_EXTRA_SLOW_IN,
+        closing: true,
+        stops: [35, 118],
+        output: (time) => 1 - clamp((time - 35) / 83),
+      })
+    ),
+    current.progress.interpolate(
+      timeline({
+        duration: 450,
+        easing: FAST_OUT_EXTRA_SLOW_IN,
+        stops: [50, 133],
+        output: (time) => clamp((time - 50) / 83),
+      })
+    )
   );
 
   return {
@@ -440,20 +548,27 @@ export function forBottomSheetAndroid({
   current,
   inverted,
   layouts: { screen },
-  closing,
 }: StackCardInterpolationProps): StackCardInterpolatedStyle {
   const translateY = multiply(
     current.progress.interpolate({
       inputRange: [0, 1],
-      outputRange: [screen.height * 0.8, 0],
+      outputRange: [screen.height * 0.2, 0],
       extrapolate: 'clamp',
     }),
     inverted
   );
 
   const opacity = conditional(
-    closing,
-    current.progress,
+    current.closing,
+    current.progress.interpolate(
+      timeline({
+        duration: 350,
+        easing: FAST_OUT_EXTRA_SLOW_IN,
+        closing: true,
+        stops: [300],
+        output: (time) => 1 - FAST_OUT_EXTRA_SLOW_IN(clamp(time / 300)),
+      })
+    ),
     current.progress.interpolate({
       inputRange: [0, 1],
       outputRange: [0, 1],
@@ -461,11 +576,29 @@ export function forBottomSheetAndroid({
     })
   );
 
-  const overlayOpacity = current.progress.interpolate({
-    inputRange: [0, 1],
-    outputRange: [0, 0.3],
-    extrapolate: 'clamp',
-  });
+  // We follow Android's window dim timing for the 0.32 scrim.
+  // This makes it reach full opacity after 128 ms and clear after 112 ms.
+  // See https://android.googlesource.com/platform/frameworks/base/+/refs/tags/android-17.0.0_r1/services/core/java/com/android/server/wm/DimmerAnimationHelper.java
+  const overlayOpacity = conditional(
+    current.closing,
+    current.progress.interpolate(
+      timeline({
+        duration: 350,
+        easing: FAST_OUT_EXTRA_SLOW_IN,
+        closing: true,
+        stops: [112],
+        output: (time) => 0.32 * (1 - clamp(time / 112)),
+      })
+    ),
+    current.progress.interpolate(
+      timeline({
+        duration: 400,
+        easing: FAST_OUT_EXTRA_SLOW_IN,
+        stops: [128],
+        output: (time) => 0.32 * clamp(time / 128),
+      })
+    )
+  );
 
   return {
     cardStyle: {
@@ -477,7 +610,73 @@ export function forBottomSheetAndroid({
 }
 
 /**
- * Simple fade animation for dialogs
+ * Standard Android dialog transition.
+ */
+export function forDialogAndroid({
+  current: { progress, closing },
+}: StackCardInterpolationProps): StackCardInterpolatedStyle {
+  const opacity = conditional(
+    closing,
+    progress.interpolate(
+      timeline({
+        duration: 220,
+        easing: (value) => decelerate(5, value),
+        closing: true,
+        stops: [150],
+        output: (time) => 1 - decelerate(3, clamp(time / 150)),
+      })
+    ),
+    progress.interpolate(
+      timeline({
+        duration: 220,
+        easing: (value) => decelerate(5, value),
+        stops: [150],
+        output: (time) => decelerate(3, clamp(time / 150)),
+      })
+    )
+  );
+
+  const scale = progress.interpolate({
+    inputRange: [0, 1],
+    outputRange: [0.9, 1],
+    extrapolate: 'clamp',
+  });
+
+  // We follow Android's window dim timing for the 0.6 dialog dim.
+  // This makes it reach or clear full opacity after 132 ms.
+  // See https://android.googlesource.com/platform/frameworks/base/+/refs/tags/android-17.0.0_r1/services/core/java/com/android/server/wm/DimmerAnimationHelper.java
+  const overlayOpacity = conditional(
+    closing,
+    progress.interpolate(
+      timeline({
+        duration: 220,
+        easing: (value) => decelerate(5, value),
+        closing: true,
+        stops: [132],
+        output: (time) => 0.6 * (1 - clamp(time / 132)),
+      })
+    ),
+    progress.interpolate(
+      timeline({
+        duration: 220,
+        easing: (value) => decelerate(5, value),
+        stops: [132],
+        output: (time) => 0.6 * clamp(time / 132),
+      })
+    )
+  );
+
+  return {
+    cardStyle: {
+      opacity,
+      transform: [{ scale }],
+    },
+    overlayStyle: { opacity: overlayOpacity },
+  };
+}
+
+/**
+ * Simple fade animation.
  */
 export function forFadeFromCenter({
   current: { progress },
@@ -487,14 +686,66 @@ export function forFadeFromCenter({
       opacity: progress.interpolate({
         inputRange: [0, 0.5, 0.9, 1],
         outputRange: [0, 0.25, 0.7, 1],
-      }),
-    },
-    overlayStyle: {
-      opacity: progress.interpolate({
-        inputRange: [0, 1],
-        outputRange: [0, 0.5],
         extrapolate: 'clamp',
       }),
+    },
+  };
+}
+
+/**
+ * Standard iOS cross-dissolve transition.
+ */
+export function forCrossDissolveIOS({
+  current,
+  next,
+}: StackCardInterpolationProps): StackCardInterpolatedStyle {
+  // UIKit cross-dissolve darkens identical light screens at the midpoint.
+  // Dimming the outgoing card reproduces this without exposing earlier screens.
+  return {
+    cardStyle: {
+      opacity: current.progress.interpolate({
+        inputRange: [0, 1],
+        outputRange: [0, 1],
+        extrapolate: 'clamp',
+      }),
+    },
+    dimStyle: next
+      ? {
+          opacity: next.progress.interpolate({
+            inputRange: [0, 1],
+            outputRange: [0, 1],
+            extrapolate: 'clamp',
+          }),
+        }
+      : undefined,
+  };
+}
+
+/**
+ * Standard iOS horizontal flip transition.
+ */
+export function forFlipIOS({
+  current,
+  next,
+  inverted,
+}: StackCardInterpolationProps): StackCardInterpolatedStyle {
+  const progress = add(current.progress, next ? next.progress : 0);
+
+  const rotateY = multiply(
+    progress.interpolate({
+      inputRange: [0, 1, 2],
+      outputRange: [180, 0, -180],
+    }),
+    inverted
+  ).interpolate({
+    inputRange: [-180, 0, 180],
+    outputRange: ['-180deg', '0deg', '180deg'],
+  });
+
+  return {
+    cardStyle: {
+      backfaceVisibility: 'hidden',
+      transform: [{ perspective: 1000 }, { rotateY }],
     },
   };
 }

--- a/packages/stack/src/TransitionConfigs/HeaderStyleInterpolators.tsx
+++ b/packages/stack/src/TransitionConfigs/HeaderStyleInterpolators.tsx
@@ -14,11 +14,9 @@ const { add, multiply } = Animated;
 export function forUIKit({
   current,
   next,
-  direction,
+  inverted,
   layouts,
 }: StackHeaderInterpolationProps): StackHeaderInterpolatedStyle {
-  const multiplier = direction === 'rtl' ? -1 : 1;
-
   const progress = add(
     current.progress.interpolate({
       inputRange: [0, 1],
@@ -45,7 +43,7 @@ export function forUIKit({
     });
 
     const translateX = multiply(
-      multiplier,
+      inverted,
       progress.interpolate({
         inputRange: [0, 1, 2],
         outputRange: [layouts.screen.width, 0, -layouts.screen.width * 0.3],
@@ -128,10 +126,9 @@ export function forFade({
 export function forSlideLeft({
   current,
   next,
-  direction,
+  inverted,
   layouts: { screen },
 }: StackHeaderInterpolationProps): StackHeaderInterpolatedStyle {
-  const isRTL = direction === 'rtl';
   const progress = add(
     current.progress.interpolate({
       inputRange: [0, 1],
@@ -147,12 +144,13 @@ export function forSlideLeft({
       : 0
   );
 
-  const translateX = progress.interpolate({
-    inputRange: [0, 1, 2],
-    outputRange: isRTL
-      ? [-screen.width, 0, screen.width]
-      : [screen.width, 0, -screen.width],
-  });
+  const translateX = multiply(
+    inverted,
+    progress.interpolate({
+      inputRange: [0, 1, 2],
+      outputRange: [screen.width, 0, -screen.width],
+    })
+  );
 
   const transform = [{ translateX }];
 
@@ -168,42 +166,13 @@ export function forSlideLeft({
  * Simple translate animation to translate the header to right.
  */
 export function forSlideRight({
-  current,
-  next,
-  direction,
-  layouts: { screen },
+  inverted,
+  ...rest
 }: StackHeaderInterpolationProps): StackHeaderInterpolatedStyle {
-  const isRTL = direction === 'rtl';
-  const progress = add(
-    current.progress.interpolate({
-      inputRange: [0, 1],
-      outputRange: [0, 1],
-      extrapolate: 'clamp',
-    }),
-    next
-      ? next.progress.interpolate({
-          inputRange: [0, 1],
-          outputRange: [0, 1],
-          extrapolate: 'clamp',
-        })
-      : 0
-  );
-
-  const translateX = progress.interpolate({
-    inputRange: [0, 1, 2],
-    outputRange: isRTL
-      ? [screen.width, 0, -screen.width]
-      : [-screen.width, 0, screen.width],
+  return forSlideLeft({
+    ...rest,
+    inverted: inverted === 1 ? -1 : 1,
   });
-
-  const transform = [{ translateX }];
-
-  return {
-    leftButtonStyle: { transform },
-    rightButtonStyle: { transform },
-    titleStyle: { transform },
-    backgroundStyle: { transform },
-  };
 }
 
 /**

--- a/packages/stack/src/TransitionConfigs/TransitionEasings.tsx
+++ b/packages/stack/src/TransitionConfigs/TransitionEasings.tsx
@@ -1,0 +1,90 @@
+import { Easing } from 'react-native';
+
+/**
+ * Exact piecewise path for Android's fast-out-extra-slow-in easing.
+ * See https://android.googlesource.com/platform/frameworks/base/+/refs/tags/android-14.0.0_r51/core/res/res/interpolator/fast_out_extra_slow_in.xml
+ */
+const FAST_OUT_EXTRA_SLOW_IN_INITIAL = Easing.bezier(0.3, 0, 0.8, 0.15);
+const FAST_OUT_EXTRA_SLOW_IN_FINAL = Easing.bezier(0.05, 0.7, 0.1, 1);
+
+export const FAST_OUT_EXTRA_SLOW_IN = (t: number) => {
+  const breakpoint = 1 / 6;
+
+  if (t < breakpoint) {
+    return 0.4 * FAST_OUT_EXTRA_SLOW_IN_INITIAL(t / breakpoint);
+  }
+
+  return (
+    0.4 +
+    0.6 * FAST_OUT_EXTRA_SLOW_IN_FINAL((t - breakpoint) / (1 - breakpoint))
+  );
+};
+
+/**
+ * See https://android.googlesource.com/platform/frameworks/base/+/refs/tags/android-17.0.0_r1/core/res/res/interpolator/fast_out_slow_in.xml
+ */
+export const FAST_OUT_SLOW_IN = Easing.bezier(0.4, 0, 0.2, 1);
+
+/**
+ * See https://android.googlesource.com/platform/frameworks/base/+/refs/tags/android-17.0.0_r1/core/res/res/interpolator/linear_out_slow_in.xml
+ */
+export const LINEAR_OUT_SLOW_IN = Easing.bezier(0, 0, 0.2, 1);
+
+/**
+ * See https://android.googlesource.com/platform/frameworks/base/+/android-9.0.0_r47/core/res/res/interpolator/activity_close_dim.xml
+ */
+export const ACTIVITY_CLOSE_DIM = Easing.bezier(0.33, 0, 1, 1);
+
+export const decelerate = (power: number, t: number) => 1 - (1 - t) ** power;
+
+export const accelerate = (power: number, t: number) => t ** power;
+
+export const clamp = (value: number) => Math.min(1, Math.max(0, value));
+
+/**
+ * Creates interpolation ranges for a property that follows its own timeline.
+ *
+ * @param options - Options for the property timeline.
+ * @param options.duration - Total transition duration in milliseconds.
+ * @param options.easing - Easing used by the transition.
+ * @param options.closing - Whether the transition is closing.
+ * @param options.stops - Times in milliseconds to include in the ranges.
+ * @param options.output - Returns the property value at a time in milliseconds.
+ */
+export function timeline({
+  duration,
+  easing,
+  closing = false,
+  stops = [],
+  output,
+}: {
+  duration: number;
+  easing: (value: number) => number;
+  closing?: boolean;
+  stops?: number[];
+  output: (time: number) => number;
+}) {
+  const times = [
+    ...new Set([
+      ...Array.from(
+        { length: Math.floor(duration / 10) + 1 },
+        (_, index) => index * 10
+      ),
+      ...stops,
+      duration,
+    ]),
+  ].sort((a, b) => a - b);
+
+  const points = times
+    .map((time) => ({
+      input: closing ? 1 - easing(time / duration) : easing(time / duration),
+      output: output(time),
+    }))
+    .sort((a, b) => a.input - b.input);
+
+  return {
+    inputRange: points.map(({ input }) => input),
+    outputRange: points.map(({ output }) => output),
+    extrapolate: 'clamp' as const,
+  };
+}

--- a/packages/stack/src/TransitionConfigs/TransitionPresets.tsx
+++ b/packages/stack/src/TransitionConfigs/TransitionPresets.tsx
@@ -3,11 +3,13 @@ import { Platform } from 'react-native';
 import type { TransitionPreset } from '../types';
 import {
   forBottomSheetAndroid,
+  forCrossDissolveIOS,
+  forDialogAndroid,
   forFadeFromBottomAndroid,
-  forFadeFromCenter as forFadeCard,
+  forFadeFromCenter,
   forFadeFromRightAndroid,
+  forFlipIOS,
   forHorizontalIOS,
-  forHorizontalIOSInverted,
   forModalPresentationIOS,
   forRevealFromBottomAndroid,
   forScaleFromCenterAndroid,
@@ -17,8 +19,12 @@ import { forFade, forUIKit } from './HeaderStyleInterpolators';
 import {
   BottomSheetSlideInSpec,
   BottomSheetSlideOutSpec,
+  DialogAndroidSpec,
   FadeInFromBottomAndroidSpec,
+  FadeInFromRightAndroidSpec,
   FadeOutToBottomAndroidSpec,
+  FadeOutToRightAndroidSpec,
+  FlipIOSSpec,
   RevealFromBottomAndroidSpec,
   ScaleFromCenterAndroidSpec,
   TransitionIOSSpec,
@@ -81,6 +87,19 @@ export const FadeFromBottomAndroid: TransitionPreset = {
 };
 
 /**
+ * Standard Android dialog transition.
+ */
+export const DialogAndroid: TransitionPreset = {
+  gestureDirection: 'vertical',
+  transitionSpec: {
+    open: DialogAndroidSpec,
+    close: DialogAndroidSpec,
+  },
+  cardStyleInterpolator: forDialogAndroid,
+  headerStyleInterpolator: forFade,
+};
+
+/**
  * Standard Android navigation transition when opening or closing an Activity on Android 9 (Pie).
  */
 export const RevealFromBottomAndroid: TransitionPreset = {
@@ -107,20 +126,20 @@ export const ScaleFromCenterAndroid: TransitionPreset = {
 };
 
 /**
- * Standard Android navigation transition when opening or closing an Activity on Android 14.
+ * Standard Android navigation transition when opening or closing an Activity on Android 14 and later.
  */
 export const FadeFromRightAndroid: TransitionPreset = {
   gestureDirection: 'horizontal',
   transitionSpec: {
-    open: FadeInFromBottomAndroidSpec,
-    close: FadeOutToBottomAndroidSpec,
+    open: FadeInFromRightAndroidSpec,
+    close: FadeOutToRightAndroidSpec,
   },
   cardStyleInterpolator: forFadeFromRightAndroid,
   headerStyleInterpolator: forFade,
 };
 
 /**
- * Standard bottom sheet slide transition for Android 10.
+ * Standard Material 3 bottom sheet transition.
  */
 export const BottomSheetAndroid: TransitionPreset = {
   gestureDirection: 'vertical',
@@ -138,10 +157,36 @@ export const BottomSheetAndroid: TransitionPreset = {
 export const ModalFadeTransition: TransitionPreset = {
   gestureDirection: 'vertical',
   transitionSpec: {
-    open: BottomSheetSlideInSpec,
-    close: BottomSheetSlideOutSpec,
+    open: TransitionIOSSpec,
+    close: TransitionIOSSpec,
   },
-  cardStyleInterpolator: forFadeCard,
+  cardStyleInterpolator: forFadeFromCenter,
+  headerStyleInterpolator: forFade,
+};
+
+/**
+ * Standard iOS horizontal flip transition.
+ */
+export const ModalFlipIOS: TransitionPreset = {
+  gestureDirection: 'horizontal',
+  transitionSpec: {
+    open: FlipIOSSpec,
+    close: FlipIOSSpec,
+  },
+  cardStyleInterpolator: forFlipIOS,
+  headerStyleInterpolator: forFade,
+};
+
+/**
+ * Standard iOS cross-dissolve transition.
+ */
+export const CrossDissolveIOS: TransitionPreset = {
+  gestureDirection: 'horizontal',
+  transitionSpec: {
+    open: TransitionIOSSpec,
+    close: TransitionIOSSpec,
+  },
+  cardStyleInterpolator: forCrossDissolveIOS,
   headerStyleInterpolator: forFade,
 };
 
@@ -174,5 +219,6 @@ export const ModalTransition = Platform.select({
  */
 export const SlideFromLeftIOS: TransitionPreset = {
   ...SlideFromRightIOS,
-  cardStyleInterpolator: forHorizontalIOSInverted,
+  gestureDirection: 'horizontal-inverted',
+  cardStyleInterpolator: forHorizontalIOS,
 };

--- a/packages/stack/src/TransitionConfigs/TransitionSpecs.tsx
+++ b/packages/stack/src/TransitionConfigs/TransitionSpecs.tsx
@@ -1,9 +1,10 @@
 import { Easing } from 'react-native';
 
 import type { TransitionSpec } from '../types';
+import { FAST_OUT_EXTRA_SLOW_IN } from './TransitionEasings';
 
 /**
- * Exact values from UINavigationController's animation configuration.
+ * Approximation of the standard iOS navigation transition.
  */
 export const TransitionIOSSpec: TransitionSpec = {
   animation: 'spring',
@@ -18,8 +19,20 @@ export const TransitionIOSSpec: TransitionSpec = {
 };
 
 /**
+ * Configuration for the standard iOS horizontal flip transition.
+ */
+export const FlipIOSSpec: TransitionSpec = {
+  animation: 'timing',
+  config: {
+    duration: 700,
+    easing: Easing.inOut(Easing.ease),
+  },
+};
+
+/**
  * Configuration for activity open animation from Android Nougat.
- * See http://aosp.opersys.com/xref/android-7.1.2_r37/xref/frameworks/base/core/res/res/anim/activity_open_enter.xml
+ * See https://android.googlesource.com/platform/frameworks/base/+/android-7.1.2_r37/core/res/res/anim/activity_open_enter.xml
+ * See https://android.googlesource.com/platform/frameworks/base/+/android-7.1.2_r37/core/res/res/anim/activity_open_exit.xml
  */
 export const FadeInFromBottomAndroidSpec: TransitionSpec = {
   animation: 'timing',
@@ -31,94 +44,115 @@ export const FadeInFromBottomAndroidSpec: TransitionSpec = {
 
 /**
  * Configuration for activity close animation from Android Nougat.
- * See http://aosp.opersys.com/xref/android-7.1.2_r37/xref/frameworks/base/core/res/res/anim/activity_close_exit.xml
+ * See https://android.googlesource.com/platform/frameworks/base/+/android-7.1.2_r37/core/res/res/anim/activity_close_enter.xml
+ * See https://android.googlesource.com/platform/frameworks/base/+/android-7.1.2_r37/core/res/res/anim/activity_close_exit.xml
  */
 export const FadeOutToBottomAndroidSpec: TransitionSpec = {
   animation: 'timing',
   config: {
-    duration: 150,
-    easing: Easing.in(Easing.linear),
+    duration: 250,
+    easing: Easing.in(Easing.poly(4)),
   },
 };
 
 /**
- * Approximate configuration for activity open animation from Android Pie.
- * See http://aosp.opersys.com/xref/android-9.0.0_r47/xref/frameworks/base/core/res/res/anim/activity_open_enter.xml
+ * Configuration for the standard Android dialog transition.
+ * See https://android.googlesource.com/platform/frameworks/base/+/refs/tags/android-17.0.0_r1/core/res/res/anim/dialog_enter.xml
+ * See https://android.googlesource.com/platform/frameworks/base/+/refs/tags/android-17.0.0_r1/core/res/res/anim/dialog_exit.xml
+ * See https://android.googlesource.com/platform/frameworks/base/+/refs/tags/android-17.0.0_r1/core/res/res/values/config.xml
+ * See https://android.googlesource.com/platform/frameworks/base/+/refs/tags/android-17.0.0_r1/core/res/res/values/themes_material.xml
+ * See https://android.googlesource.com/platform/frameworks/base/+/refs/tags/android-17.0.0_r1/services/core/java/com/android/server/wm/DimmerAnimationHelper.java
+ */
+export const DialogAndroidSpec: TransitionSpec = {
+  animation: 'timing',
+  config: {
+    duration: 220,
+    easing: Easing.out(Easing.poly(5)),
+  },
+};
+
+/**
+ * Configuration for activity open animation from Android Pie.
+ * See https://android.googlesource.com/platform/frameworks/base/+/android-9.0.0_r47/core/res/res/anim/activity_open_enter.xml
+ * See https://android.googlesource.com/platform/frameworks/base/+/android-9.0.0_r47/core/res/res/anim/activity_open_exit.xml
+ * See https://android.googlesource.com/platform/frameworks/base/+/android-9.0.0_r47/core/res/res/anim/activity_close_enter.xml
+ * See https://android.googlesource.com/platform/frameworks/base/+/android-9.0.0_r47/core/res/res/anim/activity_close_exit.xml
  */
 export const RevealFromBottomAndroidSpec: TransitionSpec = {
   animation: 'timing',
   config: {
     duration: 425,
-    // This is super rough approximation of the path used for the curve by android
-    // See http://aosp.opersys.com/xref/android-9.0.0_r47/xref/frameworks/base/core/res/res/interpolator/fast_out_extra_slow_in.xml
-    easing: Easing.bezier(0.20833, 0.82, 0.25, 1),
+    easing: FAST_OUT_EXTRA_SLOW_IN,
   },
 };
 
 /**
- * Approximate configuration for activity open animation from Android Q.
- * See http://aosp.opersys.com/xref/android-10.0.0_r2/xref/frameworks/base/core/res/res/anim/activity_open_enter.xml
+ * Configuration for activity open animation from Android Q.
+ * See https://android.googlesource.com/platform/frameworks/base/+/android-10.0.0_r2/core/res/res/anim/activity_open_enter.xml
+ * See https://android.googlesource.com/platform/frameworks/base/+/android-10.0.0_r2/core/res/res/anim/activity_open_exit.xml
+ * See https://android.googlesource.com/platform/frameworks/base/+/android-10.0.0_r2/core/res/res/anim/activity_close_enter.xml
+ * See https://android.googlesource.com/platform/frameworks/base/+/android-10.0.0_r2/core/res/res/anim/activity_close_exit.xml
  */
 export const ScaleFromCenterAndroidSpec: TransitionSpec = {
   animation: 'timing',
   config: {
     duration: 400,
-    // This is super rough approximation of the path used for the curve by android
-    // See http://aosp.opersys.com/xref/android-10.0.0_r2/xref/frameworks/base/core/res/res/interpolator/fast_out_extra_slow_in.xml
-    easing: Easing.bezier(0.20833, 0.82, 0.25, 1),
+    easing: FAST_OUT_EXTRA_SLOW_IN,
   },
 };
 
 /**
- * Approximate configuration for activity open animation from Android 14.
+ * Configuration for activity open animation from Android 14 and later.
  * See https://android.googlesource.com/platform/frameworks/base/+/refs/tags/android-14.0.0_r51/core/res/res/anim/activity_open_enter.xml
+ * See https://android.googlesource.com/platform/frameworks/base/+/refs/tags/android-14.0.0_r51/core/res/res/anim/activity_open_exit.xml
  */
 export const FadeInFromRightAndroidSpec: TransitionSpec = {
   animation: 'timing',
   config: {
     duration: 450,
-    // This is super rough approximation of the path used for the curve by android
-    // See https://android.googlesource.com/platform/frameworks/base/+/refs/tags/android-14.0.0_r51/core/res/res/interpolator/fast_out_extra_slow_in.xml
-    easing: Easing.bezier(0.20833, 0.82, 0.25, 1),
+    easing: FAST_OUT_EXTRA_SLOW_IN,
   },
 };
 
 /**
- * Approximate configuration for activity close animation from Android 14.
+ * Configuration for activity close animation from Android 14 and later.
+ * See https://android.googlesource.com/platform/frameworks/base/+/refs/tags/android-14.0.0_r51/core/res/res/anim/activity_close_enter.xml
  * See https://android.googlesource.com/platform/frameworks/base/+/refs/tags/android-14.0.0_r51/core/res/res/anim/activity_close_exit.xml
  */
-export const FadeOutToLeftAndroidSpec: TransitionSpec = {
+export const FadeOutToRightAndroidSpec: TransitionSpec = {
   animation: 'timing',
   config: {
     duration: 450,
-    // This is super rough approximation of the path used for the curve by android
-    // See https://android.googlesource.com/platform/frameworks/base/+/refs/tags/android-14.0.0_r51/core/res/res/interpolator/fast_out_extra_slow_in.xml
-    easing: Easing.bezier(0.20833, 0.82, 0.25, 1),
+    easing: FAST_OUT_EXTRA_SLOW_IN,
   },
 };
 
 /**
- * Configuration for bottom sheet slide in animation from Material Design.
- * See https://github.com/material-components/material-components-android/blob/fd3639092e1ffef9dc11bcedf79f32801d85e898/lib/java/com/google/android/material/bottomsheet/res/anim/mtrl_bottom_sheet_slide_in.xml
+ * Configuration for bottom sheet slide in animation from Material 3.
+ * See https://github.com/material-components/material-components-android/blob/1.14.0/lib/java/com/google/android/material/bottomsheet/res/anim/m3_bottom_sheet_slide_in.xml
+ * See https://github.com/material-components/material-components-android/blob/1.14.0/lib/java/com/google/android/material/motion/res/values/tokens.xml
+ * See https://github.com/material-components/material-components-android/blob/1.14.0/lib/java/com/google/android/material/dialog/res/values/tokens.xml
+ * See https://android.googlesource.com/platform/frameworks/base/+/refs/tags/android-17.0.0_r1/services/core/java/com/android/server/wm/DimmerAnimationHelper.java
  */
 export const BottomSheetSlideInSpec: TransitionSpec = {
   animation: 'timing',
   config: {
-    duration: 250,
-    // See https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/view/animation/AccelerateDecelerateInterpolator.java
-    easing: (t) => Math.cos((t + 1) * Math.PI) / 2.0 + 0.5,
+    duration: 400,
+    easing: FAST_OUT_EXTRA_SLOW_IN,
   },
 };
 
 /**
- * Configuration for bottom sheet slide out animation from Material Design.
- * See https://github.com/material-components/material-components-android/blob/fd3639092e1ffef9dc11bcedf79f32801d85e898/lib/java/com/google/android/material/bottomsheet/res/anim/mtrl_bottom_sheet_slide_in.xml
+ * Configuration for bottom sheet slide out animation from Material 3.
+ * See https://github.com/material-components/material-components-android/blob/1.14.0/lib/java/com/google/android/material/bottomsheet/res/anim/m3_bottom_sheet_slide_out.xml
+ * See https://github.com/material-components/material-components-android/blob/1.14.0/lib/java/com/google/android/material/motion/res/values/tokens.xml
+ * See https://github.com/material-components/material-components-android/blob/1.14.0/lib/java/com/google/android/material/dialog/res/values/tokens.xml
+ * See https://android.googlesource.com/platform/frameworks/base/+/refs/tags/android-17.0.0_r1/services/core/java/com/android/server/wm/DimmerAnimationHelper.java
  */
 export const BottomSheetSlideOutSpec: TransitionSpec = {
   animation: 'timing',
   config: {
-    duration: 200,
-    // See https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/view/animation/AccelerateInterpolator.java
-    easing: (t) => (t === 1.0 ? 1 : Math.pow(t, 2)),
+    duration: 350,
+    easing: FAST_OUT_EXTRA_SLOW_IN,
   },
 };

--- a/packages/stack/src/types.tsx
+++ b/packages/stack/src/types.tsx
@@ -8,7 +8,6 @@ import type {
 import type {
   DefaultNavigatorOptions,
   Descriptor,
-  LocaleDirection,
   NavigationHelpers,
   NavigationProp,
   ParamListBase,
@@ -97,6 +96,9 @@ export type StackAnimationName =
   | 'fade'
   | 'fade_from_bottom'
   | 'fade_from_right'
+  | 'flip'
+  | 'ios_from_left'
+  | 'ios_from_right'
   | 'none'
   | 'reveal_from_bottom'
   | 'scale_from_center'
@@ -107,7 +109,8 @@ export type StackAnimationName =
 type SceneOptionsDefaults = TransitionPreset & {
   animation: StackAnimationName;
   gestureEnabled: boolean;
-  cardOverlayEnabled: boolean;
+  cardOverlayEnabled: boolean | undefined;
+  cardShadowEnabled: boolean | undefined;
   headerMode: StackHeaderMode;
 };
 
@@ -127,6 +130,10 @@ export type Scene = {
    * Animated nodes representing the progress of the animation.
    */
   progress: SceneProgress;
+  /**
+   * Animated node representing whether the screen is closing.
+   */
+  closing: Animated.Value;
 };
 
 export type SceneProgress = {
@@ -257,6 +264,10 @@ export type StackHeaderProps = {
    */
   progress: SceneProgress;
   /**
+   * Direction multiplier for the transition.
+   */
+  inverted: 1 | -1;
+  /**
    * Options for the current screen.
    */
   options: StackNavigationOptions;
@@ -320,7 +331,8 @@ export type StackNavigationOptions = StackHeaderOptions &
     header?: (props: StackHeaderProps) => React.ReactNode;
     /**
      * Whether the header floats above the screen or part of the screen.
-     * Defaults to `float` on iOS for non-modals, and `screen` for the rest.
+     * Defaults to `float` on iOS for animations where the header transitions
+     * separately, and `screen` otherwise.
      */
     headerMode?: StackHeaderMode;
     /**
@@ -329,14 +341,17 @@ export type StackNavigationOptions = StackHeaderOptions &
      */
     headerShown?: boolean;
     /**
-     * Whether a shadow is visible for the card during transitions. Defaults to `true`.
+     * Whether a shadow is visible for the card during transitions.
+     * Defaults to whether `cardStyleInterpolator` returns a `shadowStyle`.
+     * Setting this overrides the default behavior.
      */
-    cardShadowEnabled?: boolean;
+    cardShadowEnabled?: boolean | undefined;
     /**
      * Whether to have a semi-transparent dark overlay visible under the card during transitions.
-     * Defaults to `true` on Android and `false` on iOS.
+     * Defaults to whether `cardStyleInterpolator` returns an `overlayStyle`.
+     * Setting this overrides the default behavior.
      */
-    cardOverlayEnabled?: boolean;
+    cardOverlayEnabled?: boolean | undefined;
     /**
      * Function that returns a React Element to display as a overlay for the card.
      */
@@ -371,8 +386,12 @@ export type StackNavigationOptions = StackHeaderOptions &
      * Supported values:
      * - 'none': don't animate the screen
      * - 'default': use the platform default animation
-     * - 'fade': fade screen in or out
+     * - 'fade': fade between screens
      * - 'fade_from_bottom': fade screen in or out from bottom
+     * - 'fade_from_right': fade screen in from the right
+     * - 'flip': flip the screen horizontally
+     * - 'ios_from_left': use the iOS-style slide from left
+     * - 'ios_from_right': use the iOS-style slide from right
      * - 'slide_from_bottom': slide in the new screen from bottom
      * - 'slide_from_right': slide in the new screen from right
      * - 'slide_from_left': slide in the new screen from left
@@ -386,7 +405,9 @@ export type StackNavigationOptions = StackHeaderOptions &
      */
     animationTypeForReplace?: 'push' | 'pop';
     /**
-     * Whether you can use gestures to dismiss this screen. Defaults to `true` on iOS, `false` on Android.
+     * Whether you can use gestures to dismiss this screen. Defaults to `true`
+     * on iOS for navigation-style transitions with an interactive dismissal,
+     * and `false` otherwise.
      * Not supported on Web.
      */
     gestureEnabled?: boolean;
@@ -440,36 +461,32 @@ export type TransitionSpec =
       >;
     };
 
+type StackCardInterpolationState = {
+  /**
+   * Animated node representing the progress value of the screen.
+   */
+  progress: Animated.AnimatedInterpolation<number>;
+  /**
+   * Animated node representing whether the screen is using the closing or
+   * opening animation (1 - closing, 0 - opening).
+   */
+  closing: Animated.AnimatedInterpolation<0 | 1>;
+};
+
 export type StackCardInterpolationProps = {
   /**
    * Values for the current screen.
    */
-  current: {
-    /**
-     * Animated node representing the progress value of the current screen.
-     */
-    progress: Animated.AnimatedInterpolation<number>;
-  };
+  current: StackCardInterpolationState;
   /**
    * Values for the screen after this one in the stack.
    * This can be `undefined` in case the screen animating is the last one.
    */
-  next?:
-    | {
-        /**
-         * Animated node representing the progress value of the next screen.
-         */
-        progress: Animated.AnimatedInterpolation<number>;
-      }
-    | undefined;
+  next?: StackCardInterpolationState | undefined;
   /**
    * The index of the card with this interpolation in the stack.
    */
   index: number;
-  /**
-   * Animated node representing whether the card is closing (1 - closing, 0 - not closing).
-   */
-  closing: Animated.AnimatedInterpolation<0 | 1>;
   /**
    * Animated node representing whether the card is being swiped (1 - swiping, 0 - not swiping).
    */
@@ -548,9 +565,9 @@ export type StackHeaderInterpolationProps = {
       }
     | undefined;
   /**
-   * Writing direction of the layout.
+   * Direction multiplier for the transition.
    */
-  direction: LocaleDirection;
+  inverted: 1 | -1;
   /**
    * Layout measurements for various items we use for animation.
    */

--- a/packages/stack/src/views/Header/Header.tsx
+++ b/packages/stack/src/views/Header/Header.tsx
@@ -11,6 +11,7 @@ import { HeaderSegment } from './HeaderSegment';
 export const Header = React.memo(function Header({
   back,
   progress,
+  inverted,
   options,
   route,
   navigation,
@@ -54,6 +55,7 @@ export const Header = React.memo(function Header({
   return (
     <HeaderSegment
       {...options}
+      inverted={inverted}
       title={getHeaderTitle(options, route.name)}
       progress={progress}
       modal={isModal}

--- a/packages/stack/src/views/Header/HeaderContainer.tsx
+++ b/packages/stack/src/views/Header/HeaderContainer.tsx
@@ -4,6 +4,7 @@ import {
   NavigationProvider,
   type Route,
   useLinkBuilder,
+  useLocale,
 } from '@react-navigation/native';
 import * as React from 'react';
 import {
@@ -17,10 +18,10 @@ import {
 import {
   forNoAnimation,
   forSlideLeft,
-  forSlideRight,
   forSlideUp,
 } from '../../TransitionConfigs/HeaderStyleInterpolators';
 import type { Scene, StackHeaderMode, StackHeaderProps } from '../../types';
+import { getInvertedMultiplier } from '../../utils/getInvertedMultiplier';
 import { Header } from './Header';
 
 export type HeaderHeight = {
@@ -53,6 +54,7 @@ export function HeaderContainer({
   const focusedRoute = getFocusedRoute();
   const parentHeaderBack = React.use(HeaderBackContext);
   const { buildHref } = useLinkBuilder();
+  const { direction } = useLocale();
 
   return (
     <View style={[styles.container, style]}>
@@ -131,6 +133,12 @@ export function HeaderContainer({
         const props: StackHeaderProps = {
           back: headerBack,
           progress: scene.progress,
+          inverted: getInvertedMultiplier(
+            isHeaderStatic && nextHeaderlessGestureDirection
+              ? nextHeaderlessGestureDirection
+              : scene.descriptor.options.gestureDirection,
+            direction === 'rtl'
+          ),
           options: scene.descriptor.options,
           route: scene.descriptor.route,
           navigation: scene.descriptor.navigation,
@@ -140,9 +148,7 @@ export function HeaderContainer({
                 ? nextHeaderlessGestureDirection === 'vertical' ||
                   nextHeaderlessGestureDirection === 'vertical-inverted'
                   ? forSlideUp
-                  : nextHeaderlessGestureDirection === 'horizontal-inverted'
-                    ? forSlideRight
-                    : forSlideLeft
+                  : forSlideLeft
                 : headerStyleInterpolator
               : forNoAnimation,
         };

--- a/packages/stack/src/views/Header/HeaderSegment.tsx
+++ b/packages/stack/src/views/Header/HeaderSegment.tsx
@@ -6,7 +6,6 @@ import {
   HeaderTitle,
   useFrameSize,
 } from '@react-navigation/elements';
-import { useLocale } from '@react-navigation/native';
 import * as React from 'react';
 import { StyleSheet, type ViewStyle } from 'react-native';
 
@@ -23,15 +22,16 @@ type Props = Omit<StackHeaderOptions, 'headerStatusBarHeight'> & {
   onGoBack?: (() => void) | undefined;
   backHref?: string | undefined;
   progress: SceneProgress;
+  inverted: 1 | -1;
   styleInterpolator: StackHeaderStyleInterpolator;
 };
 
 export function HeaderSegment(props: Props) {
-  const { direction } = useLocale();
   const layout = useFrameSize((frame) => frame, true);
 
   const {
     progress,
+    inverted,
     modal,
     onGoBack,
     backHref,
@@ -75,7 +75,7 @@ export function HeaderSegment(props: Props) {
         styleInterpolator({
           current: { progress: progress.current },
           next: progress.next && { progress: progress.next },
-          direction,
+          inverted,
           layouts: {
             header: {
               height: headerHeight,
@@ -84,7 +84,7 @@ export function HeaderSegment(props: Props) {
             screen: layout,
           },
         }),
-      [styleInterpolator, progress, direction, headerHeight, layout]
+      [styleInterpolator, progress, inverted, headerHeight, layout]
     );
 
   const headerLeft: StackHeaderOptions['headerLeft'] = left

--- a/packages/stack/src/views/Stack/Card.tsx
+++ b/packages/stack/src/views/Stack/Card.tsx
@@ -32,8 +32,16 @@ type Props = {
   interpolationIndex: number;
   opening: boolean;
   closing: boolean;
-  next: Animated.AnimatedInterpolation<number> | undefined;
-  current: Animated.AnimatedInterpolation<number>;
+  current: {
+    progress: Animated.AnimatedInterpolation<number>;
+    closing: Animated.Value;
+  };
+  next:
+    | {
+        progress: Animated.AnimatedInterpolation<number>;
+        closing: Animated.Value;
+      }
+    | undefined;
   gesture: Animated.Value;
   layout: Layout;
   insets: EdgeInsets;
@@ -52,7 +60,7 @@ type Props = {
         style: Animated.WithAnimatedValue<StyleProp<ViewStyle>>;
       }) => React.ReactNode)
     | undefined;
-  overlayEnabled: boolean;
+  overlayEnabled: boolean | undefined;
   shadowEnabled: boolean | undefined;
   gestureEnabled: boolean;
   gestureResponseDistance?: number | undefined;
@@ -121,7 +129,7 @@ const defaultOverlay = ({
 }) => (style ? <Animated.View style={[styles.overlay, style]} /> : null);
 
 function Card({
-  shadowEnabled = false,
+  shadowEnabled,
   gestureEnabled = true,
   gestureVelocityImpact = GESTURE_VELOCITY_IMPACT,
   overlay = defaultOverlay,
@@ -153,15 +161,16 @@ function Card({
   contentStyle,
 }: Props) {
   const didInitiallyAnimate = React.useRef(false);
+  const isClosingValueLockedRef = React.useRef(false);
   const lastToValueRef = React.useRef<number | undefined>(undefined);
+  const animationIdRef = React.useRef(0);
 
   const animationHandleRef = React.useRef<number | undefined>(undefined);
   const pendingGestureCallbackRef =
     React.useRef<ReturnType<typeof setTimeout>>(undefined);
   const pendingOnCloseCallbackRef =
     React.useRef<ReturnType<typeof setTimeout>>(undefined);
-
-  const [isClosing] = React.useState(() => new Animated.Value(FALSE));
+  const timeoutRef = React.useRef<ReturnType<typeof setTimeout>>(undefined);
 
   const [inverted] = React.useState(
     () =>
@@ -185,6 +194,8 @@ function Card({
       closing: boolean;
       velocity?: number;
     }) => {
+      const id = ++animationIdRef.current;
+
       const toValue = getAnimateToValue({
         closing: isClosingParam,
         layout,
@@ -194,7 +205,13 @@ function Card({
       });
 
       lastToValueRef.current = toValue;
-      isClosing.setValue(isClosingParam ? TRUE : FALSE);
+
+      // Switching between open and close mid-gesture and animation can cause a visible jump.
+      // So we lock the closing value until the animation is finished.
+      if (!isClosingValueLockedRef.current) {
+        isClosingValueLockedRef.current = true;
+        current.closing.setValue(isClosingParam ? TRUE : FALSE);
+      }
 
       const spec = isClosingParam ? transitionSpec.close : transitionSpec.open;
       const animation =
@@ -212,6 +229,9 @@ function Card({
       });
 
       const onFinish = () => {
+        current.closing.setValue(isClosingParam ? TRUE : FALSE);
+        isClosingValueLockedRef.current = false;
+
         if (isClosingParam) {
           onClose();
         } else {
@@ -232,6 +252,10 @@ function Card({
           useNativeDriver,
           isInteraction: false,
         }).start(({ finished }) => {
+          if (id !== animationIdRef.current) {
+            return;
+          }
+
           clearTimeout(pendingGestureCallbackRef.current);
 
           if (finished) {
@@ -239,6 +263,7 @@ function Card({
           }
         });
       } else {
+        gesture.setValue(toValue);
         onFinish();
       }
     }
@@ -270,17 +295,23 @@ function Card({
   } | null>(null);
 
   React.useEffect(() => {
+    const animationIdRefForCleanup = animationIdRef;
+
     return () => {
+      // Increment the animation ID when the card unmounts.
+      // This makes pending callbacks return because their IDs no longer match.
+      animationIdRefForCleanup.current++;
+      gesture.stopAnimation();
+
       if (animationHandleRef.current) {
         cancelAnimationFrame(animationHandleRef.current);
       }
 
       clearTimeout(pendingGestureCallbackRef.current);
       clearTimeout(pendingOnCloseCallbackRef.current);
+      clearTimeout(timeoutRef.current);
     };
-  }, []);
-
-  const timeoutRef = React.useRef<ReturnType<typeof setTimeout>>(undefined);
+  }, [gesture]);
 
   const maybeAnimate = useLatestCallback(() => {
     clearTimeout(pendingGestureCallbackRef.current);
@@ -365,9 +396,8 @@ function Card({
   const interpolationProps = React.useMemo(
     () => ({
       index: interpolationIndex,
-      current: { progress: current },
-      next: next && { progress: next },
-      closing: isClosing,
+      current,
+      next,
       swiping: isSwiping,
       inverted,
       layouts: {
@@ -384,7 +414,6 @@ function Card({
       interpolationIndex,
       current,
       next,
-      isClosing,
       isSwiping,
       inverted,
       layout,
@@ -405,7 +434,14 @@ function Card({
     () => {
       clearTimeout(pendingGestureCallbackRef.current);
       clearTimeout(pendingOnCloseCallbackRef.current);
+
       isSwiping.setValue(TRUE);
+
+      if (!isClosingValueLockedRef.current) {
+        isClosingValueLockedRef.current = true;
+        current.closing.setValue(TRUE);
+      }
+
       onGestureBegin?.();
     }
   );
@@ -538,13 +574,13 @@ function Card({
             // Animated needs the animated value to be used somewhere, otherwise things don't update properly.
             // If we disable animations and hide header, it could end up making the value unused.
             // So we have this dummy style that will always be used regardless of what else changed.
-            opacity: current,
+            opacity: current.progress,
           }}
           // Make sure that this view isn't removed. If this view is removed, our style with animated value won't apply
           collapsable={false}
         />
       ) : null}
-      {overlayEnabled ? (
+      {(overlayEnabled ?? overlayStyle != null) ? (
         <View style={[StyleSheet.absoluteFill, { pointerEvents: 'box-none' }]}>
           {overlay({ style: overlayStyle })}
         </View>
@@ -557,17 +593,16 @@ function Card({
             needsOffscreenAlphaCompositing={hasOpacityStyle(cardStyle)}
             style={[styles.card, cardStyle]}
           >
-            {shadowEnabled && shadowStyle && !isTransparent ? (
+            {(shadowEnabled ?? shadowStyle != null) && !isTransparent ? (
               <Animated.View
                 style={[
                   styles.shadow,
-                  gestureDirection === 'horizontal'
-                    ? [styles.shadowHorizontal, styles.shadowStart]
-                    : gestureDirection === 'horizontal-inverted'
-                      ? [styles.shadowHorizontal, styles.shadowEnd]
-                      : gestureDirection === 'vertical'
-                        ? [styles.shadowVertical, styles.shadowTop]
-                        : [styles.shadowVertical, styles.shadowBottom],
+                  gestureDirection === 'horizontal' ||
+                  gestureDirection === 'horizontal-inverted'
+                    ? styles.shadowHorizontal
+                    : gestureDirection === 'vertical'
+                      ? [styles.shadowVertical, styles.shadowTop]
+                      : [styles.shadowVertical, styles.shadowBottom],
                   { backgroundColor },
                   shadowStyle,
                 ]}
@@ -580,7 +615,9 @@ function Card({
             >
               {children}
             </CardContent>
-            {dimStyle ? <Animated.View style={[styles.dim, dimStyle]} /> : null}
+            {dimStyle != null ? (
+              <Animated.View style={[styles.dim, dimStyle]} />
+            ) : null}
           </Animated.View>
         </GestureDetector>
       </Animated.View>
@@ -597,6 +634,10 @@ const styles = StyleSheet.create({
   },
   card: {
     flex: 1,
+    // The flip animation adds `backfaceVisibility`
+    // On Android, it crashes when the style property is removed
+    // So we always add the property with the default
+    backfaceVisibility: 'visible',
     // This is necessary for gestures to work
     // Without this, gestures won't work if the child view is flattened
     pointerEvents: 'auto',
@@ -617,22 +658,17 @@ const styles = StyleSheet.create({
   },
   shadowHorizontal: {
     top: 0,
+    start: 0,
+    end: 0,
     bottom: 0,
-    width: 3,
     ...getShadowStyle({
       offset: {
-        width: -1,
-        height: 1,
+        width: 0,
+        height: -3,
       },
-      radius: 5,
-      opacity: 0.3,
+      radius: 12,
+      opacity: 0.04,
     }),
-  },
-  shadowStart: {
-    start: 0,
-  },
-  shadowEnd: {
-    end: 0,
   },
   shadowVertical: {
     start: 0,

--- a/packages/stack/src/views/Stack/Card.tsx
+++ b/packages/stack/src/views/Stack/Card.tsx
@@ -32,8 +32,16 @@ type Props = {
   interpolationIndex: number;
   opening: boolean;
   closing: boolean;
-  next: Animated.AnimatedInterpolation<number> | undefined;
-  current: Animated.AnimatedInterpolation<number>;
+  current: {
+    progress: Animated.AnimatedInterpolation<number>;
+    closing: Animated.Value;
+  };
+  next:
+    | {
+        progress: Animated.AnimatedInterpolation<number>;
+        closing: Animated.Value;
+      }
+    | undefined;
   gesture: Animated.Value;
   layout: Layout;
   insets: EdgeInsets;
@@ -52,7 +60,7 @@ type Props = {
         style: Animated.WithAnimatedValue<StyleProp<ViewStyle>>;
       }) => React.ReactNode)
     | undefined;
-  overlayEnabled: boolean;
+  overlayEnabled: boolean | undefined;
   shadowEnabled: boolean | undefined;
   gestureEnabled: boolean;
   gestureResponseDistance?: number | undefined;
@@ -121,7 +129,7 @@ const defaultOverlay = ({
 }) => (style ? <Animated.View style={[styles.overlay, style]} /> : null);
 
 function Card({
-  shadowEnabled = false,
+  shadowEnabled,
   gestureEnabled = true,
   gestureVelocityImpact = GESTURE_VELOCITY_IMPACT,
   overlay = defaultOverlay,
@@ -153,15 +161,16 @@ function Card({
   contentStyle,
 }: Props) {
   const didInitiallyAnimate = React.useRef(false);
+  const isClosingValueLockedRef = React.useRef(false);
   const lastToValueRef = React.useRef<number | undefined>(undefined);
+  const animationIdRef = React.useRef(0);
 
   const animationHandleRef = React.useRef<number | undefined>(undefined);
   const pendingGestureCallbackRef =
     React.useRef<ReturnType<typeof setTimeout>>(undefined);
   const pendingOnCloseCallbackRef =
     React.useRef<ReturnType<typeof setTimeout>>(undefined);
-
-  const [isClosing] = React.useState(() => new Animated.Value(FALSE));
+  const timeoutRef = React.useRef<ReturnType<typeof setTimeout>>(undefined);
 
   const [inverted] = React.useState(
     () =>
@@ -185,6 +194,8 @@ function Card({
       closing: boolean;
       velocity?: number;
     }) => {
+      const id = ++animationIdRef.current;
+
       const toValue = getAnimateToValue({
         closing: isClosingParam,
         layout,
@@ -194,7 +205,13 @@ function Card({
       });
 
       lastToValueRef.current = toValue;
-      isClosing.setValue(isClosingParam ? TRUE : FALSE);
+
+      // Switching between open and close mid-gesture and animation can cause a visible jump.
+      // So we lock the closing value until the animation is finished.
+      if (!isClosingValueLockedRef.current) {
+        isClosingValueLockedRef.current = true;
+        current.closing.setValue(isClosingParam ? TRUE : FALSE);
+      }
 
       const spec = isClosingParam ? transitionSpec.close : transitionSpec.open;
       const animation =
@@ -212,6 +229,9 @@ function Card({
       });
 
       const onFinish = () => {
+        current.closing.setValue(isClosingParam ? TRUE : FALSE);
+        isClosingValueLockedRef.current = false;
+
         if (isClosingParam) {
           onClose();
         } else {
@@ -232,6 +252,10 @@ function Card({
           useNativeDriver,
           isInteraction: false,
         }).start(({ finished }) => {
+          if (id !== animationIdRef.current) {
+            return;
+          }
+
           clearTimeout(pendingGestureCallbackRef.current);
 
           if (finished) {
@@ -239,6 +263,7 @@ function Card({
           }
         });
       } else {
+        gesture.setValue(toValue);
         onFinish();
       }
     }
@@ -270,17 +295,23 @@ function Card({
   } | null>(null);
 
   React.useEffect(() => {
+    const animationIdRefForCleanup = animationIdRef;
+
     return () => {
+      // Increment the animation ID when the card unmounts.
+      // This makes pending callbacks return because their IDs no longer match.
+      animationIdRefForCleanup.current++;
+      gesture.stopAnimation();
+
       if (animationHandleRef.current) {
         cancelAnimationFrame(animationHandleRef.current);
       }
 
       clearTimeout(pendingGestureCallbackRef.current);
       clearTimeout(pendingOnCloseCallbackRef.current);
+      clearTimeout(timeoutRef.current);
     };
-  }, []);
-
-  const timeoutRef = React.useRef<ReturnType<typeof setTimeout>>(undefined);
+  }, [gesture]);
 
   const maybeAnimate = useLatestCallback(() => {
     clearTimeout(pendingGestureCallbackRef.current);
@@ -365,9 +396,8 @@ function Card({
   const interpolationProps = React.useMemo(
     () => ({
       index: interpolationIndex,
-      current: { progress: current },
-      next: next && { progress: next },
-      closing: isClosing,
+      current,
+      next,
       swiping: isSwiping,
       inverted,
       layouts: {
@@ -384,7 +414,6 @@ function Card({
       interpolationIndex,
       current,
       next,
-      isClosing,
       isSwiping,
       inverted,
       layout,
@@ -405,7 +434,14 @@ function Card({
     () => {
       clearTimeout(pendingGestureCallbackRef.current);
       clearTimeout(pendingOnCloseCallbackRef.current);
+
       isSwiping.setValue(TRUE);
+
+      if (!isClosingValueLockedRef.current) {
+        isClosingValueLockedRef.current = true;
+        current.closing.setValue(TRUE);
+      }
+
       onGestureBegin?.();
     }
   );
@@ -538,13 +574,13 @@ function Card({
             // Animated needs the animated value to be used somewhere, otherwise things don't update properly.
             // If we disable animations and hide header, it could end up making the value unused.
             // So we have this dummy style that will always be used regardless of what else changed.
-            opacity: current,
+            opacity: current.progress,
           }}
           // Make sure that this view isn't removed. If this view is removed, our style with animated value won't apply
           collapsable={false}
         />
       ) : null}
-      {overlayEnabled ? (
+      {(overlayEnabled ?? overlayStyle != null) ? (
         <View style={[StyleSheet.absoluteFill, { pointerEvents: 'box-none' }]}>
           {overlay({ style: overlayStyle })}
         </View>
@@ -557,17 +593,16 @@ function Card({
             needsOffscreenAlphaCompositing={hasOpacityStyle(cardStyle)}
             style={[styles.card, cardStyle]}
           >
-            {shadowEnabled && shadowStyle && !isTransparent ? (
+            {(shadowEnabled ?? shadowStyle != null) && !isTransparent ? (
               <Animated.View
                 style={[
                   styles.shadow,
-                  gestureDirection === 'horizontal'
-                    ? [styles.shadowHorizontal, styles.shadowStart]
-                    : gestureDirection === 'horizontal-inverted'
-                      ? [styles.shadowHorizontal, styles.shadowEnd]
-                      : gestureDirection === 'vertical'
-                        ? [styles.shadowVertical, styles.shadowTop]
-                        : [styles.shadowVertical, styles.shadowBottom],
+                  gestureDirection === 'horizontal' ||
+                  gestureDirection === 'horizontal-inverted'
+                    ? styles.shadowHorizontal
+                    : gestureDirection === 'vertical'
+                      ? [styles.shadowVertical, styles.shadowTop]
+                      : [styles.shadowVertical, styles.shadowBottom],
                   { backgroundColor },
                   shadowStyle,
                 ]}
@@ -580,7 +615,9 @@ function Card({
             >
               {children}
             </CardContent>
-            {dimStyle ? <Animated.View style={[styles.dim, dimStyle]} /> : null}
+            {dimStyle != null ? (
+              <Animated.View style={[styles.dim, dimStyle]} />
+            ) : null}
           </Animated.View>
         </GestureDetector>
       </Animated.View>
@@ -617,22 +654,17 @@ const styles = StyleSheet.create({
   },
   shadowHorizontal: {
     top: 0,
+    start: 0,
+    end: 0,
     bottom: 0,
-    width: 3,
     ...getShadowStyle({
       offset: {
-        width: -1,
-        height: 1,
+        width: 0,
+        height: -3,
       },
-      radius: 5,
-      opacity: 0.3,
+      radius: 12,
+      opacity: 0.04,
     }),
-  },
-  shadowStart: {
-    start: 0,
-  },
-  shadowEnd: {
-    end: 0,
   },
   shadowVertical: {
     start: 0,

--- a/packages/stack/src/views/Stack/CardContainer.tsx
+++ b/packages/stack/src/views/Stack/CardContainer.tsx
@@ -29,6 +29,8 @@ type Props = {
   focused: boolean;
   opening: boolean;
   closing: boolean;
+  closingAnimated: Animated.Value;
+  nextClosingAnimated: Animated.Value | undefined;
   modal: boolean;
   layout: Layout;
   gesture: Animated.Value;
@@ -66,6 +68,8 @@ function CardContainerInner({
   active,
   opening,
   closing,
+  closingAnimated,
+  nextClosingAnimated,
   gesture,
   focused,
   modal,
@@ -207,6 +211,17 @@ function CardContainerInner({
 
   const animated = animation !== 'none';
 
+  const { current, next } = React.useMemo(
+    () => ({
+      current: { progress: scene.progress.current, closing: closingAnimated },
+      next:
+        scene.progress.next && nextClosingAnimated
+          ? { progress: scene.progress.next, closing: nextClosingAnimated }
+          : undefined,
+    }),
+    [closingAnimated, nextClosingAnimated, scene.progress]
+  );
+
   return (
     <Card
       animated={animated}
@@ -216,8 +231,8 @@ function CardContainerInner({
       insets={insets}
       direction={direction}
       gesture={gesture}
-      current={scene.progress.current}
-      next={scene.progress.next}
+      current={current}
+      next={next}
       opening={opening}
       closing={closing}
       onOpen={handleOpen}

--- a/packages/stack/src/views/Stack/CardStack.tsx
+++ b/packages/stack/src/views/Stack/CardStack.tsx
@@ -20,15 +20,24 @@ import {
 import type { EdgeInsets } from 'react-native-safe-area-context';
 
 import {
+  forBottomSheetAndroid,
+  forCrossDissolveIOS,
+  forDialogAndroid,
+  forFadeFromBottomAndroid,
+  forFadeFromRightAndroid,
+  forFlipIOS,
   forModalPresentationIOS,
   forNoAnimation as forNoAnimationCard,
+  forRevealFromBottomAndroid,
+  forScaleFromCenterAndroid,
+  forVerticalIOS,
 } from '../../TransitionConfigs/CardStyleInterpolators';
 import {
-  BottomSheetAndroid,
   DefaultTransition,
   FadeFromBottomAndroid,
   FadeFromRightAndroid,
   ModalFadeTransition,
+  ModalFlipIOS,
   ModalSlideFromBottomIOS,
   ModalTransition,
   RevealFromBottomAndroid,
@@ -102,16 +111,32 @@ const NAMED_TRANSITIONS_PRESETS = {
   fade: ModalFadeTransition,
   fade_from_bottom: FadeFromBottomAndroid,
   fade_from_right: FadeFromRightAndroid,
+  flip: ModalFlipIOS,
+  ios_from_left: SlideFromLeftIOS,
+  ios_from_right: SlideFromRightIOS,
   none: DefaultTransition,
   reveal_from_bottom: RevealFromBottomAndroid,
   scale_from_center: ScaleFromCenterAndroid,
   slide_from_left: SlideFromLeftIOS,
   slide_from_right: SlideFromRightIOS,
-  slide_from_bottom: Platform.select({
-    ios: ModalSlideFromBottomIOS,
-    default: BottomSheetAndroid,
-  }),
+  slide_from_bottom: ModalSlideFromBottomIOS,
 } as const satisfies Record<StackAnimationName, TransitionPreset>;
+
+const GESTURE_DISABLED_INTERPOLATORS = [
+  forCrossDissolveIOS,
+  forDialogAndroid,
+  forFadeFromBottomAndroid,
+  forFadeFromRightAndroid,
+  forFlipIOS,
+  forRevealFromBottomAndroid,
+  forScaleFromCenterAndroid,
+  forVerticalIOS,
+];
+
+const SCREEN_HEADER_INTERPOLATORS = [
+  ...GESTURE_DISABLED_INTERPOLATORS,
+  forBottomSheetAndroid,
+];
 
 const HIDDEN_HEADER_HEIGHT = { measured: false, value: 0 };
 
@@ -146,10 +171,25 @@ const getIsModalPresentation = (
 ) => {
   return (
     cardStyleInterpolator === forModalPresentationIOS ||
-    // Handle custom modal presentation interpolators as well
-    cardStyleInterpolator.name === 'forModalPresentationIOS'
+    cardStyleInterpolator.name === forModalPresentationIOS.name
   );
 };
+
+const getIsGestureEnabledByDefault = (
+  cardStyleInterpolator: StackCardStyleInterpolator
+) =>
+  !GESTURE_DISABLED_INTERPOLATORS.some(
+    (interpolator) =>
+      cardStyleInterpolator === interpolator ||
+      cardStyleInterpolator.name === interpolator.name
+  );
+
+const getIsScreenHeader = (cardStyleInterpolator: StackCardStyleInterpolator) =>
+  SCREEN_HEADER_INTERPOLATORS.some(
+    (interpolator) =>
+      cardStyleInterpolator === interpolator ||
+      cardStyleInterpolator.name === interpolator.name
+  );
 
 const getIsInModalPresentation = (
   scene: Scene,
@@ -323,7 +363,6 @@ export class CardStack extends React.Component<Props, State> {
     }
 
     const allRoutes = getAllRoutes(props.routes, props.state);
-
     const gestures = allRoutes.reduce<GestureValues>((acc, curr) => {
       const descriptor = props.descriptors[curr.key];
       const { animation } = descriptor?.options || {};
@@ -354,6 +393,13 @@ export class CardStack extends React.Component<Props, State> {
       const nextRoute = isInactive ? undefined : self[index + 1];
 
       const oldScene = state.scenes[index];
+      const previousScene =
+        oldScene?.route.key === route.key
+          ? oldScene
+          : state.scenes.find((scene) => scene.route.key === route.key);
+      const closing =
+        previousScene?.closing ??
+        new Animated.Value(props.closingRouteKeys.includes(route.key) ? 1 : 0);
 
       const currentGesture = gestures[route.key];
 
@@ -420,16 +466,17 @@ export class CardStack extends React.Component<Props, State> {
               : DefaultTransition;
 
       const {
-        gestureEnabled = Platform.OS === 'ios' && isAnimationEnabled,
         gestureDirection = transitionPreset.gestureDirection,
         transitionSpec = transitionPreset.transitionSpec,
         cardStyleInterpolator = isAnimationEnabled
           ? transitionPreset.cardStyleInterpolator
           : forNoAnimationCard,
+        gestureEnabled = Platform.OS === 'ios' &&
+          isAnimationEnabled &&
+          getIsGestureEnabledByDefault(cardStyleInterpolator),
         headerStyleInterpolator = transitionPreset.headerStyleInterpolator,
-        cardOverlayEnabled = (Platform.OS !== 'ios' &&
-          optionsForTransitionConfig.presentation !== 'transparentModal') ||
-          getIsModalPresentation(cardStyleInterpolator),
+        cardOverlayEnabled,
+        cardShadowEnabled,
       } = optionsForTransitionConfig;
 
       const headerMode: StackHeaderMode =
@@ -439,7 +486,8 @@ export class CardStack extends React.Component<Props, State> {
           optionsForTransitionConfig.presentation === 'transparentModal' ||
           nextOptions?.presentation === 'modal' ||
           nextOptions?.presentation === 'transparentModal' ||
-          getIsModalPresentation(cardStyleInterpolator)
+          getIsModalPresentation(cardStyleInterpolator) ||
+          getIsScreenHeader(cardStyleInterpolator)
         ) &&
         Platform.OS === 'ios' &&
         descriptor.options.header === undefined
@@ -456,6 +504,7 @@ export class CardStack extends React.Component<Props, State> {
             ...descriptor.options,
             animation,
             cardOverlayEnabled,
+            cardShadowEnabled,
             cardStyleInterpolator,
             gestureDirection,
             gestureEnabled,
@@ -489,6 +538,7 @@ export class CardStack extends React.Component<Props, State> {
               )
             : undefined,
         },
+        closing,
         __memo: [
           state.layout,
           descriptor,
@@ -810,10 +860,13 @@ export class CardStack extends React.Component<Props, State> {
                   // Preloaded screens should stay mounted, but remain hidden until focused
                   (!isPreloaded && index >= routes.length - 2)));
 
-            const activityMode = // Render focused and animating screens normally
+            const activityMode =
+              // Keep focused and focusing screens interactive
               focused || isFocusing
                 ? 'normal'
                 : inactiveBehavior === 'none' ||
+                    // Keep effects running until the closing animation finishes
+                    isRemoving ||
                     // Unpause preloaded or retained screens so updates are visible
                     // Handle retained explicitly as isInactive won't be updated until animation end
                     isInactive ||
@@ -870,6 +923,8 @@ export class CardStack extends React.Component<Props, State> {
                   focused={focused}
                   opening={openingRouteKeys.includes(route.key)}
                   closing={closingRouteKeys.includes(route.key)}
+                  closingAnimated={scene.closing}
+                  nextClosingAnimated={nextScene?.closing}
                   layout={layout}
                   gesture={gesture}
                   scene={scene}


### PR DESCRIPTION
This reworks the animations in JS stack to be closer to system animations.

**BREAKING CHANGE:**

Card style interpolator functions now receive `closing` in `current.closing` instead of top-level. There is also `next.closing` now.

Header style interpolators now receive `inverted` instead of `direction` to be consistent with Stack. Unlike `direction` which represented locale direction, `inverted` can represent animation direction.

New transition presets:
- `DialogAndroid`
- `ModalFlipIOS`
- `CrossDissolveIOS`

Additions to named animations:
- `flip`
- `ios_from_left`
- `ios_from_right`
