### PR TITLE
fix(stack): defer pop on gesture-driven close until the animation ends

### DIFF
--- a/packages/stack/src/views/Stack/Card.tsx
+++ b/packages/stack/src/views/Stack/Card.tsx
@@ -156,10 +156,6 @@ function Card({
   const lastToValueRef = React.useRef<number | undefined>(undefined);
 
   const animationHandleRef = React.useRef<number | undefined>(undefined);
-  const pendingGestureCallbackRef =
-    React.useRef<ReturnType<typeof setTimeout>>(undefined);
-  const pendingOnCloseCallbackRef =
-    React.useRef<ReturnType<typeof setTimeout>>(undefined);
 
   const [isClosing] = React.useState(() => new Animated.Value(FALSE));
 
@@ -200,8 +196,6 @@ function Card({
       const animation =
         spec.animation === 'spring' ? Animated.spring : Animated.timing;
 
-      clearTimeout(pendingGestureCallbackRef.current);
-
       if (animationHandleRef.current !== undefined) {
         cancelAnimationFrame(animationHandleRef.current);
       }
@@ -232,8 +226,6 @@ function Card({
           useNativeDriver,
           isInteraction: false,
         }).start(({ finished }) => {
-          clearTimeout(pendingGestureCallbackRef.current);
-
           if (finished) {
             onFinish();
           }
@@ -274,18 +266,12 @@ function Card({
       if (animationHandleRef.current) {
         cancelAnimationFrame(animationHandleRef.current);
       }
-
-      clearTimeout(pendingGestureCallbackRef.current);
-      clearTimeout(pendingOnCloseCallbackRef.current);
     };
   }, []);
 
   const timeoutRef = React.useRef<ReturnType<typeof setTimeout>>(undefined);
 
   const maybeAnimate = useLatestCallback(() => {
-    clearTimeout(pendingGestureCallbackRef.current);
-    clearTimeout(pendingOnCloseCallbackRef.current);
-
     if (!didInitiallyAnimate.current) {
       // Animate the card in on initial mount
       // Wrap in setTimeout to ensure animation starts after
@@ -403,8 +389,6 @@ function Card({
 
   const onGestureActivate: PanGestureConfig['onActivate'] = useLatestCallback(
     () => {
-      clearTimeout(pendingGestureCallbackRef.current);
-      clearTimeout(pendingOnCloseCallbackRef.current);
       isSwiping.setValue(TRUE);
       onGestureBegin?.();
     }
@@ -451,22 +435,15 @@ function Card({
           ? velocity !== 0 || translation !== 0
           : closing;
 
+      // When closing, the pop is dispatched from `animate`'s `onFinish` once
+      // the close animation ends (`handleCloseRoute` handles this case).
+      // Dispatching it while the animation was running made the state update
+      // (re-render + view unmounts) land mid-animation, which stalls its first
+      // frames on the new architecture where mounting runs on the UI thread —
+      // a visible hitch right after releasing the gesture. Pops triggered by
+      // `goBack` don't hitch because their state update happens before the
+      // animation starts; this mirrors that ordering.
       animate({ closing: shouldClose, velocity });
-
-      if (shouldClose) {
-        // We call onClose with a delay to make sure that the animation has already started
-        // This will make sure that the state update caused by this doesn't affect start of animation
-        pendingGestureCallbackRef.current = setTimeout(() => {
-          onClose();
-
-          // Check if the screen is still closing with a delay
-          // So state update from onClose has a chance to go through
-          // If route wasn't removed after onClose, re-open it
-          pendingOnCloseCallbackRef.current = setTimeout(() => {
-            maybeAnimate();
-          }, 32);
-        }, 16);
-      }
 
       onGestureEnd?.();
     });


### PR DESCRIPTION
Fixes #13210

## Problem

On a gesture-driven close, the pop is dispatched via a 16ms `setTimeout` right after the close animation starts. That state update (navigator re-render, focus changes, view unmounts) lands mid-animation. On the new architecture, mounting work runs on the UI thread — the same thread driving the native-driver animation — so the animation visibly freezes for a beat right after the finger lifts, then continues.

`goBack`-triggered pops never hitch because their ordering is reversed: the state update happens *before* any motion (the screen stays rendered via `closingRouteKeys` and animates out afterwards).

## Fix

Remove the early dispatch and let the pop come from `animate`'s `onFinish` when the close animation ends — a path `StackView.handleCloseRoute` already supports and documents:

```js
// If a route exists in state, trigger a pop
// This will happen in when the route was closed from the card component
// e.g. When the close animation triggered from a gesture ends
```

Motion first, React work after — the button ordering, mirrored. The `pendingGestureCallbackRef`/`pendingOnCloseCallbackRef` timers existed only to schedule the early pop and its re-open check, so they're removed; the re-open safety remains covered by `maybeAnimate` in `onFinish`.

## Trade-off

Navigation state (URL, focus events, listeners) updates when the close animation ends rather than ~16ms after release. That matches what's on screen, and is the same ordering `goBack` produces.

## Test plan

Verified on device (iPhone, RN 0.81.5, `newArchEnabled: true`, Expo SDK 54 + expo-router 6) with `@react-navigation/stack` 7.10.17 patched via `patch-package` with this change: the release hitch disappears entirely — swipe-back release becomes indistinguishable from the `goBack` animation. Repro repo linked in the issue.