### PR TITLE
fix: preserve opening animation for stacked screens

### DIFF
--- a/packages/stack/src/views/Stack/CardStack.tsx
+++ b/packages/stack/src/views/Stack/CardStack.tsx
@@ -506,6 +506,10 @@ export class CardStack extends React.Component<Props, State> {
         }
       }
 
+      const isTopScreenModal =
+        scenes[props.routes.length - 1]?.descriptor.options.presentation ===
+        'modal';
+
       activeStates = props.routes.map((_, index, self) => {
         // The activity state represents state of the screen:
         // 0 - inactive, the screen is detached
@@ -519,9 +523,19 @@ export class CardStack extends React.Component<Props, State> {
 
         const lastActiveState = state.activeStates[index];
         const activeAfterTransition = index >= self.length - activeScreensLimit;
+        // Recreate the activity interpolation below a remaining modal.
+        const shouldReactivateForModal =
+          props.routes.length < state.routes.length &&
+          index === self.length - activeScreensLimit - 1 &&
+          isTopScreenModal;
 
-        if (lastActiveState === STATE_INACTIVE && !activeAfterTransition) {
-          // screen was inactive before and it will still be inactive after the transition
+        if (
+          (isTopScreenModal && index < self.length - activeScreensLimit - 1) ||
+          (lastActiveState === STATE_INACTIVE &&
+            !activeAfterTransition &&
+            !shouldReactivateForModal)
+        ) {
+          // screen is deeply covered by a modal, or was inactive and will remain inactive
           activityState = STATE_INACTIVE;
         } else {
           const sceneForActivity = scenes[self.length - 1];

--- a/packages/stack/src/views/Stack/CardStack.tsx
+++ b/packages/stack/src/views/Stack/CardStack.tsx
@@ -506,9 +506,11 @@ export class CardStack extends React.Component<Props, State> {
         }
       }
 
-      const isTopScreenModal =
-        scenes[props.routes.length - 1]?.descriptor.options.presentation ===
-        'modal';
+      const focusedRouteKey = props.state.routes[props.state.index]?.key;
+      const isSingleOpeningTransition =
+        props.openingRouteKeys.length === 1 &&
+        props.openingRouteKeys[0] === focusedRouteKey &&
+        props.closingRouteKeys.length === 0;
 
       activeStates = props.routes.map((_, index, self) => {
         // The activity state represents state of the screen:
@@ -523,19 +525,21 @@ export class CardStack extends React.Component<Props, State> {
 
         const lastActiveState = state.activeStates[index];
         const activeAfterTransition = index >= self.length - activeScreensLimit;
-        // Recreate the activity interpolation below a remaining modal.
-        const shouldReactivateForModal =
+        // Recreate the activity interpolation below the active window after a
+        // route removal so the screen can appear during a later close.
+        const shouldReactivateBelowActiveWindow =
           props.routes.length < state.routes.length &&
-          index === self.length - activeScreensLimit - 1 &&
-          isTopScreenModal;
+          index === self.length - activeScreensLimit - 1;
 
         if (
-          (isTopScreenModal && index < self.length - activeScreensLimit - 1) ||
+          (isSingleOpeningTransition &&
+            index < self.length - activeScreensLimit - 1) ||
           (lastActiveState === STATE_INACTIVE &&
             !activeAfterTransition &&
-            !shouldReactivateForModal)
+            !shouldReactivateBelowActiveWindow)
         ) {
-          // screen is deeply covered by a modal, or was inactive and will remain inactive
+          // screen is deeply covered during an opening transition, or was
+          // inactive and will remain inactive
           activityState = STATE_INACTIVE;
         } else {
           const sceneForActivity = scenes[self.length - 1];


### PR DESCRIPTION
### Motivation
Opening another screen over an already-covered JS stack can skip its visible opening animation on Android, even though transition events run for the expected duration.

This regressed in `@react-navigation/stack@7.6.7` when [d98552bced](https://github.com/react-navigation/react-navigation/commit/d98552bced693a8ed04a5b9b4952838bc8660a65) removed the strict depth guard while fixing blank screens.

The guard came from [#11315](https://github.com/react-navigation/react-navigation/pull/11315), which prevents inactive routes from briefly reattaching during transitions such as `A → B → C → popTo(B)`. Restoring it unconditionally fixes the skipped animation but reintroduces blank frames in overlapping transitions.

### Approach
This change handles the activity state according to the transition lifecycle rather than checking for modal presentation:
- Apply the depth guard only when exactly one route is opening, it is the focused route, and no route is closing.
- Keep deeply covered screens numerically inactive during that opening transition.
- Preserve the existing previous-activity-state guard in other transition states.
- After a route is removed, recreate the activity interpolation immediately below the active window so that screen can appear during a later close.
There are no checks for `presentation`, modal interpolators, or modal-specific options.
This allows the incoming screen to animate without reactivating deeply covered screens, while preserving the interpolation needed to reveal the correct underlying screen during subsequent closing transitions.


| Before | After |
| -- | -- |
| ![before](https://github.com/user-attachments/assets/4cb55efc-e202-45be-96e0-0700203dad3c) | ![after](https://github.com/user-attachments/assets/d352625f-8c0b-490b-8753-a1c625974cc8) |

Fixes #13213
### Validation
Revalidated with:
- `@react-navigation/stack@7.10.23`
- `@react-navigation/native@7.3.17`
- React Native 0.79.6
- Android 16 emulator

Stock `7.10.23` still reproduces the skipped second opening animation. The updated implementation preserves the animation without reintroducing blank frames.

Validated scenarios:
- `Home → modal-1 → modal-2`
- Closing `modal-2`, followed by `modal-1`
- Equivalent non-modal vertical card transitions
- `A → B → C → popTo(B)`
- Push-style replacement ordering
- Reset with shifted route indices
- Multi-pop route ordering
- Overlapping opening transitions
- Simultaneous opening and closing routes
- Rapid heavy-render navigation sequences

A local-only `CardStack` activity-state harness covered the index-sensitive scenarios above. All seven cases passed; the temporary harness is not included in this PR.
Repository checks also passed:
- 752 tests
- TypeScript
- Declaration generation
- ESLint

### Blank-frame comparison:

Before historical fix (`7.6.6`):

![Stock 7.6.6 blank-frame contact sheet](https://github.com/user-attachments/assets/9a10f003-85bd-4b3f-8dfa-2c00ff0b118d)

After historical fix (`7.6.7`):

![Stock 7.6.7 contact sheet](https://github.com/user-attachments/assets/46048cb8-ffa5-4623-9fe8-fcc73eab6245)

Modal regression and patched behavior:

- [Stock `7.10.22` recording](https://github.com/user-attachments/assets/4cb55efc-e202-45be-96e0-0700203dad3c)
- [Patched `7.10.22` recording](https://github.com/user-attachments/assets/d352625f-8c0b-490b-8753-a1c625974cc8)

### Test plan
Android:
- Verify both opening transitions in `Home → modal-1 → modal-2`.
- Close `modal-2`, then `modal-1`, and verify the correct underlying route remains visible.
- Verify the same behavior with a non-modal vertical transition.
- Verify `A → B → C → popTo(B)` without a blank frame.
- Exercise replacement, reset, multi-pop, and overlapping transition sequences.
- Run the heavy-render rapid-navigation sequence and inspect the recorded frames.

Shared-platform regression check:
- Verify single and stacked JS-stack transitions animate correctly on iOS.
