### PR TITLE
fix(drawer): type drawerContent props with the navigator's param list

### DIFF
--- a/example/__typechecks__/common.check.tsx
+++ b/example/__typechecks__/common.check.tsx
@@ -5,10 +5,12 @@ import type {
   BottomTabNavigationOptions,
   BottomTabScreenProps,
 } from '@react-navigation/bottom-tabs';
-import type {
-  DrawerNavigationOptions,
-  DrawerNavigationProp,
-  DrawerScreenProps,
+import {
+  createDrawerNavigator,
+  type DrawerContentComponentProps,
+  type DrawerNavigationOptions,
+  type DrawerNavigationProp,
+  type DrawerScreenProps,
 } from '@react-navigation/drawer';
 import { Button } from '@react-navigation/elements';
 import {
@@ -1953,4 +1955,96 @@ useNavigationState('Invalid', (state) => state.index);
   >().toEqualTypeOf<{
     variant: 'compact' | 'regular';
   }>();
+}
+
+/**
+ * Check that the props passed to `drawerContent` use the navigator's param list
+ */
+{
+  type DrawerParamList = {
+    Home: undefined;
+    Profile: { userId: string };
+  };
+
+  const Drawer = createDrawerNavigator<DrawerParamList>();
+
+  <Drawer.Navigator
+    drawerContent={(props) => {
+      props.navigation.navigate('Home');
+      props.navigation.navigate('Profile', { userId: 'jane' });
+      props.navigation.closeDrawer();
+      props.navigation.toggleDrawer();
+
+      expectTypeOf(props.state.routes[0]!.name).toEqualTypeOf<
+        keyof DrawerParamList
+      >();
+
+      // @ts-expect-error
+      props.navigation.navigate('NotARoute');
+
+      // @ts-expect-error
+      props.navigation.navigate('Profile', { userId: 42 });
+
+      return null;
+    }}
+  >
+    <Drawer.Screen name="Home" component={() => null} />
+  </Drawer.Navigator>;
+}
+
+/**
+ * Check that `DrawerContentComponentProps` still defaults to `ParamListBase`
+ */
+{
+  const DrawerContent = (props: DrawerContentComponentProps) => {
+    // Without a param list, any route name is accepted as before
+    props.navigation.navigate('AnyRouteName');
+    props.navigation.closeDrawer();
+
+    expectTypeOf(props.state.routes[0]!.name).toEqualTypeOf<string>();
+
+    return null;
+  };
+
+  // Components using the default are still assignable to a typed navigator
+  const Drawer = createDrawerNavigator<{ Home: undefined }>();
+
+  <Drawer.Navigator drawerContent={DrawerContent}>
+    <Drawer.Screen name="Home" component={() => null} />
+  </Drawer.Navigator>;
+
+  // As well as to a navigator without a param list
+  const UntypedDrawer = createDrawerNavigator();
+
+  <UntypedDrawer.Navigator drawerContent={DrawerContent}>
+    <UntypedDrawer.Screen name="Home" component={() => null} />
+  </UntypedDrawer.Navigator>;
+}
+
+/**
+ * Check for `DrawerContentComponentProps` with an explicit param list
+ */
+{
+  type DrawerParamList = {
+    Home: undefined;
+    Profile: { userId: string };
+  };
+
+  const DrawerContent = (
+    props: DrawerContentComponentProps<DrawerParamList>
+  ) => {
+    props.navigation.navigate('Home');
+    props.navigation.navigate('Profile', { userId: 'jane' });
+
+    // @ts-expect-error
+    props.navigation.navigate('NotARoute');
+
+    return null;
+  };
+
+  const Drawer = createDrawerNavigator<DrawerParamList>();
+
+  <Drawer.Navigator drawerContent={DrawerContent}>
+    <Drawer.Screen name="Home" component={() => null} />
+  </Drawer.Navigator>;
 }

--- a/packages/drawer/src/navigators/createDrawerNavigator.tsx
+++ b/packages/drawer/src/navigators/createDrawerNavigator.tsx
@@ -68,7 +68,7 @@ export interface DrawerTypeBag extends NavigatorTypeBagBase {
   ScreenOptions: DrawerNavigationOptions;
   EventMap: DrawerNavigationEventMap;
   ActionHelpers: DrawerActionHelpers<this['ParamList']>;
-  Navigator: typeof DrawerNavigator;
+  Navigator: React.ComponentType<DrawerNavigatorProps<this['ParamList']>>;
 }
 
 export const createDrawerNavigator =

--- a/packages/drawer/src/types.tsx
+++ b/packages/drawer/src/types.tsx
@@ -24,12 +24,16 @@ export type Scene = {
 
 export type Layout = { width: number; height: number };
 
-export type DrawerNavigationConfig = {
+export type DrawerNavigationConfig<
+  ParamList extends ParamListBase = ParamListBase,
+> = {
   /**
    * Function that returns React element to render as the content of the drawer, for example, navigation items.
    * Defaults to `DrawerContent`.
    */
-  drawerContent?: (props: DrawerContentComponentProps) => React.ReactNode;
+  drawerContent?: (
+    props: DrawerContentComponentProps<ParamList>
+  ) => React.ReactNode;
 };
 
 export type DrawerNavigationOptions = HeaderOptions & {
@@ -223,9 +227,11 @@ export type DrawerNavigationOptions = HeaderOptions & {
   inactiveBehavior?: 'pause' | 'none';
 };
 
-export type DrawerContentComponentProps = {
-  state: DrawerNavigationState<ParamListBase>;
-  navigation: DrawerNavigationHelpers;
+export type DrawerContentComponentProps<
+  ParamList extends ParamListBase = ParamListBase,
+> = {
+  state: DrawerNavigationState<ParamList>;
+  navigation: DrawerNavigationHelpers<ParamList>;
   descriptors: DrawerDescriptorMap;
 };
 
@@ -271,11 +277,10 @@ export type DrawerNavigationEventMap = {
   gestureCancel: { data: undefined };
 };
 
-export type DrawerNavigationHelpers = NavigationHelpers<
-  ParamListBase,
-  DrawerNavigationEventMap
-> &
-  DrawerActionHelpers<ParamListBase>;
+export type DrawerNavigationHelpers<
+  ParamList extends ParamListBase = ParamListBase,
+> = NavigationHelpers<ParamList, DrawerNavigationEventMap> &
+  DrawerActionHelpers<ParamList>;
 
 export type DrawerNavigationProp<
   ParamList extends ParamListBase,
@@ -333,12 +338,14 @@ export type DrawerProps = {
   overlayAccessibilityLabel?: string;
 };
 
-export type DrawerNavigatorProps = DefaultNavigatorOptions<
-  ParamListBase,
-  DrawerNavigationState<ParamListBase>,
+export type DrawerNavigatorProps<
+  ParamList extends ParamListBase = ParamListBase,
+> = DefaultNavigatorOptions<
+  ParamList,
+  DrawerNavigationState<ParamList>,
   DrawerNavigationOptions,
   DrawerNavigationEventMap,
-  DrawerNavigationProp<ParamListBase>
+  DrawerNavigationProp<ParamList>
 > &
   DrawerRouterOptions &
-  DrawerNavigationConfig;
+  DrawerNavigationConfig<ParamList>;


### PR DESCRIPTION
**Motivation**

Fixes #9348.

`DrawerContentComponentProps` was hardcoded to `ParamListBase`, so route names were never checked inside a custom drawer content component. Even with a fully typed navigator, this compiled:

```ts
const Drawer = createDrawerNavigator<{ Home: undefined; Profile: { userId: string } }>();

<Drawer.Navigator
  drawerContent={(props) => {
    props.navigation.navigate('LiterallyAnything'); // no error
    return null;
  }}
/>
```

Every other navigation surface (`DrawerScreenProps`, `DrawerNavigationProp`, …) is parameterised by the param list, so this was an inconsistency people kept working around with `as unknown as DrawerNavigationProp<...>` casts (see the issue thread).

**Why the obvious fix isn't enough**

Adding a `ParamList` parameter to `DrawerContentComponentProps` on its own changes nothing user-visible. The props exposed on `Drawer.Navigator` are computed by `NavigatorProps` as:

```ts
Omit<React.ComponentProps<Navigator>, keyof DefaultNavigatorOptions<...>> & DefaultNavigatorOptions<ParamList, ...>
```

Only the `DefaultNavigatorOptions` half receives the param list. The navigator-specific half — which is where `drawerContent` lives — comes from `React.ComponentProps<Bag['Navigator']>`, and `DrawerTypeBag` pinned that to `typeof DrawerNavigator`, a concrete non-generic component. The generic was erased before it reached the user. I verified this: with only the `types.tsx` change, the `@ts-expect-error` assertions stayed unused.

`NavigatorTypeBagBase` already supports polymorphic `this` (`NavigationList` and the existing `State`/`ActionHelpers` slots use `this['ParamList']`). Declaring the `Navigator` slot as a component type over `this['ParamList']` is enough to thread the param list through, with no changes to `packages/core`:

```ts
Navigator: React.ComponentType<DrawerNavigatorProps<this['ParamList']>>;
```

**Backwards compatibility**

Every new type parameter defaults to `ParamListBase`, so this is intentionally a no-op for existing code:

- `DrawerContentComponentProps` with no type argument behaves exactly as before — any route name is accepted, `state.routes[n].name` is still `string`.
- Components typed with the bare default are still assignable to `drawerContent`, on both a typed and an untyped navigator.
- No consumer in this repo needed changing. All existing users of `DrawerContentComponentProps` / `drawerContent` (`example/src/index.tsx`, `example/src/Screens/DrawerMasterDetail.tsx`, `example/src/Showcase/DrawerShowcase.tsx`, `packages/drawer/src/views/DrawerContent.tsx`, `packages/drawer/src/views/DrawerView.tsx`) compile untouched.

The only code that starts failing is code that was already navigating to a route that doesn't exist.

`DrawerNavigationHelpers` and `DrawerNavigationConfig` also gained a defaulted parameter; neither is exported from the package entry point.

**Test plan**

Added type tests to `example/__typechecks__/common.check.tsx` covering three cases:

1. `drawerContent` on a typed navigator — valid route names and params compile, drawer helpers (`closeDrawer`/`toggleDrawer`) still resolve, `state.routes[n].name` narrows to `keyof ParamList`, and an invalid route name / wrong params are errors.
2. `DrawerContentComponentProps` with no type argument — still accepts any route name, still assignable to `drawerContent` of both a typed and an untyped navigator.
3. `DrawerContentComponentProps<ParamList>` used explicitly on a standalone component.

Counterfactual: reverting the two source files while keeping the type tests makes them fail to compile, as expected —

```
common.check.tsx: error TS2578: Unused '@ts-expect-error' directive.          (invalid route name)
common.check.tsx: error TS2344: Type '"Home" | "Profile"' does not satisfy ... (state not narrowed)
common.check.tsx: error TS2578: Unused '@ts-expect-error' directive.          (wrong params)
common.check.tsx: error TS2315: Type 'DrawerContentComponentProps' is not generic.
```

The backwards-compatibility assertions compile both with and without the change.

Green locally: `pnpm test` (81 suites / 1228 tests / 167 snapshots), `pnpm lint`, `pnpm typecheck`, `pnpm typecheck:standalone:static`, `pnpm typecheck:standalone:dynamic`, `pnpm typecheck:declarations`.
