### PR TITLE
fix: prevent state reset when history.go() takes longer than timeout on web

### DIFF
--- a/example/e2e/tests/history.test.ts
+++ b/example/e2e/tests/history.test.ts
@@ -112,46 +112,6 @@ test('keeps state in sync when browser back and forward interrupt navigation', a
   );
 });
 
-test('keeps state in sync when going back with a delayed history traversal', async ({
-  page,
-}) => {
-  await page.goto('/native-stack/article/gandalf');
-
-  await page
-    .getByRole('button', {
-      name: 'Navigate to feed',
-    })
-    .click();
-
-  await expect(page).toHaveURL(/\/native-stack\/feed\/\d+$/);
-
-  // Simulate a slow history traversal, e.g. on Firefox `history.go(n)`
-  // can take several hundred milliseconds when the main thread is busy
-  await page.evaluate(() => {
-    const originalGo = window.history.go.bind(window.history);
-
-    window.history.go = (delta?: number) => {
-      setTimeout(() => originalGo(delta), 600);
-    };
-  });
-
-  await page
-    .getByRole('button', {
-      name: 'Go back',
-    })
-    .click();
-
-  await expect(
-    page.getByRole('heading', { name: 'Article by Gandalf' })
-  ).toBeVisible();
-
-  // Once the delayed traversal settles, the URL should be in sync
-  await expect(page).toHaveURL('/native-stack/article/gandalf');
-  await expect(page).toHaveTitle(
-    'Article by Gandalf - React Navigation Example'
-  );
-});
-
 test('replaces the current browser history entry on replace', async ({
   page,
 }) => {

--- a/example/e2e/tests/history.test.ts
+++ b/example/e2e/tests/history.test.ts
@@ -112,6 +112,46 @@ test('keeps state in sync when browser back and forward interrupt navigation', a
   );
 });
 
+test('keeps state in sync when going back with a delayed history traversal', async ({
+  page,
+}) => {
+  await page.goto('/native-stack/article/gandalf');
+
+  await page
+    .getByRole('button', {
+      name: 'Navigate to feed',
+    })
+    .click();
+
+  await expect(page).toHaveURL(/\/native-stack\/feed\/\d+$/);
+
+  // Simulate a slow history traversal, e.g. on Firefox `history.go(n)`
+  // can take several hundred milliseconds when the main thread is busy
+  await page.evaluate(() => {
+    const originalGo = window.history.go.bind(window.history);
+
+    window.history.go = (delta?: number) => {
+      setTimeout(() => originalGo(delta), 600);
+    };
+  });
+
+  await page
+    .getByRole('button', {
+      name: 'Go back',
+    })
+    .click();
+
+  await expect(
+    page.getByRole('heading', { name: 'Article by Gandalf' })
+  ).toBeVisible();
+
+  // Once the delayed traversal settles, the URL should be in sync
+  await expect(page).toHaveURL('/native-stack/article/gandalf');
+  await expect(page).toHaveTitle(
+    'Article by Gandalf - React Navigation Example'
+  );
+});
+
 test('replaces the current browser history entry on replace', async ({
   page,
 }) => {

--- a/packages/native/src/__tests__/createMemoryHistory.web.test.tsx
+++ b/packages/native/src/__tests__/createMemoryHistory.web.test.tsx
@@ -250,7 +250,7 @@ test('can go back in browser history after a previous attempt failed', async () 
 
   const timedOutNavigation = history.go(-1);
 
-  jest.advanceTimersByTime(100);
+  jest.advanceTimersByTime(1000);
 
   await expect(timedOutNavigation).rejects.toThrow(
     'History was changed during navigation.'
@@ -271,7 +271,7 @@ test('can go back in browser history after a previous attempt failed', async () 
   unlisten();
 });
 
-test("doesn't treat late popstate from own traversal as user navigation", async () => {
+test('resolves go when popstate arrives before the timeout', async () => {
   jest.useFakeTimers();
 
   const state: NavigationState = {
@@ -290,36 +290,28 @@ test("doesn't treat late popstate from own traversal as user navigation", async 
   const listener = jest.fn();
   const unlisten = history.listen(listener);
 
-  // Simulate a slow traversal (e.g. Firefox when the main thread is busy)
-  // where `popstate` doesn't fire before the timeout in `go`
+  // Simulate a slow traversal, e.g. on Firefox `history.go(n)` can take
+  // several hundred milliseconds when the main thread is busy
+  const originalGo = window.history.go.bind(window.history);
   const windowGoSpy = jest
     .spyOn(window.history, 'go')
-    .mockImplementation(() => {});
+    .mockImplementation((delta) => {
+      setTimeout(() => originalGo(delta), 600);
+    });
 
-  const timedOutNavigation = history.go(-1);
+  const navigation = history.go(-1);
 
-  jest.advanceTimersByTime(100);
-
-  await expect(timedOutNavigation).rejects.toThrow(
-    'History was changed during navigation.'
-  );
-
-  windowGoSpy.mockRestore();
-
-  // The browser performs the traversal after the timeout and fires a late `popstate`
-  window.history.go(-1);
+  jest.advanceTimersByTime(600);
   jest.runAllTimers();
 
-  // The late `popstate` is from our own traversal, so it shouldn't call the listener
+  // The traversal arrived before the timeout, so it should resolve
+  // and not be treated as a user-initiated navigation
+  await expect(navigation).resolves.toBeUndefined();
+
   expect(listener).not.toHaveBeenCalled();
   expect(history.index).toBe(0);
 
-  // A user-initiated navigation afterwards should still call the listener
-  window.history.go(1);
-  jest.runAllTimers();
-
-  expect(listener).toHaveBeenCalledTimes(1);
-  expect(history.index).toBe(1);
+  windowGoSpy.mockRestore();
 
   unlisten();
 });

--- a/packages/native/src/__tests__/createMemoryHistory.web.test.tsx
+++ b/packages/native/src/__tests__/createMemoryHistory.web.test.tsx
@@ -270,3 +270,56 @@ test('can go back in browser history after a previous attempt failed', async () 
 
   unlisten();
 });
+
+test("doesn't treat late popstate from own traversal as user navigation", async () => {
+  jest.useFakeTimers();
+
+  const state: NavigationState = {
+    key: 'stack-123',
+    index: 0,
+    routeNames: ['One'],
+    routes: [{ name: 'One', key: 'One-23' }],
+    type: 'stack',
+    stale: false,
+  };
+  const history = createMemoryHistory();
+
+  history.replace({ path: '/route-one', state });
+  history.push({ path: '/route-two', state });
+
+  const listener = jest.fn();
+  const unlisten = history.listen(listener);
+
+  // Simulate a slow traversal (e.g. Firefox when the main thread is busy)
+  // where `popstate` doesn't fire before the timeout in `go`
+  const windowGoSpy = jest
+    .spyOn(window.history, 'go')
+    .mockImplementation(() => {});
+
+  const timedOutNavigation = history.go(-1);
+
+  jest.advanceTimersByTime(100);
+
+  await expect(timedOutNavigation).rejects.toThrow(
+    'History was changed during navigation.'
+  );
+
+  windowGoSpy.mockRestore();
+
+  // The browser performs the traversal after the timeout and fires a late `popstate`
+  window.history.go(-1);
+  jest.runAllTimers();
+
+  // The late `popstate` is from our own traversal, so it shouldn't call the listener
+  expect(listener).not.toHaveBeenCalled();
+  expect(history.index).toBe(0);
+
+  // A user-initiated navigation afterwards should still call the listener
+  window.history.go(1);
+  jest.runAllTimers();
+
+  expect(listener).toHaveBeenCalledTimes(1);
+  expect(history.index).toBe(1);
+
+  unlisten();
+});

--- a/packages/native/src/__tests__/createMemoryHistory.web.test.tsx
+++ b/packages/native/src/__tests__/createMemoryHistory.web.test.tsx
@@ -290,8 +290,6 @@ test('resolves go when popstate arrives before the timeout', async () => {
   const listener = jest.fn();
   const unlisten = history.listen(listener);
 
-  // Simulate a slow traversal, e.g. on Firefox `history.go(n)` can take
-  // several hundred milliseconds when the main thread is busy
   const originalGo = window.history.go.bind(window.history);
   const windowGoSpy = jest
     .spyOn(window.history, 'go')
@@ -304,8 +302,6 @@ test('resolves go when popstate arrives before the timeout', async () => {
   jest.advanceTimersByTime(600);
   jest.runAllTimers();
 
-  // The traversal arrived before the timeout, so it should resolve
-  // and not be treated as a user-initiated navigation
   await expect(navigation).resolves.toBeUndefined();
 
   expect(listener).not.toHaveBeenCalled();

--- a/packages/native/src/__tests__/createMemoryHistory.web.test.tsx
+++ b/packages/native/src/__tests__/createMemoryHistory.web.test.tsx
@@ -1,10 +1,14 @@
-import { beforeEach, expect, jest, test } from '@jest/globals';
+import { afterEach, beforeEach, expect, jest, test } from '@jest/globals';
 import type { NavigationState } from '@react-navigation/core';
 
 import { createMemoryHistory } from '../createMemoryHistory';
 
 beforeEach(() => {
   jest.useRealTimers();
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
 });
 
 test('finds previous entries without matching hash fragments', () => {
@@ -267,47 +271,6 @@ test('can go back in browser history after a previous attempt failed', async () 
   await expect(navigation).resolves.toBeUndefined();
 
   expect(listener).not.toHaveBeenCalled();
-
-  unlisten();
-});
-
-test('resolves go when popstate arrives before the timeout', async () => {
-  jest.useFakeTimers();
-
-  const state: NavigationState = {
-    key: 'stack-123',
-    index: 0,
-    routeNames: ['One'],
-    routes: [{ name: 'One', key: 'One-23' }],
-    type: 'stack',
-    stale: false,
-  };
-  const history = createMemoryHistory();
-
-  history.replace({ path: '/route-one', state });
-  history.push({ path: '/route-two', state });
-
-  const listener = jest.fn();
-  const unlisten = history.listen(listener);
-
-  const originalGo = window.history.go.bind(window.history);
-  const windowGoSpy = jest
-    .spyOn(window.history, 'go')
-    .mockImplementation((delta) => {
-      setTimeout(() => originalGo(delta), 600);
-    });
-
-  const navigation = history.go(-1);
-
-  jest.advanceTimersByTime(600);
-  jest.runAllTimers();
-
-  await expect(navigation).resolves.toBeUndefined();
-
-  expect(listener).not.toHaveBeenCalled();
-  expect(history.index).toBe(0);
-
-  windowGoSpy.mockRestore();
 
   unlisten();
 });

--- a/packages/native/src/__tests__/useLinking.web.test.tsx
+++ b/packages/native/src/__tests__/useLinking.web.test.tsx
@@ -2103,13 +2103,21 @@ test('preserves history entries when traversal is slower than the fallback timeo
   const originalGo = window.history.go.bind(window.history);
 
   const spy = jest.spyOn(window.history, 'go').mockImplementation((n) => {
-    setTimeout(() => originalGo(n), 150);
+    setTimeout(() => originalGo(n), 1500);
   });
 
   act(() => navigation.goBack());
 
+  await act(async () => {});
+
+  act(() => jest.advanceTimersByTime(1000));
+
+  await act(async () => {});
+
+  act(() => jest.advanceTimersByTime(500));
+
+  await act(async () => {});
   act(() => jest.advanceTimersByTime(100));
-  act(() => jest.advanceTimersByTime(50));
 
   await waitFor(() => expect(window.location.pathname).toBe('/'));
 
@@ -2120,6 +2128,449 @@ test('preserves history entries when traversal is slower than the fallback timeo
   await waitFor(() => expect(window.location.pathname).toBe('/profile'));
 
   expect(navigation.getCurrentRoute()?.name).toBe('Profile');
+});
+
+test('keeps the latest navigation when programmatic back is delayed', async () => {
+  const Stack = createStackNavigator();
+
+  const linking = {
+    config: {
+      screens: {
+        Home: '',
+        Profile: 'profile',
+        Settings: 'settings',
+        Feed: 'feed',
+      },
+    },
+  };
+
+  const navigation = createNavigationContainerRef<ParamListBase>();
+
+  render(
+    <NavigationContainer ref={navigation} linking={linking}>
+      <Stack.Navigator>
+        <Stack.Screen name="Home" component={TestScreen} />
+        <Stack.Screen name="Profile" component={TestScreen} />
+        <Stack.Screen name="Settings" component={TestScreen} />
+        <Stack.Screen name="Feed" component={TestScreen} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+
+  act(() => navigation.navigate('Profile'));
+
+  await waitFor(() => expect(window.location.pathname).toBe('/profile'));
+
+  act(() => navigation.navigate('Settings'));
+
+  await waitFor(() => expect(window.location.pathname).toBe('/settings'));
+
+  const originalGo = window.history.go.bind(window.history);
+
+  const spy = jest.spyOn(window.history, 'go').mockImplementation((n) => {
+    setTimeout(() => originalGo(n), 600);
+  });
+
+  act(() => navigation.goBack());
+
+  await act(async () => {});
+
+  act(() => navigation.navigate('Feed'));
+
+  await act(async () => {});
+
+  act(() => jest.advanceTimersByTime(600));
+
+  await act(async () => {});
+  act(() => jest.advanceTimersByTime(100));
+
+  await waitFor(() => expect(window.location.pathname).toBe('/feed'));
+
+  expect(navigation.getCurrentRoute()?.name).toBe('Feed');
+
+  spy.mockRestore();
+
+  act(() => window.history.back());
+
+  await waitFor(() => expect(window.location.pathname).toBe('/profile'));
+
+  expect(navigation.getCurrentRoute()?.name).toBe('Profile');
+});
+
+test('queues replace while programmatic back is delayed', async () => {
+  const Stack = createStackNavigator();
+
+  const linking = {
+    config: {
+      screens: {
+        Home: '',
+        Profile: 'profile',
+        Settings: 'settings',
+      },
+    },
+  };
+
+  const navigation = createNavigationContainerRef<ParamListBase>();
+
+  render(
+    <NavigationContainer ref={navigation} linking={linking}>
+      <Stack.Navigator>
+        <Stack.Screen name="Home" component={TestScreen} />
+        <Stack.Screen name="Profile" component={TestScreen} />
+        <Stack.Screen name="Settings" component={TestScreen} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+
+  act(() => navigation.navigate('Profile'));
+
+  await waitFor(() => expect(window.location.pathname).toBe('/profile'));
+
+  act(() => navigation.navigate('Settings'));
+
+  await waitFor(() => expect(window.location.pathname).toBe('/settings'));
+
+  const originalGo = window.history.go.bind(window.history);
+
+  const spy = jest.spyOn(window.history, 'go').mockImplementation((n) => {
+    setTimeout(() => originalGo(n), 600);
+  });
+
+  act(() => navigation.goBack());
+
+  await act(async () => {});
+
+  act(() => navigation.dispatch(StackActions.replace('Settings')));
+
+  await act(async () => {});
+
+  act(() => jest.advanceTimersByTime(600));
+
+  await act(async () => {});
+  act(() => jest.advanceTimersByTime(100));
+
+  await waitFor(() => expect(window.location.pathname).toBe('/settings'));
+
+  expect(navigation.getCurrentRoute()?.name).toBe('Settings');
+
+  spy.mockRestore();
+
+  act(() => window.history.back());
+
+  await waitFor(() => expect(window.location.pathname).toBe('/'));
+
+  expect(navigation.getCurrentRoute()?.name).toBe('Home');
+});
+
+test('applies multiple updates queued during delayed history traversal', async () => {
+  const Stack = createStackNavigator();
+
+  const linking = {
+    config: {
+      screens: {
+        Home: '',
+        A: 'a',
+        B: 'b',
+        C: 'c',
+      },
+    },
+  };
+
+  const navigation = createNavigationContainerRef<ParamListBase>();
+
+  render(
+    <NavigationContainer ref={navigation} linking={linking}>
+      <Stack.Navigator>
+        <Stack.Screen name="Home" component={TestScreen} />
+        <Stack.Screen name="A" component={TestScreen} />
+        <Stack.Screen name="B" component={TestScreen} />
+        <Stack.Screen name="C" component={TestScreen} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+
+  act(() => navigation.navigate('A'));
+
+  await waitFor(() => expect(window.location.pathname).toBe('/a'));
+
+  act(() => navigation.navigate('B'));
+
+  await waitFor(() => expect(window.location.pathname).toBe('/b'));
+
+  const originalGo = window.history.go.bind(window.history);
+
+  const spy = jest.spyOn(window.history, 'go').mockImplementation((n) => {
+    setTimeout(() => originalGo(n), 600);
+  });
+
+  act(() => navigation.goBack());
+
+  await act(async () => {});
+
+  act(() => navigation.navigate('B'));
+  act(() => navigation.navigate('C'));
+
+  await act(async () => {});
+
+  act(() => jest.advanceTimersByTime(600));
+
+  await act(async () => {});
+  act(() => jest.advanceTimersByTime(100));
+
+  await waitFor(() => expect(window.location.pathname).toBe('/c'));
+
+  expect(navigation.getCurrentRoute()?.name).toBe('C');
+
+  spy.mockRestore();
+
+  act(() => window.history.back());
+
+  await waitFor(() => expect(window.location.pathname).toBe('/a'));
+
+  expect(navigation.getCurrentRoute()?.name).toBe('A');
+});
+
+test('syncs a queued navigation after history traversal times out', async () => {
+  const Stack = createStackNavigator();
+
+  const linking = {
+    config: {
+      screens: {
+        Home: '',
+        Profile: 'profile',
+        Settings: 'settings',
+        Feed: 'feed',
+      },
+    },
+  };
+
+  const navigation = createNavigationContainerRef<ParamListBase>();
+
+  render(
+    <NavigationContainer ref={navigation} linking={linking}>
+      <Stack.Navigator>
+        <Stack.Screen name="Home" component={TestScreen} />
+        <Stack.Screen name="Profile" component={TestScreen} />
+        <Stack.Screen name="Settings" component={TestScreen} />
+        <Stack.Screen name="Feed" component={TestScreen} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+
+  act(() => navigation.navigate('Profile'));
+
+  await waitFor(() => expect(window.location.pathname).toBe('/profile'));
+
+  act(() => navigation.navigate('Settings'));
+
+  await waitFor(() => expect(window.location.pathname).toBe('/settings'));
+
+  const spy = jest.spyOn(window.history, 'go').mockImplementation(() => {});
+
+  act(() => navigation.goBack());
+
+  await act(async () => {});
+
+  act(() => navigation.navigate('Feed'));
+
+  expect(navigation.getCurrentRoute()?.name).toBe('Feed');
+
+  expect(window.location.pathname).toBe('/settings');
+
+  act(() => jest.advanceTimersByTime(1000));
+
+  await waitFor(() => expect(window.location.pathname).toBe('/feed'));
+
+  expect(navigation.getCurrentRoute()?.name).toBe('Feed');
+
+  spy.mockRestore();
+});
+
+test('rolls back prevented browser back when forward traversal is delayed', async () => {
+  const Stack = createStackNavigator();
+
+  const linking = {
+    config: {
+      screens: {
+        Home: '',
+        Profile: 'profile',
+      },
+    },
+  };
+
+  const navigation = createNavigationContainerRef<ParamListBase>();
+
+  const onPreventRemove = jest.fn();
+
+  const ProfileScreen = ({ route }: any): any => {
+    usePreventRemove(true, onPreventRemove);
+
+    return <Text>{route.name}</Text>;
+  };
+
+  render(
+    <NavigationContainer ref={navigation} linking={linking}>
+      <Stack.Navigator>
+        <Stack.Screen name="Home" component={TestScreen} />
+        <Stack.Screen name="Profile" component={ProfileScreen} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+
+  act(() => navigation.navigate('Profile'));
+
+  await waitFor(() => expect(window.location.pathname).toBe('/profile'));
+
+  const originalGo = window.history.go.bind(window.history);
+
+  const spy = jest.spyOn(window.history, 'go').mockImplementation((n) => {
+    setTimeout(() => originalGo(n), 600);
+  });
+
+  act(() => window.history.back());
+
+  await waitFor(() => expect(onPreventRemove).toHaveBeenCalledTimes(1));
+
+  expect(window.location.pathname).toBe('/');
+
+  act(() => jest.advanceTimersByTime(600));
+
+  await act(async () => {});
+  act(() => jest.advanceTimersByTime(100));
+
+  await waitFor(() => expect(window.location.pathname).toBe('/profile'));
+
+  expect(navigation.getCurrentRoute()?.name).toBe('Profile');
+
+  spy.mockRestore();
+});
+
+test('syncs a delayed multi-entry programmatic pop', async () => {
+  const Stack = createStackNavigator();
+
+  const linking = {
+    config: {
+      screens: {
+        Home: '',
+        A: 'a',
+        B: 'b',
+        C: 'c',
+      },
+    },
+  };
+
+  const navigation = createNavigationContainerRef<ParamListBase>();
+
+  render(
+    <NavigationContainer ref={navigation} linking={linking}>
+      <Stack.Navigator>
+        <Stack.Screen name="Home" component={TestScreen} />
+        <Stack.Screen name="A" component={TestScreen} />
+        <Stack.Screen name="B" component={TestScreen} />
+        <Stack.Screen name="C" component={TestScreen} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+
+  act(() => navigation.navigate('A'));
+
+  await waitFor(() => expect(window.location.pathname).toBe('/a'));
+
+  act(() => navigation.navigate('B'));
+
+  await waitFor(() => expect(window.location.pathname).toBe('/b'));
+
+  act(() => navigation.navigate('C'));
+
+  await waitFor(() => expect(window.location.pathname).toBe('/c'));
+
+  const originalGo = window.history.go.bind(window.history);
+
+  const spy = jest.spyOn(window.history, 'go').mockImplementation((n) => {
+    setTimeout(() => originalGo(n), 600);
+  });
+
+  act(() => navigation.dispatch(StackActions.pop(2)));
+
+  await act(async () => {});
+
+  act(() => jest.advanceTimersByTime(600));
+
+  await act(async () => {});
+  act(() => jest.advanceTimersByTime(100));
+
+  await waitFor(() => expect(window.location.pathname).toBe('/a'));
+
+  expect(navigation.getCurrentRoute()?.name).toBe('A');
+
+  spy.mockRestore();
+
+  act(() => window.history.forward());
+
+  await waitFor(() => expect(window.location.pathname).toBe('/b'));
+
+  expect(navigation.getCurrentRoute()?.name).toBe('B');
+});
+
+test('handles browser navigation during a delayed programmatic traversal', async () => {
+  const Stack = createStackNavigator();
+
+  const linking = {
+    config: {
+      screens: {
+        Home: '',
+        A: 'a',
+        B: 'b',
+      },
+    },
+  };
+
+  const navigation = createNavigationContainerRef<ParamListBase>();
+
+  render(
+    <NavigationContainer ref={navigation} linking={linking}>
+      <Stack.Navigator>
+        <Stack.Screen name="Home" component={TestScreen} />
+        <Stack.Screen name="A" component={TestScreen} />
+        <Stack.Screen name="B" component={TestScreen} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+
+  act(() => navigation.navigate('A'));
+
+  await waitFor(() => expect(window.location.pathname).toBe('/a'));
+
+  act(() => navigation.navigate('B'));
+
+  await waitFor(() => expect(window.location.pathname).toBe('/b'));
+
+  const originalGo = window.history.go.bind(window.history);
+
+  const spy = jest.spyOn(window.history, 'go').mockImplementation((n) => {
+    setTimeout(() => originalGo(n), 600);
+  });
+
+  act(() => navigation.goBack());
+
+  await act(async () => {});
+
+  act(() => window.history.back());
+
+  act(() => jest.advanceTimersByTime(1));
+
+  await act(async () => {});
+
+  act(() => jest.advanceTimersByTime(600));
+
+  await act(async () => {});
+  act(() => jest.advanceTimersByTime(100));
+
+  await waitFor(() => expect(window.location.pathname).toBe('/'));
+
+  expect(navigation.getCurrentRoute()?.name).toBe('Home');
+
+  spy.mockRestore();
 });
 
 test('navigates to the last screen without waiting for an interrupted one', async () => {

--- a/packages/native/src/__tests__/useLinking.web.test.tsx
+++ b/packages/native/src/__tests__/useLinking.web.test.tsx
@@ -2430,7 +2430,7 @@ test('applies multiple updates queued during delayed history traversal', async (
   await waitFor(() => expect(window.location.pathname).toBe('/c'));
 
   expect(navigation.getCurrentRoute()?.name).toBe('C');
-  expect(navigation.getRootState().routes.map((route) => route.name)).toEqual([
+  expect(navigation.getRootState()?.routes.map((route) => route.name)).toEqual([
     'Home',
     'A',
     'B',
@@ -2450,7 +2450,7 @@ test('applies multiple updates queued during delayed history traversal', async (
   await waitFor(() => expect(window.location.pathname).toBe('/c'));
 
   expect(navigation.getCurrentRoute()?.name).toBe('C');
-  expect(navigation.getRootState().routes.map((route) => route.name)).toEqual([
+  expect(navigation.getRootState()?.routes.map((route) => route.name)).toEqual([
     'Home',
     'A',
     'B',

--- a/packages/native/src/__tests__/useLinking.web.test.tsx
+++ b/packages/native/src/__tests__/useLinking.web.test.tsx
@@ -2010,7 +2010,7 @@ test("doesn't update URL until navigation to a suspending screen commits", async
 
   expect(window.location.pathname).toBe('/');
 
-  await act(() => navigation.navigate('Profile'));
+  await act(async () => navigation.navigate('Profile'));
 
   expect(window.location.pathname).toBe('/');
 
@@ -2058,11 +2058,11 @@ test("doesn't add history entry for navigation interrupted before commit", async
     </NavigationContainer>
   );
 
-  await act(() => navigation.navigate('Profile'));
+  await act(async () => navigation.navigate('Profile'));
 
   expect(window.location.pathname).toBe('/');
 
-  await act(() => navigation.dispatch(StackActions.replace('Settings')));
+  await act(async () => navigation.dispatch(StackActions.replace('Settings')));
 
   await waitFor(() => expect(window.location.pathname).toBe('/settings'));
 
@@ -2102,26 +2102,17 @@ test('preserves history entries when traversal is slower than the fallback timeo
 
   const originalGo = window.history.go.bind(window.history);
 
-  const spy = jest.spyOn(window.history, 'go').mockImplementation((n) => {
+  const goSpy = jest.spyOn(window.history, 'go').mockImplementation((n) => {
     setTimeout(() => originalGo(n), 1500);
   });
 
   act(() => navigation.goBack());
 
-  await act(async () => {});
-
-  act(() => jest.advanceTimersByTime(1000));
-
-  await act(async () => {});
-
-  act(() => jest.advanceTimersByTime(500));
-
-  await act(async () => {});
-  act(() => jest.advanceTimersByTime(100));
+  await act(() => jest.advanceTimersByTimeAsync(1600));
 
   await waitFor(() => expect(window.location.pathname).toBe('/'));
 
-  spy.mockRestore();
+  goSpy.mockRestore();
 
   act(() => window.history.forward());
 
@@ -2167,28 +2158,25 @@ test('keeps the latest navigation when programmatic back is delayed', async () =
 
   const originalGo = window.history.go.bind(window.history);
 
-  const spy = jest.spyOn(window.history, 'go').mockImplementation((n) => {
+  const goSpy = jest.spyOn(window.history, 'go').mockImplementation((n) => {
     setTimeout(() => originalGo(n), 600);
   });
 
   act(() => navigation.goBack());
 
-  await act(async () => {});
+  await act(() => jest.advanceTimersByTimeAsync(0));
+
+  expect(goSpy).toHaveBeenCalledWith(-1);
 
   act(() => navigation.navigate('Feed'));
 
-  await act(async () => {});
-
-  act(() => jest.advanceTimersByTime(600));
-
-  await act(async () => {});
-  act(() => jest.advanceTimersByTime(100));
+  await act(() => jest.advanceTimersByTimeAsync(700));
 
   await waitFor(() => expect(window.location.pathname).toBe('/feed'));
 
   expect(navigation.getCurrentRoute()?.name).toBe('Feed');
 
-  spy.mockRestore();
+  goSpy.mockRestore();
 
   act(() => window.history.back());
 
@@ -2232,28 +2220,25 @@ test('queues replace while programmatic back is delayed', async () => {
 
   const originalGo = window.history.go.bind(window.history);
 
-  const spy = jest.spyOn(window.history, 'go').mockImplementation((n) => {
+  const goSpy = jest.spyOn(window.history, 'go').mockImplementation((n) => {
     setTimeout(() => originalGo(n), 600);
   });
 
   act(() => navigation.goBack());
 
-  await act(async () => {});
+  await act(() => jest.advanceTimersByTimeAsync(0));
+
+  expect(goSpy).toHaveBeenCalledWith(-1);
 
   act(() => navigation.dispatch(StackActions.replace('Settings')));
 
-  await act(async () => {});
-
-  act(() => jest.advanceTimersByTime(600));
-
-  await act(async () => {});
-  act(() => jest.advanceTimersByTime(100));
+  await act(() => jest.advanceTimersByTimeAsync(700));
 
   await waitFor(() => expect(window.location.pathname).toBe('/settings'));
 
   expect(navigation.getCurrentRoute()?.name).toBe('Settings');
 
-  spy.mockRestore();
+  goSpy.mockRestore();
 
   act(() => window.history.back());
 
@@ -2299,35 +2284,50 @@ test('applies multiple updates queued during delayed history traversal', async (
 
   const originalGo = window.history.go.bind(window.history);
 
-  const spy = jest.spyOn(window.history, 'go').mockImplementation((n) => {
+  const goSpy = jest.spyOn(window.history, 'go').mockImplementation((n) => {
     setTimeout(() => originalGo(n), 600);
   });
 
   act(() => navigation.goBack());
 
-  await act(async () => {});
+  await act(() => jest.advanceTimersByTimeAsync(0));
+
+  expect(goSpy).toHaveBeenCalledWith(-1);
 
   act(() => navigation.navigate('B'));
   act(() => navigation.navigate('C'));
 
-  await act(async () => {});
-
-  act(() => jest.advanceTimersByTime(600));
-
-  await act(async () => {});
-  act(() => jest.advanceTimersByTime(100));
+  await act(() => jest.advanceTimersByTimeAsync(700));
 
   await waitFor(() => expect(window.location.pathname).toBe('/c'));
 
   expect(navigation.getCurrentRoute()?.name).toBe('C');
+  expect(navigation.getRootState().routes.map((route) => route.name)).toEqual([
+    'Home',
+    'A',
+    'B',
+    'C',
+  ]);
 
-  spy.mockRestore();
+  goSpy.mockRestore();
 
   act(() => window.history.back());
 
   await waitFor(() => expect(window.location.pathname).toBe('/a'));
 
   expect(navigation.getCurrentRoute()?.name).toBe('A');
+
+  act(() => window.history.forward());
+
+  await waitFor(() => expect(window.location.pathname).toBe('/c'));
+
+  expect(navigation.getCurrentRoute()?.name).toBe('C');
+  expect(navigation.getRootState().routes.map((route) => route.name)).toEqual([
+    'Home',
+    'A',
+    'B',
+    'C',
+  ]);
 });
 
 test('syncs a queued navigation after history traversal times out', async () => {
@@ -2365,11 +2365,13 @@ test('syncs a queued navigation after history traversal times out', async () => 
 
   await waitFor(() => expect(window.location.pathname).toBe('/settings'));
 
-  const spy = jest.spyOn(window.history, 'go').mockImplementation(() => {});
+  const goSpy = jest.spyOn(window.history, 'go').mockImplementation(() => {});
 
   act(() => navigation.goBack());
 
-  await act(async () => {});
+  await act(() => jest.advanceTimersByTimeAsync(0));
+
+  expect(goSpy).toHaveBeenCalledWith(-1);
 
   act(() => navigation.navigate('Feed'));
 
@@ -2377,13 +2379,15 @@ test('syncs a queued navigation after history traversal times out', async () => 
 
   expect(window.location.pathname).toBe('/settings');
 
-  act(() => jest.advanceTimersByTime(1000));
+  await act(() => jest.advanceTimersByTimeAsync(999));
+
+  expect(window.location.pathname).toBe('/settings');
+
+  await act(() => jest.advanceTimersByTimeAsync(1));
 
   await waitFor(() => expect(window.location.pathname).toBe('/feed'));
 
   expect(navigation.getCurrentRoute()?.name).toBe('Feed');
-
-  spy.mockRestore();
 });
 
 test('rolls back prevented browser back when forward traversal is delayed', async () => {
@@ -2423,7 +2427,7 @@ test('rolls back prevented browser back when forward traversal is delayed', asyn
 
   const originalGo = window.history.go.bind(window.history);
 
-  const spy = jest.spyOn(window.history, 'go').mockImplementation((n) => {
+  jest.spyOn(window.history, 'go').mockImplementation((n) => {
     setTimeout(() => originalGo(n), 600);
   });
 
@@ -2433,16 +2437,11 @@ test('rolls back prevented browser back when forward traversal is delayed', asyn
 
   expect(window.location.pathname).toBe('/');
 
-  act(() => jest.advanceTimersByTime(600));
-
-  await act(async () => {});
-  act(() => jest.advanceTimersByTime(100));
+  await act(() => jest.advanceTimersByTimeAsync(700));
 
   await waitFor(() => expect(window.location.pathname).toBe('/profile'));
 
   expect(navigation.getCurrentRoute()?.name).toBe('Profile');
-
-  spy.mockRestore();
 });
 
 test('syncs a delayed multi-entry programmatic pop', async () => {
@@ -2486,30 +2485,31 @@ test('syncs a delayed multi-entry programmatic pop', async () => {
 
   const originalGo = window.history.go.bind(window.history);
 
-  const spy = jest.spyOn(window.history, 'go').mockImplementation((n) => {
+  const goSpy = jest.spyOn(window.history, 'go').mockImplementation((n) => {
     setTimeout(() => originalGo(n), 600);
   });
 
   act(() => navigation.dispatch(StackActions.pop(2)));
 
-  await act(async () => {});
-
-  act(() => jest.advanceTimersByTime(600));
-
-  await act(async () => {});
-  act(() => jest.advanceTimersByTime(100));
+  await act(() => jest.advanceTimersByTimeAsync(700));
 
   await waitFor(() => expect(window.location.pathname).toBe('/a'));
 
   expect(navigation.getCurrentRoute()?.name).toBe('A');
 
-  spy.mockRestore();
+  goSpy.mockRestore();
 
   act(() => window.history.forward());
 
   await waitFor(() => expect(window.location.pathname).toBe('/b'));
 
   expect(navigation.getCurrentRoute()?.name).toBe('B');
+
+  act(() => window.history.forward());
+
+  await waitFor(() => expect(window.location.pathname).toBe('/c'));
+
+  expect(navigation.getCurrentRoute()?.name).toBe('C');
 });
 
 test('handles browser navigation during a delayed programmatic traversal', async () => {
@@ -2521,6 +2521,7 @@ test('handles browser navigation during a delayed programmatic traversal', async
         Home: '',
         A: 'a',
         B: 'b',
+        C: 'c',
       },
     },
   };
@@ -2533,6 +2534,7 @@ test('handles browser navigation during a delayed programmatic traversal', async
         <Stack.Screen name="Home" component={TestScreen} />
         <Stack.Screen name="A" component={TestScreen} />
         <Stack.Screen name="B" component={TestScreen} />
+        <Stack.Screen name="C" component={TestScreen} />
       </Stack.Navigator>
     </NavigationContainer>
   );
@@ -2545,32 +2547,43 @@ test('handles browser navigation during a delayed programmatic traversal', async
 
   await waitFor(() => expect(window.location.pathname).toBe('/b'));
 
+  act(() => navigation.navigate('C'));
+
+  await waitFor(() => expect(window.location.pathname).toBe('/c'));
+
   const originalGo = window.history.go.bind(window.history);
 
-  const spy = jest.spyOn(window.history, 'go').mockImplementation((n) => {
+  const goSpy = jest.spyOn(window.history, 'go').mockImplementation((n) => {
     setTimeout(() => originalGo(n), 600);
   });
 
   act(() => navigation.goBack());
 
-  await act(async () => {});
+  await act(() => jest.advanceTimersByTimeAsync(0));
+
+  expect(goSpy).toHaveBeenCalledWith(-1);
 
   act(() => window.history.back());
 
-  act(() => jest.advanceTimersByTime(1));
+  await act(() => jest.advanceTimersByTimeAsync(700));
 
-  await act(async () => {});
+  await waitFor(() => expect(window.location.pathname).toBe('/a'));
 
-  act(() => jest.advanceTimersByTime(600));
+  expect(navigation.getCurrentRoute()?.name).toBe('A');
 
-  await act(async () => {});
-  act(() => jest.advanceTimersByTime(100));
+  goSpy.mockRestore();
 
-  await waitFor(() => expect(window.location.pathname).toBe('/'));
+  act(() => window.history.forward());
 
-  expect(navigation.getCurrentRoute()?.name).toBe('Home');
+  await waitFor(() => expect(window.location.pathname).toBe('/b'));
 
-  spy.mockRestore();
+  expect(navigation.getCurrentRoute()?.name).toBe('B');
+
+  act(() => window.history.forward());
+
+  await waitFor(() => expect(window.location.pathname).toBe('/c'));
+
+  expect(navigation.getCurrentRoute()?.name).toBe('C');
 });
 
 test('navigates to the last screen without waiting for an interrupted one', async () => {
@@ -2632,8 +2645,8 @@ test('navigates to the last screen without waiting for an interrupted one', asyn
     </NavigationContainer>
   );
 
-  await act(() => navigation.navigate('A'));
-  await act(() => navigation.navigate('B'));
+  await act(async () => navigation.navigate('A'));
+  await act(async () => navigation.navigate('B'));
 
   expect(window.location.pathname).toBe('/');
 
@@ -2717,8 +2730,8 @@ test("doesn't navigate to an interrupted screen that finishes loading first", as
     </NavigationContainer>
   );
 
-  await act(() => navigation.navigate('A'));
-  await act(() => navigation.navigate('B'));
+  await act(async () => navigation.navigate('A'));
+  await act(async () => navigation.navigate('B'));
 
   expect(window.location.pathname).toBe('/');
 

--- a/packages/native/src/createMemoryHistory.tsx
+++ b/packages/native/src/createMemoryHistory.tsx
@@ -20,6 +20,11 @@ export function createMemoryHistory() {
   // We might modify the callback stored if it was interrupted, so we have a ref to identify it
   const pending: { ref: unknown; cb: (interrupted?: boolean) => void }[] = [];
 
+  // The entry we were traversing to when the timeout in `go` fired before `popstate` arrived
+  // The `popstate` may still arrive later (e.g. on Firefox when the main thread is busy)
+  // and shouldn't be confused with a user-initiated back/forward navigation in `listen`
+  let latePopState: { id: string; until: number } | null = null;
+
   const interrupt = () => {
     // If another history operation was performed we need to interrupt existing ones
     // This makes sure that calls such as `history.replace` after `history.go` don't happen
@@ -197,6 +202,13 @@ export function createMemoryHistory() {
         const timer = setTimeout(() => {
           window.removeEventListener('popstate', onPopState);
 
+          // The `popstate` for this traversal may still arrive after the timeout
+          // e.g. on Firefox the traversal can take a lot longer when the main thread is busy
+          // Remember the target entry so `listen` doesn't treat it as a user navigation
+          if (targetId != null) {
+            latePopState = { id: targetId, until: Date.now() + 1000 };
+          }
+
           const foundIndex = pending.findIndex((it) => it.ref === done);
 
           if (foundIndex > -1) {
@@ -235,6 +247,18 @@ export function createMemoryHistory() {
         if (pending.length) {
           // This was triggered by `history.go(n)`, we shouldn't call the listener
           return;
+        }
+
+        if (latePopState) {
+          const { id, until } = latePopState;
+
+          latePopState = null;
+
+          if (window.history.state?.id === id && Date.now() <= until) {
+            // This was triggered by our own `history.go(n)` that arrived after the timeout
+            // e.g. on Firefox when the main thread is busy, so we shouldn't call the listener
+            return;
+          }
         }
 
         listener();

--- a/packages/native/src/createMemoryHistory.tsx
+++ b/packages/native/src/createMemoryHistory.tsx
@@ -20,11 +20,6 @@ export function createMemoryHistory() {
   // We might modify the callback stored if it was interrupted, so we have a ref to identify it
   const pending: { ref: unknown; cb: (interrupted?: boolean) => void }[] = [];
 
-  // The entry we were traversing to when the timeout in `go` fired before `popstate` arrived
-  // The `popstate` may still arrive later (e.g. on Firefox when the main thread is busy)
-  // and shouldn't be confused with a user-initiated back/forward navigation in `listen`
-  let latePopState: { id: string; until: number } | null = null;
-
   const interrupt = () => {
     // If another history operation was performed we need to interrupt existing ones
     // This makes sure that calls such as `history.replace` after `history.go` don't happen
@@ -194,20 +189,16 @@ export function createMemoryHistory() {
 
         pending.push({ ref: done, cb: done });
 
-        // If navigation didn't happen within 100ms, assume that it won't happen
+        // If navigation didn't happen within 1000ms, assume that it won't happen
         // This may not be accurate, but hopefully it won't take so much time
         // In Chrome, navigation seems to happen instantly in next microtask
-        // But on Firefox, it seems to take much longer, around 50ms from our testing
+        // But on Firefox, the traversal can take much longer when the main thread
+        // is busy, e.g. it was measured to take up to ~900ms while rendering a new screen
+        // While the promise is pending, subsequent `pushState`/`replaceState` are queued,
+        // which avoids racing them against the in-flight traversal
         // We're using a hacky timeout since there doesn't seem to be way to know for sure
         const timer = setTimeout(() => {
           window.removeEventListener('popstate', onPopState);
-
-          // The `popstate` for this traversal may still arrive after the timeout
-          // e.g. on Firefox the traversal can take a lot longer when the main thread is busy
-          // Remember the target entry so `listen` doesn't treat it as a user navigation
-          if (targetId != null) {
-            latePopState = { id: targetId, until: Date.now() + 1000 };
-          }
 
           const foundIndex = pending.findIndex((it) => it.ref === done);
 
@@ -217,7 +208,7 @@ export function createMemoryHistory() {
           }
 
           index = this.index;
-        }, 100);
+        }, 1000);
 
         const onPopState = () => {
           // Fix createMemoryHistory.index variable's value
@@ -247,18 +238,6 @@ export function createMemoryHistory() {
         if (pending.length) {
           // This was triggered by `history.go(n)`, we shouldn't call the listener
           return;
-        }
-
-        if (latePopState) {
-          const { id, until } = latePopState;
-
-          latePopState = null;
-
-          if (window.history.state?.id === id && Date.now() <= until) {
-            // This was triggered by our own `history.go(n)` that arrived after the timeout
-            // e.g. on Firefox when the main thread is busy, so we shouldn't call the listener
-            return;
-          }
         }
 
         listener();

--- a/packages/native/src/createMemoryHistory.tsx
+++ b/packages/native/src/createMemoryHistory.tsx
@@ -194,8 +194,6 @@ export function createMemoryHistory() {
         // In Chrome, navigation seems to happen instantly in next microtask
         // But on Firefox, the traversal can take much longer when the main thread
         // is busy, e.g. it was measured to take up to ~900ms while rendering a new screen
-        // While the promise is pending, subsequent `pushState`/`replaceState` are queued,
-        // which avoids racing them against the in-flight traversal
         // We're using a hacky timeout since there doesn't seem to be way to know for sure
         const timer = setTimeout(() => {
           window.removeEventListener('popstate', onPopState);


### PR DESCRIPTION
**Motivation**

Fixes #11145

On web, `createMemoryHistory().go(n)` calls `window.history.go(n)` and waits for the `popstate` event to know when the traversal has finished. Since the browser provides no API to detect a traversal that will never happen, a 100ms timeout was used as a fallback: if `popstate` didn't arrive in time, the navigation was assumed to have failed.

The problem is that the 100ms assumption doesn't hold on Firefox. A real-world example of the impact: [Expensify/App#94571](https://github.com/Expensify/App/issues/94571) (a newly created chat immediately closes on Firefox because the late `popstate` resets navigation to the previous screen), which was fixed by patching this exact timeout in [Expensify/App#95980](https://github.com/Expensify/App/pull/95980) ([the patch](https://github.com/Expensify/App/blob/main/patches/react-navigation/%40react-navigation%2Bnative%2B7.1.33%2B003%2Bincrease-history-go-popstate-fallback-timeout.patch)). When the timeout fired before the traversal finished:

1. The pending `go()` was rejected and removed from the `pending` queue.
2. The late `popstate` then arrived with an empty `pending` queue, so `listen()` misclassified it as a user-initiated back/forward navigation and reset the app to a stale route - visible as lost screens/state after calling `navigation.navigate()` or going back on Firefox.

This PR increases the timeout to 1000ms. Besides covering the measured traversal times, keeping the `go()` promise pending longer has a second benefit: navigation state updates are serialized, so while the promise is pending, subsequent `pushState`/`replaceState` calls are queued instead of racing against the in-flight traversal. Without this, a user navigating in the app during the stuck traversal could end up with the browser history modified underneath the traversal, which lands on an unpredictable entry (deltas are resolved at execution time).

**Trade-off**

The timeout is only ever waited out in full when `popstate` never arrives - i.e. when the in-memory history is out of sync with the real browser history (edge cases around reloads/session restore). In that already broken case, the URL bar sync now lags up to 1s instead of 0.1s, on all browsers. The app itself is unaffected: screens render immediately and user interactions are never blocked. On Chrome the traversal completes in the next microtask, so the timeout value is effectively never reached in normal operation.

A timeout of any length remains a heuristic: a traversal delayed beyond 1000ms would still be misclassified. This is not fully fixable with the History API (no way to detect or cancel a pending traversal). The section below explains the proper long-term fix.

**In future: Navigation API**

The [Navigation API](https://developer.mozilla.org/en-US/docs/Web/API/Navigation_API) removes the need for this heuristic entirely:

- [`navigation.traverseTo(key)`](https://developer.mozilla.org/en-US/docs/Web/API/Navigation/traverseTo) targets a specific entry and returns `{ committed, finished }` promises, so both the "late popstate" and the "traversal never happens" cases are detected deterministically.
- The `navigate` event distinguishes traversal sources, removing the `pending`-based classification in `listen()`.

The API is baseline newly available since January 2026 (Chrome/Edge 102+, Firefox 147+, Safari 26.2+). Since older browsers will need the `popstate` fallback for years, adopting it would be a progressive enhancement and is left as a follow-up.

**Test plan**

- Unit test: `packages/native/src/__tests__/createMemoryHistory.web.test.tsx` - new test `resolves go when popstate arrives before the timeout` simulates a traversal that takes 600ms, it fails with the previous 100ms timeout and passes with this change.
