### PR TITLE
fix(stack): silence onAnimatedValueUpdate warning by registering gesture listener

### DIFF
--- a/packages/stack/src/views/Stack/Card.tsx
+++ b/packages/stack/src/views/Stack/Card.tsx
@@ -362,6 +362,20 @@ function Card({
     maybeAnimate,
   ]);
 
+  React.useEffect(() => {
+    // Register a no-op listener on the gesture value.
+    // When the gesture is updated from the native side (e.g. on iOS swipe-back)
+    // with `useNativeDriver`, React Native warns about `onAnimatedValueUpdate`
+    // being sent with no listeners registered. Attaching a listener tells the
+    // native side that JS is observing the value, silencing the warning.
+    // cf. https://github.com/react-navigation/react-navigation/issues/11564
+    const id = gesture.addListener(() => {});
+
+    return () => {
+      gesture.removeListener(id);
+    };
+  }, [gesture]);
+
   const interpolationProps = React.useMemo(
     () => ({
       index: interpolationIndex,


### PR DESCRIPTION
Fixes #11564

When the swipe-back gesture updates the `Animated.Value` with `useNativeDriver` on iOS, React Native warns about `onAnimatedValueUpdate` being sent with no listeners registered. This happens on every swipe-back gesture in the JS Stack navigator.

The fix attaches a no-op listener to the gesture `Animated.Value` on mount and removes it on unmount, so the native side knows JS is observing the value and stops emitting the warning.