### PR TITLE
fix(stack): register gesture listener to silence onAnimatedValueUpdate warning

### DIFF
--- a/packages/native/src/useLinking.native.tsx
+++ b/packages/native/src/useLinking.native.tsx
@@ -1,4 +1,5 @@
 import {
+  CommonActions,
   getActionFromState as getActionFromStateDefault,
   getStateFromPath as getStateFromPathDefault,
   type NavigationContainerRef,
@@ -209,7 +210,10 @@ export function useLinking<ParamList extends ParamListBase>(
             );
           }
         } else {
-          navigation.resetRoot(state);
+          // Use CommonActions.reset via dispatch (same as useBuildAction / linkTo)
+          // instead of resetRoot, so the action goes through the normal pipeline
+          // and stays consistent with programmatic linkTo() calls.
+          navigation.dispatch(CommonActions.reset(state));
         }
       }
     };

--- a/packages/native/src/useLinking.native.tsx
+++ b/packages/native/src/useLinking.native.tsx
@@ -1,5 +1,4 @@
 import {
-  CommonActions,
   getActionFromState as getActionFromStateDefault,
   getStateFromPath as getStateFromPathDefault,
   type NavigationContainerRef,
@@ -210,10 +209,7 @@ export function useLinking<ParamList extends ParamListBase>(
             );
           }
         } else {
-          // Use CommonActions.reset via dispatch (same as useBuildAction / linkTo)
-          // instead of resetRoot, so the action goes through the normal pipeline
-          // and stays consistent with programmatic linkTo() calls.
-          navigation.dispatch(CommonActions.reset(state));
+          navigation.resetRoot(state);
         }
       }
     };

--- a/packages/native/src/useLinking.native.tsx
+++ b/packages/native/src/useLinking.native.tsx
@@ -208,12 +208,7 @@ export function useLinking<ParamList extends ParamListBase>(
               }`
             );
           }
-        } else if (!navigation.isReady()) {
-          // Cold start — fall back to resetRoot when the container
-          // isn't initialized yet. When already running (e.g. with
-          // modals open), skip resetRoot so we don't destroy the
-          // existing stack like linkTo()/dispatch(CommonActions.reset)
-          // would have done inside useBuildAction.
+        } else {
           navigation.resetRoot(state);
         }
       }

--- a/packages/native/src/useLinking.native.tsx
+++ b/packages/native/src/useLinking.native.tsx
@@ -208,7 +208,12 @@ export function useLinking<ParamList extends ParamListBase>(
               }`
             );
           }
-        } else {
+        } else if (!navigation.isReady()) {
+          // Cold start — fall back to resetRoot when the container
+          // isn't initialized yet. When already running (e.g. with
+          // modals open), skip resetRoot so we don't destroy the
+          // existing stack like linkTo()/dispatch(CommonActions.reset)
+          // would have done inside useBuildAction.
           navigation.resetRoot(state);
         }
       }

--- a/packages/stack/src/views/Stack/Card.tsx
+++ b/packages/stack/src/views/Stack/Card.tsx
@@ -362,6 +362,20 @@ function Card({
     maybeAnimate,
   ]);
 
+  React.useEffect(() => {
+    // Register a no-op listener on the gesture value.
+    // When the gesture is updated from the native side (e.g. on iOS swipe-back)
+    // with `useNativeDriver`, React Native warns about `onAnimatedValueUpdate`
+    // being sent with no listeners registered. Attaching a listener tells the
+    // native side that JS is observing the value, silencing the warning.
+    // cf. https://github.com/react-navigation/react-navigation/issues/11564
+    const id = gesture.addListener(() => {});
+
+    return () => {
+      gesture.removeListener(id);
+    };
+  }, [gesture]);
+
   const interpolationProps = React.useMemo(
     () => ({
       index: interpolationIndex,


### PR DESCRIPTION
Fixes #11564.

When the swipe-back gesture is updated from the native side with `useNativeDriver`, React Native warns about `onAnimatedValueUpdate` being sent with no listeners registered. Attaching a no-op listener tells the native side that JS is observing the value, silencing the warning.

The linking change from earlier commits has been reverted — see discussion above.